### PR TITLE
Add pubsub tracing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - pubsub_trace
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -47,7 +47,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - pubsub_trace
+    - stage
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy
@@ -61,7 +61,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-ssv-nodes-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE
   only:
-    - pubsub_trace
+    - stage
 
 
 #blox-infra-prod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - pubsub_trace
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -47,7 +47,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - stage
+    - pubsub_trace
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy
@@ -61,7 +61,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-ssv-nodes-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE
   only:
-    - stage
+    - pubsub_trace
 
 
 #blox-infra-prod

--- a/.k8/yamls/ssv-exporter.yml
+++ b/.k8/yamls/ssv-exporter.yml
@@ -178,6 +178,8 @@ spec:
             value: "true"
           - name: IBFT_SYNC_ENABLED
             value: "true"
+          - name: PUBSUB_TRACE_OUT
+            value: "./data/pubsub_trace.out"
         volumeMounts:
         - mountPath: /data
           name: ssv-exporter

--- a/.k8/yamls/ssv-node-v2-1-deployment.yml
+++ b/.k8/yamls/ssv-node-v2-1-deployment.yml
@@ -137,6 +137,8 @@ spec:
           value: "15000"
         - name: ENABLE_PROFILE
           value: "true"
+        - name: PUBSUB_TRACE_OUT
+          value: "./data/pubsub_trace.out"
         volumeMounts:
         - mountPath: /data
           name: ssv-node-v2-1

--- a/.k8/yamls/ssv-node-v2-2-deployment.yml
+++ b/.k8/yamls/ssv-node-v2-2-deployment.yml
@@ -137,6 +137,8 @@ spec:
           value: "15000"
         - name: ENABLE_PROFILE
           value: "true"
+        - name: PUBSUB_TRACE_OUT
+          value: "./data/pubsub_trace.out"
         volumeMounts:
         - mountPath: /data
           name: ssv-node-v2-2

--- a/.k8/yamls/ssv-node-v2-3-deployment.yml
+++ b/.k8/yamls/ssv-node-v2-3-deployment.yml
@@ -137,6 +137,8 @@ spec:
           value: "15000"
         - name: ENABLE_PROFILE
           value: "true"
+        - name: PUBSUB_TRACE_OUT
+          value: "./data/pubsub_trace.out"
         volumeMounts:
         - mountPath: /data
           name: ssv-node-v2-3

--- a/.k8/yamls/ssv-node-v2-4-deployment.yml
+++ b/.k8/yamls/ssv-node-v2-4-deployment.yml
@@ -137,6 +137,8 @@ spec:
           value: "15000"
         - name: ENABLE_PROFILE
           value: "true"
+        - name: PUBSUB_TRACE_OUT
+          value: "./data/pubsub_trace.out"
         volumeMounts:
         - mountPath: /data
           name: ssv-node-v2-4

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -58,6 +58,7 @@ In order to setup a grafana dashboard do the following:
 5. Align dashboard variables:
     * `instance` - container name, used in 'instance' field for metrics coming from prometheus. \
       In the given dashboard, instances names are: `ssv-node-v2-<i>`, make sure to change according to your setup
+    * `validator_dashboard_id` - exist only in operator dashboard, points to validator dashboard
 
 **Note:** In order to show `Process Health` panels, the following K8S metrics should be exposed:
 * `kubelet_volume_stats_used_bytes`

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	HostDNS          string        `yaml:"HostDNS" env:"HOST_DNS" env-description:"External DNS node is exposed for discovery"`
 	RequestTimeout   time.Duration `yaml:"RequestTimeout" env:"P2P_REQUEST_TIMEOUT"  env-default:"5s"`
 	MaxBatchResponse uint64        `yaml:"MaxBatchResponse" env:"P2P_MAX_BATCH_RESPONSE" env-default:"50" env-description:"maximum number of returned objects in a batch"`
+	PubSubTraceJSON  string        `yaml:"PubSubTraceJSON" env:"PUBSUB_TRACE_JSON" env-description:"JSON file path to hold collected pubsub traces"`
+	//PubSubTracer     string        `yaml:"PubSubTracer" env:"PUBSUB_TRACER" env-description:"A remote tracer that collects pubsub traces"`
 
 	// objects / instances
 	HostID              peer.ID

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	HostDNS          string        `yaml:"HostDNS" env:"HOST_DNS" env-description:"External DNS node is exposed for discovery"`
 	RequestTimeout   time.Duration `yaml:"RequestTimeout" env:"P2P_REQUEST_TIMEOUT"  env-default:"5s"`
 	MaxBatchResponse uint64        `yaml:"MaxBatchResponse" env:"P2P_MAX_BATCH_RESPONSE" env-default:"50" env-description:"maximum number of returned objects in a batch"`
-	PubSubTraceJSON  string        `yaml:"PubSubTraceJSON" env:"PUBSUB_TRACE_JSON" env-description:"JSON file path to hold collected pubsub traces"`
+	PubSubTraceOut   string        `yaml:"PubSubTraceOut" env:"PUBSUB_TRACE_OUT" env-description:"File path to hold collected pubsub traces"`
 	//PubSubTracer     string        `yaml:"PubSubTracer" env:"PUBSUB_TRACER" env-description:"A remote tracer that collects pubsub traces"`
 
 	// objects / instances

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
-	"path"
 	"strings"
 	"sync"
 	"time"
@@ -119,37 +117,12 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	n.logger = logger.With(zap.String("id", n.host.ID().String()))
 	n.logger.Info("listening on port", zap.String("port", n.host.Addrs()[0].String()))
 
-	// Gossipsub registration is done before we add in any new peers
-	// due to libp2p's gossipsub implementation not taking into
-	// account previously added peers when creating the gossipsub
-	// object.
-	psOpts := []pubsub.Option{
-		//pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
-		//pubsub.WithNoAuthor(),
-		//pubsub.WithMessageIdFn(msgIDFunction),
-		//pubsub.WithSubscriptionFilter(s),
-		pubsub.WithPeerOutboundQueueSize(256),
-		pubsub.WithValidateQueueSize(256),
+	if ps, err := n.setupGossipPubsub(cfg); err != nil {
+		n.logger.Error("failed to start pubsub", zap.Error(err))
+		return nil, errors.Wrap(err, "failed to start pubsub")
+	} else {
+		n.pubsub = ps
 	}
-
-	if len(cfg.PubSubTraceOut) > 0 {
-		if tracer, err := pubsub.NewPBTracer(cfg.PubSubTraceOut); err != nil {
-			logger.Error("could not create pubsub tracer", zap.Error(err))
-		} else {
-			logger.Debug("pubusb trace file was created", zap.String("path", cfg.PubSubTraceOut))
-			psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
-		}
-	}
-
-	setPubSubParameters()
-
-	// Create a new PubSub service using the GossipSub router
-	gs, err := pubsub.NewGossipSub(ctx, n.host, psOpts...)
-	if err != nil {
-		n.logger.Error("Failed to start pubsub")
-		return nil, err
-	}
-	n.pubsub = gs
 
 	if cfg.DiscoveryType == "mdns" { // use mdns discovery {
 		// Setup Local mDNS discovery
@@ -199,6 +172,35 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	n.watchTopicPeers()
 
 	return n, nil
+}
+
+func (n *p2pNetwork) setupGossipPubsub(cfg *Config) (*pubsub.PubSub, error) {
+	// Gossipsub registration is done before we add in any new peers
+	// due to libp2p's gossipsub implementation not taking into
+	// account previously added peers when creating the gossipsub
+	// object.
+	psOpts := []pubsub.Option{
+		//pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
+		//pubsub.WithNoAuthor(),
+		//pubsub.WithMessageIdFn(msgIDFunction),
+		//pubsub.WithSubscriptionFilter(s),
+		pubsub.WithPeerOutboundQueueSize(256),
+		pubsub.WithValidateQueueSize(256),
+	}
+
+	if len(cfg.PubSubTraceOut) > 0 {
+		if tracer, err := pubsub.NewPBTracer(cfg.PubSubTraceOut); err != nil {
+			return nil, errors.Wrap(err, "could not create pubsub tracer")
+		} else {
+			n.logger.Debug("pubusb trace file was created", zap.String("path", cfg.PubSubTraceOut))
+			psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
+		}
+	}
+
+	setPubSubParameters()
+
+	// Create a new PubSub service using the GossipSub router
+	return pubsub.NewGossipSub(n.ctx, n.host, psOpts...)
 }
 
 func (n *p2pNetwork) watchTopicPeers() {
@@ -358,13 +360,4 @@ func ignorePeers() map[string]bool {
 	return map[string]bool{
 		"16Uiu2HAkvaBh2xjstjs1koEx3jpBn5Hsnz7Bv8pE4SuwFySkiAuf": true,
 	}
-}
-
-func ensureBaseDir(fpath string) error {
-	baseDir := path.Dir(fpath)
-	info, err := os.Stat(baseDir)
-	if err == nil && info.IsDir() {
-		return nil
-	}
-	return os.MkdirAll(baseDir, 0755)
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -130,6 +130,14 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 		pubsub.WithValidateQueueSize(256),
 	}
 
+	if len(cfg.PubSubTraceJSON) > 0 {
+		if tracer, err := pubsub.NewJSONTracer(cfg.PubSubTraceJSON); err != nil {
+			logger.Error("could not create JSON tracer", zap.Error(err))
+		} else {
+			psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
+		}
+	}
+
 	setPubSubParameters()
 
 	// Create a new PubSub service using the GossipSub router

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -117,12 +117,12 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	n.logger = logger.With(zap.String("id", n.host.ID().String()))
 	n.logger.Info("listening on port", zap.String("port", n.host.Addrs()[0].String()))
 
-	if ps, err := n.setupGossipPubsub(cfg); err != nil {
+	ps, err := n.setupGossipPubsub(cfg)
+	if err != nil {
 		n.logger.Error("failed to start pubsub", zap.Error(err))
 		return nil, errors.Wrap(err, "failed to start pubsub")
-	} else {
-		n.pubsub = ps
 	}
+	n.pubsub = ps
 
 	if cfg.DiscoveryType == "mdns" { // use mdns discovery {
 		// Setup Local mDNS discovery
@@ -189,12 +189,12 @@ func (n *p2pNetwork) setupGossipPubsub(cfg *Config) (*pubsub.PubSub, error) {
 	}
 
 	if len(cfg.PubSubTraceOut) > 0 {
-		if tracer, err := pubsub.NewPBTracer(cfg.PubSubTraceOut); err != nil {
+		tracer, err := pubsub.NewPBTracer(cfg.PubSubTraceOut)
+		if err != nil {
 			return nil, errors.Wrap(err, "could not create pubsub tracer")
-		} else {
-			n.logger.Debug("pubusb trace file was created", zap.String("path", cfg.PubSubTraceOut))
-			psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
 		}
+		n.logger.Debug("pubusb trace file was created", zap.String("path", cfg.PubSubTraceOut))
+		psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
 	}
 
 	setPubSubParameters()

--- a/validator/metrics.go
+++ b/validator/metrics.go
@@ -51,12 +51,9 @@ func (v *Validator) reportDutyExecutionMetrics(duty *beacon.Duty) func() {
 
 	metricsCurrentSlot.WithLabelValues(pubKey).Set(float64(duty.Slot))
 
-	metricsValidatorStatus.WithLabelValues(pubKey).Set(float64(validatorStatusRunning))
-
 	return func() {
 		metricsRunningIBFTsCount.Dec()
 		metricsRunningIBFTs.WithLabelValues(pubKey).Dec()
-		metricsValidatorStatus.WithLabelValues(pubKey).Set(float64(validatorStatusReady))
 	}
 }
 
@@ -67,5 +64,4 @@ var (
 	validatorStatusNoIndex  validatorStatus = 1
 	validatorStatusError    validatorStatus = 2
 	validatorStatusReady    validatorStatus = 3
-	validatorStatusRunning  validatorStatus = 4
 )

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -95,9 +95,10 @@ func (v *Validator) Start() error {
 		for _, ib := range v.ibfts { // init all ibfts
 			go ib.Init()
 		}
-	})
 
-	metricsValidatorStatus.WithLabelValues(v.Share.PublicKey.SerializeToHexStr()).Set(float64(validatorStatusReady))
+		metricsValidatorStatus.WithLabelValues(v.Share.PublicKey.SerializeToHexStr()).
+			Set(float64(validatorStatusReady))
+	})
 
 	return nil
 }


### PR DESCRIPTION
Following https://github.com/bloxapp/ssv/issues/310, 

This PR adds a pubsub tracer (see [go-libp2p-pubsub#tracing](https://github.com/libp2p/go-libp2p-pubsub#tracing)) which will save the tracing in a local PB file.

The file will be analyzed using [go-libp2p-pubsub-tracer](https://github.com/libp2p/go-libp2p-pubsub-tracer)

Next step -> **remote tracer**

`go-libp2p-pubsub-tracer` includes [traced](https://github.com/libp2p/go-libp2p-pubsub-tracer#traced) to record traces from multiple peers.
By adding that functionality to the exporter node, we can get tracing of the entire network.


 
