### PR TITLE
ssv - docker - debug - setup delve debugger and air live reload

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -14,7 +14,6 @@ bin = "tmp/cmd/ssvnode"
 # Customize binary.
 # This is how you start to run your application. Since my application will works like CLI, so to run it, like to make a CLI call.
 full_bin = "./tmp/cmd/ssvnode start-node -node-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
-#full_bin = "docker run start-node -node-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
 
 # This log file places in your tmp_dir.
 log = "air_errors.log"

--- a/.air.toml
+++ b/.air.toml
@@ -14,6 +14,7 @@ bin = "tmp/cmd/ssvnode"
 # Customize binary.
 # This is how you start to run your application. Since my application will works like CLI, so to run it, like to make a CLI call.
 full_bin = "./tmp/cmd/ssvnode start-node -node-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
+#full_bin = "docker run start-node -node-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
 
 # This log file places in your tmp_dir.
 log = "air_errors.log"

--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,33 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o ./tmp/cmd/ssvnode/main.go"
+# Binary file yields from `cmd`.
+bin = "tmp/cmd/ssvnode"
+
+# Customize binary.
+# This is how you start to run your application. Since my application will works like CLI, so to run it, like to make a CLI call.
+full_bin = "./tmp/cmd/ssvnode start-node -node-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
+
+# This log file places in your tmp_dir.
+log = "air_errors.log"
+# Watch these filename extensions.
+include_ext = ["go", "yaml"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["tmp"]
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+
+[log]
+# Show log time
+time = true
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/.run/config-remote-debug.run.xml
+++ b/.run/config-remote-debug.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="config-remote-debug-run" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" show_console_on_std_err="true" show_console_on_std_out="true">
+    <output_file path="_remoteDebug" is_save="true" />
+    <option name="disconnectOption" value="ASK" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -58,6 +58,3 @@ ENTRYPOINT ["/go/bin/ssvnode"]
 FROM debugger
 COPY --from=debugger go/bin/dlv /dlv
 ENTRYPOINT ["/dlv"]
-
-
-

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -55,7 +55,7 @@ COPY ./cmd/ssvnode/main.go .
 ENTRYPOINT ["/go/bin/ssvnode"]
 
 # Copy Delve debugger to ssvnode path
-FROM scratch
+FROM debugger
 COPY --from=debugger go/bin/dlv /dlv
 ENTRYPOINT ["/dlv"]
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,63 @@
+#
+# STEP 1: Prepare environment
+#
+FROM golang:1.15 AS preparer
+
+RUN apt-get update                                                        && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    curl git zip unzip wget g++ python gcc-aarch64-linux-gnu                 \
+  && rm -rf /var/lib/apt/lists/*
+RUN go version
+RUN python --version
+
+WORKDIR /go/src/github.com/bloxapp/ssv/
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+#
+# STEP 2: Build executable binary
+#
+FROM preparer AS builder
+
+# Copy files and install app
+COPY . .
+
+RUN go get -d -v ./...
+RUN CGO_ENABLED=1 GOOS=linux go install -a -tags blst_enabled -ldflags "-linkmode external -extldflags \"-static -lm\"" ./cmd/ssvnode
+#
+# STEP 3: Prepare image to run the binary
+#
+FROM alpine:3.12 AS runner
+# Install ca-certificates, bash
+RUN apk -v --update add ca-certificates bash && \
+    rm /var/cache/apk/*
+COPY --from=builder /go/bin/ssvnode /go/bin/ssvnode
+EXPOSE 40000 2345
+
+#
+# STEP 4: Prepare Live Reload - Air
+#
+FROM runner
+
+RUN apk add --update curl
+RUN curl -fLo install.sh https://raw.githubusercontent.com/cosmtrek/air/master/install.sh \
+    && chmod +x install.sh && sh install.sh
+CMD air
+
+#
+#  STEP 5: Setup Debugger Delve
+#
+FROM builder as debugger
+# Install Delve
+RUN CGO_ENABLED=0 go get -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv && pwd
+COPY ./cmd/ssvnode/main.go .
+ENTRYPOINT ["/go/bin/ssvnode"]
+
+# Copy Delve debugger to ssvnode path
+FROM scratch
+COPY --from=debugger go/bin/dlv /dlv
+ENTRYPOINT ["/dlv"]
+
+
+

--- a/docker-compose_debug.yaml
+++ b/docker-compose_debug.yaml
@@ -1,0 +1,48 @@
+version: '3.5'
+
+services:
+  ssv-node-1:
+    build:
+      context: .
+      dockerfile: Dockerfile.debug
+    command: "--listen=:2345 --headless=true --log=true --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec ./cmd/ssvnode -- start-node --node-id=1 --leader-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
+    environment:
+      DOCKER_COMPOSE: "true"
+      PUBKEY_NODE_2: "a833135e368cf9c90efbe17a7d4ca33772ef7c27a9ff1b818b5070e496be8e18bd921f8912521dce91556bab1263992f"
+      PUBKEY_NODE_3: "85ee43bbab6f09704a4c18ed24431ef84c528f2d7d3910c214c8a7638453e2bc487d62f046d8ba04fff5cf302d1e0622"
+    ports:
+      - "2345:2345"
+      - "40000:40000"
+      - "9191:9090"
+    security_opt:
+      - "seccomp:unconfined"
+    networks:
+      - bloxapp-docker
+    volumes:
+      - ./:/cmd/ssvnode
+    restart: always
+  ssv-node-2:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command:
+      - "start-node"
+      - "--node-id=2"
+      - "--leader-id=1"
+      - "--private-key=${SSV_NODE_2}"
+      - "--validator-key=${VALIDATOR_PUBLIC_KEY}"
+      - "--beacon-node-addr=${BEACON_NODE_ADDR}"
+      - "--network=${NETWORK}"
+      - "--val=${CONSENSUS_TYPE}"
+    environment:
+      DOCKER_COMPOSE: "true"
+      PUBKEY_NODE_1: "834c57dd7f9893a5a3266dabc4808509c758ce63e8822a543f73e9c274ca095efdc6f31b9dbd4ce4576747c266473d3b"
+      PUBKEY_NODE_3: "85ee43bbab6f09704a4c18ed24431ef84c528f2d7d3910c214c8a7638453e2bc487d62f046d8ba04fff5cf302d1e0622"
+    networks:
+      - bloxapp-docker
+    restart: always
+
+networks:
+  bloxapp-docker:
+    driver: bridge
+    name: bloxapp-docker

--- a/docker-compose_debug.yaml
+++ b/docker-compose_debug.yaml
@@ -1,7 +1,7 @@
 version: '3.5'
 
 services:
-  ssv-node-1:
+  ssv-node-debug:
     build:
       context: .
       dockerfile: Dockerfile.debug
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./:/cmd/ssvnode
     restart: always
-  ssv-node-2:
+  ssv-node-1:
     build:
       context: .
       dockerfile: Dockerfile
@@ -40,6 +40,26 @@ services:
     networks:
       - bloxapp-docker
     restart: always
+  ssv-node-2:
+      build:
+        context: .
+        dockerfile: Dockerfile
+      command:
+        - "start-node"
+        - "--node-id=3"
+        - "--leader-id=1"
+        - "--private-key=${SSV_NODE_3}"
+        - "--validator-key=${VALIDATOR_PUBLIC_KEY}"
+        - "--beacon-node-addr=${BEACON_NODE_ADDR}"
+        - "--network=${NETWORK}"
+        - "--val=${CONSENSUS_TYPE}"
+      environment:
+        DOCKER_COMPOSE: "true"
+        PUBKEY_NODE_1: "89791f38daa4ba0288035e6e12f11dd7c6e68651f2ae81f40a5bc5002e32281cab7b16e0ce12084619a2ce3d23d9f357"
+        PUBKEY_NODE_2: "98090f5ace3818b27b6ea2d38524556ec8c39d568a1595adb00964415eae62998c12ef015eda17f8d590f22b1778ec02"
+      networks:
+        - bloxapp-docker
+      restart: always
 
 networks:
   bloxapp-docker:

--- a/docker-compose_debug.yaml
+++ b/docker-compose_debug.yaml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.debug
-    command: "--listen=:2345 --headless=true --log=true --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec ./cmd/ssvnode -- start-node --node-id=1 --leader-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
+    command: "--listen=:2345 --headless=true --log=true --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec /go/bin/ssvnode start-node -- --node-id=1 --leader-id=1 --private-key=${SSV_NODE_1} --validator-key=${VALIDATOR_PUBLIC_KEY} --beacon-node-addr=${BEACON_NODE_ADDR} --network=${NETWORK} --val=${CONSENSUS_TYPE}"
     environment:
       DOCKER_COMPOSE: "true"
       PUBKEY_NODE_2: "a833135e368cf9c90efbe17a7d4ca33772ef7c27a9ff1b818b5070e496be8e18bd921f8912521dce91556bab1263992f"
@@ -13,7 +13,6 @@ services:
     ports:
       - "2345:2345"
       - "40000:40000"
-      - "9191:9090"
     security_opt:
       - "seccomp:unconfined"
     networks:


### PR DESCRIPTION
@roman-blox  @lior-blox  @alonmuroch - I need your help : ) 

This draft PR is a initial proposal to facilitate contribution to SSV repo by jumping from **git clone** to its **debug** stage.

1 - Setup of [Delve](https://github.com/go-delve/delve) as default debugger for SSV node container.
2 - Setup of [Air](https://github.com/cosmtrek/air) to enable live reload* to Go applications
3 - Setup a ready-to-use **docker-compose** file with **1 debugging node + 2 regular nodes instances.**

*Live Reload was inspired by [this blog post](https://medium.com/easyread/today-i-learned-golang-live-reload-for-development-using-docker-compose-air-ecc688ee076)
it enables the GO app to reload instantaneously after a code change - no need to rebuild the image/container etc


**Docker Compose command to trigger current changes:** 
```bash
docker-compose -f docker-compose_debug.yaml up -d --build
```