### PR TITLE
Backoff Connector

### DIFF
--- a/automation/qbft/scenarios/on_fork_v1.go
+++ b/automation/qbft/scenarios/on_fork_v1.go
@@ -42,7 +42,7 @@ func (f *onForkV1) NumOfOperators() int {
 }
 
 func (f *onForkV1) NumOfBootnodes() int {
-	return 0
+	return 1
 }
 
 func (f *onForkV1) Name() string {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -9,23 +9,29 @@ import (
 	"github.com/bloxapp/ssv/network/peers"
 	"github.com/bloxapp/ssv/network/streams"
 	"github.com/bloxapp/ssv/network/topics"
+	"github.com/bloxapp/ssv/utils/async"
 	"github.com/bloxapp/ssv/utils/tasks"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	libp2pdisc "github.com/libp2p/go-libp2p-discovery"
-	"github.com/prysmaticlabs/prysm/async"
 	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
+// network states
 const (
 	stateInitializing int32 = 0
 	stateForking      int32 = 1
 	stateClosing      int32 = 1
 	stateClosed       int32 = 2
 	stateReady        int32 = 10
+)
+
+const (
+	peerIndexGCInterval = 15 * time.Minute
+	reportingInterval   = 30 * time.Second
 )
 
 // p2pNetwork implements network.P2PNetwork
@@ -94,7 +100,7 @@ func (n *p2pNetwork) Close() error {
 	return n.host.Close()
 }
 
-// Start starts the required services
+// Start starts the discovery service, garbage collector (peer index), and reporting.
 func (n *p2pNetwork) Start() error {
 	if atomic.SwapInt32(&n.state, stateReady) == stateReady {
 		//return errors.New("could not setup network: in ready state")
@@ -105,11 +111,11 @@ func (n *p2pNetwork) Start() error {
 
 	go n.startDiscovery()
 
-	async.RunEvery(n.ctx, 15*time.Minute, func() {
+	async.Interval(n.ctx, peerIndexGCInterval, func() {
 		n.idx.GC()
 	})
 
-	async.RunEvery(n.ctx, 30*time.Second, func() {
+	async.Interval(n.ctx, reportingInterval, func() {
 		go n.reportAllPeers()
 		n.reportTopics()
 	})
@@ -118,10 +124,10 @@ func (n *p2pNetwork) Start() error {
 }
 
 // startDiscovery starts the required services
-// it will try to bootstrap discovery service, and inject a connect function
-// which will ignore the peer if it is connected or recently failed to connect
+// it will try to bootstrap discovery service, and inject a connect function.
+// the connect function checks if we can connect to the given peer and if so passing it to the backoff connector.
 func (n *p2pNetwork) startDiscovery() {
-	discoveredPeers := make(chan peer.AddrInfo, 128)
+	discoveredPeers := make(chan peer.AddrInfo, connectorQueueSize)
 	go func() {
 		ctx, cancel := context.WithCancel(n.ctx)
 		defer cancel()
@@ -129,17 +135,10 @@ func (n *p2pNetwork) startDiscovery() {
 	}()
 	err := tasks.Retry(func() error {
 		return n.disc.Bootstrap(func(e discovery.PeerEvent) {
-			//ctx, cancel := context.WithTimeout(n.ctx, n.cfg.RequestTimeout)
-			//defer cancel()
 			if !n.idx.CanConnect(e.AddrInfo.ID) {
 				return
 			}
 			discoveredPeers <- e.AddrInfo
-			//if err := n.host.Connect(ctx, e.AddrInfo); err != nil {
-			//	n.logger.Warn("could not connect to peer", zap.Any("peer", e), zap.Error(err))
-			//	return
-			//}
-			//n.logger.Debug("connected peer from discovery", zap.Any("peer", e))
 		})
 	}, 3)
 	if err != nil {

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -11,10 +11,12 @@ import (
 	commons2 "github.com/bloxapp/ssv/utils/commons"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	libp2pdisc "github.com/libp2p/go-libp2p-discovery"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/async"
 	"go.uber.org/zap"
+	"math/rand"
 	"net"
 	"sync/atomic"
 	"time"
@@ -69,6 +71,12 @@ func (n *p2pNetwork) SetupHost() error {
 		return errors.Wrap(err, "failed to create p2p host")
 	}
 	n.host = host
+	backoffFactory := libp2pdisc.NewExponentialDecorrelatedJitter(15*time.Second, 15*time.Minute, 2.0, rand.NewSource(0))
+	backoffConnector, err := libp2pdisc.NewBackoffConnector(host, 512, 15*time.Second, backoffFactory)
+	if err != nil {
+		return errors.Wrap(err, "could not create backoff connector")
+	}
+	n.backoffConnector = backoffConnector
 	return nil
 }
 

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -23,7 +23,20 @@ import (
 )
 
 const (
+	// defaultReqTimeout is the default timeout used for stream requests
 	defaultReqTimeout = 10 * time.Second
+	// backoffLow is when we start the backoff exponent interval
+	backoffLow = 15 * time.Second
+	// backoffLow is when we stop the backoff exponent interval
+	backoffHigh = 15 * time.Minute
+	// backoffExponentBase is the base of the backoff exponent
+	backoffExponentBase = 2.0
+	// backoffConnectorCacheSize is the cache size of the backoff connector
+	backoffConnectorCacheSize = 1024
+	// connectTimeout is the timeout used for connections
+	connectTimeout = 15 * time.Second
+	// connectorQueueSize is the buffer size of the channel used by the connector
+	connectorQueueSize = 256
 )
 
 // Setup is used to setup the network
@@ -60,7 +73,7 @@ func (n *p2pNetwork) initCfg() {
 	}
 }
 
-// SetupHost configures a libp2p host
+// SetupHost configures a libp2p host and backoff connector utility
 func (n *p2pNetwork) SetupHost() error {
 	opts, err := n.cfg.Libp2pOptions(n.fork)
 	if err != nil {
@@ -71,12 +84,14 @@ func (n *p2pNetwork) SetupHost() error {
 		return errors.Wrap(err, "failed to create p2p host")
 	}
 	n.host = host
-	backoffFactory := libp2pdisc.NewExponentialDecorrelatedJitter(15*time.Second, 15*time.Minute, 2.0, rand.NewSource(0))
-	backoffConnector, err := libp2pdisc.NewBackoffConnector(host, 512, 15*time.Second, backoffFactory)
+
+	backoffFactory := libp2pdisc.NewExponentialDecorrelatedJitter(backoffLow, backoffHigh, backoffExponentBase, rand.NewSource(0))
+	backoffConnector, err := libp2pdisc.NewBackoffConnector(host, backoffConnectorCacheSize, connectTimeout, backoffFactory)
 	if err != nil {
 		return errors.Wrap(err, "could not create backoff connector")
 	}
 	n.backoffConnector = backoffConnector
+
 	return nil
 }
 

--- a/utils/async/interval.go
+++ b/utils/async/interval.go
@@ -1,0 +1,23 @@
+package async
+
+import (
+	"context"
+	"time"
+)
+
+// Interval runs the provided function periodically every period
+func Interval(pctx context.Context, interval time.Duration, f func()) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		ctx, cancel := context.WithCancel(pctx)
+		defer cancel()
+		for {
+			select {
+			case <-ticker.C:
+				f()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/utils/async/interval_test.go
+++ b/utils/async/interval_test.go
@@ -1,0 +1,24 @@
+package async
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestInterval(t *testing.T) {
+	i := int32(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	Interval(ctx, time.Millisecond*10, func() {
+		atomic.AddInt32(&i, 1)
+	})
+	require.Equal(t, int32(0), atomic.LoadInt32(&i))
+	<-time.After(time.Millisecond * 25)
+	require.Greater(t, atomic.LoadInt32(&i), int32(1))
+	cancel()
+	val := atomic.LoadInt32(&i)
+	<-time.After(time.Millisecond * 25)
+	require.Equal(t, val, atomic.LoadInt32(&i))
+}


### PR DESCRIPTION
The idea is to avoid backoff errors when trying to connect multiple times to the same peer w/o success

- added backoff connector 
**TODO:** change to [go-libp2p/p2p/discovery/backoff/backoffconnector.go](https://github.com/libp2p/go-libp2p/blob/master/p2p/discovery/backoff/backoffconnector.go) once we update `libp2p`
- added utility for intervals