### PR TITLE
Exporter - avoid sending to non-responsive connections

### DIFF
--- a/exporter/api/broadcaster_test.go
+++ b/exporter/api/broadcaster_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"github.com/prysmaticlabs/prysm/async/event"
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,15 @@ import (
 	"testing"
 	"time"
 )
+
+func TestConn_Send_FullQueue(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	c := newConn(context.Background(), logger, nil, "test", 0)
+
+	for i := 0; i < chanSize+2; i++ {
+		c.Send([]byte(fmt.Sprintf("test-%d", i)))
+	}
+}
 
 func TestBroadcaster(t *testing.T) {
 	logger := zaptest.NewLogger(t)

--- a/exporter/api/conn.go
+++ b/exporter/api/conn.go
@@ -92,6 +92,10 @@ func (c *conn) ReadNext() []byte {
 
 // Send sends the given message
 func (c *conn) Send(msg []byte) {
+	if len(c.send) >= chanSize {
+		// don't send on full channel
+		return
+	}
 	c.send <- msg
 }
 


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/484

- Drop messages when the connection does not keep up