### PR TITLE
stop ibft instance improve

### DIFF
--- a/ibft/ibft.go
+++ b/ibft/ibft.go
@@ -140,6 +140,8 @@ func (i *ibftImpl) StartInstance(opts StartOptions) (bool, int, []byte, error) {
 			if err := i.network.BroadcastDecided(i.ValidatorShare.PublicKey.Serialize(), agg); err != nil {
 				return false, 0, nil, errors.WithMessage(err, "could not broadcast decided message")
 			}
+			i.logger.Debug("decided stage, stop & reset current instance")
+			i.currentInstance.Stop()
 			i.currentInstance = nil
 			return true, len(agg.GetSignerIds()), agg.Message.Value, nil
 		}

--- a/ibft/ibft_decided.go
+++ b/ibft/ibft_decided.go
@@ -72,6 +72,7 @@ func (i *ibftImpl) ProcessDecidedMessage(msg *proto.SignedMessage) {
 	if shouldSync {
 		if i.currentInstance != nil {
 			i.currentInstance.Stop()
+			i.currentInstance = nil // make sure instance is closed
 		}
 		// sync
 		s := ibft_sync.NewHistorySync(i.logger, i.ValidatorShare.PublicKey.Serialize(), i.GetIdentifier(), i.network, i.ibftStorage, i.validateDecidedMsg)


### PR DESCRIPTION
There are case that instance is not stopping, what causing "current instance (seqNumber - %d) is still running" error.

**Changes**

- stop instance at decided stage
- reset instance (nil) when get decided msg from network