### PR TITLE
Clean network logs

### DIFF
--- a/network/p2p/metrics.go
+++ b/network/p2p/metrics.go
@@ -44,13 +44,12 @@ func init() {
 	}
 }
 
-func reportAllConnections(n *p2pNetwork) {
-	conns := n.host.Network().Conns()
+func reportAllPeers(n *p2pNetwork) {
+	pids := n.host.Network().Peers()
 	var ids []string
-	for _, conn := range conns {
-		pid := conn.RemotePeer().String()
-		ids = append(ids, pid)
-		reportPeerIdentity(n, conn.RemotePeer())
+	for _, pid := range pids {
+		ids = append(ids, pid.String())
+		reportPeerIdentity(n, pid)
 	}
 	n.logger.Debug("connected peers status",
 		zap.Int("count", len(ids)))
@@ -66,9 +65,9 @@ func reportTopicPeers(n *p2pNetwork, name string, topic *pubsub.Topic) {
 
 func reportPeerIdentity(n *p2pNetwork, pid peer.ID) {
 	if ua, err := n.peersIndex.getUserAgent(pid); err != nil {
-		n.logger.Warn("could not report peer", zap.String("peer", pid.String()), zap.Error(err))
+		n.trace("WARNING: could not report peer", zap.String("peer", pid.String()), zap.Error(err))
 	} else {
-		n.logger.Debug("peer identity", zap.String("peer", pid.String()), zap.String("ua", string(ua)))
+		n.trace("peer identity", zap.String("peer", pid.String()), zap.String("ua", string(ua)))
 		metricsPeersIdentity.WithLabelValues(ua.OperatorID(), ua.NodeVersion(), pid.String(), ua.NodeType()).Set(1)
 	}
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -177,7 +177,7 @@ func (n *p2pNetwork) watchPeers() {
 	})
 
 	async.RunEvery(n.ctx, 1*time.Minute, func() {
-		go reportAllConnections(n)
+		go reportAllPeers(n)
 
 		// topics peers
 		n.psTopicsLock.RLock()

--- a/network/p2p/peers_index.go
+++ b/network/p2p/peers_index.go
@@ -236,8 +236,10 @@ func (pi *peersIndex) indexNode(node *enode.Node) error {
 		return errors.Wrap(err, "could not store node record in peerstore")
 	}
 	oid, err := extractOperatorIDEntry(node.Record())
+	operatorID := ""
 	if err == nil && oid != nil {
-		if err := pi.host.Peerstore().Put(info.ID, OperatorIDKey, string(*oid)); err != nil {
+		operatorID = string(*oid)
+		if err := pi.host.Peerstore().Put(info.ID, OperatorIDKey, operatorID); err != nil {
 			return errors.Wrap(err, "could not store operator id in peerstore")
 		}
 	}
@@ -248,7 +250,7 @@ func (pi *peersIndex) indexNode(node *enode.Node) error {
 		}
 	}
 	pi.logger.Debug("indexed node", zap.String("nodeType", nodeType.String()),
-		zap.Any("operatorID", *oid),
+		zap.Any("operatorID", operatorID),
 		zap.String("enr", node.String()),
 		zap.String("peerdID", info.ID.String()))
 	return nil


### PR DESCRIPTION
Cleaned some debug logs due to redundancy and overloading.
Some were changed to `trace`, which could be enabled with `NETWORK_TRACE=true`.