### PR TITLE
Decided message signers fix

### DIFF
--- a/exporter/ibft/commit_reader_test.go
+++ b/exporter/ibft/commit_reader_test.go
@@ -9,16 +9,22 @@ import (
 	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/bloxapp/ssv/storage/collections"
 	"github.com/bloxapp/ssv/utils/format"
+	"github.com/bloxapp/ssv/utils/logex"
 	validatorstorage "github.com/bloxapp/ssv/validator/storage"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/prysmaticlabs/prysm/async/event"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+func init() {
+	logex.Build("test", zapcore.DebugLevel, nil)
+}
 
 func TestCommitReader_onMessage(t *testing.T) {
 	_ = bls.Init(bls.BLS12_381)

--- a/ibft/controller/controller_running_instance.go
+++ b/ibft/controller/controller_running_instance.go
@@ -125,7 +125,8 @@ func (i *Controller) listenToLateCommitMsgs(runningInstance ibft.Instance) {
 					continue
 				}
 				logger := i.logger.With(zap.Uint64("seq", netMsg.SignedMessage.Message.SeqNumber),
-					zap.String("identifier", string(netMsg.SignedMessage.Message.Lambda)))
+					zap.String("identifier", string(netMsg.SignedMessage.Message.Lambda)),
+					zap.Uint64s("signers", netMsg.SignedMessage.SignerIds))
 				if err := runningInstance.CommitMsgValidationPipeline().Run(netMsg.SignedMessage); err != nil {
 					i.logger.Error("received invalid late commit message", zap.Error(err))
 					continue
@@ -135,7 +136,7 @@ func (i *Controller) listenToLateCommitMsgs(runningInstance ibft.Instance) {
 				if err != nil {
 					logger.Error("failed to process late commit message", zap.Error(err))
 				} else if updated != nil {
-					logger.Debug("decided message was updated")
+					logger.Debug("decided message was updated", zap.Uint64s("updated signers", updated.SignerIds))
 				}
 			} else {
 				time.Sleep(time.Millisecond * 100)

--- a/ibft/controller/controller_running_instance.go
+++ b/ibft/controller/controller_running_instance.go
@@ -71,22 +71,25 @@ instanceLoop:
 			break instanceLoop
 		}
 	}
-	// saves state
-	identifier, seq := i.currentInstance.State().Lambda.Get(), i.currentInstance.State().SeqNumber.Get()
+	// saves state as instance will be cleared
+	seq := i.currentInstance.State().SeqNumber.Get()
 	// when main instance loop breaks, nil current instance
 	i.currentInstance = nil
 	i.logger.Debug("iBFT instance result loop stopped")
 
-	// if instance was decided -> wait for late commit messages
-	// this will also pick up orphan commit messages that
-	// were not included in the decided message when quorum was achieved
-	if retRes.Decided {
-		go i.listenToLateCommitMsgs(identifier, seq)
-	} else {
-		i.msgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(identifier, seq))
-	}
+	i.afterInstance(seq, retRes)
 
 	return retRes, err
+}
+
+// afterInstance is triggered after the instance was finished
+func (i *Controller) afterInstance(seq uint64, res *ibft.InstanceResult) {
+	// if instance was decided -> wait for late commit messages
+	if res.Decided {
+		go i.listenToLateCommitMsgs(i.Identifier[:], seq)
+	} else {
+		i.msgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(i.Identifier[:], seq))
+	}
 }
 
 // instanceStageChange processes a stage change for the current instance, returns true if requires stopping the instance after stage process.

--- a/ibft/controller/controller_running_instance.go
+++ b/ibft/controller/controller_running_instance.go
@@ -148,6 +148,12 @@ func (i *Controller) listenToLateCommitMsgs(identifier []byte, seq uint64) {
 					logger.Error("failed to process late commit message", zap.Error(err))
 				} else if updated != nil {
 					logger.Debug("decided message was updated", zap.Uint64s("updated signers", updated.SignerIds))
+					if err := i.network.BroadcastDecided(i.ValidatorShare.PublicKey.Serialize(), updated); err != nil {
+						logger.Error("could not broadcast decided message", zap.Error(err))
+					}
+					logger.Debug("updated decided was broadcasted")
+					ibft.ReportDecided(i.ValidatorShare.PublicKey.SerializeToHexStr(), updated)
+					break loop
 				}
 			} else {
 				time.Sleep(time.Millisecond * 100)

--- a/ibft/controller/controller_running_instance.go
+++ b/ibft/controller/controller_running_instance.go
@@ -132,7 +132,7 @@ func (i *Controller) listenToLateCommitMsgs(runningInstance ibft.Instance) {
 					continue
 				}
 				updated, err := instance.ProcessLateCommitMsg(netMsg.SignedMessage, i.ibftStorage,
-					i.ValidatorShare.PublicKey.SerializeToHexStr())
+					i.ValidatorShare)
 				if err != nil {
 					logger.Error("failed to process late commit message", zap.Error(err))
 				} else if updated != nil {

--- a/ibft/controller/controller_running_instance.go
+++ b/ibft/controller/controller_running_instance.go
@@ -135,12 +135,13 @@ func (i *Controller) listenToLateCommitMsgs(identifier []byte, seq uint64) {
 				break loop
 			}
 			if netMsg := i.msgQueue.PopMessage(idxKey); netMsg != nil && netMsg.SignedMessage != nil {
-				if netMsg.SignedMessage.Message == nil || netMsg.SignedMessage.Message.Type != proto.RoundState_Commit {
+				if netMsg.SignedMessage.Message.Type != proto.RoundState_Commit {
 					// not a commit message -> skip
 					continue
 				}
 				logger := i.logger.With(zap.Uint64("seq", netMsg.SignedMessage.Message.SeqNumber),
 					zap.Uint64s("signers", netMsg.SignedMessage.SignerIds))
+				// TODO: need to use the fork
 				if err := instance.CommitMsgValidationPipelineV0(identifier, seq, i.ValidatorShare).Run(netMsg.SignedMessage); err != nil {
 					i.logger.Error("received invalid late commit message", zap.Error(err))
 					continue

--- a/ibft/instance/commit.go
+++ b/ibft/instance/commit.go
@@ -5,8 +5,8 @@ import (
 	"github.com/bloxapp/ssv/ibft"
 	"github.com/bloxapp/ssv/ibft/pipeline/auth"
 	"github.com/bloxapp/ssv/storage/collections"
+	"github.com/bloxapp/ssv/validator/storage"
 	"github.com/pkg/errors"
-
 	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/ibft/pipeline"
@@ -14,13 +14,18 @@ import (
 )
 
 // ProcessLateCommitMsg tries to aggregate the late commit message to the corresponding decided message
-func ProcessLateCommitMsg(msg *proto.SignedMessage, ibftStorage collections.Iibft, pubkey string) (*proto.SignedMessage, error) {
+func ProcessLateCommitMsg(msg *proto.SignedMessage, ibftStorage collections.Iibft, share *storage.Share) (*proto.SignedMessage, error) {
 	// find stored decided
 	decidedMsg, found, err := ibftStorage.GetDecided(msg.Message.Lambda, msg.Message.SeqNumber)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch decided for late commit")
+		return nil, errors.Wrap(err, "could not read decided for late commit")
 	}
 	if !found {
+		// decided message does not exist
+		return nil, nil
+	}
+	if len(decidedMsg.SignerIds) == share.CommitteeSize() {
+		// msg was signed by the entire committee
 		return nil, nil
 	}
 	// aggregate message with stored decided
@@ -30,11 +35,10 @@ func ProcessLateCommitMsg(msg *proto.SignedMessage, ibftStorage collections.Iibf
 		}
 		return nil, errors.Wrap(err, "could not aggregate commit message")
 	}
-	// save to storage
 	if err := ibftStorage.SaveDecided(decidedMsg); err != nil {
 		return nil, errors.Wrap(err, "could not save aggregated decided message")
 	}
-	ibft.ReportDecided(pubkey, msg)
+	ibft.ReportDecided(share.PublicKey.SerializeToHexStr(), msg)
 	return decidedMsg, nil
 }
 
@@ -65,12 +69,17 @@ func (i *Instance) CommitMsgValidationPipeline() pipeline.Pipeline {
 
 // CommitMsgValidationPipelineV0 is version 0
 func (i *Instance) CommitMsgValidationPipelineV0() pipeline.Pipeline {
+	return CommitMsgValidationPipelineV0(i.State().Lambda.Get(), i.State().SeqNumber.Get(), i.ValidatorShare)
+}
+
+// CommitMsgValidationPipelineV0 is version 0 of commit message validation
+func CommitMsgValidationPipelineV0(identifier []byte, seq uint64, share *storage.Share) pipeline.Pipeline {
 	return pipeline.Combine(
 		auth.BasicMsgValidation(),
 		auth.MsgTypeCheck(proto.RoundState_Commit),
-		auth.ValidateLambdas(i.State().Lambda.Get()),
-		auth.ValidateSequenceNumber(i.State().SeqNumber.Get()),
-		auth.AuthorizeMsg(i.ValidatorShare),
+		auth.ValidateLambdas(identifier),
+		auth.ValidateSequenceNumber(seq),
+		auth.AuthorizeMsg(share),
 	)
 }
 
@@ -107,7 +116,6 @@ func (i *Instance) uponCommitMsg() pipeline.Pipeline {
 				i.Logger.Info("commit iBFT instance",
 					zap.String("Lambda", hex.EncodeToString(i.State().Lambda.Get())), zap.Uint64("round", i.State().Round.Get()),
 					zap.Int("got_votes", len(sigs)))
-
 				aggMsg, err := proto.AggregateMessages(sigs)
 				if err != nil {
 					i.Logger.Error("could not aggregate commit messages after quorum", zap.Error(err))

--- a/ibft/instance/instance.go
+++ b/ibft/instance/instance.go
@@ -283,9 +283,7 @@ func (i *Instance) ProcessStageChange(stage proto.RoundState) {
 
 	// Delete all queue messages when decided, we do not need them anymore.
 	if stage == proto.RoundState_Stopped {
-		for j := uint64(1); j <= i.State().Round.Get(); j++ {
-			i.MsgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(i.State().Lambda.Get(), i.State().SeqNumber.Get()))
-		}
+		i.MsgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(i.State().Lambda.Get(), i.State().SeqNumber.Get()))
 	}
 
 	// blocking send to channel

--- a/ibft/instance/instance.go
+++ b/ibft/instance/instance.go
@@ -281,11 +281,6 @@ func (i *Instance) ProcessStageChange(stage proto.RoundState) {
 
 	i.State().Stage.Set(int32(stage))
 
-	// Delete all queue messages when decided, we do not need them anymore.
-	if stage == proto.RoundState_Stopped {
-		i.MsgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(i.State().Lambda.Get(), i.State().SeqNumber.Get()))
-	}
-
 	// blocking send to channel
 	if i.stageChangedChan != nil {
 		i.stageChangedChan <- stage

--- a/ibft/instance/instance.go
+++ b/ibft/instance/instance.go
@@ -282,7 +282,7 @@ func (i *Instance) ProcessStageChange(stage proto.RoundState) {
 	i.State().Stage.Set(int32(stage))
 
 	// Delete all queue messages when decided, we do not need them anymore.
-	if stage == proto.RoundState_Decided || stage == proto.RoundState_Stopped {
+	if stage == proto.RoundState_Stopped {
 		for j := uint64(1); j <= i.State().Round.Get(); j++ {
 			i.MsgQueue.PurgeIndexedMessages(msgqueue.IBFTMessageIndexKey(i.State().Lambda.Get(), i.State().SeqNumber.Get()))
 		}

--- a/ibft/instance/instance_test.go
+++ b/ibft/instance/instance_test.go
@@ -99,14 +99,12 @@ func TestInstanceStop(t *testing.T) {
 		SignedMessage: msg,
 		Type:          network.NetworkMsg_IBFTType,
 	})
-	time.Sleep(time.Millisecond * 200)
+	time.Sleep(time.Millisecond * 400)
 
 	// verify
 	require.True(t, instance.roundTimer.Stopped())
 	require.EqualValues(t, proto.RoundState_Stopped, instance.State().Stage.Get())
-	require.EqualValues(t, 1, instance.MsgQueue.MsgCount(msgqueue.IBFTMessageIndexKey(instance.State().Lambda.Get(), msg.Message.SeqNumber)))
-	netMsg := instance.MsgQueue.PopMessage(msgqueue.IBFTMessageIndexKey(instance.State().Lambda.Get(), msg.Message.SeqNumber))
-	require.EqualValues(t, []uint64{3}, netMsg.SignedMessage.SignerIds)
+	require.True(t, 3 <= instance.MsgQueue.MsgCount(msgqueue.IBFTMessageIndexKey(instance.State().Lambda.Get(), msg.Message.SeqNumber)))
 }
 
 func TestInit(t *testing.T) {

--- a/ibft/instance/instance_test.go
+++ b/ibft/instance/instance_test.go
@@ -104,7 +104,6 @@ func TestInstanceStop(t *testing.T) {
 	// verify
 	require.True(t, instance.roundTimer.Stopped())
 	require.EqualValues(t, proto.RoundState_Stopped, instance.State().Stage.Get())
-	require.True(t, 3 <= instance.MsgQueue.MsgCount(msgqueue.IBFTMessageIndexKey(instance.State().Lambda.Get(), msg.Message.SeqNumber)))
 }
 
 func TestInit(t *testing.T) {

--- a/ibft/instance/spectesting/tests/commit/decide_different_value.go
+++ b/ibft/instance/spectesting/tests/commit/decide_different_value.go
@@ -79,7 +79,6 @@ func (test *DecideDifferentValue) Run(t *testing.T) {
 	// qualified commit quorum
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
-	spectesting.RequireReturnedFalseNoError(t, test.instance.ProcessMessage) // we purge all messages after decided was reached
 	quorum, _ = test.instance.CommitMessages.QuorumAchieved(1, []byte("wrong value"))
 	require.True(t, quorum)
 

--- a/ibft/instance/spectesting/tests/common/duplicate_messages.go
+++ b/ibft/instance/spectesting/tests/common/duplicate_messages.go
@@ -99,7 +99,6 @@ func (test *DuplicateMessages) Run(t *testing.T) {
 	// valid commit quorum
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
-	spectesting.RequireReturnedFalseNoError(t, test.instance.ProcessMessage) // we purge all messages after decided was reached
 	quorum, _ = test.instance.CommitMessages.QuorumAchieved(1, test.inputValue)
 	require.True(t, quorum)
 

--- a/ibft/instance/spectesting/tests/prepare/prepare_at_future_round.go
+++ b/ibft/instance/spectesting/tests/prepare/prepare_at_future_round.go
@@ -75,7 +75,6 @@ func (test *PreparedAtFutureRound) Run(t *testing.T) {
 	// qualified commit quorum
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
-	spectesting.RequireReturnedFalseNoError(t, test.instance.ProcessMessage) // we purge all messages after decided was reached
 	quorum, _ = test.instance.CommitMessages.QuorumAchieved(5, test.inputValue)
 	require.True(t, quorum)
 

--- a/ibft/instance/spectesting/tests/valid_simple_run.go
+++ b/ibft/instance/spectesting/tests/valid_simple_run.go
@@ -76,7 +76,6 @@ func (test *ValidSimpleRun) Run(t *testing.T) {
 	// qualified commit quorum
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
 	spectesting.RequireReturnedTrueNoError(t, test.instance.ProcessMessage)
-	spectesting.RequireReturnedFalseNoError(t, test.instance.ProcessMessage) // we purge all messages after decided was reached
 	quorum, _ = test.instance.CommitMessages.QuorumAchieved(1, test.inputValue)
 	require.True(t, quorum)
 

--- a/utils/tasks/exec_timeout_test.go
+++ b/utils/tasks/exec_timeout_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestExecWithTimeout(t *testing.T) {
 	logex.Build("test", zap.DebugLevel, nil)
-	ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), 7*time.Millisecond)
+	ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), 10*time.Millisecond)
 	defer cancel()
 	tests := []struct {
 		name          string
@@ -24,13 +24,13 @@ func TestExecWithTimeout(t *testing.T) {
 		{
 			"Cancelled_context",
 			ctxWithTimeout,
-			12 * time.Millisecond,
+			20 * time.Millisecond,
 			3,
 		},
 		{
 			"Long_function",
 			context.TODO(),
-			7 * time.Millisecond,
+			8 * time.Millisecond,
 			3,
 		},
 	}


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/430

IBFT messages were purged once the instance decided or stopped, the behavior changed in this PR:
- when instance finished w/ decided - ctrl starts to listen for late commit messages with timeout and purge messages once done
- when instance finished w/o decided - ctrl purges messages