### PR TITLE
Decided Subnet

### DIFF
--- a/network/forks/fork.go
+++ b/network/forks/fork.go
@@ -29,6 +29,10 @@ type pubSubMapping interface {
 	// DecidedTopic returns the name used for main/decided topic,
 	// or empty string if the fork doesn't include a decided topic
 	DecidedTopic() string
+	// GetTopicFullName returns the topic full name, including prefix
+	GetTopicFullName(baseName string) string
+	// GetTopicBaseName return the base topic name of the topic, w/o ssv prefix
+	GetTopicBaseName(topicName string) string
 }
 
 type pubSubConfig interface {

--- a/network/forks/fork.go
+++ b/network/forks/fork.go
@@ -26,6 +26,9 @@ type nodeRecord interface {
 type pubSubMapping interface {
 	// ValidatorTopicID maps the given validator public key to the corresponding pubsub topic
 	ValidatorTopicID(pk []byte) []string
+	// DecidedTopic returns the name used for main/decided topic,
+	// or empty string if the fork doesn't include a decided topic
+	DecidedTopic() string
 }
 
 type pubSubConfig interface {

--- a/network/forks/v0/pubsub_mapping.go
+++ b/network/forks/v0/pubsub_mapping.go
@@ -2,7 +2,23 @@ package v0
 
 import (
 	"encoding/hex"
+	"fmt"
+	"strings"
 )
+
+const (
+	topicPrefix = "bloxstaking.ssv"
+)
+
+// GetTopicFullName returns the topic full name, including prefix
+func (v0 *ForkV0) GetTopicFullName(baseName string) string {
+	return fmt.Sprintf("%s.%s", topicPrefix, baseName)
+}
+
+// GetTopicBaseName return the base topic name of the topic, w/o ssv prefix
+func (v0 *ForkV0) GetTopicBaseName(topicName string) string {
+	return strings.Replace(topicName, fmt.Sprintf("%s.", topicPrefix), "", 1)
+}
 
 // DecidedTopic implements forks.Fork, for v0 there is no decided topic
 func (v0 *ForkV0) DecidedTopic() string {

--- a/network/forks/v0/pubsub_mapping.go
+++ b/network/forks/v0/pubsub_mapping.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 )
 
+// DecidedTopic implements forks.Fork, for v0 there is no decided topic
 func (v0 *ForkV0) DecidedTopic() string {
 	return ""
 }

--- a/network/forks/v0/pubsub_mapping.go
+++ b/network/forks/v0/pubsub_mapping.go
@@ -4,6 +4,10 @@ import (
 	"encoding/hex"
 )
 
+func (v0 *ForkV0) DecidedTopic() string {
+	return ""
+}
+
 // ValidatorTopicID - genesis version 0
 func (v0 *ForkV0) ValidatorTopicID(pkByts []byte) []string {
 	return []string{hex.EncodeToString(pkByts)}

--- a/network/forks/v1/pubsub_mapping.go
+++ b/network/forks/v1/pubsub_mapping.go
@@ -4,16 +4,29 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 const (
 	// UnknownSubnet is used when a validator public key is invalid
 	UnknownSubnet = "unknown"
 	decidedTopic  = "decided"
+
+	topicPrefix = "ssv.v1"
 )
 
 // SubnetsCount returns the subnet count for v1
 var SubnetsCount uint64 = 128
+
+// GetTopicFullName returns the topic full name, including prefix
+func (v1 *ForkV1) GetTopicFullName(baseName string) string {
+	return fmt.Sprintf("%s.%s", topicPrefix, baseName)
+}
+
+// GetTopicBaseName return the base topic name of the topic, w/o ssv prefix
+func (v1 *ForkV1) GetTopicBaseName(topicName string) string {
+	return strings.Replace(topicName, fmt.Sprintf("%s.", topicPrefix), "", 1)
+}
 
 // DecidedTopic returns decided topic name for v1
 func (v1 *ForkV1) DecidedTopic() string {

--- a/network/forks/v1/pubsub_mapping.go
+++ b/network/forks/v1/pubsub_mapping.go
@@ -9,10 +9,15 @@ import (
 const (
 	// UnknownSubnet is used when a validator public key is invalid
 	UnknownSubnet = "unknown"
+	decidedTopic  = "decided"
 )
 
 // SubnetsCount returns the subnet count for v1
 var SubnetsCount uint64 = 128
+
+func (v1 *ForkV1) DecidedTopic() string {
+	return decidedTopic
+}
 
 // ValidatorTopicID returns the topic to use for the given validator
 func (v1 *ForkV1) ValidatorTopicID(pkByts []byte) []string {

--- a/network/forks/v1/pubsub_mapping.go
+++ b/network/forks/v1/pubsub_mapping.go
@@ -15,6 +15,7 @@ const (
 // SubnetsCount returns the subnet count for v1
 var SubnetsCount uint64 = 128
 
+// DecidedTopic returns decided topic name for v1
 func (v1 *ForkV1) DecidedTopic() string {
 	return decidedTopic
 }

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -49,7 +49,7 @@ func (n *p2pNetwork) Broadcast(msg message.SSVMessage) error {
 	vpk := msg.GetIdentifier().GetValidatorPK()
 	topics := n.fork.ValidatorTopicID(vpk)
 	// for decided message, send on decided channel as well
-	if msg.MsgType == message.SSVDecidedMsgType {
+	if decidedTopic := n.fork.DecidedTopic(); len(decidedTopic) > 0 {
 		topics = append(topics, decidedTopic)
 	}
 	for _, topic := range topics {

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -38,23 +38,26 @@ func (n *p2pNetwork) Peers(pk message.ValidatorPK) ([]peer.ID, error) {
 }
 
 // Broadcast publishes the message to all peers in subnet
-func (n *p2pNetwork) Broadcast(message message.SSVMessage) error {
+func (n *p2pNetwork) Broadcast(msg message.SSVMessage) error {
 	if !n.isReady() {
 		return p2pprotocol.ErrNetworkIsNotReady
 	}
-	raw, err := n.fork.EncodeNetworkMsg(&message)
+	raw, err := n.fork.EncodeNetworkMsg(&msg)
 	if err != nil {
-		return errors.Wrap(err, "could not decode message")
+		return errors.Wrap(err, "could not decode msg")
 	}
-	vpk := message.GetIdentifier().GetValidatorPK()
+	vpk := msg.GetIdentifier().GetValidatorPK()
 	topics := n.fork.ValidatorTopicID(vpk)
-
+	// for decided message, send on decided channel as well
+	if msg.MsgType == message.SSVDecidedMsgType {
+		topics = append(topics, decidedTopic)
+	}
 	for _, topic := range topics {
 		if topic == forksv1.UnknownSubnet {
 			return errors.New("unknown topic")
 		}
 		if err := n.topicsCtrl.Broadcast(topic, raw, n.cfg.RequestTimeout); err != nil {
-			//return errors.Wrap(err, "could not broadcast message")
+			//return errors.Wrap(err, "could not broadcast msg")
 			return err
 		}
 	}

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -224,7 +224,7 @@ func (n *p2pNetwork) setupPubsub() error {
 		// run GC every 3 minutes to clear old messages
 		async.RunEvery(n.ctx, time.Minute*3, midHandler.GC)
 	}
-	_, tc, err := topics.NewPubsub(n.ctx, cfg)
+	_, tc, err := topics.NewPubsub(n.ctx, cfg, n.fork)
 	if err != nil {
 		return errors.Wrap(err, "could not setup pubsub")
 	}

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -151,11 +151,11 @@ func baseTest(ctx context.Context, t *testing.T, peers []*P, pks []string, f for
 				defer wg.Done()
 				for _, p := range peers {
 					// wait for messages
-					for ctxReadMessages.Err() == nil && p.getCount(getTopicName(validatorTopic(pk))) < minMsgCount {
+					for ctxReadMessages.Err() == nil && p.getCount(f.GetTopicFullName(validatorTopic(pk))) < minMsgCount {
 						time.Sleep(time.Millisecond * 100)
 					}
 					require.NoError(t, ctxReadMessages.Err())
-					c := p.getCount(getTopicName(validatorTopic(pk)))
+					c := p.getCount(f.GetTopicFullName(validatorTopic(pk)))
 					require.GreaterOrEqual(t, c, minMsgCount)
 					require.LessOrEqual(t, c, maxMsgCount)
 				}
@@ -283,7 +283,7 @@ func newPeer(ctx context.Context, t *testing.T, msgValidator, msgID bool, fork f
 				fork, h.ID())
 		}
 	}
-	ps, tm, err := NewPubsub(ctx, cfg)
+	ps, tm, err := NewPubsub(ctx, cfg, fork)
 	require.NoError(t, err)
 
 	p = &P{

--- a/network/topics/msg_validator.go
+++ b/network/topics/msg_validator.go
@@ -37,13 +37,13 @@ func NewSSVMsgValidator(plogger *zap.Logger, fork forks.Fork, self peer.ID) func
 		}
 		topics := fork.ValidatorTopicID(msg.GetIdentifier().GetValidatorPK())
 		// wrong topic
-		if getTopicName(topics[0]) != pmsg.GetTopic() {
+		if fork.GetTopicFullName(topics[0]) != pmsg.GetTopic() {
 			// check second topic
 			// TODO: remove after forks
-			if len(topics) == 1 || getTopicName(topics[1]) != pmsg.GetTopic() {
+			if len(topics) == 1 || fork.GetTopicFullName(topics[1]) != pmsg.GetTopic() {
 				logger.Debug("invalid: wrong topic",
 					zap.Strings("actual", topics),
-					zap.String("expected", getTopicBaseName(pmsg.GetTopic())),
+					zap.String("expected", fork.GetTopicBaseName(pmsg.GetTopic())),
 					zap.ByteString("smsg.ID", msg.GetIdentifier()))
 				reportValidationResult(validationResultTopic)
 				return pubsub.ValidationReject

--- a/network/topics/msg_validator_test.go
+++ b/network/topics/msg_validator_test.go
@@ -34,7 +34,7 @@ func TestMsgValidator(t *testing.T) {
 		pk, err := hex.DecodeString(pkHex)
 		require.NoError(t, err)
 		topics := f.ValidatorTopicID(pk)
-		pmsg := newPBMsg(raw, getTopicName(topics[0]), []byte("16Uiu2HAkyWQyCb6reWXGQeBUt9EXArk6h3aq3PsFMwLNq3pPGH1r"))
+		pmsg := newPBMsg(raw, f.GetTopicFullName(topics[0]), []byte("16Uiu2HAkyWQyCb6reWXGQeBUt9EXArk6h3aq3PsFMwLNq3pPGH1r"))
 		res := mv(context.Background(), "16Uiu2HAkyWQyCb6reWXGQeBUt9EXArk6h3aq3PsFMwLNq3pPGH1r", pmsg)
 		require.Equal(t, res, pubsub.ValidationAccept)
 	})

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -2,6 +2,7 @@ package topics
 
 import (
 	"context"
+	"github.com/bloxapp/ssv/network/forks"
 	"github.com/bloxapp/ssv/network/peers"
 	"github.com/libp2p/go-libp2p-core/discovery"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -87,7 +88,7 @@ func (cfg *PububConfig) initScoring() {
 }
 
 // NewPubsub creates a new pubsub router and the necessary components
-func NewPubsub(ctx context.Context, cfg *PububConfig) (*pubsub.PubSub, Controller, error) {
+func NewPubsub(ctx context.Context, cfg *PububConfig, fork forks.Fork) (*pubsub.PubSub, Controller, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, nil, err
 	}
@@ -133,7 +134,7 @@ func NewPubsub(ctx context.Context, cfg *PububConfig) (*pubsub.PubSub, Controlle
 		return nil, nil, err
 	}
 
-	ctrl := NewTopicsController(ctx, cfg.Logger, cfg.MsgHandler, cfg.MsgValidatorFactory, sf, ps, nil)
+	ctrl := NewTopicsController(ctx, cfg.Logger, cfg.MsgHandler, cfg.MsgValidatorFactory, sf, ps, fork, nil)
 
 	return ps, ctrl, nil
 }

--- a/network/topics/topic_container.go
+++ b/network/topics/topic_container.go
@@ -50,9 +50,6 @@ func (tc *topicContainer) Publish(ctx context.Context, data []byte) error {
 	if tc.topic == nil {
 		return ErrTopicNotReady
 	}
-	err := tc.topic.Publish(ctx, data)
-	if err == nil {
-		metricsPubsubOutbound.WithLabelValues(getTopicBaseName(tc.topic.String())).Inc()
-	}
-	return err
+
+	return tc.topic.Publish(ctx, data)
 }


### PR DESCRIPTION
This PR introduce the decided subnet, which is a topic for sending decided messages across the network.

In addition, changing topic prefix (`bloxstaking.ssv`) to be included in fork interface.
For fork v1 we'll use `ssv.v1` prefix, future versions will follow the same format (`ssv.<version>`).

The following changes are included:

- register on decided topic upon network start
- send decided messages on decided subnet