### PR TITLE
Dockerfile: force using Go's DNS resolver on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,7 @@ COPY config/* ./config/
 # Expose port for load balancing
 EXPOSE 5678 5000 4000/udp
 
+# Force using Go's DNS resolver because Alpine's DNS resolver (when netdns=cgo) may cause issues.
+ENV GODEBUG="netdns=go"
+
 #ENTRYPOINT ["/go/bin/ssvnode"]


### PR DESCRIPTION
Fixes #450 
Fixes #493 

Force using Go's DNS resolver because Alpine's DNS resolver (when `netdns=cgo`) may cause issues.