### PR TITLE
Handshake Error: item not found

### DIFF
--- a/network/peers/conn_handler.go
+++ b/network/peers/conn_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/bloxapp/ssv/utils/tasks"
 	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peerstore"
 	"go.uber.org/zap"
 	"time"
 )
@@ -31,7 +32,10 @@ func HandleConnections(ctx context.Context, logger *zap.Logger, handshaker Hands
 			// the handshake might have been triggered by the other node,
 			// therefore the handshake might be pending
 			if err == ErrIndexingInProcess || err == errHandshakeInProcess {
-				//_logger.Debug("peer handshake already in process")
+				return nil
+			}
+			// TODO: removed once handled in handshaker
+			if err == peerstore.ErrNotFound {
 				return nil
 			}
 			_logger.Warn("could not handshake with peer", zap.Error(err))

--- a/network/peers/handshaker.go
+++ b/network/peers/handshaker.go
@@ -223,7 +223,9 @@ func (h *handshaker) nodeInfoFromUserAgent(conn libp2pnetwork.Conn) (*records.No
 	uaRaw, err := h.ids.Host.Peerstore().Get(pid, userAgentKey)
 	if err != nil {
 		if err == peerstore.ErrNotFound {
-			// if user agent wasn't found, retry libp2p identify
+			// if user agent wasn't found, retry libp2p identify after 100ms
+			// TODO: find the root cause of this issue
+			time.Sleep(time.Millisecond * 100)
 			if err := h.preHandshake(conn); err != nil {
 				return nil, err
 			}

--- a/network/peers/handshaker.go
+++ b/network/peers/handshaker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bloxapp/ssv/network/streams"
 	forksprotocol "github.com/bloxapp/ssv/protocol/forks"
 	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -221,7 +222,18 @@ func (h *handshaker) nodeInfoFromUserAgent(conn libp2pnetwork.Conn) (*records.No
 	pid := conn.RemotePeer()
 	uaRaw, err := h.ids.Host.Peerstore().Get(pid, userAgentKey)
 	if err != nil {
-		return nil, err
+		if err == peerstore.ErrNotFound {
+			// if user agent wasn't found, retry libp2p identify
+			if err := h.preHandshake(conn); err != nil {
+				return nil, err
+			}
+			uaRaw, err = h.ids.Host.Peerstore().Get(pid, userAgentKey)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 	ua, ok := uaRaw.(string)
 	if !ok {


### PR DESCRIPTION
As part of this PR we silent redundant handshake errors in logs.
The underlying issue is related to bad exchange of user agent by libp2p's `identify` protocol, will be investigated in a later point in time and for now we try to silent these errors as we see good peer count.

- retry identify protocol if user agent was not found
- ignore handshake warning when user agent is not found
