### PR TITLE
Fine tune

### DIFF
--- a/eth1/goeth/goETH.go
+++ b/eth1/goeth/goETH.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	healthCheckTimeout        = 10 * time.Second
-	blocksInBatch      uint64 = 100000
+	blocksInBatch      uint64 = 25000
 )
 
 type eth1NodeStatus int32

--- a/network/p2p/discovery.go
+++ b/network/p2p/discovery.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	maxPeers = 50
+	maxPeers = 100
 )
 
 // discoveryNotifee gets notified when we find a new peer via mDNS discovery


### PR DESCRIPTION
* Increase max peers limit to `100` (was `45`)
* Reduce number of blocks in eth1-sync batch to `25K` (was `100K`)