### PR TITLE
Fix internal listeners leak

### DIFF
--- a/exporter/ibft/commit_reader.go
+++ b/exporter/ibft/commit_reader.go
@@ -49,7 +49,8 @@ func NewCommitReader(opts CommitReaderOptions) Reader {
 
 // Start starts the reader
 func (cr *commitReader) Start() error {
-	msgCn := cr.network.ReceivedMsgChan()
+	msgCn, done := cr.network.ReceivedMsgChan()
+	defer done()
 	cr.logger.Debug("listening to network messages")
 	for msg := range msgCn {
 		if processed := cr.onMessage(msg); processed {

--- a/exporter/ibft/decided_reader.go
+++ b/exporter/ibft/decided_reader.go
@@ -88,11 +88,6 @@ func (r *decidedReader) Start() error {
 	if err := r.network.SubscribeToValidatorNetwork(r.validatorShare.PublicKey); err != nil {
 		return errors.Wrap(err, "failed to subscribe topic")
 	}
-	defer func() {
-		if err := r.network.UnSubscribeValidatorNetwork(r.validatorShare.PublicKey); err != nil {
-			r.logger.Error("failed to unsubscribe topic", zap.Error(err))
-		}
-	}()
 
 	if err := tasks.Retry(func() error {
 		if err := r.sync(); err != nil {

--- a/exporter/ibft/decided_reader.go
+++ b/exporter/ibft/decided_reader.go
@@ -131,9 +131,10 @@ func (r *decidedReader) listenToNetwork(cn <-chan *proto.SignedMessage) {
 		}
 		go func(msg *proto.SignedMessage) {
 			defer logger.Debug("done with decided msg")
-			if saved, err := r.handleNewDecidedMessage(msg); err != nil && !saved {
-				logger.Error("could not handle decided message", zap.Error(err))
-			} else if err != nil {
+			if saved, err := r.handleNewDecidedMessage(msg); err != nil {
+				if !saved {
+					logger.Error("could not handle decided message", zap.Error(err))
+				}
 				logger.Error("could not check highest decided", zap.Error(err))
 			}
 		}(msg)

--- a/exporter/ibft/decided_reader.go
+++ b/exporter/ibft/decided_reader.go
@@ -112,7 +112,9 @@ func (r *decidedReader) Start() error {
 	if err := r.waitForMinPeers(r.validatorShare.PublicKey, 1); err != nil {
 		return errors.Wrap(err, "could not wait for min peers")
 	}
-	r.listenToNetwork(r.network.ReceivedDecidedChan())
+	cn, done := r.network.ReceivedDecidedChan()
+	defer done()
+	r.listenToNetwork(cn)
 	return nil
 }
 

--- a/exporter/ibft/decided_reader.go
+++ b/exporter/ibft/decided_reader.go
@@ -67,12 +67,6 @@ func newDecidedReader(opts DecidedReaderOptions) Reader {
 
 // sync starts to fetch best known decided message (highest sequence) from the network and sync to it.
 func (r *decidedReader) sync() error {
-	if err := r.network.SubscribeToValidatorNetwork(r.validatorShare.PublicKey); err != nil {
-		return errors.Wrap(err, "failed to subscribe topic")
-	}
-	// wait for network setup (subscribe to topic)
-	time.Sleep(1 * time.Second)
-
 	r.logger.Debug("syncing ibft data")
 	// creating HistorySync and starts it
 	hs := history.New(r.logger, r.validatorShare.PublicKey.Serialize(), r.identifier, r.network,

--- a/exporter/ibft/incoming_msgs.go
+++ b/exporter/ibft/incoming_msgs.go
@@ -44,11 +44,6 @@ func (i *incomingMsgsReader) Start() error {
 	if err := i.network.SubscribeToValidatorNetwork(i.publicKey); err != nil {
 		return errors.Wrap(err, "failed to subscribe topic")
 	}
-	defer func() {
-		if err := i.network.UnSubscribeValidatorNetwork(i.publicKey); err != nil {
-			i.logger.Error("failed to unsubscribe topic", zap.Error(err))
-		}
-	}()
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()

--- a/exporter/ibft/incoming_msgs.go
+++ b/exporter/ibft/incoming_msgs.go
@@ -52,7 +52,9 @@ func (i *incomingMsgsReader) Start() error {
 	if err := i.waitForMinPeers(i.publicKey, 1); err != nil {
 		return errors.Wrap(err, "could not wait for min peers")
 	}
-	i.listenToNetwork(i.network.ReceivedDecidedChan())
+	cn, done := i.network.ReceivedMsgChan()
+	defer done()
+	i.listenToNetwork(cn)
 	return nil
 }
 

--- a/exporter/ibft/incoming_msgs.go
+++ b/exporter/ibft/incoming_msgs.go
@@ -49,7 +49,10 @@ func (i *incomingMsgsReader) Start() error {
 			i.logger.Error("failed to unsubscribe topic", zap.Error(err))
 		}
 	}()
-	if err := i.waitForMinPeers(i.publicKey, 1); err != nil {
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+	if err := i.waitForMinPeers(ctx, i.publicKey, 1); err != nil {
 		return errors.Wrap(err, "could not wait for min peers")
 	}
 	cn, done := i.network.ReceivedMsgChan()
@@ -90,14 +93,12 @@ func (i *incomingMsgsReader) listenToNetwork(cn <-chan *proto.SignedMessage) {
 }
 
 // waitForMinPeers will wait until enough peers joined the topic
-func (i *incomingMsgsReader) waitForMinPeers(pk *bls.PublicKey, minPeerCount int) error {
-	ctx := commons.WaitMinPeersCtx{
-		Ctx:    context.Background(),
+func (i *incomingMsgsReader) waitForMinPeers(ctx context.Context, pk *bls.PublicKey, minPeerCount int) error {
+	return commons.WaitForMinPeers(commons.WaitMinPeersCtx{
+		Ctx:    ctx,
 		Logger: i.logger,
 		Net:    i.network,
-	}
-	return commons.WaitForMinPeers(ctx, pk.Serialize(), minPeerCount,
-		1*time.Second, 64*time.Second, false)
+	}, pk.Serialize(), minPeerCount, 1*time.Second, 64*time.Second, false)
 }
 
 func messageFields(msg *proto.SignedMessage) []zap.Field {

--- a/ibft/controller/controller_network.go
+++ b/ibft/controller/controller_network.go
@@ -36,7 +36,8 @@ func (i *Controller) waitForMinPeers(minPeerCount int, stopAtLimit bool) error {
 }
 
 func (i *Controller) listenToNetworkMessages() {
-	msgChan := i.network.ReceivedMsgChan()
+	msgChan, done := i.network.ReceivedMsgChan()
+	defer done()
 	go func() {
 		for msg := range msgChan {
 			if msg.Message != nil && i.equalIdentifier(msg.Message.Lambda) {
@@ -50,7 +51,8 @@ func (i *Controller) listenToNetworkMessages() {
 }
 
 func (i *Controller) listenToNetworkDecidedMessages() {
-	decidedChan := i.network.ReceivedDecidedChan()
+	decidedChan, done := i.network.ReceivedDecidedChan()
+	defer done()
 	go func() {
 		for msg := range decidedChan {
 			if msg.Message != nil && i.equalIdentifier(msg.Message.Lambda) {
@@ -64,7 +66,8 @@ func (i *Controller) listenToNetworkDecidedMessages() {
 }
 
 func (i *Controller) listenToSyncMessages() {
-	syncChan := i.network.ReceivedSyncMsgChan()
+	syncChan, done := i.network.ReceivedSyncMsgChan()
+	defer done()
 	go func() {
 		for msg := range syncChan {
 			if msg.Msg != nil && i.equalIdentifier(msg.Msg.Lambda) {

--- a/ibft/sync/test_utils.go
+++ b/ibft/sync/test_utils.go
@@ -122,8 +122,8 @@ func (n *TestNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) erro
 }
 
 // ReceivedMsgChan impl
-func (n *TestNetwork) ReceivedMsgChan() <-chan *proto.SignedMessage {
-	return nil
+func (n *TestNetwork) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
+	return nil, func() {}
 }
 
 // BroadcastSignature impl
@@ -132,8 +132,8 @@ func (n *TestNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMess
 }
 
 // ReceivedSignatureChan impl
-func (n *TestNetwork) ReceivedSignatureChan() <-chan *proto.SignedMessage {
-	return nil
+func (n *TestNetwork) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func()) {
+	return nil, func() {}
 }
 
 // BroadcastDecided impl
@@ -142,8 +142,8 @@ func (n *TestNetwork) BroadcastDecided(topicName []byte, msg *proto.SignedMessag
 }
 
 // ReceivedDecidedChan impl
-func (n *TestNetwork) ReceivedDecidedChan() <-chan *proto.SignedMessage {
-	return nil
+func (n *TestNetwork) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func()) {
+	return nil, func() {}
 }
 
 // GetHighestDecidedInstance impl
@@ -265,8 +265,8 @@ func (n *TestNetwork) RespondToLastChangeRoundMsg(stream network.SyncStream, msg
 }
 
 // ReceivedSyncMsgChan implementation
-func (n *TestNetwork) ReceivedSyncMsgChan() <-chan *network.SyncChanObj {
-	return nil
+func (n *TestNetwork) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func()) {
+	return nil, func() {}
 }
 
 // SubscribeToValidatorNetwork subscribing and listen to validator network

--- a/ibft/sync/test_utils.go
+++ b/ibft/sync/test_utils.go
@@ -274,11 +274,6 @@ func (n *TestNetwork) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) er
 	return nil
 }
 
-// UnSubscribeValidatorNetwork unsubscribes a validators topic
-func (n *TestNetwork) UnSubscribeValidatorNetwork(validatorPk *bls.PublicKey) error {
-	return nil
-}
-
 // AllPeers returns all connected peers for a validator PK
 func (n *TestNetwork) AllPeers(validatorPk []byte) ([]string, error) {
 	return n.peers, nil

--- a/monitoring/metrics/health_check.go
+++ b/monitoring/metrics/health_check.go
@@ -36,7 +36,7 @@ func WaitUntilHealthy(logger *zap.Logger, component interface{}, name string) {
 		if len(errs) == 0 {
 			break
 		}
-		logger.Warn(name + " is not healthy, trying again in 1sec", zap.Any("errors", errs))
+		logger.Warn(name+" is not healthy, trying again in 1sec", zap.Any("errors", errs))
 		time.Sleep(1 * time.Second)
 	}
 	logger.Debug(name + " is healthy")

--- a/network/local/local.go
+++ b/network/local/local.go
@@ -49,21 +49,21 @@ func (n *Local) CopyWithLocalNodeID(id peer.ID) *Local {
 }
 
 // ReceivedMsgChan implements network.Local interface
-func (n *Local) ReceivedMsgChan() <-chan *proto.SignedMessage {
+func (n *Local) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
 	n.createChannelMutex.Lock()
 	defer n.createChannelMutex.Unlock()
 	c := make(chan *proto.SignedMessage)
 	n.msgC = append(n.msgC, c)
-	return c
+	return c, func() {}
 }
 
 // ReceivedSignatureChan returns the channel with signatures
-func (n *Local) ReceivedSignatureChan() <-chan *proto.SignedMessage {
+func (n *Local) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func()) {
 	n.createChannelMutex.Lock()
 	defer n.createChannelMutex.Unlock()
 	c := make(chan *proto.SignedMessage)
 	n.sigC = append(n.sigC, c)
-	return c
+	return c, func() {}
 }
 
 // Broadcast implements network.Local interface
@@ -102,12 +102,12 @@ func (n *Local) BroadcastDecided(topicName []byte, msg *proto.SignedMessage) err
 }
 
 // ReceivedDecidedChan returns the channel for decided messages
-func (n *Local) ReceivedDecidedChan() <-chan *proto.SignedMessage {
+func (n *Local) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func()) {
 	n.createChannelMutex.Lock()
 	defer n.createChannelMutex.Unlock()
 	c := make(chan *proto.SignedMessage)
 	n.decidedC = append(n.decidedC, c)
-	return c
+	return c, func() {}
 }
 
 // GetHighestDecidedInstance sends a highest decided request to peers and returns answers.
@@ -136,13 +136,13 @@ func (n *Local) RespondToHighestDecidedInstance(stream network.SyncStream, msg *
 }
 
 // ReceivedSyncMsgChan returns the channel for sync messages
-func (n *Local) ReceivedSyncMsgChan() <-chan *network.SyncChanObj {
+func (n *Local) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func()) {
 	n.createChannelMutex.Lock()
 	defer n.createChannelMutex.Unlock()
 	c := make(chan *network.SyncChanObj)
 	n.syncC = append(n.syncC, c)
 	n.syncPeers[fmt.Sprintf("%d", len(n.syncPeers))] = c
-	return c
+	return c, func() {}
 }
 
 // GetDecidedByRange returns a list of decided signed messages up to 25 in a batch.

--- a/network/local/local.go
+++ b/network/local/local.go
@@ -174,11 +174,6 @@ func (n *Local) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error {
 	return nil
 }
 
-// UnSubscribeValidatorNetwork unsubscribes a validators topic
-func (n *Local) UnSubscribeValidatorNetwork(validatorPk *bls.PublicKey) error {
-	return nil
-}
-
 // AllPeers returns all connected peers for a validator PK
 func (n *Local) AllPeers(validatorPk []byte) ([]string, error) {
 	ret := make([]string, 0)

--- a/network/local/local_test.go
+++ b/network/local/local_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestMsgChan(t *testing.T) {
 	net := NewLocalNetwork()
-	c1, c2, c3, c4 := net.ReceivedMsgChan(), net.ReceivedMsgChan(), net.ReceivedMsgChan(), net.ReceivedMsgChan()
+	c1, _ := net.ReceivedMsgChan()
+	c2, _ := net.ReceivedMsgChan()
+	c3, _ := net.ReceivedMsgChan()
+	c4, _ := net.ReceivedMsgChan()
 
 	testMsg := &proto.SignedMessage{
 		Signature: []byte{1, 2, 3, 4},
@@ -42,8 +45,10 @@ func TestMsgChan(t *testing.T) {
 
 func TestSigChan(t *testing.T) {
 	net := NewLocalNetwork()
-	c1, c2, c3, c4 := net.ReceivedSignatureChan(), net.ReceivedSignatureChan(), net.ReceivedSignatureChan(), net.ReceivedSignatureChan()
-
+	c1, _ := net.ReceivedSignatureChan()
+	c2, _ := net.ReceivedSignatureChan()
+	c3, _ := net.ReceivedSignatureChan()
+	c4, _ := net.ReceivedSignatureChan()
 	testMsg := &proto.SignedMessage{
 		Signature: []byte{1, 2, 3, 4},
 		SignerIds: []uint64{1, 2, 3, 4},
@@ -73,7 +78,10 @@ func TestSigChan(t *testing.T) {
 
 func TestDecidedChan(t *testing.T) {
 	net := NewLocalNetwork()
-	c1, c2, c3, c4 := net.ReceivedDecidedChan(), net.ReceivedDecidedChan(), net.ReceivedDecidedChan(), net.ReceivedDecidedChan()
+	c1, _ := net.ReceivedDecidedChan()
+	c2, _ := net.ReceivedDecidedChan()
+	c3, _ := net.ReceivedDecidedChan()
+	c4, _ := net.ReceivedDecidedChan()
 
 	testMsg := &proto.SignedMessage{
 		Signature: []byte{1, 2, 3, 4},
@@ -104,7 +112,8 @@ func TestDecidedChan(t *testing.T) {
 
 func TestGetHighestDecided(t *testing.T) {
 	net := NewLocalNetwork()
-	_, c2 := net.ReceivedSyncMsgChan(), net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+	c2, _ := net.ReceivedSyncMsgChan()
 
 	go func() {
 		msg := <-c2
@@ -128,7 +137,8 @@ func TestGetHighestDecided(t *testing.T) {
 
 func TestGetDecidedByRange(t *testing.T) {
 	net := NewLocalNetwork()
-	_, c2 := net.ReceivedSyncMsgChan(), net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+	c2, _ := net.ReceivedSyncMsgChan()
 
 	go func() {
 		msg := <-c2
@@ -152,7 +162,11 @@ func TestGetDecidedByRange(t *testing.T) {
 
 func TestGetAllPeers(t *testing.T) {
 	net := NewLocalNetwork()
-	_, _, _, _ = net.ReceivedSyncMsgChan(), net.ReceivedSyncMsgChan(), net.ReceivedSyncMsgChan(), net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+	_, _ = net.ReceivedSyncMsgChan()
+
 	res, err := net.AllPeers([]byte{})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"0", "1", "2", "3"}, res)

--- a/network/network.go
+++ b/network/network.go
@@ -47,13 +47,13 @@ type SyncStream interface {
 // Reader is the interface for reading messages from the network
 type Reader interface {
 	// ReceivedMsgChan is a channel that forwards new propagated messages to a subscriber
-	ReceivedMsgChan() <-chan *proto.SignedMessage
+	ReceivedMsgChan() (<-chan *proto.SignedMessage, func())
 	// ReceivedSignatureChan returns the channel with signatures
-	ReceivedSignatureChan() <-chan *proto.SignedMessage
+	ReceivedSignatureChan() (<-chan *proto.SignedMessage, func())
 	// ReceivedDecidedChan returns the channel for decided messages
-	ReceivedDecidedChan() <-chan *proto.SignedMessage
+	ReceivedDecidedChan() (<-chan *proto.SignedMessage, func())
 	// ReceivedSyncMsgChan returns the channel for sync messages
-	ReceivedSyncMsgChan() <-chan *SyncChanObj
+	ReceivedSyncMsgChan() (<-chan *SyncChanObj, func())
 	// SubscribeToValidatorNetwork subscribes and listens to validator's network
 	SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error
 	// UnSubscribeValidatorNetwork unsubscribes from validator's network

--- a/network/network.go
+++ b/network/network.go
@@ -56,8 +56,6 @@ type Reader interface {
 	ReceivedSyncMsgChan() (<-chan *SyncChanObj, func())
 	// SubscribeToValidatorNetwork subscribes and listens to validator's network
 	SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error
-	// UnSubscribeValidatorNetwork unsubscribes from validator's network
-	UnSubscribeValidatorNetwork(validatorPk *bls.PublicKey) error
 	// AllPeers returns all connected peers for a validator PK
 	AllPeers(validatorPk []byte) ([]string, error)
 	// SubscribeToMainTopic subscribes to main topic

--- a/network/p2p/listeners.go
+++ b/network/p2p/listeners.go
@@ -26,6 +26,7 @@ func (n *p2pNetwork) registerListener(ls listener) func() {
 	return func() {
 		n.listenersLock.Lock()
 		defer n.listenersLock.Unlock()
+
 		delete(n.listeners, id)
 	}
 }

--- a/network/p2p/listeners_test.go
+++ b/network/p2p/listeners_test.go
@@ -1,0 +1,76 @@
+package p2p
+
+import (
+	"context"
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/network"
+	"go.uber.org/zap/zaptest"
+	"sync"
+	"testing"
+)
+
+func TestListeners(t *testing.T) {
+	n := p2pNetwork{
+		logger:        zaptest.NewLogger(t),
+		listeners:     map[string]listener{},
+		listenersLock: &sync.Mutex{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	ibftCn1, ibftCnDone1 := n.ReceivedMsgChan()
+	// checks that ibftCn1 received 3 messages
+	wg.Add(3)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ibftCn1:
+				if ok {
+					wg.Done()
+				}
+			}
+		}
+	}()
+
+	ibftCn2, ibftCnDone2 := n.ReceivedMsgChan()
+	// checks that ibftCn2 received 2 messages (it will be closed after 2 messages)
+	wg.Add(2)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ibftCn2:
+				if ok {
+					wg.Done()
+				}
+			}
+		}
+	}()
+
+	msg := &proto.SignedMessage{
+		Message: &proto.Message{
+			Type:      proto.RoundState_ChangeRound,
+			Round:     1,
+			Lambda:    []byte{1, 2, 3, 4},
+			SeqNumber: 1,
+			Value:     []byte{},
+		},
+		Signature: []byte{},
+		SignerIds: []uint64{1},
+	}
+
+	n.propagateSignedMsg(&network.Message{Type: network.NetworkMsg_IBFTType, SignedMessage: msg})
+	n.propagateSignedMsg(&network.Message{Type: network.NetworkMsg_IBFTType, SignedMessage: msg})
+	n.propagateSignedMsg(&network.Message{Type: network.NetworkMsg_DecidedType, SignedMessage: msg})
+	ibftCnDone2()
+	n.propagateSignedMsg(&network.Message{Type: network.NetworkMsg_IBFTType, SignedMessage: msg})
+	ibftCnDone1()
+
+	wg.Wait()
+}

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
 	"go.uber.org/zap"
 
-	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
 )
 
@@ -46,20 +45,14 @@ const (
 	legacyMsgStream = "/sync/0.0.1"
 )
 
-type listener struct {
-	msgCh     chan *proto.SignedMessage
-	sigCh     chan *proto.SignedMessage
-	decidedCh chan *proto.SignedMessage
-	syncCh    chan *network.SyncChanObj
-}
-
 // p2pNetwork implements network.Network interface using P2P
 type p2pNetwork struct {
 	ctx             context.Context
 	cfg             *Config
 	listenersLock   sync.Locker
 	dv5Listener     discv5Listener
-	listeners       []listener
+	//listeners       []listener
+	listenersMap    map[string]listener
 	logger          *zap.Logger
 	privKey         *ecdsa.PrivateKey
 	peers           *peers.Status

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -78,6 +78,7 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	n := &p2pNetwork{
 		ctx:             ctx,
 		cfg:             cfg,
+		listenersMap:    map[string]listener{},
 		listenersLock:   &sync.Mutex{},
 		logger:          logger,
 		operatorPrivKey: cfg.OperatorPrivateKey,

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -47,10 +47,10 @@ const (
 
 // p2pNetwork implements network.Network interface using P2P
 type p2pNetwork struct {
-	ctx             context.Context
-	cfg             *Config
-	listenersLock   sync.Locker
-	dv5Listener     discv5Listener
+	ctx           context.Context
+	cfg           *Config
+	listenersLock sync.Locker
+	dv5Listener   discv5Listener
 	//listeners       []listener
 	listenersMap    map[string]listener
 	logger          *zap.Logger

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -47,12 +47,11 @@ const (
 
 // p2pNetwork implements network.Network interface using P2P
 type p2pNetwork struct {
-	ctx           context.Context
-	cfg           *Config
-	listenersLock sync.Locker
-	dv5Listener   discv5Listener
-	//listeners       []listener
-	listenersMap    map[string]listener
+	ctx             context.Context
+	cfg             *Config
+	listenersLock   sync.Locker
+	dv5Listener     discv5Listener
+	listeners       map[string]listener
 	logger          *zap.Logger
 	privKey         *ecdsa.PrivateKey
 	peers           *peers.Status
@@ -78,7 +77,7 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	n := &p2pNetwork{
 		ctx:             ctx,
 		cfg:             cfg,
-		listenersMap:    map[string]listener{},
+		listeners:       map[string]listener{},
 		listenersLock:   &sync.Mutex{},
 		logger:          logger,
 		operatorPrivKey: cfg.OperatorPrivateKey,

--- a/network/p2p/p2p_decided.go
+++ b/network/p2p/p2p_decided.go
@@ -42,9 +42,5 @@ func (n *p2pNetwork) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func())
 		decidedCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	//n.listenersLock.Lock()
-	//n.listeners = append(n.listeners, ls)
-	//n.listenersLock.Unlock()
-
 	return ls.decidedCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_decided.go
+++ b/network/p2p/p2p_decided.go
@@ -37,14 +37,14 @@ func (n *p2pNetwork) BroadcastDecided(topicName []byte, msg *proto.SignedMessage
 }
 
 // ReceivedDecidedChan returns the channel for decided messages
-func (n *p2pNetwork) ReceivedDecidedChan() <-chan *proto.SignedMessage {
+func (n *p2pNetwork) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func()) {
 	ls := listener{
 		decidedCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	n.listenersLock.Lock()
-	n.listeners = append(n.listeners, ls)
-	n.listenersLock.Unlock()
+	//n.listenersLock.Lock()
+	//n.listeners = append(n.listeners, ls)
+	//n.listenersLock.Unlock()
 
-	return ls.decidedCh
+	return ls.decidedCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -29,14 +29,14 @@ func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error
 }
 
 // ReceivedMsgChan return a channel with messages
-func (n *p2pNetwork) ReceivedMsgChan() <-chan *proto.SignedMessage {
+func (n *p2pNetwork) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
 	ls := listener{
 		msgCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	n.listenersLock.Lock()
-	n.listeners = append(n.listeners, ls)
-	n.listenersLock.Unlock()
+	//n.listenersLock.Lock()
+	//n.listeners = append(n.listeners, ls)
+	//n.listenersLock.Unlock()
 
-	return ls.msgCh
+	return ls.msgCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -34,9 +34,5 @@ func (n *p2pNetwork) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
 		msgCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	//n.listenersLock.Lock()
-	//n.listeners = append(n.listeners, ls)
-	//n.listenersLock.Unlock()
-
 	return ls.msgCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_listeners.go
+++ b/network/p2p/p2p_listeners.go
@@ -20,13 +20,13 @@ func (n *p2pNetwork) registerListener(ls listener) func() {
 	n.listenersLock.Lock()
 	defer n.listenersLock.Unlock()
 
-	id := fmt.Sprintf("%d:%d", len(n.listenersMap), time.Now().UnixNano())
-	n.listenersMap[id] = ls
+	id := fmt.Sprintf("%d:%d", len(n.listeners), time.Now().UnixNano())
+	n.listeners[id] = ls
 
 	return func() {
 		n.listenersLock.Lock()
 		defer n.listenersLock.Unlock()
-		delete(n.listenersMap, id)
+		delete(n.listeners, id)
 	}
 }
 
@@ -59,7 +59,7 @@ func (n *p2pNetwork) getListeners() []listener {
 	n.listenersLock.Lock()
 	defer n.listenersLock.Unlock()
 	var listeners []listener
-	for _, ls := range n.listenersMap {
+	for _, ls := range n.listeners {
 		listeners = append(listeners, ls)
 	}
 	return listeners

--- a/network/p2p/p2p_listeners.go
+++ b/network/p2p/p2p_listeners.go
@@ -1,0 +1,84 @@
+package p2p
+
+import (
+	"fmt"
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/network"
+	"go.uber.org/zap"
+	"time"
+)
+
+type listener struct {
+	msgCh     chan *proto.SignedMessage
+	sigCh     chan *proto.SignedMessage
+	decidedCh chan *proto.SignedMessage
+	syncCh    chan *network.SyncChanObj
+}
+
+func (n *p2pNetwork) registerListener(ls listener) func() {
+	n.listenersLock.Lock()
+	defer n.listenersLock.Unlock()
+
+	id := fmt.Sprintf("%d:%d", len(n.listenersMap), time.Now().UnixNano())
+	n.listenersMap[id] = ls
+
+	return func() {
+		n.listenersLock.Lock()
+		defer n.listenersLock.Unlock()
+		delete(n.listenersMap, id)
+	}
+}
+
+// propagateSignedMsg takes an incoming message (from validator's topic)
+// and propagates it to the corresponding internal listeners
+func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
+	if cm == nil || cm.SignedMessage == nil {
+		n.logger.Debug("could not propagate nil message")
+		return
+	}
+	n.logger.Debug("propagating msg to internal listeners", zap.String("type", cm.Type.String()),
+		zap.Any("msg", cm.SignedMessage))
+
+	// copy listeners with lock, to avoid data races
+	n.listenersLock.Lock()
+	var listeners []listener
+	for _, ls := range n.listenersMap {
+		listeners = append(listeners, ls)
+	}
+	n.listenersLock.Unlock()
+
+	switch cm.Type {
+	case network.NetworkMsg_IBFTType:
+		go propagateIBFTMessage(listeners, cm.SignedMessage)
+	case network.NetworkMsg_SignatureType:
+		go propagateSigMessage(listeners, cm.SignedMessage)
+	case network.NetworkMsg_DecidedType:
+		go propagateDecidedMessage(listeners, cm.SignedMessage)
+	default:
+		n.logger.Error("received unsupported message", zap.Int32("msg type", int32(cm.Type)))
+	}
+}
+
+func propagateIBFTMessage(listeners []listener, msg *proto.SignedMessage) {
+	for _, ls := range listeners {
+		if ls.msgCh != nil {
+			ls.msgCh <- msg
+		}
+	}
+}
+
+func propagateSigMessage(listeners []listener, msg *proto.SignedMessage) {
+	for _, ls := range listeners {
+		if ls.sigCh != nil {
+			ls.sigCh <- msg
+		}
+	}
+}
+
+func propagateDecidedMessage(listeners []listener, msg *proto.SignedMessage) {
+	for _, ls := range listeners {
+		if ls.decidedCh != nil {
+			ls.decidedCh <- msg
+		}
+	}
+}

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -10,22 +10,6 @@ import (
 	"strings"
 )
 
-// UnSubscribeValidatorNetwork unsubscribes a validators topic
-func (n *p2pNetwork) UnSubscribeValidatorNetwork(validatorPk *bls.PublicKey) error {
-	pubKey := validatorPk.SerializeToHexStr()
-
-	n.psTopicsLock.Lock()
-	cancel, ok := n.psSubs[pubKey]
-	n.psTopicsLock.Unlock()
-
-	if ok {
-		cancel()
-	} else {
-		return errors.New("could not find active subscription")
-	}
-	return nil
-}
-
 // SubscribeToValidatorNetwork  for new validator create new topic, subscribe and start listen
 func (n *p2pNetwork) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error {
 	n.psTopicsLock.Lock()

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -3,8 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"github.com/bloxapp/ssv/ibft/proto"
-	"github.com/bloxapp/ssv/network"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/pkg/errors"
@@ -174,52 +172,6 @@ func (n *p2pNetwork) listen(ctx context.Context, sub *pubsub.Subscription) {
 				reportLastMsg(msg.ReceivedFrom.String())
 			}
 			n.propagateSignedMsg(cm)
-		}
-	}
-}
-
-// propagateSignedMsg takes an incoming message (from validator's topic)
-// and propagates it to the corresponding internal listeners
-func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
-	if cm == nil || cm.SignedMessage == nil {
-		n.logger.Debug("could not propagate nil message")
-		return
-	}
-	n.logger.Debug("propagating msg to internal listeners", zap.String("type", cm.Type.String()),
-		zap.Any("msg", cm.SignedMessage))
-
-	switch cm.Type {
-	case network.NetworkMsg_IBFTType:
-		go propagateIBFTMessage(n.listeners, cm.SignedMessage)
-	case network.NetworkMsg_SignatureType:
-		go propagateSigMessage(n.listeners, cm.SignedMessage)
-	case network.NetworkMsg_DecidedType:
-		go propagateDecidedMessage(n.listeners, cm.SignedMessage)
-	default:
-		n.logger.Error("received unsupported message", zap.Int32("msg type", int32(cm.Type)))
-	}
-}
-
-func propagateIBFTMessage(listeners []listener, msg *proto.SignedMessage) {
-	for _, ls := range listeners {
-		if ls.msgCh != nil {
-			ls.msgCh <- msg
-		}
-	}
-}
-
-func propagateSigMessage(listeners []listener, msg *proto.SignedMessage) {
-	for _, ls := range listeners {
-		if ls.sigCh != nil {
-			ls.sigCh <- msg
-		}
-	}
-}
-
-func propagateDecidedMessage(listeners []listener, msg *proto.SignedMessage) {
-	for _, ls := range listeners {
-		if ls.decidedCh != nil {
-			ls.decidedCh <- msg
 		}
 	}
 }

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -26,14 +26,14 @@ func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessa
 }
 
 // ReceivedSignatureChan returns the channel with signatures
-func (n *p2pNetwork) ReceivedSignatureChan() <-chan *proto.SignedMessage {
+func (n *p2pNetwork) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func()) {
 	ls := listener{
 		sigCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	n.listenersLock.Lock()
-	n.listeners = append(n.listeners, ls)
-	n.listenersLock.Unlock()
+	//n.listenersLock.Lock()
+	//n.listeners = append(n.listeners, ls)
+	//n.listenersLock.Unlock()
 
-	return ls.sigCh
+	return ls.sigCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -31,9 +31,5 @@ func (n *p2pNetwork) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func(
 		sigCh: make(chan *proto.SignedMessage, MsgChanSize),
 	}
 
-	//n.listenersLock.Lock()
-	//n.listeners = append(n.listeners, ls)
-	//n.listenersLock.Unlock()
-
 	return ls.sigCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -77,7 +77,7 @@ func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream network
 		return
 	}
 	cm.SyncMessage.FromPeerID = netSyncStream.RemotePeer()
-	for _, ls := range n.listeners {
+	for _, ls := range n.listenersMap {
 		go func(ls listener, nm network.Message) {
 			switch nm.Type {
 			case network.NetworkMsg_SyncType:

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -77,7 +77,8 @@ func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream network
 		return
 	}
 	cm.SyncMessage.FromPeerID = netSyncStream.RemotePeer()
-	for _, ls := range n.listenersMap {
+	listeners := n.getListeners()
+	for _, ls := range listeners {
 		go func(ls listener, nm network.Message) {
 			switch nm.Type {
 			case network.NetworkMsg_SyncType:

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -152,9 +152,5 @@ func (n *p2pNetwork) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func())
 		syncCh: make(chan *network.SyncChanObj, MsgChanSize),
 	}
 
-	//n.listenersLock.Lock()
-	//n.listeners = append(n.listeners, ls)
-	//n.listenersLock.Unlock()
-
 	return ls.syncCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -147,14 +147,14 @@ func (n *p2pNetwork) RespondToLastChangeRoundMsg(stream network.SyncStream, msg 
 }
 
 // ReceivedSyncMsgChan returns the channel for sync messages
-func (n *p2pNetwork) ReceivedSyncMsgChan() <-chan *network.SyncChanObj {
+func (n *p2pNetwork) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func()) {
 	ls := listener{
 		syncCh: make(chan *network.SyncChanObj, MsgChanSize),
 	}
 
-	n.listenersLock.Lock()
-	n.listeners = append(n.listeners, ls)
-	n.listenersLock.Unlock()
+	//n.listenersLock.Lock()
+	//n.listeners = append(n.listeners, ls)
+	//n.listenersLock.Unlock()
 
-	return ls.syncCh
+	return ls.syncCh, n.registerListener(ls)
 }

--- a/network/p2p/p2p_sync_test.go
+++ b/network/p2p/p2p_sync_test.go
@@ -63,7 +63,8 @@ func TestSyncMessageBroadcasting(t *testing.T) {
 	peer1, peer2 := testPeers(t, logger)
 
 	// set receivers
-	peer2Chan := peer2.ReceivedSyncMsgChan()
+	peer2Chan, done := peer2.ReceivedSyncMsgChan()
+	defer done()
 
 	var receivedStream network.SyncStream
 	go func() {

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -40,8 +40,10 @@ func TestP2PNetworker(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	peer1Chan := peer1.ReceivedMsgChan()
-	peer2Chan := peer2.ReceivedMsgChan()
+	peer1Chan, done1 := peer1.ReceivedMsgChan()
+	defer done1()
+	peer2Chan, done2 := peer2.ReceivedMsgChan()
+	defer done2()
 
 	time.Sleep(time.Second)
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -119,7 +119,8 @@ func (v *Validator) Start() error {
 }
 
 func (v *Validator) listenToSignatureMessages() {
-	sigChan := v.network.ReceivedSignatureChan()
+	sigChan, done := v.network.ReceivedSignatureChan()
+	defer done()
 	for sigMsg := range sigChan {
 		if sigMsg == nil {
 			v.logger.Debug("got nil message")


### PR DESCRIPTION
- improved internal listeners to be de-registered when done
- exporter: add context in waitForMinPeers
- exporter: avoid over-subscription in sync