### PR TITLE
check if the node is registered on topic instead of throwing error

### DIFF
--- a/ibft/sync/test_utils.go
+++ b/ibft/sync/test_utils.go
@@ -128,6 +128,11 @@ func (n *testNetwork) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) er
 	return nil
 }
 
+// IsSubscribeToValidatorNetwork checks if there is a subscription to the validator topic
+func (n *testNetwork) IsSubscribeToValidatorNetwork(validatorPk *bls.PublicKey) bool {
+	return false
+}
+
 // AllPeers returns all connected peers for a validator PK
 func (n *testNetwork) AllPeers(validatorPk []byte) ([]string, error) {
 	return n.peers, nil

--- a/network/local/local.go
+++ b/network/local/local.go
@@ -174,6 +174,11 @@ func (n *Local) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error {
 	return nil
 }
 
+// IsSubscribeToValidatorNetwork checks if there is a subscription to the validator topic
+func (n *Local) IsSubscribeToValidatorNetwork(validatorPk *bls.PublicKey) bool {
+	return false
+}
+
 // AllPeers returns all connected peers for a validator PK
 func (n *Local) AllPeers(validatorPk []byte) ([]string, error) {
 	ret := make([]string, 0)

--- a/network/network.go
+++ b/network/network.go
@@ -68,6 +68,9 @@ type Network interface {
 	// SubscribeToValidatorNetwork subscribing and listen to validator network
 	SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error
 
+	// IsSubscribeToValidatorNetwork checks if there is a subscription to the validator topic
+	IsSubscribeToValidatorNetwork(validatorPk *bls.PublicKey) bool
+
 	// AllPeers returns all connected peers for a validator PK
 	AllPeers(validatorPk []byte) ([]string, error)
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -204,6 +204,12 @@ func (n *p2pNetwork) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) err
 	return nil
 }
 
+// IsSubscribeToValidatorNetwork checks if there is a subscription to the validator topic
+func (n *p2pNetwork) IsSubscribeToValidatorNetwork(validatorPk *bls.PublicKey) bool {
+	_, ok := n.cfg.Topics[validatorPk.SerializeToHexStr()]
+	return ok
+}
+
 // ReceivedMsgChan return a channel with messages
 func (n *p2pNetwork) listen(sub *pubsub.Subscription) {
 	go func(sub *pubsub.Subscription) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -79,6 +79,10 @@ func New(opt Options, ibftStorage collections.Iibft) *Validator {
 
 // Start validator
 func (v *Validator) Start() error {
+	if v.network.IsSubscribeToValidatorNetwork(v.Share.PublicKey) {
+		v.logger.Debug("already subscribed to validator's topic")
+		return nil
+	}
 	if err := v.network.SubscribeToValidatorNetwork(v.Share.PublicKey); err != nil {
 		return errors.Wrap(err, "failed to subscribe topic")
 	}


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/109

Verify topic subscription before setup, in order to avoid error logs when trying to register to a subscribed topic