### PR TITLE
Fix nil pointer issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - nil_pointer_issue
+    - stage
 
 Deploy to blox-infra-stage cluster:
   stage: deploy
@@ -46,7 +46,7 @@ Deploy to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - nil_pointer_issue
+    - stage
 
 #blox-infra-prod
 Build prod Docker image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - nil_pointer_issue
 
 Deploy to blox-infra-stage cluster:
   stage: deploy
@@ -46,7 +46,7 @@ Deploy to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - stage
+    - nil_pointer_issue
 
 #blox-infra-prod
 Build prod Docker image:

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -239,6 +239,10 @@ func (n *p2pNetwork) listen(sub *pubsub.Subscription) {
 
 func (n *p2pNetwork) propagateSignedMsg(cm network.Message) {
 	logger := n.logger.With(zap.String("func", "propagateSignedMsg"))
+	if cm.SignedMessage == nil {
+		logger.Debug("could not propagate nil message")
+		return
+	}
 	for _, ls := range n.listeners {
 		go func(ls listener, sm proto.SignedMessage, msgType network.NetworkMsg) {
 			switch msgType {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -210,7 +210,7 @@ func (n *p2pNetwork) IsSubscribeToValidatorNetwork(validatorPk *bls.PublicKey) b
 	return ok
 }
 
-// ReceivedMsgChan return a channel with messages
+// listen listens to some validator's topic
 func (n *p2pNetwork) listen(sub *pubsub.Subscription) {
 	n.logger.Info("start listen to topic", zap.String("topic", sub.Topic()))
 	for {
@@ -232,14 +232,18 @@ func (n *p2pNetwork) listen(sub *pubsub.Subscription) {
 				n.logger.Error("failed to unmarshal message", zap.Error(err))
 				continue
 			}
-			n.propagateSignedMsg(cm)
+			n.propagateSignedMsg(&cm)
 		}
 	}
 }
 
-func (n *p2pNetwork) propagateSignedMsg(cm network.Message) {
+// propagateSignedMsg takes an incoming message (from validator's topic)
+// and propagates it to the corresponding internal listeners
+func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
 	logger := n.logger.With(zap.String("func", "propagateSignedMsg"))
-	if cm.SignedMessage == nil {
+	// TODO: find a better way to deal with nil message
+	// 	i.e. avoid sending nil messages in the network
+	if cm == nil || cm.SignedMessage == nil {
 		logger.Debug("could not propagate nil message")
 		return
 	}

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -65,8 +65,11 @@ func (n *p2pNetwork) handleStream() {
 	})
 }
 
+// propagateSyncMsg takes an incoming sync message and propagates it on the internal sync channel
 func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream *SyncStream) {
 	logger := n.logger.With(zap.String("func", "propagateSyncMsg"))
+	// TODO: find a better way to deal with nil message
+	// 	i.e. avoid sending nil messages in the network
 	if netSyncStream == nil || cm == nil {
 		logger.Debug("could not propagate nil message")
 		return

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -66,6 +66,11 @@ func (n *p2pNetwork) handleStream() {
 }
 
 func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream *SyncStream) {
+	logger := n.logger.With(zap.String("func", "propagateSyncMsg"))
+	if netSyncStream == nil || cm == nil {
+		logger.Debug("could not propagate nil message")
+		return
+	}
 	cm.SyncMessage.FromPeerID = netSyncStream.stream.Conn().RemotePeer().String()
 	for _, ls := range n.listeners {
 		go func(ls listener, nm network.Message) {


### PR DESCRIPTION
Fixing an issue that was found on `ssv-node-v2-1` :
```
738a48d001a3e708540a98975e4f64537f834742d5", "node_id": 4, "role": "ATTESTER"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13aafd6]

goroutine 722 [running]:
github.com/bloxapp/ssv/network/p2p.(p2pNetwork).propagateSignedMsg(0xc0000e4600, 0x0, 0x0, 0x0, 0x0, 0x1)
    /go/src/github.com/bloxapp/ssv/network/p2p/p2p.go:260 +0x1d6
github.com/bloxapp/ssv/network/p2p.(p2pNetwork).listen(0xc0000e4600, 0xc00c77bcc0)
    /go/src/github.com/bloxapp/ssv/network/p2p/p2p.go:235 +0x6fa
created by github.com/bloxapp/ssv/network/p2p.(p2pNetwork).SubscribeToValidatorNetwork
    /go/src/github.com/bloxapp/ssv/network/p2p/p2p.go:202 +0x1ea
make: ** [Makefile:61: start-node] Error 2
```