### PR TITLE
allow passing operators to share options

### DIFF
--- a/config/example_share.yaml
+++ b/config/example_share.yaml
@@ -15,3 +15,8 @@ ssv:
           <share-pubkey-node2>: <node2-id>
           <share-pubkey-node3>: <node3-id>
           <share-pubkey-node4>: <node4-id>
+        Operators:
+          - <operator-key-base64>
+          - <operator-key-base64>
+          - <operator-key-base64>
+          - <operator-key-base64>

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,7 +1,7 @@
 #
 # STEP 1: Prepare environment
 #
-FROM golang:1.15 AS preparer
+FROM golang:1.17 AS preparer
 
 RUN apt-get update && apt upgrade -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \

--- a/validator/storage/share.go
+++ b/validator/storage/share.go
@@ -32,7 +32,7 @@ type Share struct {
 	Committee    map[uint64]*proto.Node
 	Metadata     *beacon.ValidatorMetadata // pointer in order to support nil
 	OwnerAddress string
-	operators    [][]byte
+	Operators    [][]byte
 }
 
 //  serializedShare struct
@@ -47,7 +47,7 @@ type serializedShare struct {
 
 // IsOperatorShare checks whether the share belongs to operator
 func (s *Share) IsOperatorShare(operatorPubKey string) bool {
-	for _, op := range s.operators {
+	for _, op := range s.Operators {
 		if string(op) == operatorPubKey {
 			return true
 		}
@@ -127,7 +127,7 @@ func (s *Share) Serialize() ([]byte, error) {
 		Committee:    map[uint64]*proto.Node{},
 		Metadata:     s.Metadata,
 		OwnerAddress: s.OwnerAddress,
-		Operators:    s.operators,
+		Operators:    s.Operators,
 	}
 	// copy committee by value
 	for k, n := range s.Committee {
@@ -168,7 +168,7 @@ func (s *Share) Deserialize(obj basedb.Obj) (*Share, error) {
 		Committee:    value.Committee,
 		Metadata:     value.Metadata,
 		OwnerAddress: value.OwnerAddress,
-		operators:    value.Operators,
+		Operators:    value.Operators,
 	}, nil
 }
 
@@ -182,17 +182,17 @@ func (s *Share) OperatorReady() bool {
 	return s.NodeID != 0
 }
 
-// SetOperators set operators public keys
+// SetOperators set Operators public keys
 func (s *Share) SetOperators(ops [][]byte) {
-	s.operators = make([][]byte, len(ops))
-	copy(s.operators, ops[:])
-	s.operators = ops
+	s.Operators = make([][]byte, len(ops))
+	copy(s.Operators, ops[:])
+	s.Operators = ops
 }
 
-// HashOperators hash all operators keys key
+// HashOperators hash all Operators keys key
 func (s *Share) HashOperators() []string {
-	hashes := make([]string, len(s.operators))
-	for i, o := range s.operators {
+	hashes := make([]string, len(s.Operators))
+	for i, o := range s.Operators {
 		hashes[i] = fmt.Sprintf("%x", sha256.Sum256(o))
 	}
 	return hashes

--- a/validator/storage/share_opts.go
+++ b/validator/storage/share_opts.go
@@ -14,6 +14,7 @@ type ShareOptions struct {
 	ShareKey     string         `yaml:"ShareKey" env:"LOCAL_SHARE_KEY" env-description:"Local share key"`
 	Committee    map[string]int `yaml:"Committee" env:"LOCAL_COMMITTEE" env-description:"Local validator committee array"`
 	OwnerAddress string         `yaml:"OwnerAddress" env:"LOCAL_OWNER_ADDRESS" env-description:"Local validator owner address"`
+	Operators    []string       `yaml:"Operators" env:"LOCAL_OPERATORS" env-description:"Local validator selected operators"`
 }
 
 // ToShare creates a Share instance from ShareOptions
@@ -41,6 +42,11 @@ func (options *ShareOptions) ToShare() (*Share, error) {
 			}
 		}
 
+		var operators [][]byte
+		for _, op := range options.Operators {
+			operators = append(operators, []byte(op))
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -51,6 +57,7 @@ func (options *ShareOptions) ToShare() (*Share, error) {
 			PublicKey:    validatorPk,
 			Committee:    ibftCommittee,
 			OwnerAddress: options.OwnerAddress,
+			Operators:    operators,
 		}
 		return &share, nil
 	}

--- a/validator/storage/share_test.go
+++ b/validator/storage/share_test.go
@@ -64,11 +64,11 @@ func TestShare_HashOperators(t *testing.T) {
 		PublicKey: nil,
 		Metadata:  nil,
 		Committee: map[uint64]*proto.Node{},
-		operators: make([][]byte, 4),
+		Operators: make([][]byte, 4),
 	}
 	for i := uint64(1); i <= 4; i++ {
 		share.Committee[i] = &proto.Node{}
-		share.operators[int(i-1)] = []byte{byte(i)}
+		share.Operators[int(i-1)] = []byte{byte(i)}
 	}
 
 	hashes := share.HashOperators()


### PR DESCRIPTION
After the change of saving all operators needs to check each share if  belong to operator. 
because of this change need to add to local shares the operators field 