### PR TITLE
Readiness log indicator

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -31,8 +31,8 @@ type goClient struct {
 
 // New init new client and go-client instance
 func New(opt beacon.Options) (beacon.Beacon, error) {
-	logger := opt.Logger.With(zap.String("component", "go-client"), zap.String("network", opt.Network))
-	logger.Info("connecting to client...")
+	logger := opt.Logger.With(zap.String("component", "goClient"), zap.String("network", opt.Network))
+	logger.Info("connecting to beacon client...")
 	autoClient, err := auto.New(opt.Context,
 		// WithAddress supplies the address of the beacon node, in host:port format.
 		auto.WithAddress(opt.BeaconNodeAddr),
@@ -45,7 +45,7 @@ func New(opt beacon.Options) (beacon.Beacon, error) {
 	}
 
 	logger = logger.With(zap.String("name", autoClient.Name()), zap.String("address", autoClient.Address()))
-	logger.Info("successfully connected to client")
+	logger.Info("successfully connected to beacon client")
 
 	_client := &goClient{
 		ctx:      opt.Context,

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -105,7 +105,6 @@ var StartNodeCmd = &cobra.Command{
 		cfg.SSVOptions.ValidatorOptions.ShareEncryptionKeyProvider = operatorStorage.GetPrivateKey
 
 		// create new eth1 client
-		Logger.Info("using registry contract address", zap.String("addr", cfg.ETH1Options.RegistryContractAddr))
 		if len(cfg.ETH1Options.RegistryContractABI) > 0 {
 			Logger.Info("using registry contract abi", zap.String("abi", cfg.ETH1Options.RegistryContractABI))
 			if err = eth1.LoadABI(cfg.ETH1Options.RegistryContractABI); err != nil {

--- a/eth1/goeth/goETH.go
+++ b/eth1/goeth/goETH.go
@@ -46,7 +46,8 @@ type eth1Client struct {
 
 // NewEth1Client creates a new instance
 func NewEth1Client(opts ClientOptions) (eth1.Client, error) {
-	logger := opts.Logger
+	logger := opts.Logger.With(zap.String("component", "eth1GoETH"))
+	logger.Info("eth1 addresses", zap.String("address", opts.NodeAddr), zap.String("contract", opts.RegistryContractAddr))
 
 	ec := eth1Client{
 		ctx:                        opts.Ctx,
@@ -92,12 +93,13 @@ func (ec *eth1Client) Sync(fromBlock *big.Int) error {
 // connect connects to eth1 client
 func (ec *eth1Client) connect() error {
 	// Create an IPC based RPC connection to a remote node
-	ec.logger.Info("dialing node", zap.String("addr", ec.nodeAddr))
+	ec.logger.Info("dialing eth1 node...")
 	conn, err := ethclient.Dial(ec.nodeAddr)
 	if err != nil {
 		ec.logger.Error("failed to reconnect to the Ethereum client", zap.Error(err))
 		return err
 	}
+	ec.logger.Info("successfully connected to eth1 goETH")
 	ec.conn = conn
 	return nil
 }

--- a/ibft/change_round.go
+++ b/ibft/change_round.go
@@ -60,6 +60,7 @@ func (i *Instance) uponChangeRoundFullQuorum() pipeline.Pipeline {
 
 		// change round if quorum reached
 		if !quorum {
+			i.Logger.Debug("change round - quorum not reached")
 			return nil
 		}
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -65,6 +65,8 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	// init empty topics map
 	cfg.Topics = make(map[string]*pubsub.Topic)
 
+	logger = logger.With(zap.String("component", "p2p"))
+
 	n := &p2pNetwork{
 		ctx:           ctx,
 		cfg:           cfg,

--- a/network/p2p/p2p_decided.go
+++ b/network/p2p/p2p_decided.go
@@ -23,7 +23,7 @@ func (n *p2pNetwork) BroadcastDecided(topicName []byte, msg *proto.SignedMessage
 		return errors.Wrap(err, "failed to get topic")
 	}
 
-	n.logger.Debug("Broadcasting to topic", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
+	n.logger.Debug("Broadcasting decided message", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
 	return topic.Publish(n.ctx, msgBytes)
 }
 

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -23,7 +23,7 @@ func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error
 		return errors.Wrap(err, "failed to get topic")
 	}
 
-	n.logger.Debug("Broadcasting to topic", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
+	n.logger.Debug("Broadcasting ibft message", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
 	return topic.Publish(n.ctx, msgBytes)
 }
 

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -22,7 +22,7 @@ func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessa
 		return errors.Wrap(err, "failed to get topic")
 	}
 
-	n.logger.Debug("Broadcasting to topic", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
+	n.logger.Debug("Broadcasting signature message", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
 	return topic.Publish(n.ctx, msgBytes)
 }
 

--- a/operator/node.go
+++ b/operator/node.go
@@ -60,7 +60,7 @@ type operatorNode struct {
 func New(opts Options) Node {
 	ssv := &operatorNode{
 		context:             opts.Context,
-		logger:              opts.Logger,
+		logger:              opts.Logger.With(zap.String("component", "operatorNode")),
 		genesisEpoch:        opts.GenesisEpoch,
 		dutyLimit:           opts.DutyLimit,
 		validatorController: opts.ValidatorController,
@@ -78,7 +78,7 @@ func New(opts Options) Node {
 
 // Start starts to stream duties and run IBFT instances
 func (n *operatorNode) Start() error {
-	n.logger.Info("starting node -> IBFT")
+	n.logger.Info("All required services are ready. OPERATOR SUCCESSFULLY CONFIGURED AND NOW RUNNING!")
 	go n.beacon.StartReceivingBlocks() // in order to get the latest slot (for attestation purposes)
 	n.validatorController.StartValidators()
 	return n.startDutiesTicker()
@@ -86,7 +86,7 @@ func (n *operatorNode) Start() error {
 
 // StartEth1 starts the eth1 events sync and streaming
 func (n *operatorNode) StartEth1(syncOffset *eth1.SyncOffset) error {
-	n.logger.Info("starting node -> eth1")
+	n.logger.Info("starting operator node syncing with eth1")
 
 	// setup validator controller to listen to ValidatorAdded events
 	// this will handle events from the sync as well

--- a/validator/controller.go
+++ b/validator/controller.go
@@ -70,15 +70,12 @@ func NewController(options ControllerOptions) IController {
 		Logger: options.Logger,
 	})
 
-	err := collection.LoadMultipleFromConfig(options.Shares)
-	if err != nil {
-		options.Logger.Error("failed to load all validators from config", zap.Error(err))
-	}
+	collection.LoadMultipleFromConfig(options.Shares)
 
 	ctrl := controller{
 		collection:                 collection,
 		context:                    options.Context,
-		logger:                     options.Logger,
+		logger:                     options.Logger.With(zap.String("component", "validatorsController")),
 		signatureCollectionTimeout: options.SignatureCollectionTimeout,
 		slotQueue:                  options.SlotQueue,
 		beacon:                     options.Beacon,
@@ -111,7 +108,11 @@ func (c *controller) setupValidators() map[string]*Validator {
 	if err != nil {
 		c.logger.Fatal("Failed to get validators shares", zap.Error(err))
 	}
-
+	if len(validatorsShare) == 0 {
+		c.logger.Info("operator have no validators no setup")
+	} else {
+		c.logger.Info("starting validators setup...")
+	}
 	res := make(map[string]*Validator)
 	for _, validatorShare := range validatorsShare {
 		printValidatorShare(c.logger, validatorShare)


### PR DESCRIPTION
Improve startup logs to be more readable for users

load validators from config

“operator is setup and fired successfully”  
"Broadcasting to topic" - add topic name in order to distinct between validators