### PR TITLE
V2 Alignment of Config Defaults

### DIFF
--- a/network/forks/genesis/pubsub_mapping.go
+++ b/network/forks/genesis/pubsub_mapping.go
@@ -12,7 +12,7 @@ const (
 	UnknownSubnet = "unknown"
 	decidedTopic  = "decided"
 
-	topicPrefix = "ssv.v1.1"
+	topicPrefix = "ssv.v2"
 )
 
 // subnetsCount returns the subnet count for genesis

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	// DiscoveryTrace is a flag to turn on/off discovery tracing in logs
 	DiscoveryTrace bool `yaml:"DiscoveryTrace" env:"DISCOVERY_TRACE" env-description:"Flag to turn on/off discovery tracing in logs"`
 	// NetworkID is the network of this node
-	NetworkID string `yaml:"NetworkID" env:"NETWORK_ID" env-default:"ssv-testnet" env-description:"Network ID is the network of this node"`
+	NetworkID string `yaml:"NetworkID" env:"NETWORK_ID" env-default:"ssv-testnet-v2" env-description:"Network ID is the network of this node"`
 	// NetworkPrivateKey is used for network identity, MUST be injected
 	NetworkPrivateKey *ecdsa.PrivateKey
 	// OperatorPublicKey is used for operator identity, optional


### PR DESCRIPTION
Config alignment for V2:

- modified the default value of following configs so `v2` network won't merge with `v1`:
  - `NETWORK_ID`
  - `BOOTNODES` (**TODO**)
- changed pubsub topic prefix