### PR TITLE
Exporter: support multi instances

### DIFF
--- a/cli/exporter/node.go
+++ b/cli/exporter/node.go
@@ -42,6 +42,10 @@ type config struct {
 	IbftSyncEnabled                 bool          `yaml:"IbftSyncEnabled" env:"IBFT_SYNC_ENABLED" env-default:"false" env-description:"enable ibft sync for all topics"`
 	ValidatorMetaDataUpdateInterval time.Duration `yaml:"ValidatorMetaDataUpdateInterval" env:"VALIDATOR_METADATA_UPDATE_INTERVAL" env-default:"12m" env-description:"set the interval at which validator metadata gets updated"`
 	NetworkPrivateKey               string        `yaml:"NetworkPrivateKey" env:"NETWORK_PRIVATE_KEY" env-description:"private key for network identity"`
+
+	// TODO: change this after network refactoring
+	NumOfInstances int `yaml:"NumOfInstances" env:"NUM_OF_INSTANCES" env-default:"1" env-description:"number of existing exporter instances"`
+	InstanceID     int `yaml:"InstanceID" env:"INSTANCE_ID" env-default:"0" env-description:"current instance ID"`
 }
 
 var cfg config
@@ -154,6 +158,8 @@ var StartExporterNodeCmd = &cobra.Command{
 		exporterOptions.CleanRegistryData = cfg.ETH1Options.CleanRegistryData
 		exporterOptions.ValidatorMetaDataUpdateInterval = cfg.ValidatorMetaDataUpdateInterval
 		exporterOptions.UseMainTopic = cfg.P2pNetworkConfig.UseMainTopic
+		exporterOptions.NumOfInstances = cfg.NumOfInstances
+		exporterOptions.InstanceID = cfg.InstanceID
 
 		exporterNode = exporter.New(*exporterOptions)
 

--- a/exporter/node_test.go
+++ b/exporter/node_test.go
@@ -149,15 +149,17 @@ func newMockExporter() (*exporter, error) {
 	ws := api.NewWsServer(context.Background(), logger, nil, nil, false)
 
 	opts := Options{
-		Ctx:        context.Background(),
-		Beacon:     beacon.NewMockBeacon(map[uint64][]*beacon.Duty{}, map[spec.BLSPubKey]*v1.Validator{}),
-		Logger:     logger,
-		ETHNetwork: nil,
-		Eth1Client: nil,
-		Network:    nil,
-		DB:         db,
-		WS:         ws,
-		WsAPIPort:  0,
+		Ctx:            context.Background(),
+		Beacon:         beacon.NewMockBeacon(map[uint64][]*beacon.Duty{}, map[spec.BLSPubKey]*v1.Validator{}),
+		Logger:         logger,
+		ETHNetwork:     nil,
+		Eth1Client:     nil,
+		Network:        nil,
+		DB:             db,
+		WS:             ws,
+		WsAPIPort:      0,
+		NumOfInstances: 1,
+		InstanceID:     0,
 	}
 	e := New(opts)
 	ws.UseQueryHandler(e.(*exporter).handleQueryRequests)


### PR DESCRIPTION
This is a mitigation for scaling issues of the exporter, until we'll refactor networking and move to subnets.

In order to distribute validators across multiple exporter instances, each instance has a unique ID (int) and is aware of the total number of instances, both passed through env.

The way to determine which exporter works on a validator:

`instance = hex(validator_public_key) % num_of_instances`
