### PR TITLE
Subnets Discovery

### DIFF
--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -51,6 +51,9 @@ func (dvs *DiscV5Service) subnetFilter(subnets ...uint64) func(node *enode.Node)
 // subnetFilter checks if the node has an interest in the given subnet
 func (dvs *DiscV5Service) sharedSubnetsFilter(n int) func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {
+		if n == 0 {
+			return true
+		}
 		if len(dvs.subnets) == 0 {
 			dvs.logger.Debug("subnets were not configured yet")
 			return true
@@ -60,7 +63,7 @@ func (dvs *DiscV5Service) sharedSubnetsFilter(n int) func(node *enode.Node) bool
 			dvs.logger.Debug("could not read subnets entry")
 			return false
 		}
-		shared := sharedSubnets(dvs.subnets, nodeSubnets, n)
+		shared := records.SharedSubnets(dvs.subnets, nodeSubnets, n)
 		dvs.logger.Debug("shared subnets", zap.Ints("shared", shared))
 
 		return len(shared) >= n

--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -33,12 +33,17 @@ func (dvs *DiscV5Service) badNodeFilter(node *enode.Node) bool {
 }
 
 // subnetFilter checks if the node has an interest in the given subnet
-func (dvs *DiscV5Service) subnetFilter(subnet uint64) func(node *enode.Node) bool {
+func (dvs *DiscV5Service) subnetFilter(subnets ...uint64) func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {
-		subnets, err := records.GetSubnetsEntry(node.Record())
+		fromEntry, err := records.GetSubnetsEntry(node.Record())
 		if err != nil {
 			return false
 		}
-		return subnets[subnet] > 0
+		for _, subnet := range subnets {
+			if fromEntry[subnet] > 0 {
+				return true
+			}
+		}
+		return false
 	}
 }

--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -47,3 +47,22 @@ func (dvs *DiscV5Service) subnetFilter(subnets ...uint64) func(node *enode.Node)
 		return false
 	}
 }
+
+// subnetFilter checks if the node has an interest in the given subnet
+func (dvs *DiscV5Service) sharedSubnetsFilter(n int) func(node *enode.Node) bool {
+	return func(node *enode.Node) bool {
+		if len(dvs.subnets) == 0 {
+			dvs.logger.Debug("subnets were not configured yet")
+			return true
+		}
+		nodeSubnets, err := records.GetSubnetsEntry(node.Record())
+		if err != nil {
+			dvs.logger.Debug("could not read subnets entry")
+			return false
+		}
+		shared := sharedSubnets(dvs.subnets, nodeSubnets, n)
+		dvs.logger.Debug("shared subnets", zap.Ints("shared", shared))
+
+		return len(shared) >= n
+	}
+}

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -277,6 +277,7 @@ func (dvs *DiscV5Service) publishENR() {
 	}
 	defer atomic.StoreInt32(&dvs.publishState, publishStateReady)
 	dvs.discover(ctx, func(e PeerEvent) {
+		metricPublishEnrPings.Inc()
 		err := dvs.dv5Listener.Ping(e.Node)
 		if err != nil {
 			if err.Error() == "RPC timeout" {
@@ -286,7 +287,8 @@ func (dvs *DiscV5Service) publishENR() {
 			dvs.logger.Warn("could not ping node", zap.String("targetNodeENR", e.Node.String()), zap.Error(err))
 			return
 		}
-		dvs.logger.Debug("ping success", zap.String("targetNodeENR", e.Node.String()))
+		metricPublishEnrPongs.Inc()
+		//dvs.logger.Debug("ping success", zap.String("targetNodeENR", e.Node.String()))
 	}, time.Millisecond*100, dvs.badNodeFilter)
 }
 

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -136,16 +136,12 @@ func (dvs *DiscV5Service) Node(info peer.AddrInfo) (*enode.Node, error) {
 // Bootstrap start looking for new nodes
 // note that this function blocks
 func (dvs *DiscV5Service) Bootstrap(handler HandleNewPeer) error {
-	sharedSubnetFilter := dvs.sharedSubnetsFilter(1)
 	dvs.discover(dvs.ctx, func(e PeerEvent) {
-		// exit if we don't have at least 1 shared subnet
-		if !sharedSubnetFilter(e.Node) {
-			metricRejectedNodes.Inc()
-			return
-		}
 		// if we reached peers limit, make sure to accept peers with more than 10% shared subnets
 		if dvs.limitNodeFilter(e.Node) {
-			if !dvs.sharedSubnetsFilter(dvs.fork.Subnets() / 10)(e.Node) {
+			//desired := dvs.fork.Subnets() / 10
+			desired := 5
+			if !dvs.sharedSubnetsFilter(desired)(e.Node) {
 				metricRejectedNodes.Inc()
 				return
 			}

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"github.com/bloxapp/ssv/network/forks"
 	forksfactory "github.com/bloxapp/ssv/network/forks/factory"
 	"github.com/bloxapp/ssv/network/peers"
 	"github.com/bloxapp/ssv/network/records"
@@ -12,15 +13,16 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"net"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	defaultDiscoveryInterval = time.Second
-	//publishENRTimeout        = time.Minute
+	publishENRTimeout        = time.Minute
 
-	publishStateReady = int32(0)
-	//publishStatePending = int32(1)
+	publishStateReady   = int32(0)
+	publishStatePending = int32(1)
 )
 
 // NodeProvider is an interface for managing ENRs
@@ -48,7 +50,9 @@ type DiscV5Service struct {
 
 	publishState int32
 	conn         *net.UDPConn
-	forkv        forksprotocol.ForkVersion
+
+	fork  forks.Fork
+	forkv forksprotocol.ForkVersion
 }
 
 func newDiscV5Service(pctx context.Context, discOpts *Options) (Service, error) {
@@ -60,6 +64,7 @@ func newDiscV5Service(pctx context.Context, discOpts *Options) (Service, error) 
 		publishState: publishStateReady,
 		conns:        discOpts.ConnIndex,
 		forkv:        discOpts.ForkVersion,
+		fork:         forksfactory.NewFork(discOpts.ForkVersion),
 	}
 	dvs.logger.Debug("configuring discv5 discovery", zap.Any("discOpts", discOpts))
 	if err := dvs.initDiscV5Listener(discOpts); err != nil {
@@ -90,14 +95,17 @@ func (dvs *DiscV5Service) Self() *enode.LocalNode {
 }
 
 // UpdateForkVersion updates the fork version used to filter nodes, and also the entry in ENR
-// TODO: uncomment publishENR
 func (dvs *DiscV5Service) UpdateForkVersion(forkv forksprotocol.ForkVersion) error {
+	if dvs.forkv == forkv {
+		return nil
+	}
 	dvs.forkv = forkv
+	dvs.fork = forksfactory.NewFork(forkv)
 	err := records.SetForkVersionEntry(dvs.dv5Listener.LocalNode(), forkv.String())
 	if err != nil {
 		return err
 	}
-	//go dvs.publishENR()
+	go dvs.publishENR()
 	return nil
 }
 
@@ -217,47 +225,48 @@ func (dvs *DiscV5Service) discover(ctx context.Context, handler HandleNewPeer, i
 }
 
 // RegisterSubnets adds the given subnets and publish the updated node record
-func (dvs *DiscV5Service) RegisterSubnets(subnets ...int64) error {
+func (dvs *DiscV5Service) RegisterSubnets(subnets ...int) error {
 	if len(subnets) == 0 {
 		return nil
 	}
-	err := records.UpdateSubnets(dvs.dv5Listener.LocalNode(), 128, subnets, nil)
+	err := records.UpdateSubnets(dvs.dv5Listener.LocalNode(), dvs.fork.Subnets(), subnets, nil)
 	if err != nil {
 		return errors.Wrap(err, "could not update ENR")
 	}
-	//go dvs.publishENR()
+	go dvs.publishENR()
 	return nil
 }
 
 // DeregisterSubnets removes the given subnets and publish the updated node record
-func (dvs *DiscV5Service) DeregisterSubnets(subnets ...int64) error {
+func (dvs *DiscV5Service) DeregisterSubnets(subnets ...int) error {
 	if len(subnets) == 0 {
 		return nil
 	}
-	err := records.UpdateSubnets(dvs.dv5Listener.LocalNode(), 128, nil, subnets)
+	err := records.UpdateSubnets(dvs.dv5Listener.LocalNode(), dvs.fork.Subnets(), nil, subnets)
 	if err != nil {
 		return errors.Wrap(err, "could not update ENR")
 	}
-	//go dvs.publishENR()
+	go dvs.publishENR()
 	return nil
 }
 
-//// publishENR publishes the new ENR across the network
-//func (dvs *DiscV5Service) publishENR() {
-//	ctx, done := context.WithTimeout(dvs.ctx, publishENRTimeout)
-//	defer done()
-//	if !atomic.CompareAndSwapInt32(&dvs.publishState, publishStateReady, publishStatePending) {
-//		// pending
-//		return
-//	}
-//	defer atomic.StoreInt32(&dvs.publishState, publishStateReady)
-//	dvs.discover(ctx, func(e PeerEvent) {
-//		err := dvs.dv5Listener.Ping(e.Node)
-//		if err != nil {
-//			dvs.logger.Warn("could not ping node", zap.String("ENR", e.Node.String()), zap.Error(err))
-//		}
-//	}, time.Millisecond*100, dvs.badNodeFilter)
-//}
+// publishENR publishes the new ENR across the network
+func (dvs *DiscV5Service) publishENR() {
+	ctx, done := context.WithTimeout(dvs.ctx, publishENRTimeout)
+	defer done()
+	if !atomic.CompareAndSwapInt32(&dvs.publishState, publishStateReady, publishStatePending) {
+		// pending
+		dvs.logger.Debug("pending publish ENR")
+		return
+	}
+	defer atomic.StoreInt32(&dvs.publishState, publishStateReady)
+	dvs.discover(ctx, func(e PeerEvent) {
+		err := dvs.dv5Listener.Ping(e.Node)
+		if err != nil {
+			dvs.logger.Warn("could not ping node", zap.String("ENR", e.Node.String()), zap.Error(err))
+		}
+	}, time.Millisecond*100, dvs.badNodeFilter)
+}
 
 func (dvs *DiscV5Service) createLocalNode(discOpts *Options, ipAddr net.IP) (*enode.LocalNode, error) {
 	opts := discOpts.DiscV5Opts

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -138,7 +138,7 @@ func (dvs *DiscV5Service) Node(info peer.AddrInfo) (*enode.Node, error) {
 func (dvs *DiscV5Service) Bootstrap(handler HandleNewPeer) error {
 	dvs.discover(dvs.ctx, func(e PeerEvent) {
 		// if we reached peers limit, make sure to accept peers with more than 10% shared subnets
-		if dvs.limitNodeFilter(e.Node) {
+		if !dvs.limitNodeFilter(e.Node) {
 			//desired := dvs.fork.Subnets() / 10
 			desired := 5
 			if !dvs.sharedSubnetsFilter(desired)(e.Node) {

--- a/network/discovery/local_service.go
+++ b/network/discovery/local_service.go
@@ -91,13 +91,13 @@ func (md *localDiscovery) FindPeers(ctx context.Context, ns string, opt ...disco
 }
 
 // RegisterSubnets implements Service
-func (md *localDiscovery) RegisterSubnets(subnets ...int64) error {
+func (md *localDiscovery) RegisterSubnets(subnets ...int) error {
 	// TODO
 	return nil
 }
 
 // DeregisterSubnets implements Service
-func (md *localDiscovery) DeregisterSubnets(subnets ...int64) error {
+func (md *localDiscovery) DeregisterSubnets(subnets ...int) error {
 	// TODO
 	return nil
 }

--- a/network/discovery/metrics.go
+++ b/network/discovery/metrics.go
@@ -7,6 +7,10 @@ import (
 )
 
 var (
+	metricRejectedNodes = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ssv:network:discovery:rejected",
+		Help: "Counts nodes that were found with discovery but rejected",
+	})
 	metricFoundNodes = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "ssv:network:discovery:found",
 		Help: "Counts nodes that were found with discovery",
@@ -15,6 +19,9 @@ var (
 
 func init() {
 	if err := prometheus.Register(metricFoundNodes); err != nil {
+		log.Println("could not register prometheus collector")
+	}
+	if err := prometheus.Register(metricRejectedNodes); err != nil {
 		log.Println("could not register prometheus collector")
 	}
 }

--- a/network/discovery/metrics.go
+++ b/network/discovery/metrics.go
@@ -15,6 +15,14 @@ var (
 		Name: "ssv:network:discovery:found",
 		Help: "Counts nodes that were found with discovery",
 	})
+	metricPublishEnrPings = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ssv:network:discovery:enr_ping",
+		Help: "Counts the number of ping requests we made as part of ENR publishing",
+	})
+	metricPublishEnrPongs = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ssv:network:discovery:enr_pong",
+		Help: "Counts the number of pong responses we got as part of ENR publishing",
+	})
 )
 
 func init() {
@@ -22,6 +30,12 @@ func init() {
 		log.Println("could not register prometheus collector")
 	}
 	if err := prometheus.Register(metricRejectedNodes); err != nil {
+		log.Println("could not register prometheus collector")
+	}
+	if err := prometheus.Register(metricPublishEnrPings); err != nil {
+		log.Println("could not register prometheus collector")
+	}
+	if err := prometheus.Register(metricPublishEnrPongs); err != nil {
 		log.Println("could not register prometheus collector")
 	}
 }

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -47,8 +47,8 @@ type Options struct {
 type Service interface {
 	discovery.Discovery
 	io.Closer
-	RegisterSubnets(subnets ...int64) error
-	DeregisterSubnets(subnets ...int64) error
+	RegisterSubnets(subnets ...int) error
+	DeregisterSubnets(subnets ...int) error
 	Bootstrap(handler HandleNewPeer) error
 	UpdateForkVersion(forkv forksprotocol.ForkVersion) error
 }

--- a/network/discovery/subnets.go
+++ b/network/discovery/subnets.go
@@ -5,10 +5,26 @@ import (
 	"strconv"
 )
 
-const (
-	// SubnetsCount is the count of subnets in the network
-	SubnetsCount = 128
-)
+// subnetFilter checks if the node has an interest in the given subnet
+func sharedSubnets(a, b []byte, maxLen int) []int {
+	var shared []int
+	if maxLen == 0 {
+		maxLen = len(a)
+	}
+	for subnet, aval := range a {
+		if aval == 0 {
+			continue
+		}
+		if b[subnet] == 0 {
+			continue
+		}
+		shared = append(shared, subnet)
+		if len(shared) == maxLen {
+			break
+		}
+	}
+	return shared
+}
 
 var regPool = format.NewRegexpPool("\\w+:bloxstaking\\.ssv\\.(\\d+)")
 

--- a/network/discovery/subnets.go
+++ b/network/discovery/subnets.go
@@ -5,27 +5,6 @@ import (
 	"strconv"
 )
 
-// subnetFilter checks if the node has an interest in the given subnet
-func sharedSubnets(a, b []byte, maxLen int) []int {
-	var shared []int
-	if maxLen == 0 {
-		maxLen = len(a)
-	}
-	for subnet, aval := range a {
-		if aval == 0 {
-			continue
-		}
-		if b[subnet] == 0 {
-			continue
-		}
-		shared = append(shared, subnet)
-		if len(shared) == maxLen {
-			break
-		}
-	}
-	return shared
-}
-
 var regPool = format.NewRegexpPool("\\w+:bloxstaking\\.ssv\\.(\\d+)")
 
 // nsToSubnet converts the given topic to subnet

--- a/network/discovery/subnets.go
+++ b/network/discovery/subnets.go
@@ -14,7 +14,7 @@ var regPool = format.NewRegexpPool("\\w+:bloxstaking\\.ssv\\.(\\d+)")
 
 // nsToSubnet converts the given topic to subnet
 // TODO: return other value than zero upon failure?
-func nsToSubnet(ns string) int64 {
+func nsToSubnet(ns string) int {
 	r, done := regPool.Get()
 	defer done()
 	found := r.FindStringSubmatch(ns)
@@ -25,7 +25,7 @@ func nsToSubnet(ns string) int64 {
 	if err != nil {
 		return -1
 	}
-	return int64(val)
+	return int(val)
 }
 
 // isSubnet checks if the given string is a subnet string

--- a/network/discovery/subnets_test.go
+++ b/network/discovery/subnets_test.go
@@ -9,31 +9,31 @@ func TestNsToSubnet(t *testing.T) {
 	tests := []struct {
 		name     string
 		ns       string
-		expected int64
+		expected int
 		isSubnet bool
 	}{
 		{
 			"dummy string",
 			"xxx",
-			int64(-1),
+			-1,
 			false,
 		},
 		{
 			"invalid int",
 			"floodsub:bloxstaking.ssv.xxx",
-			int64(-1),
+			-1,
 			false,
 		},
 		{
 			"invalid",
 			"floodsub:ssv.1",
-			int64(-1),
+			-1,
 			false,
 		},
 		{
 			"valid",
 			"floodsub:bloxstaking.ssv.21",
-			int64(21),
+			21,
 			true,
 		},
 	}

--- a/network/forks/fork.go
+++ b/network/forks/fork.go
@@ -33,11 +33,15 @@ type pubSubMapping interface {
 	GetTopicFullName(baseName string) string
 	// GetTopicBaseName return the base topic name of the topic, w/o ssv prefix
 	GetTopicBaseName(topicName string) string
+	// ValidatorSubnet returns the subnet for the given validator
+	ValidatorSubnet(validatorPKHex string) int
 }
 
 type pubSubConfig interface {
 	// MsgID is the msgID function to use for pubsub
 	MsgID() MsgIDFunc
+	// Subnets returns the subnets count for this fork
+	Subnets() int
 }
 
 type libp2pConfig interface {

--- a/network/forks/v0/pubsub_cfg.go
+++ b/network/forks/v0/pubsub_cfg.go
@@ -8,6 +8,6 @@ func (v0 *ForkV0) MsgID() forks.MsgIDFunc {
 }
 
 // Subnets returns the subnets count for this fork
-func (v0 *ForkV0) Subnets() int64 {
+func (v0 *ForkV0) Subnets() int {
 	return 0
 }

--- a/network/forks/v0/pubsub_mapping.go
+++ b/network/forks/v0/pubsub_mapping.go
@@ -25,6 +25,11 @@ func (v0 *ForkV0) DecidedTopic() string {
 	return ""
 }
 
+// ValidatorSubnet implements forks.Fork, for v0 there are no subnets
+func (v0 *ForkV0) ValidatorSubnet(validatorPKHex string) int {
+	return -1
+}
+
 // ValidatorTopicID - genesis version 0
 func (v0 *ForkV0) ValidatorTopicID(pkByts []byte) []string {
 	return []string{hex.EncodeToString(pkByts)}

--- a/network/forks/v1/node_record.go
+++ b/network/forks/v1/node_record.go
@@ -14,7 +14,7 @@ func (f *ForkV1) DecorateNode(node *enode.LocalNode, args map[string]interface{}
 	var subnets []byte
 	raw, ok := args["subnets"]
 	if !ok {
-		subnets = make([]byte, SubnetsCount)
+		subnets = make([]byte, subnetsCount)
 	} else {
 		subnets = raw.([]byte)
 	}

--- a/network/forks/v1/pubsub_cfg.go
+++ b/network/forks/v1/pubsub_cfg.go
@@ -5,6 +5,9 @@ import (
 	scrypto "github.com/bloxapp/ssv/utils/crypto"
 )
 
+// subnetsCount returns the subnet count for v1
+var subnetsCount uint64 = 128
+
 // MsgID returns msg_id for the given message
 func (v1 *ForkV1) MsgID() forks.MsgIDFunc {
 	return func(msg []byte) string {
@@ -18,6 +21,6 @@ func (v1 *ForkV1) MsgID() forks.MsgIDFunc {
 }
 
 // Subnets returns the subnets count for this fork
-func (v1 *ForkV1) Subnets() int64 {
-	return int64(SubnetsCount)
+func (v1 *ForkV1) Subnets() int {
+	return int(subnetsCount)
 }

--- a/network/forks/v1/pubsub_mapping.go
+++ b/network/forks/v1/pubsub_mapping.go
@@ -15,9 +15,6 @@ const (
 	topicPrefix = "ssv.v1.1"
 )
 
-// SubnetsCount returns the subnet count for v1
-var SubnetsCount uint64 = 128
-
 // GetTopicFullName returns the topic full name, including prefix
 func (v1 *ForkV1) GetTopicFullName(baseName string) string {
 	return fmt.Sprintf("%s.%s", topicPrefix, baseName)
@@ -36,26 +33,25 @@ func (v1 *ForkV1) DecidedTopic() string {
 // ValidatorTopicID returns the topic to use for the given validator
 func (v1 *ForkV1) ValidatorTopicID(pkByts []byte) []string {
 	pkHex := hex.EncodeToString(pkByts)
-	subnet := validatorSubnet(pkHex)
+	subnet := v1.ValidatorSubnet(pkHex)
 	return []string{pkHex, topicOf(subnet)}
 }
 
 // topicOf returns the topic for the given subnet
-func topicOf(subnet int64) string {
+func topicOf(subnet int) string {
 	if subnet < 0 {
 		return UnknownSubnet
 	}
 	return fmt.Sprintf("%d", subnet)
 }
 
-// validatorSubnet returns the subnet for the given validator
-// TODO: allow reuse by other components
-func validatorSubnet(validatorPKHex string) int64 {
+// ValidatorSubnet returns the subnet for the given validator
+func (v1 *ForkV1) ValidatorSubnet(validatorPKHex string) int {
 	if len(validatorPKHex) < 10 {
 		return -1
 	}
 	val := hexToUint64(validatorPKHex[:10])
-	return int64(val % SubnetsCount)
+	return int(val % subnetsCount)
 }
 
 func hexToUint64(hexStr string) uint64 {

--- a/network/forks/v2/node_record.go
+++ b/network/forks/v2/node_record.go
@@ -14,7 +14,7 @@ func (f *ForkV2) DecorateNode(node *enode.LocalNode, args map[string]interface{}
 	var subnets []byte
 	raw, ok := args["subnets"]
 	if !ok {
-		subnets = make([]byte, SubnetsCount)
+		subnets = make([]byte, subnetsCount)
 	} else {
 		subnets = raw.([]byte)
 	}

--- a/network/forks/v2/pubsub_cfg.go
+++ b/network/forks/v2/pubsub_cfg.go
@@ -18,6 +18,6 @@ func (v2 *ForkV2) MsgID() forks.MsgIDFunc {
 }
 
 // Subnets returns the subnets count for this fork
-func (v2 *ForkV2) Subnets() int64 {
-	return int64(SubnetsCount)
+func (v2 *ForkV2) Subnets() int {
+	return int(subnetsCount)
 }

--- a/network/forks/v2/pubsub_mapping.go
+++ b/network/forks/v2/pubsub_mapping.go
@@ -15,13 +15,13 @@ const (
 	topicPrefix = "ssv.v1.1"
 )
 
-// SubnetsCount returns the subnet count for v1
-var SubnetsCount uint64 = 128
+// subnetsCount returns the subnet count for v2
+var subnetsCount uint64 = 128
 
 // ValidatorTopicID returns the topic to use for the given validator
 func (v2 *ForkV2) ValidatorTopicID(pkByts []byte) []string {
 	pkHex := hex.EncodeToString(pkByts)
-	subnet := validatorSubnet(pkHex)
+	subnet := v2.ValidatorSubnet(pkHex)
 	return []string{topicOf(subnet)}
 }
 
@@ -41,21 +41,20 @@ func (v2 *ForkV2) DecidedTopic() string {
 }
 
 // topicOf returns the topic for the given subnet
-func topicOf(subnet int64) string {
+func topicOf(subnet int) string {
 	if subnet < 0 {
 		return UnknownSubnet
 	}
 	return fmt.Sprintf("%d", subnet)
 }
 
-// validatorSubnet returns the subnet for the given validator
-// TODO: allow reuse by other components
-func validatorSubnet(validatorPKHex string) int64 {
+// ValidatorSubnet returns the subnet for the given validator
+func (v2 *ForkV2) ValidatorSubnet(validatorPKHex string) int {
 	if len(validatorPKHex) < 10 {
 		return -1
 	}
 	val := hexToUint64(validatorPKHex[:10])
-	return int64(val % SubnetsCount)
+	return int(val % subnetsCount)
 }
 
 func hexToUint64(hexStr string) uint64 {

--- a/network/network.go
+++ b/network/network.go
@@ -27,4 +27,6 @@ type P2PNetwork interface {
 	Setup() error
 	// Start starts the network
 	Start() error
+	// UpdateSubnets will update the registered subnets according to active validators
+	UpdateSubnets()
 }

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/bloxapp/ssv/network/forks"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
-	"strconv"
 	"strings"
 	"time"
 
@@ -164,24 +163,4 @@ func userAgent(fromCfg string) string {
 		return fromCfg
 	}
 	return uc.GetBuildData()
-}
-
-// parseSubnets parses a given subnet string
-func parseSubnets(subnetsStr string) ([]byte, error) {
-	var res []byte
-	for i := 0; i < len(subnetsStr); i++ {
-		val, err := strconv.ParseUint(string(subnetsStr[i]), 16, 8)
-		if err != nil {
-			return nil, err
-		}
-		mask := fmt.Sprintf("%04b", val)
-		for j := 0; j < len(mask); j++ {
-			val, err := strconv.ParseUint(string(mask[j]), 2, 8)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, uint8(val))
-		}
-	}
-	return res, nil
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -218,5 +218,5 @@ func (n *p2pNetwork) UpdateSubnets() {
 	if err != nil {
 		n.logger.Warn("could not register subnets", zap.Error(err))
 	}
-	n.logger.Debug("updated subnets")
+	n.logger.Debug("updated subnets", zap.Any("subnets", n.subnets))
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bloxapp/ssv/network/forks"
 	forksfactory "github.com/bloxapp/ssv/network/forks/factory"
 	"github.com/bloxapp/ssv/network/peers"
+	"github.com/bloxapp/ssv/network/records"
 	"github.com/bloxapp/ssv/network/streams"
 	"github.com/bloxapp/ssv/network/topics"
 	"github.com/bloxapp/ssv/utils/async"
@@ -219,4 +220,8 @@ func (n *p2pNetwork) UpdateSubnets() {
 		n.logger.Warn("could not register subnets", zap.Error(err))
 	}
 	n.logger.Debug("updated subnets", zap.Any("subnets", n.subnets))
+
+	self := n.idx.Self()
+	self.Metadata.Subnets = records.Subnets(n.subnets).String()
+	n.idx.UpdateSelfRecord(self)
 }

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -106,7 +106,6 @@ func (n *p2pNetwork) Unsubscribe(pk message.ValidatorPK) error {
 			return errors.New("unknown topic")
 		}
 		if err := n.topicsCtrl.Unsubscribe(topic, false); err != nil {
-			//return errors.Wrap(err, "could not broadcast message")
 			return err
 		}
 	}

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -140,6 +140,7 @@ func (n *p2pNetwork) setupPeerServices() error {
 	self.Metadata = &records.NodeMetadata{
 		OperatorID:  n.cfg.OperatorID,
 		NodeVersion: commons2.GetNodeVersion(),
+		Subnets:     records.Subnets(n.subnets).String(),
 	}
 	n.idx = peers.NewPeersIndex(n.logger, n.host.Network(), self, func() int {
 		return n.cfg.MaxPeers

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -159,9 +159,12 @@ func (n *p2pNetwork) setupPeerServices() error {
 	if n.cfg.ForkVersion != forksprotocol.V0ForkVersion {
 		filters = append(filters, peers.ForkVersionFilter(func() forksprotocol.ForkVersion {
 			return n.cfg.ForkVersion
-		}), peers.NetworkIDFilter(n.cfg.NetworkID))
+		}))
 	}
-	handshaker := peers.NewHandshaker(n.ctx, n.logger, n.streamCtrl, n.idx, n.idx, ids, filters...)
+	filters = append(filters, peers.NetworkIDFilter(n.cfg.NetworkID))
+	handshaker := peers.NewHandshaker(n.ctx, n.logger, n.streamCtrl, n.idx, n.idx, ids, func() records.Subnets {
+		return n.subnets
+	}, filters...)
 	n.host.SetStreamHandler(peers.NodeInfoProtocol, handshaker.Handler())
 	n.logger.Debug("handshaker is ready")
 

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -77,7 +77,8 @@ func (n *p2pNetwork) initCfg() {
 		n.cfg.UserAgent = userAgent(n.cfg.UserAgent)
 	}
 	if len(n.cfg.Subnets) > 0 {
-		subnets, err := parseSubnets(strings.Replace(n.cfg.Subnets, "0x", "", 1))
+		s := make(records.Subnets, 0)
+		subnets, err := s.FromString(strings.Replace(n.cfg.Subnets, "0x", "", 1))
 		if err != nil {
 			// TODO: handle
 			return

--- a/network/peers/handshaker.go
+++ b/network/peers/handshaker.go
@@ -122,7 +122,7 @@ func (h *handshaker) Handler() libp2pnetwork.StreamHandler {
 				h.logger.Warn("reached peers limit", zap.Error(err))
 				return
 			}
-		}/* else if ok, _ := SharedSubnetsFilter(h.subnetsProvider, 1)(ni); !ok {
+		} /* else if ok, _ := SharedSubnetsFilter(h.subnetsProvider, 1)(ni); !ok {
 			return errors.New("ignoring peer w/o shared subnets")
 		}*/
 		self, err := h.infoStore.SelfSealed()
@@ -207,7 +207,7 @@ func (h *handshaker) Handshake(conn libp2pnetwork.Conn) error {
 		if !ok {
 			return errors.New("reached peers limit")
 		}
-	}/* else if ok, _ := SharedSubnetsFilter(h.subnetsProvider, 1)(ni); !ok {
+	} /* else if ok, _ := SharedSubnetsFilter(h.subnetsProvider, 1)(ni); !ok {
 		return errors.New("ignoring peer w/o shared subnets")
 	}*/
 

--- a/network/peers/handshaker.go
+++ b/network/peers/handshaker.go
@@ -146,6 +146,7 @@ func (h *handshaker) Handshake(conn libp2pnetwork.Conn) error {
 	}
 	defer h.pending.Delete(pid.String())
 	// first, check that we didn't reach peers limit
+	// TODO: resolve
 	if h.connIdx.Limit(conn.Stat().Direction) {
 		return errors.New("reached peers limit")
 	}

--- a/network/peers/peers_index.go
+++ b/network/peers/peers_index.go
@@ -64,7 +64,7 @@ func (pi *peersIndex) IsBad(id peer.ID) bool {
 	threshold := -10000.0
 	scores, err := pi.GetScore(id, "")
 	if err != nil {
-		logger.Warn("could not read score", zap.Error(err))
+		//logger.Debug("could not read score", zap.Error(err))
 		return false
 	}
 	for _, score := range scores {

--- a/network/records/metadata.go
+++ b/network/records/metadata.go
@@ -14,6 +14,8 @@ type NodeMetadata struct {
 	ExecutionNode string
 	// ConsensusNode is the "name/version" of the beacon node
 	ConsensusNode string
+	// Subnets represents the subnets that our node is subscribed to
+	Subnets string
 }
 
 // Encode encodes the metadata into bytes

--- a/network/records/node_info.go
+++ b/network/records/node_info.go
@@ -22,8 +22,6 @@ type NodeInfo struct {
 	NetworkID string
 	// Metadata holds node's general information
 	Metadata *NodeMetadata
-
-	// TODO: add fields, e.g. subnets
 }
 
 // NewNodeInfo creates a new node info

--- a/network/records/subnets.go
+++ b/network/records/subnets.go
@@ -100,6 +100,27 @@ func (s Subnets) FromString(subnetsStr string) (Subnets, error) {
 	return data, nil
 }
 
+// SharedSubnets returns the shared subnets
+func SharedSubnets(a, b []byte, maxLen int) []int {
+	var shared []int
+	if maxLen == 0 {
+		maxLen = len(a)
+	}
+	for subnet, aval := range a {
+		if aval == 0 {
+			continue
+		}
+		if b[subnet] == 0 {
+			continue
+		}
+		shared = append(shared, subnet)
+		if len(shared) == maxLen {
+			break
+		}
+	}
+	return shared
+}
+
 func getCharMask(str string) ([]byte, error) {
 	val, err := strconv.ParseUint(str, 16, 8)
 	if err != nil {

--- a/network/records/subnets.go
+++ b/network/records/subnets.go
@@ -106,6 +106,9 @@ func SharedSubnets(a, b []byte, maxLen int) []int {
 	if maxLen == 0 {
 		maxLen = len(a)
 	}
+	if len(a) == 0 || len(b) == 0 {
+		return shared
+	}
 	for subnet, aval := range a {
 		if aval == 0 {
 			continue

--- a/network/records/subnets.go
+++ b/network/records/subnets.go
@@ -10,7 +10,7 @@ import (
 
 // UpdateSubnets updates subnets entry according to the given changes.
 // count is the amount of subnets, in case that the entry doesn't exist as we want to initialize it
-func UpdateSubnets(node *enode.LocalNode, count int, added []int64, removed []int64) error {
+func UpdateSubnets(node *enode.LocalNode, count int, added []int, removed []int) error {
 	subnets, err := GetSubnetsEntry(node.Node().Record())
 	if err != nil {
 		return errors.Wrap(err, "could not read subnets entry from enr")

--- a/network/records/subnets_test.go
+++ b/network/records/subnets_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bloxapp/ssv/network/commons"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +39,42 @@ func Test_SubnetsEntry(t *testing.T) {
 		} else {
 			require.Equal(t, byte(0), subnetsFromEnr[i])
 		}
+	}
+}
+
+func TestSubnetsParsing(t *testing.T) {
+	subtests := []struct {
+		name        string
+		str         string
+		shouldError bool
+	}{
+		{
+			"all subnets",
+			"0xffffffffffffffffffffffffffffffff",
+			//"0x11111111111111111111111111111111",
+			false,
+		},
+		{
+			"partial subnets",
+			"0x57b080fffd743d9878dc41a184ab160a",
+			false,
+		},
+		{
+			"invalid",
+			"xxx",
+			true,
+		},
+	}
+
+	for _, subtest := range subtests {
+		t.Run(subtest.name, func(t *testing.T) {
+			s, err := Subnets{}.FromString(subtest.str)
+			if subtest.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, strings.Replace(subtest.str, "0x", "", 1), s.String())
+			}
+		})
 	}
 }

--- a/operator/node.go
+++ b/operator/node.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -134,6 +133,7 @@ func (n *operatorNode) Start() error {
 
 	n.validatorsCtrl.StartValidators()
 	n.validatorsCtrl.StartNetworkHandlers()
+	go n.net.UpdateSubnets()
 	go n.validatorsCtrl.UpdateValidatorMetaDataLoop()
 	go n.listenForCurrentSlot()
 	n.dutyCtrl.Start()

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -331,18 +331,6 @@ func (c *controller) StartValidators() {
 		return
 	}
 	c.setupValidators(shares)
-	//// inject handler for finding relevant operators
-	//p2p.UseLookupOperatorHandler(c.network, func(oid string) bool {
-	//	_, ok := c.operatorsIDs.Load(oid)
-	//	return ok
-	//})
-	// print current relevant operators (ids)
-	ids := []string{}
-	c.operatorsIDs.Range(func(key, value interface{}) bool {
-		ids = append(ids, key.(string))
-		return true
-	})
-	c.logger.Debug("relevant operators", zap.Int("len", len(ids)), zap.Strings("op_ids", ids))
 }
 
 // setupValidators setup and starts validators from the given shares


### PR DESCRIPTION
This PR enables nodes to discover peers based on their subscribed subnets.

- network forks: api to get subnets count and validator subnet
- update subscribed subnets entry (ENR) upon start
  - TODO: update entry dynamically / expose discovery interface to be used by pubsub for that purpose
- publish ENR upon subnets change (using pings)
- added discovery metrics
- discover loop: check shared subnets if peers limit reached
- subnets cold start: loaded subnets upon start to ensure we post a (somewhat) updated ENR