### PR TITLE
Validator owner address handling

### DIFF
--- a/eth1/goeth/goETH.go
+++ b/eth1/goeth/goETH.go
@@ -256,8 +256,7 @@ func (ec *eth1Client) listenToSubscription(logs chan types.Log, sub ethereum.Sub
 
 // syncSmartContractsEvents sync events history of the given contract
 func (ec *eth1Client) syncSmartContractsEvents(fromBlock *big.Int) error {
-	ec.logger.Debug("syncing smart contract events",
-		zap.Uint64("fromBlock", fromBlock.Uint64()))
+	ec.logger.Debug("syncing smart contract events", zap.Uint64("fromBlock", fromBlock.Uint64()))
 
 	contractAbi, err := abi.JSON(strings.NewReader(ec.contractABI))
 	if err != nil {

--- a/validator/storage/share.go
+++ b/validator/storage/share.go
@@ -25,18 +25,20 @@ func (keys PubKeys) Aggregate() bls.PublicKey {
 
 // Share storage model
 type Share struct {
-	NodeID    uint64
-	PublicKey *bls.PublicKey
-	Committee map[uint64]*proto.Node
-	Metadata  *beacon.ValidatorMetadata // pointer in order to support nil
+	NodeID       uint64
+	PublicKey    *bls.PublicKey
+	Committee    map[uint64]*proto.Node
+	Metadata     *beacon.ValidatorMetadata // pointer in order to support nil
+	OwnerAddress string
 }
 
 //  serializedShare struct
 type serializedShare struct {
-	NodeID    uint64
-	ShareKey  []byte
-	Committee map[uint64]*proto.Node
-	Metadata  *beacon.ValidatorMetadata // pointer in order to support nil
+	NodeID       uint64
+	ShareKey     []byte
+	Committee    map[uint64]*proto.Node
+	Metadata     *beacon.ValidatorMetadata // pointer in order to support nil
+	OwnerAddress string
 }
 
 // CommitteeSize returns the IBFT committee size
@@ -107,9 +109,10 @@ func (s *Share) VerifySignedMessage(msg *proto.SignedMessage) error {
 // Serialize share to []byte
 func (s *Share) Serialize() ([]byte, error) {
 	value := serializedShare{
-		NodeID:    s.NodeID,
-		Committee: map[uint64]*proto.Node{},
-		Metadata:  s.Metadata,
+		NodeID:       s.NodeID,
+		Committee:    map[uint64]*proto.Node{},
+		Metadata:     s.Metadata,
+		OwnerAddress: s.OwnerAddress,
 	}
 	// copy committee by value
 	for k, n := range s.Committee {

--- a/validator/storage/share_opts.go
+++ b/validator/storage/share_opts.go
@@ -9,17 +9,18 @@ import (
 
 // ShareOptions - used to load validator share from config
 type ShareOptions struct {
-	NodeID    uint64         `yaml:"NodeID" env:"NodeID" env-description:"Local share node ID"`
-	PublicKey string         `yaml:"PublicKey" env:"LOCAL_NODE_ID" env-description:"Local validator public key"`
-	ShareKey  string         `yaml:"ShareKey" env:"LOCAL_SHARE_KEY" env-description:"Local share key"`
-	Committee map[string]int `yaml:"Committee" env:"LOCAL_COMMITTEE" env-description:"Local validator committee array"`
+	NodeID       uint64         `yaml:"NodeID" env:"NodeID" env-description:"Local share node ID"`
+	PublicKey    string         `yaml:"PublicKey" env:"LOCAL_NODE_ID" env-description:"Local validator public key"`
+	ShareKey     string         `yaml:"ShareKey" env:"LOCAL_SHARE_KEY" env-description:"Local share key"`
+	Committee    map[string]int `yaml:"Committee" env:"LOCAL_COMMITTEE" env-description:"Local validator committee array"`
+	OwnerAddress string         `yaml:"OwnerAddress" env:"LOCAL_OWNER_ADDRESS" env-description:"Local validator owner address"`
 }
 
 // ToShare creates a Share instance from ShareOptions
 func (options *ShareOptions) ToShare() (*Share, error) {
 	var err error
 
-	if len(options.PublicKey) > 0 && len(options.ShareKey) > 0 && len(options.Committee) > 0 {
+	if len(options.PublicKey) > 0 && len(options.ShareKey) > 0 && len(options.Committee) > 0 && len(options.OwnerAddress) > 0 {
 		validatorPk := &bls.PublicKey{}
 		if err = validatorPk.DeserializeHexStr(options.PublicKey); err != nil {
 			return nil, errors.Wrap(err, "failed to decode validator key")
@@ -45,10 +46,11 @@ func (options *ShareOptions) ToShare() (*Share, error) {
 		}
 
 		share := Share{
-			NodeID:    options.NodeID,
-			Metadata:  nil,
-			PublicKey: validatorPk,
-			Committee: ibftCommittee,
+			NodeID:       options.NodeID,
+			Metadata:     nil,
+			PublicKey:    validatorPk,
+			Committee:    ibftCommittee,
+			OwnerAddress: options.OwnerAddress,
 		}
 		return &share, nil
 	}

--- a/validator/storage/share_opts_test.go
+++ b/validator/storage/share_opts_test.go
@@ -17,6 +17,7 @@ func TestShareOptionsToShare(t *testing.T) {
 		PublicKey: sk.GetPublicKey().SerializeToHexStr(),
 		NodeID:    1,
 		Committee: map[string]int{},
+		OwnerAddress: "0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e",
 	}
 
 	t.Run("valid ShareOptions", func(t *testing.T) {
@@ -28,6 +29,7 @@ func TestShareOptionsToShare(t *testing.T) {
 		require.NotNil(t, share)
 		require.Equal(t, len(share.Committee), 4)
 		require.Equal(t, share.PublicKey.GetHexString(), origShare.PublicKey.GetHexString())
+		require.Equal(t, share.OwnerAddress, origShare.OwnerAddress)
 	})
 
 	t.Run("empty ShareOptions", func(t *testing.T) {

--- a/validator/storage/share_opts_test.go
+++ b/validator/storage/share_opts_test.go
@@ -13,10 +13,10 @@ func TestShareOptionsToShare(t *testing.T) {
 	origShare, sk := generateRandomValidatorShare()
 
 	shareOpts := ShareOptions{
-		ShareKey:  sk.SerializeToHexStr(),
-		PublicKey: sk.GetPublicKey().SerializeToHexStr(),
-		NodeID:    1,
-		Committee: map[string]int{},
+		ShareKey:     sk.SerializeToHexStr(),
+		PublicKey:    sk.GetPublicKey().SerializeToHexStr(),
+		NodeID:       1,
+		Committee:    map[string]int{},
 		OwnerAddress: "0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e",
 	}
 

--- a/validator/storage/storage_test.go
+++ b/validator/storage/storage_test.go
@@ -87,9 +87,9 @@ func generateRandomValidatorShare() (*Share, *bls.SecretKey) {
 	}
 
 	return &Share{
-		NodeID:    1,
-		PublicKey: sk.GetPublicKey(),
-		Committee: ibftCommittee,
+		NodeID:       1,
+		PublicKey:    sk.GetPublicKey(),
+		Committee:    ibftCommittee,
 		OwnerAddress: "0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e",
 	}, &sk
 }

--- a/validator/storage/storage_test.go
+++ b/validator/storage/storage_test.go
@@ -90,5 +90,6 @@ func generateRandomValidatorShare() (*Share, *bls.SecretKey) {
 		NodeID:    1,
 		PublicKey: sk.GetPublicKey(),
 		Committee: ibftCommittee,
+		OwnerAddress: "0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e",
 	}, &sk
 }

--- a/validator/utils.go
+++ b/validator/utils.go
@@ -63,6 +63,7 @@ func ShareFromValidatorAddedEvent(validatorAddedEvent abiparser.ValidatorAddedEv
 	if err := validatorShare.PublicKey.Deserialize(validatorAddedEvent.PublicKey); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to deserialize share public key")
 	}
+	validatorShare.OwnerAddress = validatorAddedEvent.OwnerAddress.String()
 	var shareKey *bls.SecretKey
 
 	ibftCommittee := map[uint64]*proto.Node{}


### PR DESCRIPTION
The purpose of this PR is to handle already exist OwnerAddress field.
in the next ssv-node version`CleanRegistryData` should be enabled by default
https://bloxxx.atlassian.net/browse/BLOXSSV-681