### PR TITLE
Peer ID of outgoing sync messages

### DIFF
--- a/ibft/sync/history/fetch_highest.go
+++ b/ibft/sync/history/fetch_highest.go
@@ -101,6 +101,8 @@ func (s *Sync) getHighestDecidedFromPeers(peers []string) []*network.SyncMessage
 					zap.String("identifier", hex.EncodeToString(s.identifier)))
 				return
 			}
+			// save a reference of the peer id
+			res.FromPeerID = peer
 
 			lock.Lock()
 			results = append(results, res)

--- a/utils/rsaencryption/rsa_encryption.go
+++ b/utils/rsaencryption/rsa_encryption.go
@@ -54,11 +54,11 @@ func DecodeKey(sk *rsa.PrivateKey, hashBase64 string) (string, error) {
 // ConvertPemToPrivateKey return rsa private key from secret key
 func ConvertPemToPrivateKey(skPem string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(skPem))
-	enc := x509.IsEncryptedPEMBlock(block)
+	enc := x509.IsEncryptedPEMBlock(block) //nolint
 	b := block.Bytes
 	if enc {
 		var err error
-		b, err = x509.DecryptPEMBlock(block, nil)
+		b, err = x509.DecryptPEMBlock(block, nil) //nolint
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to decrypt private key")
 		}


### PR DESCRIPTION
This PR helps to be prepared for the new network version, where we reduced the `FromPeerID` field and therefore needs to mitigate it in older nodes.

The solution in this case is to save a reference of the sending `peer.ID`, specifically for highest decided requests, which might be complemented with additional requests for sync, and therefore we need the `peer.ID` to know who to call.

**TODO:** fix the lint error which was ignored in this PR