### PR TITLE
P2P Fixes and Logs

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -131,7 +131,6 @@ func (dvs *DiscV5Service) Node(info peer.AddrInfo) (*enode.Node, error) {
 		nodes = dvs.dv5Listener.Lookup(id)
 		node = findNode(nodes, id)
 	}
-	logger.Debug("managed to find node")
 	return node, nil
 }
 

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -60,7 +60,10 @@ type Config struct {
 	// ForkVersion to use
 	ForkVersion forksprotocol.ForkVersion
 	// Logger to used by network services
-	Logger *zap.Logger
+	Logger                    *zap.Logger
+	PubsubOutQueueSize        int `yaml:"PubsubOutQueueSize" env:"PUBSUB_OUT_Q_SIZE" env-description:"The size that we assign to the outbound pubsub message queue"`
+	PubsubValidationQueueSize int `yaml:"PubsubValidationQueueSize" env:"PUBSUB_VAL_Q_SIZE" env-description:"The size that we assign to the pubsub validation queue"`
+	PubsubValidateThrottle    int `yaml:"PubsubPubsubValidateThrottle" env:"PUBSUB_VAL_THROTTLE" env-description:"The amount of goroutines used for pubsub msg validation"`
 }
 
 // Libp2pOptions creates options list for the libp2p host

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -60,7 +60,8 @@ type Config struct {
 	// ForkVersion to use
 	ForkVersion forksprotocol.ForkVersion
 	// Logger to used by network services
-	Logger                    *zap.Logger
+	Logger *zap.Logger
+
 	PubsubOutQueueSize        int `yaml:"PubsubOutQueueSize" env:"PUBSUB_OUT_Q_SIZE" env-description:"The size that we assign to the outbound pubsub message queue"`
 	PubsubValidationQueueSize int `yaml:"PubsubValidationQueueSize" env:"PUBSUB_VAL_Q_SIZE" env-description:"The size that we assign to the pubsub validation queue"`
 	PubsubValidateThrottle    int `yaml:"PubsubPubsubValidateThrottle" env:"PUBSUB_VAL_THROTTLE" env-description:"The amount of goroutines used for pubsub msg validation"`

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 	RequestTimeout   time.Duration `yaml:"RequestTimeout" env:"P2P_REQUEST_TIMEOUT"  env-default:"5s"`
 	MaxBatchResponse uint64        `yaml:"MaxBatchResponse" env:"P2P_MAX_BATCH_RESPONSE" env-default:"25" env-description:"Maximum number of returned objects in a batch"`
-	MaxPeers         int           `yaml:"MaxPeers" env:"P2P_MAX_PEERS" env-default:"50" env-description:"Connected peers limit for connections"`
+	MaxPeers         int           `yaml:"MaxPeers" env:"P2P_MAX_PEERS" env-default:"70" env-description:"Connected peers limit for connections"`
 	TopicMaxPeers    int           `yaml:"TopicMaxPeers" env:"P2P_TOPIC_MAX_PEERS" env-default:"5" env-description:"Connected peers limit per pubsub topic"`
 
 	// Subnets is a static bit list of subnets that this node will register upon start.

--- a/network/p2p/metrics.go
+++ b/network/p2p/metrics.go
@@ -60,12 +60,6 @@ func (n *p2pNetwork) reportAllPeers() {
 	MetricsAllConnectedPeers.Set(float64(len(ids)))
 }
 
-func (n *p2pNetwork) reportSubnetsStats() {
-	stats := n.idx.GetSubnetsStats()
-	n.logger.Debug("network subnets",
-		zap.Any("stats", stats))
-}
-
 func (n *p2pNetwork) reportTopics() {
 	topics := n.topicsCtrl.Topics()
 	nTopics := len(topics)

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -124,32 +124,13 @@ func (n *p2pNetwork) Start() error {
 
 	go n.startDiscovery()
 
-	async.Interval(n.ctx, connManagerGCInterval, func() {
-		allPeers := n.host.Network().Peers()
-		currentCount := len(allPeers)
-		if currentCount < n.cfg.MaxPeers {
-			return
-		}
-		ctx, cancel := context.WithTimeout(n.ctx, connManagerGCTimeout)
-		defer cancel()
+	async.Interval(n.ctx, connManagerGCInterval, n.peersBalancing)
 
-		connMgr := peers.NewConnManager(n.logger, n.libConnManager, n.idx)
-		mySubnets := records.Subnets(n.subnets).Clone()
-		connMgr.TagBestPeers(n.cfg.MaxPeers-1, mySubnets, allPeers, n.cfg.TopicMaxPeers)
-		connMgr.TrimPeers(ctx, n.host.Network())
-	})
-
-	async.Interval(n.ctx, peerIndexGCInterval, func() {
-		n.idx.GC()
-	})
+	async.Interval(n.ctx, peerIndexGCInterval, n.idx.GC)
 
 	async.Interval(n.ctx, reportingInterval, func() {
 		go n.reportAllPeers()
 		n.reportTopics()
-	})
-
-	async.Interval(n.ctx, reportingInterval/15, func() {
-		n.reportSubnetsStats()
 	})
 
 	if err := n.registerInitialTopics(); err != nil {
@@ -157,6 +138,21 @@ func (n *p2pNetwork) Start() error {
 	}
 
 	return nil
+}
+
+func (n *p2pNetwork) peersBalancing() {
+	allPeers := n.host.Network().Peers()
+	currentCount := len(allPeers)
+	if currentCount < n.cfg.MaxPeers {
+		return
+	}
+	ctx, cancel := context.WithTimeout(n.ctx, connManagerGCTimeout)
+	defer cancel()
+
+	connMgr := peers.NewConnManager(n.logger, n.libConnManager, n.idx)
+	mySubnets := records.Subnets(n.subnets).Clone()
+	connMgr.TagBestPeers(n.cfg.MaxPeers-1, mySubnets, allPeers, n.cfg.TopicMaxPeers)
+	connMgr.TrimPeers(ctx, n.host.Network())
 }
 
 func (n *p2pNetwork) registerInitialTopics() error {
@@ -243,7 +239,6 @@ func (n *p2pNetwork) UpdateSubnets() {
 	n.activeValidatorsLock.Unlock()
 
 	if len(subnetsToAdd) == 0 {
-		n.logger.Debug("no changes in subnets")
 		return
 	}
 
@@ -251,16 +246,14 @@ func (n *p2pNetwork) UpdateSubnets() {
 	self.Metadata.Subnets = records.Subnets(n.subnets).String()
 	n.idx.UpdateSelfRecord(self)
 
-	allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
-	subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
-	n.logger.Debug("updated subnets (node-info)", zap.Any("subnets", subnetsList))
-
 	err := n.disc.RegisterSubnets(subnetsToAdd...)
 	if err != nil {
 		n.logger.Warn("could not register subnets", zap.Error(err))
 		return
 	}
-	n.logger.Debug("updated subnets (discovery)", zap.Any("subnets", n.subnets))
+	allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
+	subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
+	n.logger.Debug("updated subnets (node-info)", zap.Any("subnets", subnetsList))
 }
 
 // getMaxPeers returns max peers of the given topic.

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -189,7 +189,6 @@ func (n *p2pNetwork) handlePubsubMessages(topic string, msg *pubsub.Message) err
 		return nil
 	}
 	if msg == nil {
-		logger.Warn("got nil message")
 		return nil
 	}
 	ssvMsg, err := n.fork.DecodeNetworkMsg(msg.GetData())
@@ -199,7 +198,6 @@ func (n *p2pNetwork) handlePubsubMessages(topic string, msg *pubsub.Message) err
 		return nil
 	}
 	if ssvMsg == nil {
-		logger.Debug("nil message")
 		return nil
 	}
 	logger = withIncomingMsgFields(logger, msg, ssvMsg)

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -255,6 +255,9 @@ func (n *p2pNetwork) setupPubsub() error {
 		MsgHandler: n.handlePubsubMessages,
 		ScoreIndex: n.idx,
 		//Discovery: n.disc,
+		OutboundQueueSize:   n.cfg.PubsubOutQueueSize,
+		ValidationQueueSize: n.cfg.PubsubValidationQueueSize,
+		ValidateThrottle:    n.cfg.PubsubValidateThrottle,
 	}
 
 	if !n.cfg.PubSubScoring {

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -237,7 +237,7 @@ func (ctrl *topicsCtrl) start(name string, tc *topicContainer) {
 	for {
 		err := ctrl.listen(tc.sub)
 		// rejoin in case failed for some reason
-		if err != nil {
+		if err != nil && ctrl.ctx.Err() == nil {
 			ctrl.logger.Warn("could not listen to topic", zap.String("topic", name), zap.Error(err))
 			time.Sleep(time.Second)
 			err = ctrl.rejoinTopic(name)
@@ -285,7 +285,6 @@ func (ctrl *topicsCtrl) listen(sub *pubsub.Subscription) error {
 // setupTopicValidator registers the topic validator
 func (ctrl *topicsCtrl) setupTopicValidator(name string) error {
 	if ctrl.msgValidatorFactory != nil {
-		ctrl.logger.Debug("setup topic validator", zap.String("topic", name))
 		// first try to unregister in case there is already a msg validator for that topic (e.g. fork scenario)
 		_ = ctrl.ps.UnregisterTopicValidator(name)
 		var opts []pubsub.ValidatorOpt

--- a/network/topics/gossipsub_params.go
+++ b/network/topics/gossipsub_params.go
@@ -20,7 +20,7 @@ var (
 	// gsMcacheLen number of windows to retain full messages in cache for `IWANT` responses
 	gsMcacheLen = 80
 	// gsMcacheGossip number of windows to gossip about
-	gsMcacheGossip = 3
+	gsMcacheGossip = 4
 
 	// heartbeat interval frequency of heartbeat, milliseconds
 	gsHeartbeatInterval = 800 * time.Millisecond

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -22,7 +22,7 @@ const (
 // the following are kept in vars to allow flexibility (e.g. in tests)
 var (
 	// validationQueueSize is the size that we assign to the validation queue
-	validationQueueSize = 128
+	validationQueueSize = 512
 	// outboundQueueSize is the size that we assign to the outbound message queue
 	outboundQueueSize = 32
 	// scoreInspectInterval is the interval for performing score inspect, which goes over all peers scores
@@ -98,7 +98,7 @@ func NewPubsub(ctx context.Context, cfg *PububConfig, fork forks.Fork) (*pubsub.
 		pubsub.WithPeerOutboundQueueSize(outboundQueueSize),
 		pubsub.WithValidateQueueSize(validationQueueSize),
 		//pubsub.WithFloodPublish(true),
-		pubsub.WithValidateThrottle(2048),
+		pubsub.WithValidateThrottle(1024),
 		pubsub.WithSubscriptionFilter(sf),
 		pubsub.WithGossipSubParams(gossipSubParam()),
 		//pubsub.WithPeerFilter(func(pid peer.ID, topic string) bool {

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -22,9 +22,9 @@ const (
 // the following are kept in vars to allow flexibility (e.g. in tests)
 var (
 	// validationQueueSize is the size that we assign to the validation queue
-	validationQueueSize = 512
+	validationQueueSize = 256
 	// outboundQueueSize is the size that we assign to the outbound message queue
-	outboundQueueSize = 32
+	outboundQueueSize = 128
 	// scoreInspectInterval is the interval for performing score inspect, which goes over all peers scores
 	scoreInspectInterval = time.Minute
 )

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -26,7 +26,7 @@ var (
 	// outboundQueueSize is the size that we assign to the outbound message queue
 	outboundQueueSize = 128
 	// validateThrottle is the amount of goroutines used for pubsub msg validation
-	validateThrottle  = 1024
+	validateThrottle = 1024
 	// scoreInspectInterval is the interval for performing score inspect, which goes over all peers scores
 	scoreInspectInterval = time.Minute
 )

--- a/protocol/v1/sync/changeround/fetcher.go
+++ b/protocol/v1/sync/changeround/fetcher.go
@@ -61,7 +61,7 @@ func (crf *changeRoundFetcher) GetChangeRoundMessages(identifier message.Identif
 			logger.Warn("change round api error", zap.Error(err))
 			continue
 		}
-		logger.Debug("last change round by peer", zap.Int("count", len(syncMsg.Data))) // TODO necessary log?
+
 		for _, sm := range syncMsg.Data {
 			if err := handler(sm); err != nil {
 				logger.Warn("could not handle message", zap.Error(err))


### PR DESCRIPTION
This PR contains the following changes and fixes:

- increased default max peers to increase message delivery
- modify gossip params to avoid bursts in high load
- increased validation and outbound queues size so messages won't get dropped
- added configs for pubsub params
- logs cleanup
