### PR TITLE
Restore update indices but keep fetching during sync

### DIFF
--- a/validator/validators_map.go
+++ b/validator/validators_map.go
@@ -47,20 +47,6 @@ func (vm *validatorsMap) ForEach(iterator validatorIterator) error {
 	return nil
 }
 
-// UpdateValidatorShare updates the share of the corresponding validator
-func (vm *validatorsMap) UpdateValidatorShare(share *storage.Share) bool {
-	// main lock
-	vm.lock.RLock()
-	defer vm.lock.RUnlock()
-
-	if v, ok := vm.validatorsMap[share.PublicKey.SerializeToHexStr()]; ok {
-		v.Share = share
-		return true
-	}
-
-	return false
-}
-
 // GetValidator returns a validator
 func (vm *validatorsMap) GetValidator(pubKey string) (*Validator, bool) {
 	// main lock


### PR DESCRIPTION
Coming back to update indices but now it shouldn't be disruptive as before as indices are normally fetched on validator added. In case it was failed for some reason (e.g. validator is not deposited yet) then the index will be updated on the next GetIndices round.