### PR TITLE
Use compatible with ARM version of ristretto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/attestantio/go-eth2-client v0.6.30
 	github.com/bloxapp/eth2-key-manager v1.1.3-0.20211102055147-c66d220973fd
 	github.com/dgraph-io/badger/v3 v3.2103.2
+	github.com/dgraph-io/ristretto v0.1.1-0.20211022170458-efb105d0ca5e
 	github.com/ethereum/go-ethereum v1.10.10
 	github.com/ferranbt/fastssz v0.0.0-20210905181407-59cf6761a7d5
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Restarting ssv on ARM fails with following error:
`2021-11-07T13:19:56.084012Z     FATAL   operator/node.go:89     failed to create db!    {"app": "SSV-Node:v0.1.4", "error": "failed to open badger: while opening memtables error: while opening fid: 1 error: while updating skiplist error: mremap size mismatch: requested: 3549 got: 134217728", "errorVerbose": "while opening memtables error: while opening fid: 1 error: while updating skiplist error: mremap size mismatch: requested: 3549 got: 134217728\nfailed to open badger\ngithub.com/bloxapp/ssv/storage/kv.New\n\t/go/src/github.com/bloxapp/ssv/storage/kv/badger.go:40\ngithub.com/bloxapp/ssv/storage.GetStorageFactory\n\t/go/src/github.com/bloxapp/ssv/storage/main.go:13\ngithub.com/bloxapp/ssv/cli/operator.glob..func1\n\t/go/src/github.com/bloxapp/ssv/cli/operator/node.go:87\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895\ngithub.com/bloxapp/ssv/cli.Execute\n\t/go/src/github.com/bloxapp/ssv/cli/cli.go:29\nmain.main\n\t/go/src/github.com/bloxapp/ssv/cmd/ssvnode/main.go:16\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1136"}`
This happens due to ristretto version used has errors on ARM. These errors were fixed in the latest master branch of ristretto, so this patch tells go to use it. I've tested it and now restarting ssv works fine on ARM (attestations work as well).