### PR TITLE
Read only mode for operator node

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bloxapp/ssv/monitoring/metrics"
 	"github.com/bloxapp/ssv/network/p2p"
 	"github.com/bloxapp/ssv/operator"
+	"github.com/bloxapp/ssv/operator/duties"
 	v0 "github.com/bloxapp/ssv/operator/forks/v0"
 	"github.com/bloxapp/ssv/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
@@ -37,6 +38,8 @@ type config struct {
 	MetricsAPIPort     int    `yaml:"MetricsAPIPort" env:"METRICS_API_PORT" env-description:"port of metrics api"`
 	EnableProfile      bool   `yaml:"EnableProfile" env:"ENABLE_PROFILE" env-description:"flag that indicates whether go profiling tools are enabled"`
 	NetworkPrivateKey  string `yaml:"NetworkPrivateKey" env:"NETWORK_PRIVATE_KEY" env-description:"private key for network identity"`
+
+	ReadOnlyMode bool `yaml:"ReadOnlyMode" env:"READ_ONLY_MODE" env-description:"a flag to turn on read only operator"`
 }
 
 var cfg config
@@ -170,6 +173,9 @@ var StartNodeCmd = &cobra.Command{
 
 		validatorCtrl := validator.NewController(cfg.SSVOptions.ValidatorOptions)
 		cfg.SSVOptions.ValidatorController = validatorCtrl
+		if cfg.ReadOnlyMode {
+			cfg.SSVOptions.DutyExec = duties.NewReadOnlyExecutor(Logger)
+		}
 		operatorNode = operator.New(cfg.SSVOptions)
 
 		if cfg.MetricsAPIPort > 0 {

--- a/operator/duties/controller_test.go
+++ b/operator/duties/controller_test.go
@@ -88,7 +88,7 @@ func (e *executorMock) ExecuteDuty(duty *beacon.Duty) error {
 	return nil
 }
 
-func execWithWaitGroup(t *testing.T, wg *sync.WaitGroup) dutyExecutor {
+func execWithWaitGroup(t *testing.T, wg *sync.WaitGroup) DutyExecutor {
 	return &executorMock{t, wg}
 }
 

--- a/operator/node.go
+++ b/operator/node.go
@@ -32,6 +32,7 @@ type Options struct {
 	Eth1Client          eth1.Client
 	DB                  basedb.IDb
 	ValidatorController validator.Controller
+	DutyExec            duties.DutyExecutor
 	// genesis epoch
 	GenesisEpoch uint64 `yaml:"GenesisEpoch" env:"GENESIS_EPOCH" env-description:"Genesis Epoch SSV node will start"`
 	// max slots for duty to wait
@@ -74,6 +75,7 @@ func New(opts Options) Node {
 			ValidatorController: opts.ValidatorController,
 			GenesisEpoch:        opts.GenesisEpoch,
 			DutyLimit:           opts.DutyLimit,
+			Executor:            opts.DutyExec,
 		}),
 
 		fork: opts.Fork,


### PR DESCRIPTION
Enables to pass a config flag to turn off duty execution in an operator node, means that the node won't take part in validator's consensus