### PR TITLE
Remove data races for current ibft instance object

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - ibft_instance_data_race
 
 Deploy to blox-infra-stage cluster:
   stage: deploy
@@ -46,7 +46,7 @@ Deploy to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - stage
+    - ibft_instance_data_race
 
 #blox-infra-prod
 Build prod Docker image:

--- a/ibft/ibft_decided.go
+++ b/ibft/ibft_decided.go
@@ -84,8 +84,8 @@ func (i *ibftImpl) ProcessDecidedMessage(msg *proto.SignedMessage) {
 func (i *ibftImpl) forceDecideCurrentInstance(msg *proto.SignedMessage) bool {
 	if i.decidedForCurrentInstance(msg) {
 		// stop current instance
-		if i.currentInstance != nil {
-			i.currentInstance.ForceDecide(msg)
+		if currentInstance := i.CurrentInstance(); currentInstance != nil {
+			currentInstance.ForceDecide(msg)
 		}
 		return true
 	}
@@ -111,7 +111,8 @@ func (i *ibftImpl) decidedMsgKnown(msg *proto.SignedMessage) (bool, error) {
 
 // decidedForCurrentInstance returns true if msg has same seq number is current instance
 func (i *ibftImpl) decidedForCurrentInstance(msg *proto.SignedMessage) bool {
-	return i.currentInstance != nil && i.currentInstance.State.SeqNumber == msg.Message.SeqNumber
+	currentInstance := i.CurrentInstance()
+	return currentInstance != nil && currentInstance.State.SeqNumber == msg.Message.SeqNumber
 }
 
 // decidedRequiresSync returns true if:

--- a/ibft/ibft_decided_test.go
+++ b/ibft/ibft_decided_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"sync"
 	"testing"
 	"time"
 )
@@ -171,6 +172,7 @@ func TestDecidedRequiresSync(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ibft := ibftImpl{
+				currentInstanceLock: &sync.RWMutex{},
 				currentInstance: test.currentInstance,
 				ibftStorage:     &testStorage{highestDecided: test.highestDecided},
 			}
@@ -248,7 +250,7 @@ func TestDecideIsCurrentInstance(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ibft := ibftImpl{currentInstance: test.currentInstance}
+			ibft := ibftImpl{currentInstance: test.currentInstance, currentInstanceLock: &sync.RWMutex{}}
 			require.EqualValues(t, test.expectedRes, ibft.decidedForCurrentInstance(test.msg))
 		})
 	}

--- a/ibft/ibft_sequence.go
+++ b/ibft/ibft_sequence.go
@@ -16,8 +16,8 @@ func (i *ibftImpl) canStartNewInstance(opts InstanceOptions) error {
 	if !i.initFinished {
 		return errors.New("iBFT hasn't initialized yet")
 	}
-	if i.currentInstance != nil {
-		return errors.Errorf("current instance (%d) is still running", i.currentInstance.State.SeqNumber)
+	if currentInstance := i.CurrentInstance(); currentInstance != nil {
+		return errors.Errorf("current instance (%d) is still running", currentInstance.State.SeqNumber)
 	}
 	highestKnown, err := i.highestKnownDecided()
 	if err != nil {

--- a/ibft/ibft_sequence_test.go
+++ b/ibft/ibft_sequence_test.go
@@ -132,7 +132,7 @@ func TestCanStartNewInstance(t *testing.T) {
 			i := testIBFTInstance(t)
 			i.initFinished = test.initFinished
 			if test.currentInstance != nil {
-				i.currentInstance = test.currentInstance
+				i.setCurrentInstance(test.currentInstance)
 			}
 			if test.storage != nil {
 				i.ibftStorage = test.storage

--- a/ibft/ibft_sequence_test.go
+++ b/ibft/ibft_sequence_test.go
@@ -9,12 +9,14 @@ import (
 	validatorstorage "github.com/bloxapp/ssv/validator/storage"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"sync"
 	"testing"
 )
 
 func testIBFTInstance(t *testing.T) *ibftImpl {
 	return &ibftImpl{
 		Identifier: []byte("lambda_11"),
+		currentInstanceLock: &sync.RWMutex{},
 		//instances: make([]*Instance, 0),
 	}
 }

--- a/ibft/ibft_sync.go
+++ b/ibft/ibft_sync.go
@@ -33,8 +33,8 @@ func (i *ibftImpl) SyncIBFT() {
 	i.logger.Info("syncing iBFT..")
 
 	// stop current instance and return any waiting chan.
-	if i.currentInstance != nil {
-		i.currentInstance.Stop()
+	if i.CurrentInstance() != nil {
+		i.CurrentInstance().Stop()
 	}
 
 	// sync

--- a/validator/test_utils.go
+++ b/validator/test_utils.go
@@ -58,6 +58,10 @@ func (t *testIBFT) Init() {
 	_ = pk.Deserialize(refPk)
 }
 
+func (t *testIBFT) CurrentInstance() *ibft.Instance {
+	return nil
+}
+
 func (t *testIBFT) StartInstance(opts ibft.StartOptions) (*ibft.InstanceResult, error) {
 	return &ibft.InstanceResult{
 		Decided: t.decided,


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/238

Wrap currentInstance access with functions and lock, and therefore avoid the data races for that object.