### PR TITLE
Exporter: skip setup for validator w/o metadata

### DIFF
--- a/exporter/node.go
+++ b/exporter/node.go
@@ -312,6 +312,10 @@ func (exp *exporter) triggerValidator(validatorPubKey *bls.PublicKey) error {
 func (exp *exporter) setup(validatorShare *validatorstorage.Share) error {
 	pubKey := validatorShare.PublicKey.SerializeToHexStr()
 	logger := exp.logger.With(zap.String("pubKey", pubKey))
+	if !validatorShare.HasMetadata() {
+		logger.Debug("validator w/o metadata,skipped setup")
+		return nil
+	}
 	logger.Debug("setup validator")
 	defer logger.Debug("setup validator done")
 	validator.ReportValidatorStatus(pubKey, validatorShare.Metadata, exp.logger)


### PR DESCRIPTION
Avoid starting a validator w/o metadata, as it won't have any operators subscribed to its topic.

The idea is to reduce the amount of topic announcements for irrelevant topics, as it seems to creates massive amount of goroutines due to retries.