### PR TITLE
Ignore old contract data

### DIFF
--- a/eth1/sync.go
+++ b/eth1/sync.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultSyncOffset string = "49e08f"
+	defaultSyncOffset string = "4D9EF3"
 )
 
 // SyncOffset is the type of variable used for passing around the offset


### PR DESCRIPTION
Start fetching events since the switch to `prater`