### PR TITLE
Exporter re-sync indices

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ Build prod Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
   only:
-    - main
+    - os/exporter_resync_indices
 
 
 Deploy ssv exporter to blox-infra-prod cluster:
@@ -99,7 +99,7 @@ Deploy ssv exporter to blox-infra-prod cluster:
     - mv ./kubectl /usr/bin/kubectl
     - .k8/scripts/deploy-prod-yamls-on-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - main
+    - os/exporter_resync_indices
 
 Deploy ssv-nodes to blox-infra-prod cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ Build prod Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
   only:
-    - os/exporter_resync_indices
+    - main
 
 
 Deploy ssv exporter to blox-infra-prod cluster:
@@ -99,7 +99,7 @@ Deploy ssv exporter to blox-infra-prod cluster:
     - mv ./kubectl /usr/bin/kubectl
     - .k8/scripts/deploy-prod-yamls-on-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - os/exporter_resync_indices
+    - main
 
 Deploy ssv-nodes to blox-infra-prod cluster:
   stage: deploy

--- a/migrations/migration_4_clean_exporter_registry_data.go
+++ b/migrations/migration_4_clean_exporter_registry_data.go
@@ -1,0 +1,18 @@
+package migrations
+
+import (
+	"context"
+	"github.com/pkg/errors"
+)
+
+var migrationCleanExporterRegistryData = Migration{
+	Name: "migration_4_clean_exporter_registry_data",
+	Run: func(ctx context.Context, opt Options, key []byte) error {
+		storage := opt.exporterStorage()
+		err := storage.CleanRegistryData()
+		if err != nil {
+			return errors.Wrap(err, "could not clean registry data")
+		}
+		return opt.Db.Set(migrationsPrefix, key, migrationCompleted)
+	},
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -21,6 +21,7 @@ var (
 		migrationExample2,
 		migrationCleanAllRegistryData,
 		migrationCleanOperatorNodeRegistryData,
+		migrationCleanExporterRegistryData,
 	}
 )
 

--- a/validator/controller.go
+++ b/validator/controller.go
@@ -341,7 +341,6 @@ func (c *controller) handleValidatorAddedEvent(
 	isOperatorShare bool,
 ) (*validatorstorage.Share, error) {
 	pubKey := hex.EncodeToString(validatorAddedEvent.PublicKey)
-	metricsValidatorStatus.WithLabelValues(pubKey).Set(float64(validatorStatusInactive))
 	validatorShare, found, err := c.collection.GetValidatorShare(validatorAddedEvent.PublicKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not check if validator share exist")
@@ -359,6 +358,7 @@ func (c *controller) handleValidatorAddedEvent(
 		if isOperatorShare {
 			logger := c.logger.With(zap.String("pubKey", pubKey))
 			logger.Debug("ValidatorAdded event was handled successfully")
+			metricsValidatorStatus.WithLabelValues(pubKey).Set(float64(validatorStatusInactive))
 		}
 	}
 	return validatorShare, nil


### PR DESCRIPTION
this pr including:
- make the ETH1 history sync to be in synchronic way
- migration to re-sync operators/validators information in exporter
- fix reporting all validator added events to prometheus but only that belongs to operator
