### PR TITLE
Exporter - added decided api

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - exporter-decided-api
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -47,7 +47,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION
   only:
-    - stage
+    - exporter-decided-api
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy

--- a/beacon/types.go
+++ b/beacon/types.go
@@ -26,17 +26,3 @@ const (
 	RoleTypeAggregator
 	RoleTypeProposer
 )
-
-// ToRoleType takes a string and convert it to RoleType
-func ToRoleType(role string) RoleType {
-	switch role {
-	case "ATTESTER":
-		return RoleTypeAttester
-	case "AGGREGATOR":
-		return RoleTypeAggregator
-	case "PROPOSER":
-		return RoleTypeProposer
-	default:
-		return RoleTypeUnknown
-	}
-}

--- a/beacon/types.go
+++ b/beacon/types.go
@@ -26,3 +26,17 @@ const (
 	RoleTypeAggregator
 	RoleTypeProposer
 )
+
+// ToRoleType takes a string and convert it to RoleType
+func ToRoleType(role string) RoleType {
+	switch role {
+	case "ATTESTER":
+		return RoleTypeAttester
+	case "AGGREGATOR":
+		return RoleTypeAggregator
+	case "PROPOSER":
+		return RoleTypeProposer
+	default:
+		return RoleTypeUnknown
+	}
+}

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/bloxapp/ssv/beacon"
 	"github.com/bloxapp/ssv/exporter/storage"
 )
 
@@ -52,19 +51,6 @@ const (
 	// RoleProposer is an enum for proposer role
 	RoleProposer DutyRole = "PROPOSER"
 )
-
-func ToBeaconRoleType(dr DutyRole) beacon.RoleType {
-	switch dr {
-	case RoleAttester:
-		return beacon.RoleTypeAttester
-	case RoleAggregator:
-		return beacon.RoleTypeAggregator
-	case RoleProposer:
-		return beacon.RoleTypeProposer
-	default:
-		return beacon.RoleTypeUnknown
-	}
-}
 
 // ValidatorsMessage represents message for validators response
 type ValidatorsMessage struct {

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/bloxapp/ssv/exporter/storage"
+import (
+	"github.com/bloxapp/ssv/beacon"
+	"github.com/bloxapp/ssv/exporter/storage"
+)
 
 // Message represents an exporter message
 type Message struct {
@@ -20,7 +23,7 @@ type MessageFilter struct {
 	To int64 `json:"to"`
 	// Role is the duty type enum, optional as it's relevant for IBFT data
 	Role DutyRole `json:"role,omitempty"`
-	// PublicKey is optional as it's relevant for IBFT data
+	// PublicKey is optional, used for fetching decided messages or information about specific validator/operator
 	PublicKey string `json:"publicKey,omitempty"`
 }
 
@@ -32,8 +35,8 @@ const (
 	TypeValidator MessageType = "validator"
 	// TypeOperator is an enum for operator type messages
 	TypeOperator MessageType = "operator"
-	// TypeIBFT is an enum for ibft type messages
-	TypeIBFT MessageType = "ibft"
+	// TypeDecided is an enum for ibft type messages
+	TypeDecided MessageType = "decided"
 	// TypeError is an enum for error type messages
 	TypeError MessageType = "error"
 )
@@ -49,6 +52,19 @@ const (
 	// RoleProposer is an enum for proposer role
 	RoleProposer DutyRole = "PROPOSER"
 )
+
+func ToBeaconRoleType(dr DutyRole) beacon.RoleType {
+	switch dr {
+	case RoleAttester:
+		return beacon.RoleTypeAttester
+	case RoleAggregator:
+		return beacon.RoleTypeAggregator
+	case RoleProposer:
+		return beacon.RoleTypeProposer
+	default:
+		return beacon.RoleTypeUnknown
+	}
+}
 
 // ValidatorsMessage represents message for validators response
 type ValidatorsMessage struct {

--- a/exporter/node.go
+++ b/exporter/node.go
@@ -196,8 +196,8 @@ func (exp *exporter) processIncomingExportRequests(incoming pubsub.SubjectChanne
 			handleOperatorsQuery(exp.logger, exp.storage, &nm)
 		case api.TypeValidator:
 			handleValidatorsQuery(exp.logger, exp.storage, &nm)
-		case api.TypeIBFT:
-			handleDutiesQuery(exp.logger, &nm)
+		case api.TypeDecided:
+			handleDecidedQuery(exp.logger, exp.storage, exp.ibftStorage, &nm)
 		case api.TypeError:
 			handleErrorQuery(exp.logger, &nm)
 		default:

--- a/exporter/node.go
+++ b/exporter/node.go
@@ -289,10 +289,6 @@ func (exp *exporter) triggerValidator(validatorPubKey *bls.PublicKey) error {
 func (exp *exporter) setup(validatorShare *validatorstorage.Share) error {
 	pubKey := validatorShare.PublicKey.SerializeToHexStr()
 	logger := exp.logger.With(zap.String("pubKey", pubKey))
-	// report validator status upon setup finished
-	defer func() {
-		validator.ReportValidatorStatus(pubKey, validatorShare.Metadata, exp.logger)
-	}()
 	decidedReader := exp.getDecidedReader(validatorShare)
 	if err := tasks.Retry(func() error {
 		if err := decidedReader.Sync(); err != nil {

--- a/exporter/query_handlers.go
+++ b/exporter/query_handlers.go
@@ -2,12 +2,10 @@ package exporter
 
 import (
 	"fmt"
-	"github.com/bloxapp/ssv/beacon"
 	"github.com/bloxapp/ssv/exporter/api"
 	"github.com/bloxapp/ssv/exporter/storage"
 	"github.com/bloxapp/ssv/ibft/sync/incoming"
 	"github.com/bloxapp/ssv/storage/collections"
-	validator "github.com/bloxapp/ssv/validator"
 	"go.uber.org/zap"
 )
 
@@ -71,7 +69,7 @@ func handleDecidedQuery(logger *zap.Logger, validatorStorage storage.ValidatorsC
 		res.Data = []string{"internal error - could not find validator"}
 	} else {
 		v := validators[0]
-		identifier := validator.IdentifierFormat([]byte(v.PublicKey), beacon.ToRoleType(string(nm.Msg.Filter.Role)))
+		identifier := fmt.Sprintf("%s_%s", v.PublicKey,string(nm.Msg.Filter.Role))
 		msgs, err := incoming.GetDecidedInRange([]byte(identifier), uint64(nm.Msg.Filter.From),
 			uint64(nm.Msg.Filter.To), logger, ibftStorage)
 		if err != nil {

--- a/exporter/query_handlers.go
+++ b/exporter/query_handlers.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"fmt"
+	"github.com/bloxapp/ssv/beacon"
 	"github.com/bloxapp/ssv/exporter/api"
 	"github.com/bloxapp/ssv/exporter/storage"
 	"github.com/bloxapp/ssv/ibft/sync/incoming"
@@ -70,7 +71,7 @@ func handleDecidedQuery(logger *zap.Logger, validatorStorage storage.ValidatorsC
 		res.Data = []string{"internal error - could not find validator"}
 	} else {
 		v := validators[0]
-		identifier := validator.IdentifierFormat([]byte(v.PublicKey), api.ToBeaconRoleType(nm.Msg.Filter.Role))
+		identifier := validator.IdentifierFormat([]byte(v.PublicKey), beacon.ToRoleType(string(nm.Msg.Filter.Role)))
 		msgs, err := incoming.GetDecidedInRange([]byte(identifier), uint64(nm.Msg.Filter.From),
 			uint64(nm.Msg.Filter.To), logger, ibftStorage)
 		if err != nil {

--- a/exporter/query_handlers_test.go
+++ b/exporter/query_handlers_test.go
@@ -3,11 +3,17 @@ package exporter
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/bloxapp/ssv/beacon"
 	"github.com/bloxapp/ssv/exporter/api"
 	"github.com/bloxapp/ssv/exporter/storage"
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/ibft/sync"
 	ssvstorage "github.com/bloxapp/ssv/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
+	"github.com/bloxapp/ssv/storage/collections"
+	"github.com/bloxapp/ssv/validator"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -72,8 +78,9 @@ func TestHandleErrorQuery(t *testing.T) {
 }
 
 func TestHandleOperatorsQuery(t *testing.T) {
-	s, l, done := newStorageForTest()
+	db, l, done := newDBAndLoggerForTest()
 	defer done()
+	s, _ := newStorageForTest(db, l)
 
 	ois := []storage.OperatorInformation{
 		{
@@ -152,8 +159,9 @@ func TestHandleOperatorsQuery(t *testing.T) {
 }
 
 func TestHandleValidatorsQuery(t *testing.T) {
-	s, l, done := newStorageForTest()
+	db, l, done := newDBAndLoggerForTest()
 	defer done()
+	s, _ := newStorageForTest(db, l)
 
 	vis := []storage.ValidatorInformation{
 		{
@@ -229,7 +237,47 @@ func TestHandleValidatorsQuery(t *testing.T) {
 	})
 }
 
-func newStorageForTest() (storage.Storage, *zap.Logger, func()) {
+func TestHandleDecidedQuery(t *testing.T) {
+	db, l, done := newDBAndLoggerForTest()
+	defer done()
+	exporterStorage, ibftStorage := newStorageForTest(db, l)
+	_ = bls.Init(bls.BLS12_381)
+
+	sks, _ := sync.GenerateNodes(4)
+	pk := sks[1].GetPublicKey()
+	identifier := validator.IdentifierFormat(pk.Serialize(), beacon.RoleTypeAttester)
+	decided250Seq := sync.DecidedArr(t, 250, sks, []byte(identifier))
+
+	// save decided
+	for _, d := range decided250Seq {
+		require.NoError(t, ibftStorage.SaveDecided(d))
+	}
+	require.NoError(t, exporterStorage.SaveValidatorInformation(&storage.ValidatorInformation{
+		PublicKey: pk.SerializeToHexStr(),
+	}))
+
+	nm := api.NetworkMessage{
+		Msg: api.Message{
+			Type:   api.TypeDecided,
+			Filter: api.MessageFilter{
+				PublicKey: pk.SerializeToHexStr(),
+				From: 0,
+				To: 250,
+				Role: api.RoleAttester,
+			},
+		},
+		Err:  nil,
+		Conn: nil,
+	}
+	require.Nil(t, nm.Msg.Data)
+	handleDecidedQuery(l, exporterStorage, ibftStorage, &nm)
+	require.NotNil(t, nm.Msg.Data)
+	msgs, ok := nm.Msg.Data.([]*proto.SignedMessage)
+	require.True(t, ok)
+	require.Equal(t, 251, len(msgs)) // seq 0 - 250
+}
+
+func newDBAndLoggerForTest() (basedb.IDb, *zap.Logger, func()) {
 	logger := zap.L()
 	db, err := ssvstorage.GetStorageFactory(basedb.Options{
 		Type:   "badger-memory",
@@ -239,10 +287,15 @@ func newStorageForTest() (storage.Storage, *zap.Logger, func()) {
 	if err != nil {
 		return nil, nil, func() {}
 	}
-	s := storage.NewExporterStorage(db, logger)
-	return s, logger, func() {
+	return db, logger, func() {
 		db.Close()
 	}
+}
+
+func newStorageForTest(db basedb.IDb, logger *zap.Logger) (storage.Storage, collections.Iibft) {
+	sExporter := storage.NewExporterStorage(db, logger)
+	sIbft := collections.NewIbft(db, logger, "attestation")
+	return sExporter, &sIbft
 }
 
 func getMockOperatorLinks() []storage.OperatorNodeLink {

--- a/exporter/validators_metadata.go
+++ b/exporter/validators_metadata.go
@@ -28,7 +28,7 @@ func (exp *exporter) warmupValidatorsMetaData() error {
 		exp.logger.Error("could not get validators shares for metadata update", zap.Error(err))
 		return err
 	}
-	exp.updateValidatorsMetadata(shares, 100)
+	exp.updateValidatorsMetadata(shares, metaDataBatchSize)
 	return err
 }
 
@@ -49,6 +49,6 @@ func (exp *exporter) updateValidatorsMetadata(shares []*validatorstorage.Share, 
 
 		// reset start and end
 		start = end
-		end = int(math.Min(float64(len(shares)), float64(start + batchSize)))
+		end = int(math.Min(float64(len(shares)), float64(start+batchSize)))
 	}
 }

--- a/ibft/sync/history/history_test.go
+++ b/ibft/sync/history/history_test.go
@@ -28,7 +28,7 @@ func TestSync(t *testing.T) {
 		Lambda:    []byte("lambda"),
 		SeqNumber: 2,
 	})
-	decided250Seq := sync.DecidedArr(t, 250, sks)
+	decided250Seq := sync.DecidedArr(t, 250, sks, []byte("lambda"))
 
 	tests := []struct {
 		name               string

--- a/ibft/sync/incoming/fetch_decided.go
+++ b/ibft/sync/incoming/fetch_decided.go
@@ -55,7 +55,7 @@ func GetDecidedInRange(identifier []byte, start, end uint64, logger *zap.Logger,
 	for i := start; i <= end; i++ {
 		decidedMsg, found, err := storage.GetDecided(identifier, i)
 		logger = logger.With(zap.ByteString("identifier", identifier), zap.Uint64("sequence", i))
-		if !found{
+		if !found {
 			logger.Error("decided was not found")
 			continue
 		}

--- a/ibft/sync/incoming/fetch_decided.go
+++ b/ibft/sync/incoming/fetch_decided.go
@@ -49,6 +49,7 @@ func (s *ReqHandler) validateGetDecidedReq(msg *network.SyncChanObj) error {
 	return nil
 }
 
+// GetDecidedInRange returns decided messages of the validator (and role) for the given range
 func GetDecidedInRange(identifier []byte, start, end uint64, logger *zap.Logger, storage collections.Iibft) ([]*proto.SignedMessage, error) {
 	ret := make([]*proto.SignedMessage, 0)
 	for i := start; i <= end; i++ {

--- a/ibft/sync/incoming/fetch_decided_test.go
+++ b/ibft/sync/incoming/fetch_decided_test.go
@@ -13,7 +13,7 @@ import (
 func TestTestNetwork_GetDecidedByRange(t *testing.T) {
 	sks, _ := sync.GenerateNodes(4)
 
-	decided250Seq := sync.DecidedArr(t, 250, sks)
+	decided250Seq := sync.DecidedArr(t, 250, sks, []byte("lambda"))
 
 	tests := []struct {
 		name           string

--- a/ibft/sync/test_utils.go
+++ b/ibft/sync/test_utils.go
@@ -46,14 +46,14 @@ func GenerateNodes(cnt int) (map[uint64]*bls.SecretKey, map[uint64]*proto.Node) 
 	return sks, nodes
 }
 
-// DecidedArr returns an array of signed decided msgs
-func DecidedArr(t *testing.T, maxSeq uint64, sks map[uint64]*bls.SecretKey) []*proto.SignedMessage {
+// DecidedArr returns an array of signed decided msgs for the given identifier
+func DecidedArr(t *testing.T, maxSeq uint64, sks map[uint64]*bls.SecretKey, identifier []byte) []*proto.SignedMessage {
 	ret := make([]*proto.SignedMessage, 0)
 	for i := uint64(0); i <= maxSeq; i++ {
 		ret = append(ret, MultiSignMsg(t, []uint64{1, 2, 3}, sks, &proto.Message{
 			Type:      proto.RoundState_Decided,
 			Round:     1,
-			Lambda:    []byte("lambda"),
+			Lambda:    identifier[:],
 			SeqNumber: i,
 		}))
 	}


### PR DESCRIPTION
Added WS API for exporting decided messages.

## Usage

Request filter should include:
* `publicKey` - validator's public key
* `role` - role type
* `from` / `to` - range
```json
{
  "type":"decided",
  "filter": { 
    "publicKey": "80bced0450cfad50f38b856d06c3678e5436f6d29f793e83962b961e21dd7c77b9a94b9ae5a5fa6cc7bd0e7d22abee8f",
    "role": "ATTESTER", 
    "from":16526,
    "to":16527
  }
}
```

```json
{
  "type": "decided",
  "filter": {...},
  "data": [
    {
      "message": {
        "type": 3,
        "round": 1,
        "lambda": "...",
        "seq_number": 16526,
        "value": "..."
      },
      "signature": "...",
      "signer_ids": [1, 4, 3]
    },
    {
      "message": {
        "type": 3,
        "round": 1,
        "lambda": "...",
        "seq_number": 16527,
        "value": "..."
      },
      "signature": "...",
      "signer_ids": [2, 1, 4]
    }
  ]
}
```