### PR TITLE
F+1 catch bump round fix

### DIFF
--- a/ibft/instance.go
+++ b/ibft/instance.go
@@ -237,10 +237,14 @@ func (i *Instance) Stopped() bool {
 
 // BumpRound is used to set bump round by 1
 func (i *Instance) BumpRound() {
+	i.bumpToRound(i.State.Round.Get() + 1)
+}
+
+func (i *Instance) bumpToRound(round uint64) {
 	i.processChangeRoundQuorumOnce = sync.Once{}
 	i.processPrepareQuorumOnce = sync.Once{}
 	i.processCommitQuorumOnce = sync.Once{}
-	newRound := i.State.Round.Get() + 1
+	newRound := round
 	i.State.Round.Set(newRound)
 	metricsIBFTRound.WithLabelValues(string(i.State.Lambda.Get()),
 		i.ValidatorShare.PublicKey.SerializeToHexStr()).Set(float64(newRound))

--- a/ibft/partial_change_round.go
+++ b/ibft/partial_change_round.go
@@ -55,7 +55,7 @@ func (i *Instance) uponChangeRoundPartialQuorum(msgs []*network.Message) (bool, 
 
 	// TODO - could have a race condition where msgs are processed in a different thread and then we trigger round change here
 	if foundPartialQuorum {
-		i.State.Round.Set(lowestChangeRound)
+		i.bumpToRound(lowestChangeRound)
 		metricsIBFTRound.WithLabelValues(string(i.State.Lambda.Get()),
 			i.ValidatorShare.PublicKey.SerializeToHexStr()).Set(float64(lowestChangeRound))
 

--- a/ibft/partial_change_round.go
+++ b/ibft/partial_change_round.go
@@ -56,8 +56,6 @@ func (i *Instance) uponChangeRoundPartialQuorum(msgs []*network.Message) (bool, 
 	// TODO - could have a race condition where msgs are processed in a different thread and then we trigger round change here
 	if foundPartialQuorum {
 		i.bumpToRound(lowestChangeRound)
-		metricsIBFTRound.WithLabelValues(string(i.State.Lambda.Get()),
-			i.ValidatorShare.PublicKey.SerializeToHexStr()).Set(float64(lowestChangeRound))
 
 		i.Logger.Info("found f+1 change round quorum, bumped round", zap.Uint64("new round", i.State.Round.Get()))
 		i.resetRoundTimer()

--- a/ibft/spectesting/tests/change_round_partial_quorum_and_decide.go
+++ b/ibft/spectesting/tests/change_round_partial_quorum_and_decide.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"github.com/bloxapp/ssv/ibft"
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/ibft/spectesting"
+	"github.com/bloxapp/ssv/network"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// ChangeRoundThePartialQuorumTheDecide tests coming to consensus after an f+1 (after change round)
+type ChangeRoundThePartialQuorumTheDecide struct {
+	instance   *ibft.Instance
+	inputValue []byte
+	lambda     []byte
+}
+
+// Name returns test name
+func (test *ChangeRoundThePartialQuorumTheDecide) Name() string {
+	return "pre-prepare -> change round -> bump f+1 to higher round-> change round-> decide"
+}
+
+// Prepare prepares the test
+func (test *ChangeRoundThePartialQuorumTheDecide) Prepare(t *testing.T) {
+	test.lambda = []byte{1, 2, 3, 4}
+	test.inputValue = spectesting.TestInputValue()
+
+	test.instance = spectesting.TestIBFTInstance(t, test.lambda)
+	test.instance.State.Round.Set(1)
+
+	// load messages to queue
+	for _, msg := range test.MessagesSequence(t) {
+		test.instance.MsgQueue.AddMessage(&network.Message{
+			SignedMessage: msg,
+			Type:          network.NetworkMsg_IBFTType,
+		})
+	}
+}
+
+// MessagesSequence includes all test messages
+func (test *ChangeRoundThePartialQuorumTheDecide) MessagesSequence(t *testing.T) []*proto.SignedMessage {
+	return []*proto.SignedMessage{
+		spectesting.PrePrepareMsg(t, spectesting.TestSKs()[0], test.lambda, test.inputValue, 1, 1),
+
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[0], test.lambda, 2, 1),
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[1], test.lambda, 2, 2),
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[2], test.lambda, 2, 3),
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[3], test.lambda, 2, 4),
+
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[2], test.lambda, 5, 3),
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[3], test.lambda, 5, 4),
+		spectesting.ChangeRoundMsg(t, spectesting.TestSKs()[0], test.lambda, 5, 1),
+
+		spectesting.PrePrepareMsg(t, spectesting.TestSKs()[0], test.lambda, test.inputValue, 5, 1),
+
+		spectesting.PrepareMsg(t, spectesting.TestSKs()[0], test.lambda, test.inputValue, 5, 1),
+		spectesting.PrepareMsg(t, spectesting.TestSKs()[1], test.lambda, test.inputValue, 5, 2),
+		spectesting.PrepareMsg(t, spectesting.TestSKs()[2], test.lambda, test.inputValue, 5, 3),
+		spectesting.PrepareMsg(t, spectesting.TestSKs()[3], test.lambda, test.inputValue, 5, 4),
+
+		spectesting.CommitMsg(t, spectesting.TestSKs()[0], test.lambda, test.inputValue, 5, 1),
+		spectesting.CommitMsg(t, spectesting.TestSKs()[1], test.lambda, test.inputValue, 5, 2),
+		spectesting.CommitMsg(t, spectesting.TestSKs()[2], test.lambda, test.inputValue, 5, 3),
+		spectesting.CommitMsg(t, spectesting.TestSKs()[3], test.lambda, test.inputValue, 5, 4),
+	}
+}
+
+// Run runs the test
+func (test *ChangeRoundThePartialQuorumTheDecide) Run(t *testing.T) {
+	// pre-prepare
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.SimulateTimeout(test.instance, 2)
+
+	// change round
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	justified, err := test.instance.JustifyRoundChange(2)
+	require.NoError(t, err)
+	require.True(t, justified)
+
+	// f+1
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessChangeRoundPartialQuorum)
+	require.EqualValues(t, 5, test.instance.State.Round.Get())
+
+	// full change round quorum
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
+	require.EqualValues(t, proto.RoundState_PrePrepare, test.instance.State.Stage.Get())
+	justified, err = test.instance.JustifyRoundChange(5)
+	require.NoError(t, err)
+	require.True(t, justified)
+
+	// check pre-prepare justification
+	err = test.instance.JustifyPrePrepare(2)
+	require.NoError(t, err)
+
+	// process all messages
+	for {
+		if res, _ := test.instance.ProcessMessage(); !res {
+			break
+		}
+	}
+	require.EqualValues(t, proto.RoundState_Decided, test.instance.State.Stage.Get())
+}

--- a/ibft/spectesting/tests/spec_test.go
+++ b/ibft/spectesting/tests/spec_test.go
@@ -22,6 +22,7 @@ var tests = []SpecTest{
 	&DuplicateMessages{},
 	&ValidSimpleRun{},
 	&ChangeRoundPartialQuorum{},
+	&ChangeRoundThePartialQuorumTheDecide{},
 }
 
 func TestAllSpecTests(t *testing.T) {


### PR DESCRIPTION
This solves an issue of bumping round (while f+1 catch up) directly by calling state.round ++ which doesn't execute the necessary bump round logic. 
This caused f+1 to sometimes not execute the change round quorum as it didn't reset:
i.processChangeRoundQuorumOnce = sync.Once{}
	i.processPrepareQuorumOnce = sync.Once{}
	i.processCommitQuorumOnce = sync.Once{} 