### PR TITLE
Async to Sync processing ETH1 events

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - os/eth1_v2_events
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -68,7 +68,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - stage
+    - os/eth1_v2_events
 
 
 #blox-infra-prod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - os/eth1_v2_events
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -68,7 +68,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - os/eth1_v2_events
+    - stage
 
 
 #blox-infra-prod

--- a/eth1/sync.go
+++ b/eth1/sync.go
@@ -72,8 +72,7 @@ func SyncEth1Events(logger *zap.Logger, client Client, storage SyncOffsetStorage
 			if syncEndedEvent, ok = event.Data.(SyncEndedEvent); ok {
 				return
 			}
-			logger.Debug("got new event from eth1 sync",
-				zap.Uint64("BlockNumber", event.Log.BlockNumber))
+			logger.Debug("got new event from eth1 sync", zap.Uint64("BlockNumber", event.Log.BlockNumber))
 			if handler != nil {
 				queue(*event)
 			}


### PR DESCRIPTION
Resolve https://github.com/bloxapp/ssv/issues/461

Move async to sync processing the ETH1 events
on node startup, all events should be scanned and processed before we can start their instance.