### PR TITLE
Entry for Operator PubKey Hash

### DIFF
--- a/network/p2p/discovery_discv5.go
+++ b/network/p2p/discovery_discv5.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers/scorers"
 	"go.uber.org/zap"
@@ -126,7 +125,7 @@ func (n *p2pNetwork) createExtendedLocalNode(ipAddr net.IP) (*enode.LocalNode, e
 	}
 
 	if len(operatorPubKey) > 0 {
-		localNode, err = addOperatorPubKeyEntry(localNode, []byte(pubKeyHash(operatorPubKey)))
+		localNode, err = addOperatorPubKeyHashEntry(localNode, pubKeyHash(operatorPubKey))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create public key entry")
 		}
@@ -253,27 +252,4 @@ func (dvl *dv5Logger) Log(r *log.Record) error {
 	default:
 	}
 	return nil
-}
-
-// addOperatorPubKeyEntry adds public key entry ('pk') to the node.
-// contains the sha256 (hex encoded) of the operator public key
-func addOperatorPubKeyEntry(node *enode.LocalNode, pkHash []byte) (*enode.LocalNode, error) {
-	bitL, err := bitfield.NewBitlist64FromBytes(64, pkHash)
-	if err != nil {
-		return node, err
-	}
-	entry := enr.WithEntry("pk", bitL.ToBitlist())
-	node.Set(entry)
-	return node, nil
-}
-
-// extractOperatorPubKeyEntry extracts the value of public key entry ('pk')
-func extractOperatorPubKeyEntry(record *enr.Record) ([]byte, error) {
-	bitL := bitfield.NewBitlist(64)
-	entry := enr.WithEntry("pk", &bitL)
-	err := record.Load(entry)
-	if err != nil {
-		return nil, err
-	}
-	return bitL.Bytes(), nil
 }

--- a/network/p2p/op_key_entry.go
+++ b/network/p2p/op_key_entry.go
@@ -28,14 +28,15 @@ func extractOperatorPubKeyHashEntry(record *enr.Record) (*PublicKeyHash, error) 
 // PublicKeyHash is the "pkh" key, which holds a public key hash
 type PublicKeyHash string
 
+// ENRKey implements enr.Entry, returns the entry key
 func (pkh PublicKeyHash) ENRKey() string { return "pkh" }
 
-// EncodeRLP implements rlp.Encoder.
+// EncodeRLP implements rlp.Encoder
 func (pkh PublicKeyHash) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []byte(pkh))
 }
 
-// DecodeRLP implements rlp.Decoder.
+// DecodeRLP implements rlp.Decoder
 func (pkh *PublicKeyHash) DecodeRLP(s *rlp.Stream) error {
 	buf, err := s.Bytes()
 	if err != nil {
@@ -44,4 +45,3 @@ func (pkh *PublicKeyHash) DecodeRLP(s *rlp.Stream) error {
 	*pkh = PublicKeyHash(buf)
 	return nil
 }
-

--- a/network/p2p/op_key_entry.go
+++ b/network/p2p/op_key_entry.go
@@ -1,0 +1,47 @@
+package p2p
+
+import (
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/rlp"
+	"io"
+)
+
+// addOperatorPubKeyHashEntry adds operator-public-key-hash entry ('pkh') to the node
+func addOperatorPubKeyHashEntry(node *enode.LocalNode, pkHash string) (*enode.LocalNode, error) {
+	node.Set(PublicKeyHash(pkHash))
+	return node, nil
+}
+
+// extractOperatorPubKeyHashEntry extracts the value of operator-public-key-hash entry ('pkh')
+func extractOperatorPubKeyHashEntry(record *enr.Record) (*PublicKeyHash, error) {
+	pkh := new(PublicKeyHash)
+	if err := record.Load(pkh); err != nil {
+		if enr.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return pkh, nil
+}
+
+// PublicKeyHash is the "pkh" key, which holds a public key hash
+type PublicKeyHash string
+
+func (pkh PublicKeyHash) ENRKey() string { return "pkh" }
+
+// EncodeRLP implements rlp.Encoder.
+func (pkh PublicKeyHash) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []byte(pkh))
+}
+
+// DecodeRLP implements rlp.Decoder.
+func (pkh *PublicKeyHash) DecodeRLP(s *rlp.Stream) error {
+	buf, err := s.Bytes()
+	if err != nil {
+		return err
+	}
+	*pkh = PublicKeyHash(buf)
+	return nil
+}
+

--- a/network/p2p/op_key_entry_test.go
+++ b/network/p2p/op_key_entry_test.go
@@ -38,4 +38,3 @@ func genPublicKey() *bls.PublicKey {
 
 	return sk.GetPublicKey()
 }
-

--- a/network/p2p/op_key_entry_test.go
+++ b/network/p2p/op_key_entry_test.go
@@ -5,13 +5,12 @@ import (
 	"crypto/rand"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 
 	"testing"
 )
 
-func Test_ENR_OperatorPubKeyEntry(t *testing.T) {
+func Test_ENR_OperatorPubKeyHashEntry(t *testing.T) {
 	priv, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
 	require.NoError(t, err)
 	pk := convertFromInterfacePrivKey(priv)
@@ -20,15 +19,16 @@ func Test_ENR_OperatorPubKeyEntry(t *testing.T) {
 	require.NoError(t, err)
 	node, err := createLocalNode(pk, ip, 12000, 13000)
 	require.NoError(t, err)
-	node, err = addOperatorPubKeyEntry(node, []byte(pubKeyHash(pubkey.SerializeToHexStr())))
+
+	pkHash, err := extractOperatorPubKeyHashEntry(node.Node().Record())
+	require.NoError(t, err)
+	require.Nil(t, pkHash)
+	node, err = addOperatorPubKeyHashEntry(node, pubKeyHash(pubkey.SerializeToHexStr()))
 	require.NoError(t, err)
 
-	pkHashRecord, err := extractOperatorPubKeyEntry(node.Node().Record())
+	pkHash, err = extractOperatorPubKeyHashEntry(node.Node().Record())
 	require.NoError(t, err)
-	pkHash := []byte(pubKeyHash(pubkey.SerializeToHexStr()))
-	bitL, err := bitfield.NewBitlist64FromBytes(64, pkHash)
-	require.NoError(t, err)
-	require.True(t, bytes.Equal(pkHashRecord, bitL.ToBitlist().Bytes()))
+	require.True(t, bytes.Equal([]byte(*pkHash), []byte(pubKeyHash(pubkey.SerializeToHexStr()))))
 }
 
 func genPublicKey() *bls.PublicKey {
@@ -38,3 +38,4 @@ func genPublicKey() *bls.PublicKey {
 
 	return sk.GetPublicKey()
 }
+


### PR DESCRIPTION
- Added implementation of the needed interfaces for an ENR entry (`enr.Entry`, `rlp.Decoder` and `rlp.Encoder`)
- Added `pkh` entry to node's ENR
