### PR TITLE
Operators public keys

### DIFF
--- a/validator/storage/share_test.go
+++ b/validator/storage/share_test.go
@@ -57,3 +57,20 @@ func TestThresholdSize(t *testing.T) {
 		})
 	}
 }
+
+func TestShare_HashOperators(t *testing.T) {
+	share := &Share{
+		NodeID:    0,
+		PublicKey: nil,
+		Metadata:  nil,
+		Committee: map[uint64]*proto.Node{},
+		operators: make([][]byte, 4),
+	}
+	for i := uint64(1); i <= 4; i++ {
+		share.Committee[i] = &proto.Node{}
+		share.operators[int(i-1)] = []byte{byte(i)}
+	}
+
+	hashes := share.HashOperators()
+	require.Len(t, hashes, 4)
+}

--- a/validator/utils.go
+++ b/validator/utils.go
@@ -87,6 +87,7 @@ func ShareFromValidatorAddedEvent(validatorAddedEvent abiparser.ValidatorAddedEv
 		}
 	}
 	validatorShare.Committee = ibftCommittee
+	validatorShare.SetOperators(validatorAddedEvent.OperatorPublicKeys)
 
 	return &validatorShare, shareKey, nil
 }

--- a/validator/validators_map.go
+++ b/validator/validators_map.go
@@ -86,6 +86,21 @@ func (vm *validatorsMap) Size() int {
 	return len(vm.validatorsMap)
 }
 
+// IsOperatorInCommittee checks if the given operator exist in some validator's committee (for all validators)
+func (vm *validatorsMap) IsOperatorInCommittee(pkhash string) bool {
+	vm.lock.RLock()
+	defer vm.lock.RUnlock()
+
+	for pk, val := range vm.validatorsMap {
+		if val.IsOperatorInCommittee(pkhash) {
+			vm.logger.Debug("found operator in committee",
+				zap.String("operator pk hash", pkhash), zap.String("validator pk", pk))
+			return true
+		}
+	}
+	return false
+}
+
 func printShare(s *storage.Share, logger *zap.Logger, msg string) {
 	var committee []string
 	for _, c := range s.Committee {


### PR DESCRIPTION
This PR is a preparation for peers limit change (#487)

- added operators-public-keys collection on share
- values are being hashed once per validator instantiation

**NOTE:** `CleanRegistryData` is required (run once) to align old data