### PR TITLE
Fix instance loop

### DIFF
--- a/ibft/ibft.go
+++ b/ibft/ibft.go
@@ -41,7 +41,7 @@ type IBFT interface {
 	Init()
 
 	// StartInstance starts a new instance by the given options
-	StartInstance(opts StartOptions) (chan *InstanceResult, error)
+	StartInstance(opts StartOptions) (*InstanceResult, error)
 
 	// NextSeqNumber returns the previous decided instance seq number + 1
 	// In case it's the first instance it returns 0
@@ -69,9 +69,6 @@ type ibftImpl struct {
 
 	// flags
 	initFinished bool
-
-	// channels
-	instanceResultChan chan *InstanceResult
 
 	// mutex
 	instanceResultChanLock sync.Mutex
@@ -113,7 +110,7 @@ func (i *ibftImpl) Init() {
 	i.logger.Debug("iBFT implementation init finished")
 }
 
-func (i *ibftImpl) StartInstance(opts StartOptions) (chan *InstanceResult, error) {
+func (i *ibftImpl) StartInstance(opts StartOptions) (*InstanceResult, error) {
 	instanceOpts, err := i.instanceOptionsFromStartOptions(opts)
 	if err != nil {
 		return nil, errors.WithMessage(err, "can't generate instance options")

--- a/ibft/ibft.go
+++ b/ibft/ibft.go
@@ -32,7 +32,6 @@ type StartOptions struct {
 type InstanceResult struct {
 	Decided bool
 	Msg     *proto.SignedMessage
-	Error   error
 }
 
 // IBFT represents behavior of the IBFT

--- a/ibft/ibft_decided.go
+++ b/ibft/ibft_decided.go
@@ -63,9 +63,9 @@ func (i *ibftImpl) ProcessDecidedMessage(msg *proto.SignedMessage) {
 	}
 
 	// decided for current instance
-	if i.forceDecideCurrentInstance(msg) {
-		return
-	}
+	//if i.forceDecideCurrentInstance(msg) {
+	//	return
+	//}
 
 	// decided for later instances which require a full sync
 	shouldSync, err := i.decidedRequiresSync(msg)
@@ -81,41 +81,41 @@ func (i *ibftImpl) ProcessDecidedMessage(msg *proto.SignedMessage) {
 
 // forceDecideCurrentInstance will force the current instance to decide provided a signed decided msg.
 // will return true if executed, false otherwise
-func (i *ibftImpl) forceDecideCurrentInstance(msg *proto.SignedMessage) bool {
-	if i.decidedForCurrentInstance(msg) {
-		i.logger.Info("received decided msg for current instance.")
-
-		// stop current instance
-		if i.currentInstance != nil {
-			i.currentInstance.Stop()
-		}
-
-		// save to db
-		if err := i.ibftStorage.SaveDecided(msg); err != nil {
-			i.pushAndCloseInstanceResultChan(&InstanceResult{
-				Decided: true,
-				Error:   errors.WithMessage(err, "could not save decided message to storage"),
-			})
-			return true
-		}
-		if err := i.ibftStorage.SaveHighestDecidedInstance(msg); err != nil {
-			i.pushAndCloseInstanceResultChan(&InstanceResult{
-				Decided: true,
-				Error:   errors.WithMessage(err, "could not save highest decided message to storage"),
-			})
-			return true
-		}
-
-		// push to chan
-		i.pushAndCloseInstanceResultChan(&InstanceResult{
-			Decided: true,
-			Msg:     msg,
-			Error:   nil,
-		})
-		return true
-	}
-	return false
-}
+//func (i *ibftImpl) forceDecideCurrentInstance(msg *proto.SignedMessage) bool {
+//	if i.decidedForCurrentInstance(msg) {
+//		i.logger.Info("received decided msg for current instance.")
+//
+//		// stop current instance
+//		if i.currentInstance != nil {
+//			i.currentInstance.Stop()
+//		}
+//
+//		// save to db
+//		if err := i.ibftStorage.SaveDecided(msg); err != nil {
+//			i.pushAndCloseInstanceResultChan(&InstanceResult{
+//				Decided: true,
+//				Error:   errors.WithMessage(err, "could not save decided message to storage"),
+//			})
+//			return true
+//		}
+//		if err := i.ibftStorage.SaveHighestDecidedInstance(msg); err != nil {
+//			i.pushAndCloseInstanceResultChan(&InstanceResult{
+//				Decided: true,
+//				Error:   errors.WithMessage(err, "could not save highest decided message to storage"),
+//			})
+//			return true
+//		}
+//
+//		// push to chan
+//		i.pushAndCloseInstanceResultChan(&InstanceResult{
+//			Decided: true,
+//			Msg:     msg,
+//			Error:   nil,
+//		})
+//		return true
+//	}
+//	return false
+//}
 
 // highestKnownDecided returns the highest known decided instance
 func (i *ibftImpl) highestKnownDecided() (*proto.SignedMessage, error) {

--- a/ibft/ibft_running_instance.go
+++ b/ibft/ibft_running_instance.go
@@ -20,54 +20,66 @@ func (i *ibftImpl) startInstanceWithOptions(instanceOpts InstanceOptions, value 
 
 	// main instance callback loop
 	var retRes *InstanceResult
+	var err error
 instanceLoop:
 	for {
-		switch stage := <-stageChan; stage {
-		case proto.RoundState_Prepare:
-			if err := i.ibftStorage.SaveCurrentInstance(i.GetIdentifier(), i.currentInstance.State); err != nil {
-				i.logger.Error("could not save prepare msg to storage", zap.Error(err))
+		select {
+		case stage := <-stageChan:
+			e, exit := i.instanceStageChange(stage)
+			if e != nil {
+				err = e
+				break instanceLoop
 			}
-		case proto.RoundState_Decided:
-			agg, err := i.currentInstance.CommittedAggregatedMsg()
-			if err != nil {
+			if exit { // exited with no error means instance decided
+				// fetch decided msg and return
+				retMsg, e := i.ibftStorage.GetDecided(i.Identifier, instanceOpts.SeqNumber)
+				if e != nil {
+					err = e
+					break instanceLoop
+				}
+				if retMsg == nil {
+					err = errors.New("could not fetch decided msg after instance finished")
+					break instanceLoop
+				}
 				retRes = &InstanceResult{
 					Decided: true,
-					Error:   errors.WithMessage(err, "could not get aggregated commit msg and save to storage"),
+					Msg:     retMsg,
 				}
 				break instanceLoop
 			}
-			if err := i.ibftStorage.SaveDecided(agg); err != nil {
-				retRes = &InstanceResult{
-					Decided: true,
-					Error:   errors.WithMessage(err, "could not save aggregated commit msg to storage"),
-				}
-				break instanceLoop
-			}
-			if err := i.ibftStorage.SaveHighestDecidedInstance(agg); err != nil {
-				retRes = &InstanceResult{
-					Decided: true,
-					Error:   errors.WithMessage(err, "could not save highest decided message to storage"),
-				}
-				break instanceLoop
-			}
-			if err := i.network.BroadcastDecided(i.ValidatorShare.PublicKey.Serialize(), agg); err != nil {
-				retRes = &InstanceResult{
-					Decided: true,
-					Error:   errors.WithMessage(err, "could not broadcast decided message"),
-				}
-				break instanceLoop
-			}
-			i.logger.Info("decided current instance", zap.String("identifier", string(agg.Message.Lambda)), zap.Uint64("seqNum", agg.Message.SeqNumber))
-			retRes = &InstanceResult{
-				Decided: true,
-				Msg:     agg,
-				Error:   nil,
-			}
-		case proto.RoundState_Stopped:
-			i.logger.Info("current iBFT instance stopped, nilling currentInstance", zap.Uint64("seqNum", i.currentInstance.State.SeqNumber))
-			break instanceLoop
 		}
 	}
+	// when main instance loop breaks, nil current instance
 	i.currentInstance = nil
-	return retRes, nil
+	return retRes, err
+}
+
+// instanceStageChange processes a stage change for the current instance, returns true if requires stopping the instance after stage process.
+func (i *ibftImpl) instanceStageChange(stage proto.RoundState) (error, bool) {
+	switch stage {
+	case proto.RoundState_Prepare:
+		if err := i.ibftStorage.SaveCurrentInstance(i.GetIdentifier(), i.currentInstance.State); err != nil {
+			return errors.Wrap(err, "could not save prepare msg to storage"), true
+		}
+	case proto.RoundState_Decided:
+		agg, err := i.currentInstance.CommittedAggregatedMsg()
+		if err != nil {
+			return errors.Wrap(err, "could not get aggregated commit msg and save to storage"), true
+		}
+		if err := i.ibftStorage.SaveDecided(agg); err != nil {
+			return errors.Wrap(err, "could not save aggregated commit msg to storage"), true
+		}
+		if err := i.ibftStorage.SaveHighestDecidedInstance(agg); err != nil {
+			return errors.Wrap(err, "could not save highest decided message to storage"), true
+		}
+		if err := i.network.BroadcastDecided(i.ValidatorShare.PublicKey.Serialize(), agg); err != nil {
+			return errors.Wrap(err, "could not broadcast decided message"), true
+		}
+		i.logger.Info("decided current instance", zap.String("identifier", string(agg.Message.Lambda)), zap.Uint64("seqNum", agg.Message.SeqNumber))
+		return nil, false
+	case proto.RoundState_Stopped:
+		i.logger.Info("current iBFT instance stopped, nilling currentInstance", zap.Uint64("seqNum", i.currentInstance.State.SeqNumber))
+		return nil, true
+	}
+	return nil, false
 }

--- a/ibft/ibft_sync.go
+++ b/ibft/ibft_sync.go
@@ -36,9 +36,6 @@ func (i *ibftImpl) SyncIBFT() {
 	if i.currentInstance != nil {
 		i.currentInstance.Stop()
 	}
-	i.pushAndCloseInstanceResultChan(&InstanceResult{
-		Decided: false,
-	})
 
 	// sync
 	s := ibft_sync.NewHistorySync(i.logger, i.ValidatorShare.PublicKey.Serialize(), i.GetIdentifier(), i.network, i.ibftStorage, i.validateDecidedMsg)

--- a/ibft/instance_test.go
+++ b/ibft/instance_test.go
@@ -184,5 +184,5 @@ func TestSetStage(t *testing.T) {
 	require.True(t, stopped)
 	lock.Unlock()
 	require.EqualValues(t, proto.RoundState_Stopped, instance.State.Stage)
-	require.Nil(t, instance.stageChangedChan)
+	require.NotNil(t, instance.stageChangedChan)
 }

--- a/validator/duty_execution.go
+++ b/validator/duty_execution.go
@@ -204,13 +204,8 @@ func (v *Validator) comeToConsensusOnInputValue(ctx context.Context, logger *zap
 	if err != nil {
 		return 0, nil, 0, errors.WithMessage(err, "ibft instance failed")
 	}
-
-	//result := <-resChan
 	if result == nil {
 		return 0, nil, seqNumber, errors.Wrap(err, "instance result returned nil")
-	}
-	if result.Error != nil {
-		return 0, nil, seqNumber, errors.Wrap(err, "instance returned with error")
 	}
 	if !result.Decided {
 		return 0, nil, seqNumber, errors.New("instance did not decide")

--- a/validator/duty_execution.go
+++ b/validator/duty_execution.go
@@ -193,7 +193,7 @@ func (v *Validator) comeToConsensusOnInputValue(ctx context.Context, logger *zap
 		return 0, nil, 0, errors.Wrap(err, "failed to calculate next sequence number")
 	}
 
-	resChan, err := v.ibfts[role].StartInstance(ibft.StartOptions{
+	result, err := v.ibfts[role].StartInstance(ibft.StartOptions{
 		Duty:           duty,
 		ValidatorShare: *v.Share,
 		Logger:         l,
@@ -205,7 +205,7 @@ func (v *Validator) comeToConsensusOnInputValue(ctx context.Context, logger *zap
 		return 0, nil, 0, errors.WithMessage(err, "ibft instance failed")
 	}
 
-	result := <-resChan
+	//result := <-resChan
 	if result == nil {
 		return 0, nil, seqNumber, errors.Wrap(err, "instance result returned nil")
 	}

--- a/validator/test_utils.go
+++ b/validator/test_utils.go
@@ -57,23 +57,17 @@ func (t *testIBFT) Init() {
 	_ = pk.Deserialize(refPk)
 }
 
-func (t *testIBFT) StartInstance(opts ibft.StartOptions) (chan *ibft.InstanceResult, error) {
-	ret := make(chan *ibft.InstanceResult)
-
-	go func() {
-		time.Sleep(time.Millisecond * 200)
-		ret <- &ibft.InstanceResult{
-			Decided: t.decided,
-			Msg: &proto.SignedMessage{
-				Message: &proto.Message{
-					Value: opts.Value,
-				},
-				SignerIds: make([]uint64, t.signaturesCount),
+func (t *testIBFT) StartInstance(opts ibft.StartOptions) (*ibft.InstanceResult, error) {
+	return &ibft.InstanceResult{
+		Decided: t.decided,
+		Msg: &proto.SignedMessage{
+			Message: &proto.Message{
+				Value: opts.Value,
 			},
-			Error: nil,
-		}
-	}()
-	return ret, nil
+			SignerIds: make([]uint64, t.signaturesCount),
+		},
+		Error: nil,
+	}, nil
 }
 
 // GetIBFTCommittee returns a map of the iBFT committee where the key is the member's id.

--- a/validator/test_utils.go
+++ b/validator/test_utils.go
@@ -66,7 +66,6 @@ func (t *testIBFT) StartInstance(opts ibft.StartOptions) (*ibft.InstanceResult, 
 			},
 			SignerIds: make([]uint64, t.signaturesCount),
 		},
-		Error: nil,
 	}, nil
 }
 


### PR DESCRIPTION
This PR will make the flow validator -> execute duty -> come to consensus -> startInstanceWithOptions -> decided instance one single thread.
This should solve the current instance nilling issues we had + better error handling.

This disables decided msg for current instance handling, will enable later on