### PR TITLE
Pubsub Topics Management

### DIFF
--- a/network/p2p/options.go
+++ b/network/p2p/options.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"fmt"
+	ssv_pubsub "github.com/bloxapp/ssv/network/p2p/pubsub"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/peer"
 	noise "github.com/libp2p/go-libp2p-noise"
@@ -152,7 +153,7 @@ func (n *p2pNetwork) newGossipPubsub(cfg *Config) (*pubsub.PubSub, error) {
 
 	// TODO: change this implementation as part of networking epic
 	if cfg.PubSubTraceOut == "log" {
-		psOpts = append(psOpts, pubsub.WithEventTracer(newTracer(n.logger, psTraceStateWithLogging)))
+		psOpts = append(psOpts, pubsub.WithEventTracer(ssv_pubsub.NewTracer(n.logger, true)))
 	} else if len(cfg.PubSubTraceOut) > 0 {
 		tracer, err := pubsub.NewPBTracer(cfg.PubSubTraceOut)
 		if err != nil {
@@ -162,7 +163,7 @@ func (n *p2pNetwork) newGossipPubsub(cfg *Config) (*pubsub.PubSub, error) {
 		psOpts = append(psOpts, pubsub.WithEventTracer(tracer))
 	} else {
 		// if pubsub trace flag was not set, turn on pubsub tracer with prometheus reporting
-		psOpts = append(psOpts, pubsub.WithEventTracer(newTracer(n.logger, psTraceStateWithReporting)))
+		psOpts = append(psOpts, pubsub.WithEventTracer(ssv_pubsub.NewTracer(n.logger, false)))
 	}
 
 	setGlobalPubSubParameters()

--- a/network/p2p/p2p_ibft.go
+++ b/network/p2p/p2p_ibft.go
@@ -6,10 +6,11 @@ import (
 	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"time"
 )
 
 // Broadcast propagates a signed message to all peers
-func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error {
+func (n *p2pNetwork) Broadcast(pk []byte, msg *proto.SignedMessage) error {
 	msgBytes, err := n.fork.EncodeNetworkMsg(&network.Message{
 		SignedMessage: msg,
 		Type:          network.NetworkMsg_IBFTType,
@@ -18,15 +19,18 @@ func (n *p2pNetwork) Broadcast(topicName []byte, msg *proto.SignedMessage) error
 		return errors.Wrap(err, "failed to marshal message")
 	}
 
-	topic, err := n.getTopic(topicName)
+	topicID := n.fork.ValidatorTopicID(pk)
+	name := getTopicName(topicID)
+
+	peers, err := n.topicManager.Peers(name)
 	if err != nil {
-		return errors.Wrap(err, "failed to get topic")
+		return errors.Wrap(err, "could not check peers")
 	}
+	n.logger.Debug("Broadcasting ibft message", zap.Uint64("seqNum", msg.Message.SeqNumber),
+		zap.String("lambda", string(msg.Message.Lambda)), zap.String("topic", topicID),
+		zap.Any("peers", peers))
 
-	n.logger.Debug("broadcasting ibft msg", zap.Uint64("seqNum", msg.Message.SeqNumber), zap.String("msgType", msg.Message.Type.String()), zap.String("lambda", string(msg.Message.Lambda)),
-		zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
-
-	return topic.Publish(n.ctx, msgBytes)
+	return n.topicManager.Broadcast(name, msgBytes, time.Second*5)
 }
 
 // ReceivedMsgChan return a channel with messages

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -1,129 +1,66 @@
 package p2p
 
 import (
-	"context"
 	"fmt"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/libp2p/go-libp2p-core/peer"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"strings"
-	"sync/atomic"
 )
 
 // SubscribeToValidatorNetwork  for new validator create new topic, subscribe and start listen
 func (n *p2pNetwork) SubscribeToValidatorNetwork(validatorPk *bls.PublicKey) error {
-	n.psTopicsLock.Lock()
-	defer n.psTopicsLock.Unlock()
-
-	pubKey := validatorPk.SerializeToHexStr()
-	logger := n.logger.With(zap.String("who", "SubscribeToValidatorNetwork"), zap.String("pubKey", pubKey))
-
-	if _, ok := n.cfg.Topics[pubKey]; !ok {
-		if err := n.joinTopic(pubKey); err != nil {
-			return errors.Wrap(err, "failed to join to topic")
-		}
-		logger.Debug("joined topic")
-	} else {
-		logger.Debug("known topic")
+	topicID := n.fork.ValidatorTopicID(validatorPk.Serialize())
+	name := getTopicName(topicID)
+	cn, err := n.topicManager.Subscribe(name)
+	if err != nil {
+		return err
 	}
 
-	if _, ok := n.psSubs[pubKey]; !ok {
-		sub, err := n.cfg.Topics[pubKey].Subscribe()
-		if err != nil {
-			if err != pubsub.ErrTopicClosed {
-				return errors.Wrap(err, "failed to subscribe on Topic")
-			}
-			// rejoin a topic in case it was closed, and trying to subscribe again
-			if err := n.joinTopic(pubKey); err != nil {
-				return errors.Wrap(err, "failed to join to topic")
-			}
-			sub, err = n.cfg.Topics[pubKey].Subscribe()
-			if err != nil {
-				return errors.Wrap(err, "failed to subscribe on Topic")
+	go func() {
+		for n.ctx.Err() == nil {
+			select {
+			case msg := <-cn:
+				if msg == nil {
+					continue
+				}
+				n.trace("received raw network msg", zap.ByteString("network.Message bytes", msg.Data))
+				cm, err := n.fork.DecodeNetworkMsg(msg.Data)
+				if err != nil {
+					n.logger.Error("failed to un-marshal message", zap.Error(err))
+					continue
+				}
+				if n.reportLastMsg && len(msg.ReceivedFrom) > 0 {
+					reportLastMsg(msg.ReceivedFrom.String())
+				}
+				n.propagateSignedMsg(cm)
+			default:
+				return
 			}
 		}
-		logger.Debug("subscribed to topic")
-		ctx, cancel := context.WithCancel(n.ctx)
-		n.psSubs[pubKey] = cancel
-		go func() {
-			topicName := sub.Topic()
-			n.listen(ctx, sub)
-			// close topic and mark it as not subscribed
-			n.psTopicsLock.Lock()
-			defer n.psTopicsLock.Unlock()
-			if err := n.closeTopic(topicName); err != nil {
-				n.logger.Error("failed to close topic", zap.String("topic", topicName), zap.Error(err))
-			}
-			// make sure the context is canceled once listen was done from some reason
-			if cancel, ok := n.psSubs[pubKey]; ok {
-				defer cancel()
-				delete(n.psSubs, pubKey)
-			}
-		}()
-	} else {
-		logger.Debug("subscription exist")
-	}
+	}()
 
 	return nil
 }
 
 // AllPeers returns all connected peers for a validator PK (except for the validator itself)
 func (n *p2pNetwork) AllPeers(validatorPk []byte) ([]string, error) {
-	topic, err := n.getTopic(validatorPk)
+	topicID := n.fork.ValidatorTopicID(validatorPk)
+	name := getTopicName(topicID)
+	peers, err := n.topicManager.Peers(name)
 	if err != nil {
 		return nil, err
 	}
-
-	return n.allPeersOfTopic(topic), nil
-}
-
-// joinTopic joins to the given topic and mark it in topics map
-// this method is not thread-safe - should be called after psTopicsLock was acquired
-func (n *p2pNetwork) joinTopic(pubKey string) error {
-	topic, err := n.pubsub.Join(getTopicName(pubKey))
-	if err != nil {
-		return errors.Wrap(err, "failed to join to topic")
-	}
-	n.cfg.Topics[pubKey] = topic
-	return nil
-}
-
-// closeTopic closes the given topic
-func (n *p2pNetwork) closeTopic(topicName string) error {
-	pk := unwrapTopicName(topicName)
-	if t, ok := n.cfg.Topics[pk]; ok {
-		delete(n.cfg.Topics, pk)
-		return t.Close()
-	}
-	return nil
-}
-
-// getTopic return topic by validator public key
-func (n *p2pNetwork) getTopic(validatorPK []byte) (*pubsub.Topic, error) {
-	n.psTopicsLock.RLock()
-	defer n.psTopicsLock.RUnlock()
-
-	if validatorPK == nil {
-		return nil, errors.New("ValidatorPk is nil")
-	}
-	topic := n.fork.ValidatorTopicID(validatorPK)
-	if _, ok := n.cfg.Topics[topic]; !ok {
-		return nil, errors.New("topic is not exist or registered")
-	}
-	return n.cfg.Topics[topic], nil
+	return n.allPeersOfTopic(peers), nil
 }
 
 // AllPeers returns all connected peers for a validator PK (except for the validator itself and public peers like exporter)
-func (n *p2pNetwork) allPeersOfTopic(topic *pubsub.Topic) []string {
+func (n *p2pNetwork) allPeersOfTopic(peers []peer.ID) []string {
 	ret := make([]string, 0)
 
 	skippedPeers := map[string]bool{
 		n.cfg.ExporterPeerID: true,
 	}
-	for _, p := range topic.ListPeers() {
+	for _, p := range peers {
 		nodeType, err := n.peersIndex.getNodeType(p)
 		if err != nil {
 			n.logger.Debug("could not get node type", zap.String("peer", p.String()))
@@ -140,36 +77,6 @@ func (n *p2pNetwork) allPeersOfTopic(topic *pubsub.Topic) []string {
 	return ret
 }
 
-// listen listens on the given subscription
-func (n *p2pNetwork) listen(ctx context.Context, sub *pubsub.Subscription) {
-	t := sub.Topic()
-	defer sub.Cancel()
-	n.logger.Info("start listen to topic", zap.String("topic", t))
-	for {
-		select {
-		case <-ctx.Done():
-			n.logger.Info("context is done, subscription will be cancelled", zap.String("topic", t))
-			return
-		default:
-			msg, err := sub.Next(ctx)
-			if err != nil {
-				n.logger.Error("failed to get message from subscription Topics", zap.Error(err))
-				return
-			}
-			n.trace("received raw network msg", zap.ByteString("network.Message bytes", msg.Data))
-			cm, err := n.fork.DecodeNetworkMsg(msg.Data)
-			if err != nil {
-				n.logger.Error("failed to un-marshal message", zap.Error(err))
-				continue
-			}
-			if n.reportLastMsg && len(msg.ReceivedFrom) > 0 {
-				reportLastMsg(msg.ReceivedFrom.String())
-			}
-			n.propagateSignedMsg(cm)
-		}
-	}
-}
-
 // validateNodeType return if peer nodeType is valid.
 func validateNodeType(nt NodeType) bool {
 	return nt != Exporter
@@ -180,39 +87,7 @@ func getTopicName(pk string) string {
 	return fmt.Sprintf("%s.%s", topicPrefix, pk)
 }
 
-// getTopicName return formatted topic name
-func unwrapTopicName(topicName string) string {
-	return strings.Replace(topicName, fmt.Sprintf("%s.", topicPrefix), "", 1)
-}
-
-// pubsub tracer
-var (
-	psTraceStateWithReporting uint32 = 0
-	psTraceStateWithLogging   uint32 = 1
-)
-
-type psTracer struct {
-	logger *zap.Logger
-	state  uint32
-}
-
-func newTracer(logger *zap.Logger, state uint32) pubsub.EventTracer {
-	return &psTracer{logger: logger.With(zap.String("who", "pubsubTrace")), state: state}
-}
-
-func (pst *psTracer) Trace(evt *ps_pb.TraceEvent) {
-	reportPubsubTrace(evt.GetType().String())
-	if atomic.LoadUint32(&pst.state) < psTraceStateWithLogging {
-		return
-	}
-	pid := ""
-	id, err := peer.IDFromBytes(evt.PeerID)
-	if err != nil {
-		pst.logger.Debug("could not convert peer.ID", zap.Error(err))
-	} else {
-		pid = id.String()
-	}
-	pst.logger.Debug("pubsub event",
-		zap.String("type", evt.GetType().String()),
-		zap.String("peer", pid))
-}
+//// getTopicName return formatted topic name
+//func unwrapTopicName(topicName string) string {
+//	return strings.Replace(topicName, fmt.Sprintf("%s.", topicPrefix), "", 1)
+//}

--- a/network/p2p/p2p_signatures.go
+++ b/network/p2p/p2p_signatures.go
@@ -6,10 +6,11 @@ import (
 	"github.com/bloxapp/ssv/network/commons/listeners"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"time"
 )
 
 // BroadcastSignature broadcasts the given signature for the given lambda
-func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessage) error {
+func (n *p2pNetwork) BroadcastSignature(pk []byte, msg *proto.SignedMessage) error {
 	msgBytes, err := n.fork.EncodeNetworkMsg(&network.Message{
 		SignedMessage: msg,
 		Type:          network.NetworkMsg_SignatureType,
@@ -17,13 +18,19 @@ func (n *p2pNetwork) BroadcastSignature(topicName []byte, msg *proto.SignedMessa
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal message")
 	}
-	topic, err := n.getTopic(topicName)
-	if err != nil {
-		return errors.Wrap(err, "failed to get topic")
-	}
 
-	n.logger.Debug("Broadcasting signature message", zap.String("lambda", string(msg.Message.Lambda)), zap.Any("topic", topic), zap.Any("peers", topic.ListPeers()))
-	return topic.Publish(n.ctx, msgBytes)
+	topicID := n.fork.ValidatorTopicID(pk)
+	name := getTopicName(topicID)
+
+	peers, err := n.topicManager.Peers(name)
+	if err != nil {
+		return errors.Wrap(err, "could not check peers")
+	}
+	n.logger.Debug("Broadcasting signature message", zap.Uint64("seqNum", msg.Message.SeqNumber),
+		zap.String("lambda", string(msg.Message.Lambda)), zap.String("topic", topicID),
+		zap.Any("peers", peers))
+
+	return n.topicManager.Broadcast(name, msgBytes, time.Second*5)
 }
 
 // ReceivedSignatureChan returns the channel with signatures

--- a/network/p2p/pubsub/ps_topic.go
+++ b/network/p2p/pubsub/ps_topic.go
@@ -1,0 +1,100 @@
+package pubsub
+
+import (
+	"context"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"go.uber.org/zap"
+	"sync/atomic"
+)
+
+const (
+	topicStateClosed      = uint32(0)
+	topicStateJoining     = uint32(1)
+	topicStateJoined      = uint32(2)
+	topicStateSubscribing = uint32(3)
+	topicStateSubscribed  = uint32(4)
+)
+
+// psTopic is an internal wrapper for pubsub.Topic
+// it has a reference for the current active subscription,
+// and in addition a state to manage concurrent access to the topic
+type psTopic struct {
+	logger *zap.Logger
+
+	state     uint32
+	topic     *pubsub.Topic
+	sub       *pubsub.Subscription
+	cancelSub context.CancelFunc
+}
+
+// newTopic creates a new instance of psTopic
+func newTopic(logger *zap.Logger) *psTopic {
+	return &psTopic{
+		logger: logger,
+		state:  topicStateClosed,
+	}
+}
+
+// getState returns current state of the topic
+func (ta *psTopic) getState() uint32 {
+	return atomic.LoadUint32(&ta.state)
+}
+
+// setState updates state and returns previous state
+func (ta *psTopic) setState(newState uint32) uint32 {
+	return atomic.SwapUint32(&ta.state, newState)
+}
+
+// join updates state to joined
+func (ta *psTopic) join(topic *pubsub.Topic) {
+	if atomic.CompareAndSwapUint32(&ta.state, topicStateJoining, topicStateJoined) {
+		ta.topic = topic
+	}
+}
+
+// joining set state to topicStateJoining
+func (ta *psTopic) joining() {
+	ta.topic = nil
+	ta.sub = nil
+	ta.cancelSub = nil
+	ta.setState(topicStateJoining)
+}
+
+// subscribing set state to topicStateSubscribing
+func (ta *psTopic) subscribing() {
+	ta.sub = nil
+	ta.cancelSub = nil
+	ta.setState(topicStateSubscribing)
+}
+
+// subscribe updates state to subscribed
+func (ta *psTopic) subscribe(sub *pubsub.Subscription, cancel context.CancelFunc) {
+	if atomic.CompareAndSwapUint32(&ta.state, topicStateSubscribing, topicStateSubscribed) {
+		ta.sub = sub
+		ta.cancelSub = cancel
+	}
+}
+
+// close set state to topicStateClosed
+func (ta *psTopic) close() {
+	if ta.setState(topicStateClosed) != topicStateClosed {
+		if ta.cancelSub != nil {
+			ta.cancelSub()
+		}
+		if ta.sub != nil {
+			ta.sub.Cancel()
+		}
+		if ta.topic != nil {
+			name := ta.topic.String()
+			if err := ta.topic.Close(); err != nil {
+				ta.logger.Warn("could not close topic", zap.String("name", name), zap.Error(err))
+			}
+			ta.topic = nil
+		}
+	}
+}
+
+// canPublish returns whether we can publish on the topic
+func (ta *psTopic) canPublish() bool {
+	return ta.getState() >= topicStateJoined
+}

--- a/network/p2p/pubsub/topic_manager.go
+++ b/network/p2p/pubsub/topic_manager.go
@@ -1,0 +1,198 @@
+package pubsub
+
+import (
+	"context"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"sync"
+	"time"
+)
+
+const (
+	bufSize = 32
+)
+
+var (
+	// ErrInProcess happens when you try to subscribe multiple times concurrently
+	// exported so the caller can decide how to act upon it
+	ErrInProcess = errors.New("in process")
+	// ErrCouldNotJoin is exported so the caller can track reasons of failures when calling Subscribe
+	ErrCouldNotJoin = errors.New("could not join topic")
+	// ErrCouldNotSubscribe is exported so the caller can track reasons of failures when calling Subscribe
+	ErrCouldNotSubscribe = errors.New("could not subscribe topic")
+)
+
+// TopicManager is an interface for managing pubsub topics
+type TopicManager interface {
+	// Subscribe subscribes to the given topic
+	Subscribe(topic string) (<-chan *pubsub.Message, error)
+	// Unsubscribe unsubscribes from the given topic
+	Unsubscribe(topic string) error
+	// Broadcast publishes the message on the given topic
+	Broadcast(topic string, data []byte, timeout time.Duration) error
+}
+
+// topicManager implements
+type topicManager struct {
+	ctx    context.Context
+	logger *zap.Logger
+	ps     *pubsub.PubSub
+	// scoreParams is a function that helps to set scoring params on topics
+	scoreParams func(string) *pubsub.TopicScoreParams
+	// topics holds all the available topics
+	topics *sync.Map
+}
+
+// NewTopicManager creates an instance of TopicManager
+func NewTopicManager(ctx context.Context, logger *zap.Logger, pubSub *pubsub.PubSub, scoreParams func(string) *pubsub.TopicScoreParams) TopicManager {
+	return &topicManager{
+		ctx:         ctx,
+		logger:      logger,
+		ps:          pubSub,
+		scoreParams: scoreParams,
+		topics:      &sync.Map{},
+	}
+}
+
+// Subscribe subscribes to the given topic
+func (tm *topicManager) Subscribe(topicName string) (<-chan *pubsub.Message, error) {
+	return tm.subscribe(topicName)
+}
+
+// Unsubscribe unsubscribes from the given topic
+func (tm *topicManager) Unsubscribe(topicName string) error {
+	topic := tm.getTopic(topicName)
+	if topic == nil {
+		return nil
+	}
+	tm.topics.Delete(topicName)
+	topic.close()
+	return nil
+}
+
+// Broadcast publishes the message on the given topic
+func (tm *topicManager) Broadcast(topicName string, data []byte, timeout time.Duration) error {
+	//topic := tm.fork.ValidatorTopicID(pk)
+	topic, err := tm.joinTopic(topicName)
+	if err != nil {
+		return err
+	}
+	if !topic.canPublish() {
+		return errors.New("can't publish message as topic is not ready")
+	}
+	//data, err := tm.fork.EncodeNetworkMsg(msg)
+	//if err != nil {
+	//	return errors.Wrap(err, "could not encode message")
+	//}
+	ctx, done := context.WithTimeout(tm.ctx, timeout)
+	defer done()
+
+	return topic.topic.Publish(ctx, data)
+}
+
+// getTopic returns the topic wrapper if exist
+func (tm *topicManager) getTopic(name string) *psTopic {
+	t, ok := tm.topics.Load(name)
+	if !ok {
+		return nil
+	}
+	return t.(*psTopic)
+}
+
+// joinTopic joins the given topic and returns the wrapper
+func (tm *topicManager) joinTopic(name string) (*psTopic, error) {
+	topic := tm.getTopic(name)
+	if topic == nil {
+		topic = newTopic(tm.logger)
+	}
+	switch topic.getState() {
+	case topicStateJoining:
+		return topic, ErrInProcess
+	case topicStateClosed:
+		topic.joining()
+		t, err := tm.ps.Join(name)
+		if err != nil {
+			tm.logger.Warn("could not join topic", zap.String("name", name), zap.Error(err))
+			topic.close()
+			return nil, ErrCouldNotJoin
+		}
+		if tm.scoreParams != nil {
+			err = t.SetScoreParams(tm.scoreParams(name))
+			if err != nil {
+				topic.close()
+				return nil, errors.Wrap(err, "could not set score params")
+			}
+		}
+		topic.join(t)
+		tm.topics.Store(name, topic)
+	default:
+	}
+	return topic, nil
+}
+
+// subscribe to the given topic and returns a channel to read the messages from
+func (tm *topicManager) subscribe(name string) (<-chan *pubsub.Message, error) {
+	adapter, err := tm.joinTopic(name)
+	if err != nil {
+		return nil, err
+	}
+	switch adapter.getState() {
+	case topicStateSubscribing:
+		return nil, ErrInProcess
+	case topicStateJoined:
+		adapter.subscribing()
+		sub, err := adapter.topic.Subscribe()
+		if err == pubsub.ErrTopicClosed {
+			// rejoin a topic in case it was closed, and try to subscribe again
+			adapter.close()
+			adapter, err = tm.joinTopic(name)
+			if err != nil {
+				return nil, err
+			}
+			sub, err = adapter.topic.Subscribe()
+			if err != nil {
+				tm.logger.Warn("could not subscribe to topic", zap.String("topic", name), zap.Error(err))
+			}
+		}
+		if sub == nil {
+			adapter.close()
+			return nil, ErrCouldNotSubscribe
+		}
+		in, cancel := tm.listen(sub)
+		adapter.subscribe(sub, cancel)
+		tm.topics.Store(name, adapter)
+		return in, nil
+	default:
+	}
+	return nil, nil
+}
+
+// listen handles incoming messages from the topic
+func (tm *topicManager) listen(sub *pubsub.Subscription) (chan *pubsub.Message, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(tm.ctx)
+	in := make(chan *pubsub.Message, bufSize)
+	go func() {
+		logger := tm.logger.With(zap.String("topic", sub.Topic()))
+		defer close(in)
+		defer sub.Cancel()
+		logger.Info("start listening to topic")
+		for ctx.Err() == nil {
+			msg, err := sub.Next(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					logger.Debug("stop listening to topic: context is done")
+					return
+				}
+				logger.Warn("stop listening to topic: could not read message from subscription", zap.Error(err))
+				return
+			}
+			if msg == nil {
+				logger.Warn("got empty message from subscription")
+				continue
+			}
+			in <- msg
+		}
+	}()
+	return in, cancel
+}

--- a/network/p2p/pubsub/topic_manager_test.go
+++ b/network/p2p/pubsub/topic_manager_test.go
@@ -52,7 +52,7 @@ func TestTopicManager(t *testing.T) {
 	// listen to topics
 	for i := 0; i < nTopics; i++ {
 		for _, p := range peers {
-			go subTopic(p, i, nil)
+			go subTopic(p, i)
 			// simulate concurrency, by trying to subscribe twice
 			<-time.After(time.Millisecond)
 			go subTopic(p, i, ErrInProcess, errTopicAlreadyExists)

--- a/network/p2p/pubsub/topic_manager_test.go
+++ b/network/p2p/pubsub/topic_manager_test.go
@@ -1,0 +1,184 @@
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"github.com/bloxapp/ssv/network/p2p/discovery"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewTopicManager(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nPeers := 4
+	nTopics := 4
+
+	peers := newPeers(ctx, t, nPeers)
+
+	subTopic := func(p *P, i int, potentialErr error) {
+		tname := topicName(i)
+		in, err := p.tm.Subscribe(tname)
+		if potentialErr == nil {
+			require.NoError(t, err)
+		} else if err != nil {
+			require.Equal(t, potentialErr, err)
+		}
+		if in == nil {
+			return
+		}
+		for ctx.Err() == nil {
+			next := <-in
+			p.saveMsg(tname, next)
+		}
+	}
+
+	// listen to topics
+	for i := 0; i < nTopics; i++ {
+		for _, p := range peers {
+			go subTopic(p, i, nil)
+			// simulate concurrency, by trying to subscribe twice
+			<-time.After(time.Millisecond)
+			go subTopic(p, i, ErrInProcess)
+		}
+	}
+
+	// let the peers join topics
+	<-time.After(time.Second * 5)
+
+	// publish some messages
+	for i := 0; i < nTopics; i++ {
+		for _, p := range peers {
+			go func(p *P, i int) {
+				require.NoError(t, p.tm.Broadcast(topicName(i), []byte("dummy message 1"), time.Second*3))
+			}(p, i)
+		}
+	}
+
+	// let the messages propagate
+	<-time.After(time.Second * 5)
+
+	for i := 0; i < nTopics; i++ {
+		for j, p := range peers {
+			c := p.getCount(topicName(i))
+			//t.Logf("peer %d got %d messages for %s", j, c, topicName(i))
+			require.Equal(t, nPeers, c, "peer %d got %d messages for %s", j, c, topicName(i))
+		}
+	}
+
+	// unsubscribe
+	var wg sync.WaitGroup
+	for i := 0; i < nTopics; i++ {
+		for _, p := range peers {
+			wg.Add(1)
+			go func(p *P, i int) {
+				defer wg.Done()
+				require.NoError(t, p.tm.Unsubscribe(topicName(i)))
+			}(p, i)
+		}
+	}
+	wg.Wait()
+}
+
+func topicName(i int) string {
+	return fmt.Sprintf("ssv-test-%d", i)
+}
+
+type P struct {
+	host host.Host
+	ps   *pubsub.PubSub
+	tm   *topicManager
+
+	connsCount uint64
+
+	msgsLock sync.Locker
+	msgs     map[string][]*pubsub.Message
+}
+
+func (p *P) getCount(t string) int {
+	p.msgsLock.Lock()
+	defer p.msgsLock.Unlock()
+
+	msgs, ok := p.msgs[t]
+	if !ok {
+		return 0
+	}
+	return len(msgs)
+}
+
+func (p *P) saveMsg(t string, msg *pubsub.Message) {
+	p.msgsLock.Lock()
+	defer p.msgsLock.Unlock()
+
+	msgs, ok := p.msgs[t]
+	if !ok {
+		msgs = make([]*pubsub.Message, 0)
+	}
+	msgs = append(msgs, msg)
+	p.msgs[t] = msgs
+}
+
+func newPeers(ctx context.Context, t *testing.T, n int) []*P {
+	peers := make([]*P, n)
+	for i := 0; i < n; i++ {
+		peers[i] = newPeer(ctx, t, 256)
+	}
+	t.Logf("%d peers were created", n)
+	for ctx.Err() == nil {
+		done := 0
+		for _, p := range peers {
+			if atomic.LoadUint64(&p.connsCount) > uint64(n/2) {
+				done++
+			}
+		}
+		if done == len(peers) {
+			break
+		}
+	}
+	t.Log("peers are connected")
+	return peers
+}
+
+func newPeer(ctx context.Context, t *testing.T, qSize int) *P {
+	host, err := libp2p.New(ctx,
+		libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
+	require.NoError(t, err)
+	require.NoError(t, discovery.SetupMdnsDiscovery(ctx, zap.L(), host))
+
+	gsParams := pubsub.DefaultGossipSubParams()
+	psOpts := []pubsub.Option{
+		//pubsub.WithMessageIdFn(n.msgId),
+		//pubsub.WithSubscriptionFilter(s),
+		pubsub.WithPeerOutboundQueueSize(qSize),
+		pubsub.WithValidateQueueSize(qSize),
+		pubsub.WithFloodPublish(true),
+		pubsub.WithGossipSubParams(gsParams),
+		pubsub.WithEventTracer(NewTracer(zap.L(), true)),
+	}
+	ps, err := pubsub.NewGossipSub(ctx, host, psOpts...)
+	require.NoError(t, err)
+	tm := NewTopicManager(ctx, zaptest.NewLogger(t), ps, nil)
+
+	p := &P{
+		host:     host,
+		ps:       ps,
+		tm:       tm.(*topicManager),
+		msgs:     make(map[string][]*pubsub.Message),
+		msgsLock: &sync.Mutex{},
+	}
+	host.Network().Notify(&libp2pnetwork.NotifyBundle{
+		ConnectedF: func(network libp2pnetwork.Network, conn libp2pnetwork.Conn) {
+			atomic.AddUint64(&p.connsCount, 1)
+		},
+	})
+	return p
+}

--- a/network/p2p/pubsub/tracer.go
+++ b/network/p2p/pubsub/tracer.go
@@ -1,0 +1,68 @@
+package pubsub
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
+	"sync/atomic"
+)
+
+var (
+	metricsPubsubTrace = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ssv:network:pubsub:trace",
+		Help: "Traces of pubsub messages",
+	}, []string{"type"})
+)
+
+// pubsub tracer states
+const (
+	psTraceStateWithReporting uint32 = 0
+	psTraceStateWithLogging   uint32 = 1
+)
+
+// psTracer helps to trace pubsub events
+// it can run with logging in addition to reporting (on by default)
+type psTracer struct {
+	logger *zap.Logger
+	state  uint32
+}
+
+// NewTracer creates an instance of psTracer
+func NewTracer(logger *zap.Logger, withLogging bool) pubsub.EventTracer {
+	state := psTraceStateWithReporting
+	if withLogging {
+		state = psTraceStateWithLogging
+	}
+	return &psTracer{logger: logger.With(zap.String("who", "pubsubTrace")), state: state}
+}
+
+// Trace handles events, implementation of pubsub.EventTracer
+func (pst *psTracer) Trace(evt *ps_pb.TraceEvent) {
+	pst.report(evt)
+	if atomic.LoadUint32(&pst.state) < psTraceStateWithLogging {
+		return
+	}
+	pst.log(evt)
+}
+
+// report reports metric
+func (pst *psTracer) report(evt *ps_pb.TraceEvent) {
+	metricsPubsubTrace.WithLabelValues(evt.GetType().String()).Inc()
+}
+
+// log prints event to log
+func (pst *psTracer) log(evt *ps_pb.TraceEvent) {
+	pid := "unknown"
+	id, err := peer.IDFromBytes(evt.PeerID)
+	if err != nil {
+		pst.logger.Debug("could not convert peer.ID", zap.Error(err))
+	} else {
+		pid = id.String()
+	}
+	pst.logger.Debug("pubsub event",
+		zap.String("type", evt.GetType().String()),
+		zap.String("peer", pid))
+}


### PR DESCRIPTION
- added `TopicManager` for orchestrating topics, subscriptions and their life cycle
- reduced lock for topics
  - using `sync.Map` instead (our scenario is few writes, multiple reads)
  - added an atomic state to topics