### PR TITLE
Event queue leak fix

### DIFF
--- a/ibft/instance/eventqueue/queue_test.go
+++ b/ibft/instance/eventqueue/queue_test.go
@@ -2,6 +2,7 @@ package eventqueue
 
 import (
 	"github.com/stretchr/testify/require"
+	"sync/atomic"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func TestQueue(t *testing.T) {
 		q := New()
 
 		require.Nil(t, q.Pop())
-		require.True(t, q.Add(func() {}))
+		require.True(t, q.Add(NewEvent(func() {})))
 		require.NotNil(t, q.Pop())
 		require.Nil(t, q.Pop())
 	})
@@ -19,11 +20,11 @@ func TestQueue(t *testing.T) {
 	t.Run("add multiple", func(t *testing.T) {
 		q := New()
 
-		require.True(t, q.Add(func() {}))
-		require.True(t, q.Add(func() {}))
-		require.True(t, q.Add(func() {}))
-		require.True(t, q.Add(func() {}))
-		require.True(t, q.Add(func() {}))
+		require.True(t, q.Add(NewEvent(func() {})))
+		require.True(t, q.Add(NewEvent(func() {})))
+		require.True(t, q.Add(NewEvent(func() {})))
+		require.True(t, q.Add(NewEvent(func() {})))
+		require.True(t, q.Add(NewEvent(func() {})))
 		require.NotNil(t, q.Pop())
 		require.NotNil(t, q.Pop())
 		require.NotNil(t, q.Pop())
@@ -33,13 +34,25 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("clear and stop", func(t *testing.T) {
+		var drained uint32
 		q := New()
 
-		require.True(t, q.Add(func() {}))
+		cancel := func() {
+			atomic.AddUint32(&drained, uint32(1))
+		}
+		require.True(t, q.Add(NewEventWithCancel(func() {}, cancel)))
+		require.True(t, q.Add(NewEventWithCancel(func() {}, cancel)))
+		require.True(t, q.Add(NewEventWithCancel(func() {}, cancel)))
 		q.ClearAndStop()
 		require.Nil(t, q.Pop())
-		require.False(t, q.Add(func() {}))
+		require.False(t, q.Add(NewEventWithCancel(func() {}, cancel)))
 		require.Nil(t, q.Pop())
+		// sleep so cancel functions will be executed
+		for {
+			if atomic.LoadUint32(&drained) >= uint32(3) {
+				return
+			}
+		}
 	})
 
 }

--- a/ibft/instance/instance.go
+++ b/ibft/instance/instance.go
@@ -209,19 +209,19 @@ func (i *Instance) Start(inputValue []byte) error {
 
 // ForceDecide will attempt to decide the instance with provided decided signed msg.
 func (i *Instance) ForceDecide(msg *proto.SignedMessage) {
-	i.eventQueue.Add(func() {
+	i.eventQueue.Add(eventqueue.NewEvent(func() {
 		i.Logger.Info("trying to force instance decision.")
 		if err := i.DecidedMsgPipeline().Run(msg); err != nil {
 			i.Logger.Error("force decided pipeline error", zap.Error(err))
 		}
-	})
+	}))
 }
 
 // Stop will trigger a stopped for the entire instance
 func (i *Instance) Stop() {
 	// stop can be run just once
 	i.runStopOnce.Do(func() {
-		if added := i.eventQueue.Add(i.stop); !added {
+		if added := i.eventQueue.Add(eventqueue.NewEvent(i.stop)); !added {
 			i.Logger.Debug("could not add 'stop' to event queue")
 		}
 	})


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/434 by wrapping an event/function with a struct to include a cancel function that would be called when the queue will be stopped and drained.