### PR TITLE
Empty validator operators hotfix

### DIFF
--- a/migrations/migration_5_clean_shares.go
+++ b/migrations/migration_5_clean_shares.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"context"
+	"github.com/pkg/errors"
+)
+
+var migrationCleanValidatorRegistryData = Migration{
+	Name: "migration_5_clean_validator_registry_data",
+	Run: func(ctx context.Context, opt Options, key []byte) error {
+		nodeStorage := opt.nodeStorage()
+		err := nodeStorage.CleanRegistryData()
+		if err != nil {
+			return errors.Wrap(err, "could not clean node registry data")
+		}
+
+		validatorStorage := opt.validatorStorage()
+		err = validatorStorage.CleanRegistryData()
+		if err != nil {
+			return errors.Wrap(err, "could not clean validator registry data")
+		}
+		return opt.Db.Set(migrationsPrefix, key, migrationCompleted)
+	},
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -22,6 +22,7 @@ var (
 		migrationCleanAllRegistryData,
 		migrationCleanOperatorNodeRegistryData,
 		migrationCleanExporterRegistryData,
+		migrationCleanValidatorRegistryData,
 	}
 )
 

--- a/validator/controller.go
+++ b/validator/controller.go
@@ -350,7 +350,7 @@ func (c *controller) handleValidatorAddedEvent(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create share")
 		}
-		if err := c.onNewShare(newValShare, shareSecret); err != nil {
+		if err := c.onNewShare(newValShare, shareSecret, isOperatorShare); err != nil {
 			metricsValidatorStatus.WithLabelValues(pubKey).Set(float64(validatorStatusError))
 			return nil, err
 		}
@@ -404,12 +404,14 @@ func (c *controller) onMetadataUpdated(pk string, meta *beacon.ValidatorMetadata
 
 // onNewShare is called when a new validator was added or during registry sync
 // if the validator was persisted already, this function won't be called
-func (c *controller) onNewShare(share *validatorstorage.Share, shareSecret *bls.SecretKey) error {
+func (c *controller) onNewShare(share *validatorstorage.Share, shareSecret *bls.SecretKey, isOperatorShare bool) error {
 	logger := c.logger.With(zap.String("pubKey", share.PublicKey.SerializeToHexStr()))
-	if updated, err := UpdateShareMetadata(share, c.beacon); err != nil {
-		logger.Warn("could not add validator metadata", zap.Error(err))
-	} else if !updated {
-		logger.Warn("could not find validator metadata")
+	if isOperatorShare {
+		if updated, err := UpdateShareMetadata(share, c.beacon); err != nil {
+			logger.Warn("could not add validator metadata", zap.Error(err))
+		} else if !updated {
+			logger.Warn("could not find validator metadata")
+		}
 	}
 
 	// in case this validator belongs to operator, the secret key is not nil


### PR DESCRIPTION
- add migration to clean registry data
- get metadata only for operator shares