### PR TITLE
Fix sync issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - fix_sync_issues
 
 Deploy to blox-infra-stage cluster:
   stage: deploy
@@ -46,7 +46,7 @@ Deploy to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - stage
+    - fix_sync_issues
 
 #blox-infra-prod
 Build prod Docker image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - fix_sync_issues
+    - stage
 
 Deploy to blox-infra-stage cluster:
   stage: deploy
@@ -46,7 +46,7 @@ Deploy to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - fix_sync_issues
+    - stage
 
 #blox-infra-prod
 Build prod Docker image:

--- a/ibft/sync/history_test.go
+++ b/ibft/sync/history_test.go
@@ -455,7 +455,7 @@ func TestSync(t *testing.T) {
 			"",
 		},
 		{
-			"try syncing to seq 2, error on history fetch",
+			"try syncing to seq 2 with missing the last, error on history fetch",
 			[]byte{1, 2, 3, 4},
 			[]byte("lambda"),
 			[]string{"2"},
@@ -470,6 +470,57 @@ func TestSync(t *testing.T) {
 			nil,
 			2,
 			"could not fetch decided by range during sync: returned decided by range messages miss sequence number 2",
+		},
+		{
+			"try syncing to seq 2 with missing in middle, error on history fetch",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided2,
+				"3": decided2,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0, decided2},
+				"3": {decided0, decided2},
+			},
+			nil,
+			2,
+			"could not fetch decided by range during sync: returned decided by range messages miss sequence number 1",
+		},
+		{
+			"try syncing to seq 2 with missing in start, error on history fetch",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided2,
+				"3": decided2,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided1, decided2},
+				"3": {decided1, decided2},
+			},
+			nil,
+			2,
+			"could not fetch decided by range during sync: returned decided by range messages miss sequence number 0",
+		},
+		{
+			"try syncing with differ decided peers",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided1,
+				"3": decided0,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0, decided1},
+				"3": {decided0},
+			},
+			nil,
+			1,
+			"",
 		},
 	}
 

--- a/ibft/sync/history_test.go
+++ b/ibft/sync/history_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"errors"
 	"github.com/bloxapp/ssv/ibft/proto"
+	ssvstorage "github.com/bloxapp/ssv/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/bloxapp/ssv/storage/collections"
 	"github.com/bloxapp/ssv/storage/kv"
@@ -354,6 +355,149 @@ func TestFindHighest(t *testing.T) {
 					require.Nil(t, res)
 				} else {
 					require.EqualValues(t, test.expectedHighestSeq, res.Message.SeqNumber)
+				}
+			}
+		})
+	}
+}
+
+func ibftStorage(t *testing.T) collections.IbftStorage {
+	db, err := ssvstorage.GetStorageFactory(basedb.Options{
+		Type:   "badger-memory",
+		Logger: zap.L(),
+		Path:   "",
+	})
+	require.NoError(t, err)
+	return collections.NewIbft(db, zap.L(), "attestation")
+}
+
+func TestSync(t *testing.T) {
+	sks, _ := GenerateNodes(4)
+	decided0 := multiSignMsg(t, []uint64{1, 2, 3}, sks, &proto.Message{
+		Type:      proto.RoundState_Decided,
+		Round:     1,
+		Lambda:    []byte("lambda"),
+		SeqNumber: 0,
+	})
+	decided1 := multiSignMsg(t, []uint64{1, 2, 3}, sks, &proto.Message{
+		Type:      proto.RoundState_Decided,
+		Round:     1,
+		Lambda:    []byte("lambda"),
+		SeqNumber: 1,
+	})
+	decided2 := multiSignMsg(t, []uint64{1, 2, 3}, sks, &proto.Message{
+		Type:      proto.RoundState_Decided,
+		Round:     1,
+		Lambda:    []byte("lambda"),
+		SeqNumber: 2,
+	})
+
+	tests := []struct {
+		name               string
+		valdiatorPK        []byte
+		identifier         []byte
+		peers              []string
+		highestMap         map[string]*proto.SignedMessage
+		decidedArrMap      map[string][]*proto.SignedMessage
+		errorMap           map[string]error
+		expectedHighestSeq int64
+		expectedError      string
+	}{
+		{
+			"sync to seq 0",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided0,
+				"3": decided0,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0},
+				"3": {decided0},
+			},
+			nil,
+			0,
+			"",
+		},
+		{
+			"sync to seq 1",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided1,
+				"3": decided1,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0, decided1},
+				"3": {decided0, decided1},
+			},
+			nil,
+			1,
+			"",
+		},
+		{
+			"sync to seq 2",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided2,
+				"3": decided2,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0, decided1, decided2},
+				"3": {decided0, decided1, decided2},
+			},
+			nil,
+			2,
+			"",
+		},
+		{
+			"try syncing to seq 2, error on history fetch",
+			[]byte{1, 2, 3, 4},
+			[]byte("lambda"),
+			[]string{"2"},
+			map[string]*proto.SignedMessage{
+				"2": decided2,
+				"3": decided2,
+			},
+			map[string][]*proto.SignedMessage{
+				"2": {decided0, decided1},
+				"3": {decided0, decided1},
+			},
+			nil,
+			2,
+			"could not fetch decided by range during sync: returned decided by range messages miss sequence number 2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := ibftStorage(t)
+			s := NewHistorySync(zap.L(), test.valdiatorPK, test.identifier, newTestNetwork(t, test.peers, 100, test.highestMap, test.errorMap, test.decidedArrMap, nil), &storage, func(msg *proto.SignedMessage) error {
+				return nil
+			})
+			err := s.Start()
+
+			if len(test.expectedError) > 0 {
+				require.EqualError(t, err, test.expectedError)
+			} else {
+				require.NoError(t, err)
+				if test.expectedHighestSeq == -1 {
+					//require.Nil(t, res)
+				} else {
+					// verify saved instances
+					for i := int64(0); i <= test.expectedHighestSeq; i++ {
+						decided, err := storage.GetDecided(test.identifier, uint64(i))
+						require.NoError(t, err)
+						require.EqualValues(t, uint64(i), decided.Message.SeqNumber)
+					}
+					// verify saved highest
+					highest, err := storage.GetHighestDecidedInstance(test.identifier)
+					require.NoError(t, err)
+					require.EqualValues(t, test.expectedHighestSeq, highest.Message.SeqNumber)
 				}
 			}
 		})


### PR DESCRIPTION
Resolving sync issues - 

1. **Decided seqNum 0** - 
In case when operator receives remote decided seqNum 0 and local is empty (notFound) we need to save decided 0 and not skip syncing as current happening (what leaving operator not in sync and "stuck")
2. **Handle missing decided** - 
When syncing with peer for range of decided (e.g from 0 to 10) and one of the decided is missing the operator is stuck in infinite loop. this pr handle that case and will raise and error.

**Also added tests for those cases.