### PR TITLE
Refactor internal msg listeners

### DIFF
--- a/eth1/sync_test.go
+++ b/eth1/sync_test.go
@@ -51,10 +51,11 @@ func TestSyncEth1Error(t *testing.T) {
 func TestSyncEth1HandlerError(t *testing.T) {
 	logger, eth1Client, storage := setupStorageWithEth1ClientMock()
 	go func() {
+		<-time.After(time.Millisecond*25)
 		logs := []types.Log{{BlockNumber: DefaultSyncOffset().Uint64() - 1}, {BlockNumber: DefaultSyncOffset().Uint64()}}
 		eth1Client.Feed.Send(&Event{Data: struct{}{}, Log: logs[0]})
 		eth1Client.Feed.Send(&Event{Data: struct{}{}, Log: logs[1]})
-		eth1Client.Feed.Send(&Event{Data: SyncEndedEvent{Logs: logs, Success: true}})
+		eth1Client.Feed.Send(&Event{Data: SyncEndedEvent{Logs: logs, Success: false}})
 	}()
 	err := SyncEth1Events(logger, eth1Client, storage, nil, func(event Event) error {
 		return errors.New("test")

--- a/eth1/sync_test.go
+++ b/eth1/sync_test.go
@@ -51,7 +51,7 @@ func TestSyncEth1Error(t *testing.T) {
 func TestSyncEth1HandlerError(t *testing.T) {
 	logger, eth1Client, storage := setupStorageWithEth1ClientMock()
 	go func() {
-		<-time.After(time.Millisecond*25)
+		<-time.After(time.Millisecond * 25)
 		logs := []types.Log{{BlockNumber: DefaultSyncOffset().Uint64() - 1}, {BlockNumber: DefaultSyncOffset().Uint64()}}
 		eth1Client.Feed.Send(&Event{Data: struct{}{}, Log: logs[0]})
 		eth1Client.Feed.Send(&Event{Data: struct{}{}, Log: logs[1]})

--- a/network/commons/listeners/container.go
+++ b/network/commons/listeners/container.go
@@ -1,0 +1,102 @@
+package listeners
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"github.com/bloxapp/ssv/network"
+	"go.uber.org/zap"
+	"math/big"
+	"sync"
+	"time"
+)
+
+// Container is an interface for of listeners container
+type Container interface {
+	// Register registers a new listener and returns a function for de-registration
+	Register(l *Listener) func()
+	// GetListeners returns all active listeners
+	GetListeners(msgType network.NetworkMsg) []*Listener
+}
+
+type listeners map[network.NetworkMsg][]*Listener
+
+type listenersContainer struct {
+	ctx       context.Context
+	lock      *sync.RWMutex
+	logger    *zap.Logger
+	listeners listeners
+}
+
+// NewListenersContainer creates a new instance of listeners container
+func NewListenersContainer(ctx context.Context, logger *zap.Logger) Container {
+	return &listenersContainer{
+		ctx:       ctx,
+		lock:      &sync.RWMutex{},
+		logger:    logger,
+		listeners: make(listeners),
+	}
+}
+
+func (lc *listenersContainer) Register(l *Listener) func() {
+	lc.addListener(l)
+
+	return func() {
+		lc.removeListener(l.msgType, l.id)
+	}
+}
+
+func (lc *listenersContainer) GetListeners(msgType network.NetworkMsg) []*Listener {
+	lc.lock.RLock()
+	defer lc.lock.RUnlock()
+
+	lss, ok := lc.listeners[msgType]
+	if !ok {
+		return []*Listener{}
+	}
+	res := make([]*Listener, len(lss))
+	copy(res, lss)
+	return res
+}
+
+func (lc *listenersContainer) addListener(l *Listener) {
+	r, err := rand.Int(rand.Reader, new(big.Int).SetInt64(int64(1000000)))
+	if err != nil {
+		lc.logger.Error("could not create random number for listener")
+		return
+	}
+
+	lc.lock.Lock()
+	defer lc.lock.Unlock()
+
+	lss, ok := lc.listeners[l.msgType]
+	if !ok {
+		lss = make([]*Listener, 0)
+	}
+	id := fmt.Sprintf("%d:%d:%d", len(lss), time.Now().UnixNano(), r.Int64())
+	l.id = id
+	lss = append(lss, l)
+	lc.listeners[l.msgType] = lss
+}
+
+func (lc *listenersContainer) removeListener(msgType network.NetworkMsg, id string) {
+	lc.lock.Lock()
+	defer lc.lock.Unlock()
+
+	ls, ok := lc.listeners[msgType]
+	if !ok {
+		return
+	}
+	for i, l := range ls {
+		if l.id == id {
+			lc.listeners[msgType] = append(ls[:i], ls[i+1:]...)
+			// faster way of removing the item
+			// it will mess up the order of the slice
+			//ls[i] = ls[len(ls)-1]
+			//ls[len(ls)-1] = nil
+			//ls = ls[:len(ls)-1]
+			//lc.listeners[msgType] = ls
+			return
+		}
+	}
+}

--- a/network/commons/listeners/container.go
+++ b/network/commons/listeners/container.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Container is an interface for of listeners container
+// Container is an interface for managing internal listeners
 type Container interface {
 	// Register registers a new listener and returns a function for de-registration
 	Register(l *Listener) func()

--- a/network/commons/listeners/container_test.go
+++ b/network/commons/listeners/container_test.go
@@ -1,0 +1,73 @@
+package listeners
+
+import (
+	"context"
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/network"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestListenersContainer(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lsCont := NewListenersContainer(ctx, logger)
+
+	var wg sync.WaitGroup
+
+	n := 100
+
+	var count int32
+	l := NewListener(network.NetworkMsg_IBFTType)
+	deregister := lsCont.Register(l)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer deregister()
+
+		cn := l.MsgChan()
+		for msg := range cn {
+			require.NotNil(t, msg)
+			atomic.AddInt32(&count, 1)
+			if atomic.LoadInt32(&count) == int32(n-1) {
+				return
+			}
+		}
+	}()
+
+	propagate := func(msg *proto.SignedMessage) {
+		lss := lsCont.GetListeners(network.NetworkMsg_IBFTType)
+		for _, ls := range lss {
+			ls.MsgChan() <- msg
+		}
+	}
+
+	go func() {
+		for i := 0; i < n; i++ {
+			go propagate(&proto.SignedMessage{
+				Message: &proto.Message{
+					Type:      proto.RoundState_ChangeRound,
+					Round:     1,
+					Lambda:    []byte{1, 2, 3, 4},
+					SeqNumber: uint64(i + 1),
+					Value:     []byte{},
+				},
+				Signature: []byte{},
+				SignerIds: []uint64{1},
+			})
+		}
+	}()
+
+	wg.Wait()
+
+	require.Equal(t, int32(n-1), atomic.LoadInt32(&count))
+	// wait for de-registration
+	time.After(time.Millisecond * 100)
+	lss := lsCont.GetListeners(network.NetworkMsg_IBFTType)
+	require.Equal(t, 0, len(lss))
+}

--- a/network/commons/listeners/container_test.go
+++ b/network/commons/listeners/container_test.go
@@ -22,6 +22,7 @@ func TestListenersContainer(t *testing.T) {
 
 	n := 100
 
+	// counting incoming IBFT messages (should get n messages)
 	var count int32
 	l := NewListener(network.NetworkMsg_IBFTType)
 	deregister := lsCont.Register(l)
@@ -47,6 +48,7 @@ func TestListenersContainer(t *testing.T) {
 		}
 	}
 
+	// sending n messages
 	go func() {
 		for i := 0; i < n; i++ {
 			go propagate(&proto.SignedMessage{
@@ -66,7 +68,7 @@ func TestListenersContainer(t *testing.T) {
 	wg.Wait()
 
 	require.Equal(t, int32(n-1), atomic.LoadInt32(&count))
-	// wait for de-registration
+	// wait for de-registration and ensure listener is not available afterwards
 	time.After(time.Millisecond * 100)
 	lss := lsCont.GetListeners(network.NetworkMsg_IBFTType)
 	require.Equal(t, 0, len(lss))

--- a/network/commons/listeners/listener.go
+++ b/network/commons/listeners/listener.go
@@ -1,0 +1,70 @@
+package listeners
+
+import (
+	"github.com/bloxapp/ssv/ibft/proto"
+	"github.com/bloxapp/ssv/network"
+)
+
+const (
+	// MsgChanSize is the buffer size of the message channel
+	MsgChanSize = 128
+)
+
+// Listener represents an internal listener
+type Listener struct {
+	msgCh     chan *proto.SignedMessage
+	sigCh     chan *proto.SignedMessage
+	decidedCh chan *proto.SignedMessage
+	syncCh    chan *network.SyncChanObj
+
+	msgType network.NetworkMsg
+	id      string
+}
+
+// MsgChan returns the underlying msg channel
+func (l *Listener) MsgChan() chan *proto.SignedMessage {
+	return l.msgCh
+}
+
+// SigChan returns the underlying signature channel
+func (l *Listener) SigChan() chan *proto.SignedMessage {
+	return l.sigCh
+}
+
+// DecidedChan returns the underlying decided channel
+func (l *Listener) DecidedChan() chan *proto.SignedMessage {
+	return l.decidedCh
+}
+
+// SyncChan returns the underlying sync channel
+func (l *Listener) SyncChan() chan *network.SyncChanObj {
+	return l.syncCh
+}
+
+// NewListener creates a new instance of listener
+func NewListener(msgType network.NetworkMsg) *Listener {
+	switch msgType {
+	case network.NetworkMsg_IBFTType:
+		return &Listener{
+			msgCh:   make(chan *proto.SignedMessage, MsgChanSize),
+			msgType: network.NetworkMsg_IBFTType,
+		}
+	case network.NetworkMsg_SignatureType:
+		return &Listener{
+			sigCh:   make(chan *proto.SignedMessage, MsgChanSize),
+			msgType: network.NetworkMsg_SignatureType,
+		}
+	case network.NetworkMsg_DecidedType:
+		return &Listener{
+			decidedCh: make(chan *proto.SignedMessage, MsgChanSize),
+			msgType:   network.NetworkMsg_DecidedType,
+		}
+	case network.NetworkMsg_SyncType:
+		return &Listener{
+			syncCh:  make(chan *network.SyncChanObj, MsgChanSize),
+			msgType: network.NetworkMsg_SyncType,
+		}
+	default:
+		return nil
+	}
+}

--- a/network/p2p/listeners.go
+++ b/network/p2p/listeners.go
@@ -1,170 +1,11 @@
 package p2p
 
 import (
-	"context"
-	"crypto/rand"
-	"fmt"
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"go.uber.org/zap"
-	"math/big"
-	"sync"
-	"time"
 )
-
-type listener struct {
-	msgCh     chan *proto.SignedMessage
-	sigCh     chan *proto.SignedMessage
-	decidedCh chan *proto.SignedMessage
-	syncCh    chan *network.SyncChanObj
-
-	msgType network.NetworkMsg
-	id      string
-}
-
-func (l *listener) MsgChan() chan *proto.SignedMessage {
-	return l.msgCh
-}
-
-func (l *listener) SigChan() chan *proto.SignedMessage {
-	return l.sigCh
-}
-
-func (l *listener) DecidedChan() chan *proto.SignedMessage {
-	return l.decidedCh
-}
-
-func (l *listener) SyncChan() chan *network.SyncChanObj {
-	return l.syncCh
-}
-
-func newListener(msgType network.NetworkMsg) *listener {
-	switch msgType {
-	case network.NetworkMsg_IBFTType:
-		return &listener{
-			msgCh:  make(chan *proto.SignedMessage, MsgChanSize),
-			msgType: network.NetworkMsg_IBFTType,
-		}
-	case network.NetworkMsg_SignatureType:
-		return &listener{
-			sigCh:  make(chan *proto.SignedMessage, MsgChanSize),
-			msgType: network.NetworkMsg_SignatureType,
-		}
-	case network.NetworkMsg_DecidedType:
-		return &listener{
-			decidedCh:  make(chan *proto.SignedMessage, MsgChanSize),
-			msgType: network.NetworkMsg_DecidedType,
-		}
-	case network.NetworkMsg_SyncType:
-		return &listener{
-			syncCh:  make(chan *network.SyncChanObj, MsgChanSize),
-			msgType: network.NetworkMsg_SyncType,
-		}
-	default:
-		return nil
-	}
-}
-
-type listeners map[network.NetworkMsg][]*listener
-
-type listenersContainer struct {
-	ctx       context.Context
-	lock      *sync.RWMutex
-	logger    *zap.Logger
-	listeners listeners
-	added     chan *listener
-	removed   chan *listener
-}
-
-func newListenersContainer(ctx context.Context, logger *zap.Logger) *listenersContainer {
-	return &listenersContainer{
-		ctx:       ctx,
-		lock:      &sync.RWMutex{},
-		logger:    logger,
-		listeners: make(listeners),
-		added:     make(chan *listener, 1),
-		removed:   make(chan *listener, 1),
-	}
-}
-
-func (lc *listenersContainer) Start() {
-	for {
-		select {
-		case l := <-lc.added:
-			if l != nil {
-				lc.addListener(l)
-			}
-		case l := <-lc.removed:
-			if l != nil {
-				lc.removeListener(l.msgType, l.id)
-			}
-		case <-lc.ctx.Done():
-			return
-		}
-	}
-}
-
-func (lc *listenersContainer) register(l *listener) func() {
-	lc.added <- l
-
-	return func() {
-		lc.removed <- l
-	}
-}
-
-func (lc *listenersContainer) getListeners(msgType network.NetworkMsg) []*listener {
-	lc.lock.RLock()
-	defer lc.lock.RUnlock()
-
-	lss, ok := lc.listeners[msgType]
-	if !ok {
-		return []*listener{}
-	}
-	res := make([]*listener, len(lss))
-	copy(res, lss)
-	return res
-}
-
-func (lc *listenersContainer) addListener(l *listener) {
-	lc.lock.Lock()
-	defer lc.lock.Unlock()
-
-	r, err := rand.Int(rand.Reader, new(big.Int).SetInt64(int64(1000000)))
-	if err != nil {
-		lc.logger.Error("could not create random number for listener")
-		return
-	}
-	lss, ok := lc.listeners[l.msgType]
-	if !ok {
-		lss = make([]*listener, 0)
-	}
-	id := fmt.Sprintf("%d:%d:%d", len(lss), time.Now().UnixNano(), r.Int64())
-	l.id = id
-	lss = append(lss, l)
-	lc.listeners[l.msgType] = lss
-}
-
-func (lc *listenersContainer) removeListener(msgType network.NetworkMsg, id string) {
-	lc.lock.Lock()
-	defer lc.lock.Unlock()
-
-	ls, ok := lc.listeners[msgType]
-	if !ok {
-		return
-	}
-	for i, l := range ls {
-		if l.id == id {
-			//n.ls[msgType] = append(ls[:i], ls[i+1:]...)
-			// faster way of removing the item
-			// it will mess up the order of the slice but it doesn't matter here
-			ls[i] = ls[len(ls)-1]
-			ls[len(ls)-1] = nil
-			ls = ls[:len(ls)-1]
-			lc.listeners[msgType] = ls
-			return
-		}
-	}
-}
 
 // propagateSignedMsg takes an incoming message (from validator's topic)
 // and propagates it to the corresponding internal listeners
@@ -174,7 +15,7 @@ func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
 		return
 	}
 
-	lss := n.listenersContainer.getListeners(cm.Type)
+	lss := n.listeners.GetListeners(cm.Type)
 
 	switch cm.Type {
 	case network.NetworkMsg_IBFTType:
@@ -188,34 +29,38 @@ func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
 	}
 }
 
-func propagateIBFTMessage(listeners []*listener, msg *proto.SignedMessage) {
+func propagateIBFTMessage(listeners []*listeners.Listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
-		if ls.msgCh != nil {
-			ls.msgCh <- msg
+		cn := ls.MsgChan()
+		if cn != nil {
+			cn <- msg
 		}
 	}
 }
 
-func propagateSigMessage(listeners []*listener, msg *proto.SignedMessage) {
+func propagateSigMessage(listeners []*listeners.Listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
-		if ls.sigCh != nil {
-			ls.sigCh <- msg
+		cn := ls.SigChan()
+		if cn != nil {
+			cn <- msg
 		}
 	}
 }
 
-func propagateDecidedMessage(listeners []*listener, msg *proto.SignedMessage) {
+func propagateDecidedMessage(listeners []*listeners.Listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
-		if ls.decidedCh != nil {
-			ls.decidedCh <- msg
+		cn := ls.DecidedChan()
+		if cn != nil {
+			cn <- msg
 		}
 	}
 }
 
-func propagateSyncMessage(listeners []*listener, cm *network.Message, netSyncStream network.SyncStream) {
+func propagateSyncMessage(listeners []*listeners.Listener, cm *network.Message, netSyncStream network.SyncStream) {
 	for _, ls := range listeners {
-		if ls.syncCh != nil {
-			ls.syncCh <- &network.SyncChanObj{
+		cn := ls.SyncChan()
+		if cn != nil {
+			cn <- &network.SyncChanObj{
 				Msg:    cm.SyncMessage,
 				Stream: netSyncStream,
 			}

--- a/network/p2p/listeners.go
+++ b/network/p2p/listeners.go
@@ -1,12 +1,14 @@
 package p2p
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
 	"go.uber.org/zap"
 	"math/big"
+	"sync"
 	"time"
 )
 
@@ -15,26 +17,152 @@ type listener struct {
 	sigCh     chan *proto.SignedMessage
 	decidedCh chan *proto.SignedMessage
 	syncCh    chan *network.SyncChanObj
+
+	msgType network.NetworkMsg
+	id      string
 }
 
-// registerListener registers the given listener
-func (n *p2pNetwork) registerListener(ls listener) func() {
-	r, err := rand.Int(rand.Reader, new(big.Int).SetInt64(int64(1000000)))
-	if err != nil {
-		n.logger.Error("could not create random number for listener")
+func (l *listener) MsgChan() chan *proto.SignedMessage {
+	return l.msgCh
+}
+
+func (l *listener) SigChan() chan *proto.SignedMessage {
+	return l.sigCh
+}
+
+func (l *listener) DecidedChan() chan *proto.SignedMessage {
+	return l.decidedCh
+}
+
+func (l *listener) SyncChan() chan *network.SyncChanObj {
+	return l.syncCh
+}
+
+func newListener(msgType network.NetworkMsg) *listener {
+	switch msgType {
+	case network.NetworkMsg_IBFTType:
+		return &listener{
+			msgCh:  make(chan *proto.SignedMessage, MsgChanSize),
+			msgType: network.NetworkMsg_IBFTType,
+		}
+	case network.NetworkMsg_SignatureType:
+		return &listener{
+			sigCh:  make(chan *proto.SignedMessage, MsgChanSize),
+			msgType: network.NetworkMsg_SignatureType,
+		}
+	case network.NetworkMsg_DecidedType:
+		return &listener{
+			decidedCh:  make(chan *proto.SignedMessage, MsgChanSize),
+			msgType: network.NetworkMsg_DecidedType,
+		}
+	case network.NetworkMsg_SyncType:
+		return &listener{
+			syncCh:  make(chan *network.SyncChanObj, MsgChanSize),
+			msgType: network.NetworkMsg_SyncType,
+		}
+	default:
+		return nil
 	}
+}
 
-	n.listenersLock.Lock()
-	defer n.listenersLock.Unlock()
+type listeners map[network.NetworkMsg][]*listener
 
-	id := fmt.Sprintf("%d:%d:%d", len(n.listeners), time.Now().UnixNano(), r.Int64())
-	n.listeners[id] = ls
+type listenersContainer struct {
+	ctx       context.Context
+	lock      *sync.RWMutex
+	logger    *zap.Logger
+	listeners listeners
+	added     chan *listener
+	removed   chan *listener
+}
+
+func newListenersContainer(ctx context.Context, logger *zap.Logger) *listenersContainer {
+	return &listenersContainer{
+		ctx:       ctx,
+		lock:      &sync.RWMutex{},
+		logger:    logger,
+		listeners: make(listeners),
+		added:     make(chan *listener, 1),
+		removed:   make(chan *listener, 1),
+	}
+}
+
+func (lc *listenersContainer) Start() {
+	for {
+		select {
+		case l := <-lc.added:
+			if l != nil {
+				lc.addListener(l)
+			}
+		case l := <-lc.removed:
+			if l != nil {
+				lc.removeListener(l.msgType, l.id)
+			}
+		case <-lc.ctx.Done():
+			return
+		}
+	}
+}
+
+func (lc *listenersContainer) register(l *listener) func() {
+	lc.added <- l
 
 	return func() {
-		n.listenersLock.Lock()
-		defer n.listenersLock.Unlock()
+		lc.removed <- l
+	}
+}
 
-		delete(n.listeners, id)
+func (lc *listenersContainer) getListeners(msgType network.NetworkMsg) []*listener {
+	lc.lock.RLock()
+	defer lc.lock.RUnlock()
+
+	lss, ok := lc.listeners[msgType]
+	if !ok {
+		return []*listener{}
+	}
+	res := make([]*listener, len(lss))
+	copy(res, lss)
+	return res
+}
+
+func (lc *listenersContainer) addListener(l *listener) {
+	lc.lock.Lock()
+	defer lc.lock.Unlock()
+
+	r, err := rand.Int(rand.Reader, new(big.Int).SetInt64(int64(1000000)))
+	if err != nil {
+		lc.logger.Error("could not create random number for listener")
+		return
+	}
+	lss, ok := lc.listeners[l.msgType]
+	if !ok {
+		lss = make([]*listener, 0)
+	}
+	id := fmt.Sprintf("%d:%d:%d", len(lss), time.Now().UnixNano(), r.Int64())
+	l.id = id
+	lss = append(lss, l)
+	lc.listeners[l.msgType] = lss
+}
+
+func (lc *listenersContainer) removeListener(msgType network.NetworkMsg, id string) {
+	lc.lock.Lock()
+	defer lc.lock.Unlock()
+
+	ls, ok := lc.listeners[msgType]
+	if !ok {
+		return
+	}
+	for i, l := range ls {
+		if l.id == id {
+			//n.ls[msgType] = append(ls[:i], ls[i+1:]...)
+			// faster way of removing the item
+			// it will mess up the order of the slice but it doesn't matter here
+			ls[i] = ls[len(ls)-1]
+			ls[len(ls)-1] = nil
+			ls = ls[:len(ls)-1]
+			lc.listeners[msgType] = ls
+			return
+		}
 	}
 }
 
@@ -46,33 +174,21 @@ func (n *p2pNetwork) propagateSignedMsg(cm *network.Message) {
 		return
 	}
 
-	listeners := n.getListeners()
+	lss := n.listenersContainer.getListeners(cm.Type)
 
 	switch cm.Type {
 	case network.NetworkMsg_IBFTType:
-		go propagateIBFTMessage(listeners, cm.SignedMessage)
+		go propagateIBFTMessage(lss, cm.SignedMessage)
 	case network.NetworkMsg_SignatureType:
-		go propagateSigMessage(listeners, cm.SignedMessage)
+		go propagateSigMessage(lss, cm.SignedMessage)
 	case network.NetworkMsg_DecidedType:
-		go propagateDecidedMessage(listeners, cm.SignedMessage)
+		go propagateDecidedMessage(lss, cm.SignedMessage)
 	default:
 		n.logger.Error("received unsupported message", zap.Int32("msg type", int32(cm.Type)))
 	}
 }
 
-// getListeners copies listeners to avoid data races when iterating over listeners
-func (n *p2pNetwork) getListeners() []listener {
-	n.listenersLock.RLock()
-	defer n.listenersLock.RUnlock()
-
-	var listeners []listener
-	for _, ls := range n.listeners {
-		listeners = append(listeners, ls)
-	}
-	return listeners
-}
-
-func propagateIBFTMessage(listeners []listener, msg *proto.SignedMessage) {
+func propagateIBFTMessage(listeners []*listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
 		if ls.msgCh != nil {
 			ls.msgCh <- msg
@@ -80,7 +196,7 @@ func propagateIBFTMessage(listeners []listener, msg *proto.SignedMessage) {
 	}
 }
 
-func propagateSigMessage(listeners []listener, msg *proto.SignedMessage) {
+func propagateSigMessage(listeners []*listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
 		if ls.sigCh != nil {
 			ls.sigCh <- msg
@@ -88,7 +204,7 @@ func propagateSigMessage(listeners []listener, msg *proto.SignedMessage) {
 	}
 }
 
-func propagateDecidedMessage(listeners []listener, msg *proto.SignedMessage) {
+func propagateDecidedMessage(listeners []*listener, msg *proto.SignedMessage) {
 	for _, ls := range listeners {
 		if ls.decidedCh != nil {
 			ls.decidedCh <- msg
@@ -96,7 +212,7 @@ func propagateDecidedMessage(listeners []listener, msg *proto.SignedMessage) {
 	}
 }
 
-func propagateSyncMessage(listeners []listener, cm *network.Message, netSyncStream network.SyncStream) {
+func propagateSyncMessage(listeners []*listener, cm *network.Message, netSyncStream network.SyncStream) {
 	for _, ls := range listeners {
 		if ls.syncCh != nil {
 			ls.syncCh <- &network.SyncChanObj{

--- a/network/p2p/listeners_test.go
+++ b/network/p2p/listeners_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"go.uber.org/zap/zaptest"
 	"sync"
 	"testing"
@@ -17,7 +18,7 @@ func TestListeners(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	n.listenersContainer = newListenersContainer(ctx, logger)
+	n.listeners = listeners.NewListenersContainer(ctx, logger)
 
 	testCtx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()

--- a/network/p2p/listeners_test.go
+++ b/network/p2p/listeners_test.go
@@ -10,14 +10,17 @@ import (
 )
 
 func TestListeners(t *testing.T) {
+	logger := zaptest.NewLogger(t)
 	n := p2pNetwork{
-		logger:        zaptest.NewLogger(t),
-		listeners:     map[string]listener{},
-		listenersLock: &sync.RWMutex{},
+		logger: logger,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	n.listenersContainer = newListenersContainer(ctx, logger)
+
+	testCtx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
 
 	var wg sync.WaitGroup
 
@@ -27,7 +30,7 @@ func TestListeners(t *testing.T) {
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-testCtx.Done():
 				return
 			case _, ok := <-ibftCn1:
 				if ok {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/bloxapp/ssv/network/forks"
 	"github.com/bloxapp/ssv/utils/commons"
 	"github.com/bloxapp/ssv/utils/rsaencryption"
@@ -47,18 +48,18 @@ const (
 
 // p2pNetwork implements network.Network interface using P2P
 type p2pNetwork struct {
-	ctx                context.Context
-	cfg                *Config
-	dv5Listener        discv5Listener
-	listenersContainer *listenersContainer
-	logger             *zap.Logger
-	privKey            *ecdsa.PrivateKey
-	peers              *peers.Status
-	host               p2pHost.Host
-	pubsub             *pubsub.PubSub
-	peersIndex         PeersIndex
-	operatorPrivKey    *rsa.PrivateKey
-	fork               forks.Fork
+	ctx             context.Context
+	cfg             *Config
+	dv5Listener     discv5Listener
+	listeners       listeners.Container
+	logger          *zap.Logger
+	privKey         *ecdsa.PrivateKey
+	peers           *peers.Status
+	host            p2pHost.Host
+	pubsub          *pubsub.PubSub
+	peersIndex      PeersIndex
+	operatorPrivKey *rsa.PrivateKey
+	fork            forks.Fork
 
 	psSubs       map[string]context.CancelFunc
 	psTopicsLock *sync.RWMutex
@@ -75,17 +76,17 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 	logger = logger.With(zap.String("component", "p2p"))
 
 	n := &p2pNetwork{
-		ctx:                ctx,
-		cfg:                cfg,
-		listenersContainer: newListenersContainer(ctx, logger),
-		logger:             logger,
-		operatorPrivKey:    cfg.OperatorPrivateKey,
-		privKey:            cfg.NetworkPrivateKey,
-		psSubs:             make(map[string]context.CancelFunc),
-		psTopicsLock:       &sync.RWMutex{},
-		reportLastMsg:      cfg.ReportLastMsg,
-		fork:               cfg.Fork,
-		nodeType:           cfg.NodeType,
+		ctx:             ctx,
+		cfg:             cfg,
+		listeners:       listeners.NewListenersContainer(ctx, logger),
+		logger:          logger,
+		operatorPrivKey: cfg.OperatorPrivateKey,
+		privKey:         cfg.NetworkPrivateKey,
+		psSubs:          make(map[string]context.CancelFunc),
+		psTopicsLock:    &sync.RWMutex{},
+		reportLastMsg:   cfg.ReportLastMsg,
+		fork:            cfg.Fork,
+		nodeType:        cfg.NodeType,
 	}
 
 	n.cfg.BootnodesENRs = filterInvalidENRs(n.logger, TransformEnr(n.cfg.Enr))
@@ -126,8 +127,6 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config) (network.Network,
 		return nil, errors.Wrap(err, "failed to start pubsub")
 	}
 	n.pubsub = ps
-
-	go n.listenersContainer.Start()
 
 	if err := n.setupDiscovery(); err != nil {
 		return nil, errors.Wrap(err, "failed to setup discovery")

--- a/network/p2p/p2p_decided.go
+++ b/network/p2p/p2p_decided.go
@@ -38,9 +38,10 @@ func (n *p2pNetwork) BroadcastDecided(topicName []byte, msg *proto.SignedMessage
 
 // ReceivedDecidedChan returns the channel for decided messages
 func (n *p2pNetwork) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func()) {
-	ls := listener{
+	ls := &listener{
 		decidedCh: make(chan *proto.SignedMessage, MsgChanSize),
+		msgType:   network.NetworkMsg_DecidedType,
 	}
 
-	return ls.decidedCh, n.registerListener(ls)
+	return ls.decidedCh, n.listenersContainer.register(ls)
 }

--- a/network/p2p/p2p_decided.go
+++ b/network/p2p/p2p_decided.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -38,10 +39,7 @@ func (n *p2pNetwork) BroadcastDecided(topicName []byte, msg *proto.SignedMessage
 
 // ReceivedDecidedChan returns the channel for decided messages
 func (n *p2pNetwork) ReceivedDecidedChan() (<-chan *proto.SignedMessage, func()) {
-	ls := &listener{
-		decidedCh: make(chan *proto.SignedMessage, MsgChanSize),
-		msgType:   network.NetworkMsg_DecidedType,
-	}
+	ls := listeners.NewListener(network.NetworkMsg_DecidedType)
 
-	return ls.decidedCh, n.listenersContainer.register(ls)
+	return ls.DecidedChan(), n.listeners.Register(ls)
 }

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -30,9 +30,10 @@ func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error
 
 // ReceivedMsgChan return a channel with messages
 func (n *p2pNetwork) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
-	ls := listener{
-		msgCh: make(chan *proto.SignedMessage, MsgChanSize),
+	ls := &listener{
+		msgCh:   make(chan *proto.SignedMessage, MsgChanSize),
+		msgType: network.NetworkMsg_IBFTType,
 	}
 
-	return ls.msgCh, n.registerListener(ls)
+	return ls.msgCh, n.listenersContainer.register(ls)
 }

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -30,10 +31,7 @@ func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error
 
 // ReceivedMsgChan return a channel with messages
 func (n *p2pNetwork) ReceivedMsgChan() (<-chan *proto.SignedMessage, func()) {
-	ls := &listener{
-		msgCh:   make(chan *proto.SignedMessage, MsgChanSize),
-		msgType: network.NetworkMsg_IBFTType,
-	}
+	ls := listeners.NewListener(network.NetworkMsg_IBFTType)
 
-	return ls.msgCh, n.listenersContainer.register(ls)
+	return ls.MsgChan(), n.listeners.Register(ls)
 }

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -27,9 +27,10 @@ func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessa
 
 // ReceivedSignatureChan returns the channel with signatures
 func (n *p2pNetwork) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func()) {
-	ls := listener{
-		sigCh: make(chan *proto.SignedMessage, MsgChanSize),
+	ls := &listener{
+		sigCh:   make(chan *proto.SignedMessage, MsgChanSize),
+		msgType: network.NetworkMsg_SignatureType,
 	}
 
-	return ls.sigCh, n.registerListener(ls)
+	return ls.sigCh, n.listenersContainer.register(ls)
 }

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"github.com/bloxapp/ssv/ibft/proto"
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -27,10 +28,7 @@ func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessa
 
 // ReceivedSignatureChan returns the channel with signatures
 func (n *p2pNetwork) ReceivedSignatureChan() (<-chan *proto.SignedMessage, func()) {
-	ls := &listener{
-		sigCh:   make(chan *proto.SignedMessage, MsgChanSize),
-		msgType: network.NetworkMsg_SignatureType,
-	}
+	ls := listeners.NewListener(network.NetworkMsg_SignatureType)
 
-	return ls.sigCh, n.listenersContainer.register(ls)
+	return ls.SigChan(), n.listeners.Register(ls)
 }

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -77,6 +77,6 @@ func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream network
 		return
 	}
 	cm.SyncMessage.FromPeerID = netSyncStream.RemotePeer()
-	listeners := n.getListeners()
-	go propagateSyncMessage(listeners, cm, netSyncStream)
+	ls := n.listenersContainer.getListeners(network.NetworkMsg_SyncType)
+	go propagateSyncMessage(ls, cm, netSyncStream)
 }

--- a/network/p2p/p2p_stream.go
+++ b/network/p2p/p2p_stream.go
@@ -77,6 +77,6 @@ func (n *p2pNetwork) propagateSyncMsg(cm *network.Message, netSyncStream network
 		return
 	}
 	cm.SyncMessage.FromPeerID = netSyncStream.RemotePeer()
-	ls := n.listenersContainer.getListeners(network.NetworkMsg_SyncType)
+	ls := n.listeners.GetListeners(network.NetworkMsg_SyncType)
 	go propagateSyncMessage(ls, cm, netSyncStream)
 }

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"github.com/bloxapp/ssv/network"
+	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/pkg/errors"
@@ -148,10 +149,7 @@ func (n *p2pNetwork) RespondToLastChangeRoundMsg(stream network.SyncStream, msg 
 
 // ReceivedSyncMsgChan returns the channel for sync messages
 func (n *p2pNetwork) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func()) {
-	ls := &listener{
-		syncCh:  make(chan *network.SyncChanObj, MsgChanSize),
-		msgType: network.NetworkMsg_SyncType,
-	}
+	ls := listeners.NewListener(network.NetworkMsg_SyncType)
 
-	return ls.syncCh, n.listenersContainer.register(ls)
+	return ls.SyncChan(), n.listeners.Register(ls)
 }

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -148,9 +148,10 @@ func (n *p2pNetwork) RespondToLastChangeRoundMsg(stream network.SyncStream, msg 
 
 // ReceivedSyncMsgChan returns the channel for sync messages
 func (n *p2pNetwork) ReceivedSyncMsgChan() (<-chan *network.SyncChanObj, func()) {
-	ls := listener{
-		syncCh: make(chan *network.SyncChanObj, MsgChanSize),
+	ls := &listener{
+		syncCh:  make(chan *network.SyncChanObj, MsgChanSize),
+		msgType: network.NetworkMsg_SyncType,
 	}
 
-	return ls.syncCh, n.registerListener(ls)
+	return ls.syncCh, n.listenersContainer.register(ls)
 }


### PR DESCRIPTION
- extract listeners from p2p package for reuse and cleaning in general
- added container to manage thread-safe listeners registration, de-registration and invocation
- resolved high memory+goroutines in the previous implementation