### PR TITLE
Align qbft prepare message processing with spec

### DIFF
--- a/protocol/v1/qbft/instance/change_round_test.go
+++ b/protocol/v1/qbft/instance/change_round_test.go
@@ -376,7 +376,7 @@ func TestValidateChangeRoundMessage(t *testing.T) {
 					},
 				}),
 			},
-			expectedError: "round change justification invalid: msg round wrong",
+			expectedError: "round change justification invalid: round is wrong",
 		},
 		{
 			name:                "invalid prepared and justification round",
@@ -404,7 +404,7 @@ func TestValidateChangeRoundMessage(t *testing.T) {
 					},
 				}),
 			},
-			expectedError: "round change justification invalid: msg round wrong",
+			expectedError: "round change justification invalid: round is wrong",
 		},
 		{
 			name:                "invalid justification instance",

--- a/protocol/v1/qbft/instance/change_round_test.go
+++ b/protocol/v1/qbft/instance/change_round_test.go
@@ -47,7 +47,7 @@ func (v0 *testFork) PrePrepareMsgValidationPipeline(share *beacon.Share, state *
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
-		preprepare.ValidatePrePrepareMsg(roundLeader),
+		preprepare.ValidatePrePrepareMsg(share, state, roundLeader),
 	)
 }
 

--- a/protocol/v1/qbft/instance/forks/genesis/fork.go
+++ b/protocol/v1/qbft/instance/forks/genesis/fork.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/forks"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/prepare"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/preprepare"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
@@ -56,6 +57,7 @@ func (g *ForkGenesis) PrepareMsgValidationPipeline(share *beacon.Share, state *q
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
+		prepare.ValidatePrepareMsg(),
 	)
 }
 

--- a/protocol/v1/qbft/instance/forks/genesis/fork.go
+++ b/protocol/v1/qbft/instance/forks/genesis/fork.go
@@ -57,7 +57,7 @@ func (g *ForkGenesis) PrepareMsgValidationPipeline(share *beacon.Share, state *q
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
-		prepare.ValidatePrepareMsg(),
+		prepare.ValidatePrepareMsgSigners(),
 	)
 }
 

--- a/protocol/v1/qbft/instance/forks/genesis/fork.go
+++ b/protocol/v1/qbft/instance/forks/genesis/fork.go
@@ -44,7 +44,7 @@ func (g *ForkGenesis) PrePrepareMsgValidationPipeline(share *beacon.Share, state
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
-		preprepare.ValidatePrePrepareMsg(roundLeader),
+		preprepare.ValidatePrePrepareMsg(share, state, roundLeader),
 	)
 }
 

--- a/protocol/v1/qbft/instance/instance.go
+++ b/protocol/v1/qbft/instance/instance.go
@@ -265,7 +265,7 @@ func (i *Instance) ProcessMsg(msg *specqbft.SignedMessage) (bool, error) {
 		}
 	case specqbft.PrepareMsgType:
 		if err := i.PrepareMsgPipeline().Run(msg); err != nil {
-			return false, fmt.Errorf("invalid prepare message: %w", err)
+			return false, err
 		}
 	case specqbft.CommitMsgType:
 		if err := i.CommitMsgPipeline().Run(msg); err != nil {

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"bytes"
 	"fmt"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
-	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
 
 // PrePrepareMsgPipeline is the main pre-prepare msg pipeline
@@ -30,58 +28,12 @@ func (i *Instance) PrePrepareMsgPipeline() pipelines.SignedMessagePipeline {
 
 			return nil
 		}),
-		pipelines.CombineQuiet(
-			signedmsg.ValidateRound(i.State().GetRound()),
-			i.UponPrePrepareMsg(),
-		),
+		i.UponPrePrepareMsg(),
 	)
 }
 
 func (i *Instance) prePrepareMsgValidationPipeline() pipelines.SignedMessagePipeline {
 	return i.fork.PrePrepareMsgValidationPipeline(i.ValidatorShare, i.State(), i.RoundLeader)
-}
-
-// JustifyPrePrepare implements:
-// predicate JustifyPrePrepare(hPRE-PREPARE, λi, round, value)
-// 	return
-// 		round = 1
-// 		∨ received a quorum Qrc of valid <ROUND-CHANGE, λi, round, prj , pvj> messages such that:
-// 			∀ <ROUND-CHANGE, λi, round, prj , pvj> ∈ Qrc : prj = ⊥ ∧ prj = ⊥
-// 			∨ received a quorum of valid <PREPARE, λi, pr, value> messages such that:
-// 				(pr, value) = HighestPrepared(Qrc)
-func (i *Instance) JustifyPrePrepare(round uint64, proposalData *specqbft.ProposalData) error {
-	if round == 1 {
-		return nil
-	}
-
-	for _, rc := range proposalData.RoundChangeJustification {
-		if err := i.validateRoundChange(rc); err != nil {
-			return errors.Wrap(err, "change round msg not valid")
-		}
-	}
-
-	if quorum, _, _ := i.changeRoundQuorum(proposalData.RoundChangeJustification); !quorum {
-		return errors.New("no change round quorum")
-	}
-	notPrepared, highest, err := i.HighestPrepared(specqbft.Round(round))
-	if err != nil {
-		return err
-	}
-	if notPrepared {
-		return nil
-	}
-	if !bytes.Equal(proposalData.Data, highest.PreparedValue) {
-		return errors.New("preparedValue different than highest prepared")
-	}
-	return nil
-}
-
-func (i *Instance) validateRoundChange(signedMsg *specqbft.SignedMessage) error {
-	if len(signedMsg.GetSigners()) != 1 {
-		return errors.New("msg allows 1 signer")
-	}
-
-	return nil
 }
 
 /*
@@ -95,15 +47,20 @@ func (i *Instance) UponPrePrepareMsg() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("upon pre-prepare msg", func(signedMessage *specqbft.SignedMessage) error {
 		i.State().ProposalAcceptedForCurrentRound.Store(signedMessage)
 
+		newRound := signedMessage.Message.Round
+
+		if currentRound := i.State().GetRound(); signedMessage.Message.Round > currentRound {
+			i.Logger.Debug("received future justified proposal, bumping into its round and resetting timer",
+				zap.Uint64("current_round", uint64(currentRound)),
+				zap.Uint64("future_round", uint64(signedMessage.Message.Round)),
+			)
+			i.ResetRoundTimer()
+			i.bumpToRound(newRound)
+		}
+
 		prepareMsg, err := signedMessage.Message.GetProposalData()
 		if err != nil {
 			return errors.Wrap(err, "failed to get prepare message")
-		}
-
-		// Pre-prepare justification
-		err = i.JustifyPrePrepare(uint64(signedMessage.Message.Round), prepareMsg)
-		if err != nil {
-			return err
 		}
 
 		// mark state

--- a/protocol/v1/qbft/instance/prepare_test.go
+++ b/protocol/v1/qbft/instance/prepare_test.go
@@ -103,5 +103,5 @@ func TestPreparePipeline(t *testing.T) {
 	instance.fork = testingFork(instance)
 	pipeline := instance.PrepareMsgPipeline()
 	// TODO: fix bad-looking name
-	require.EqualValues(t, "combination of: combination of: basic msg validation, type check, lambda, sequence, authorize, , add prepare msg, if first pipeline non error, continue to second, ", pipeline.Name())
+	require.EqualValues(t, "combination of: validate proposal, combination of: combination of: basic msg validation, type check, lambda, sequence, authorize, , round, validate proposal, add prepare msg, , upon prepare msg, ", pipeline.Name())
 }

--- a/protocol/v1/qbft/validation/changeround/validate_justification.go
+++ b/protocol/v1/qbft/validation/changeround/validate_justification.go
@@ -79,10 +79,10 @@ func (p *validateJustification) validateRoundChangeJustification(rcj *specqbft.S
 		return errors.New("change round justification sequence is wrong")
 	}
 	if signedMessage.Message.Round <= rcj.Message.Round {
-		return errors.New("msg round wrong")
+		return errors.New("round is wrong")
 	}
 	if roundChangeData.PreparedRound != rcj.Message.Round {
-		return errors.New("msg round wrong")
+		return errors.New("round is wrong")
 	}
 	if !bytes.Equal(signedMessage.Message.Identifier, rcj.Message.Identifier) {
 		return errors.New("change round justification msg Lambda not equal to msg Lambda not equal to instance lambda")

--- a/protocol/v1/qbft/validation/changeround/validate_justification.go
+++ b/protocol/v1/qbft/validation/changeround/validate_justification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 	"github.com/bloxapp/ssv/protocol/v1/types"
 )
 
@@ -57,7 +58,7 @@ func (p *validateJustification) Run(signedMessage *specqbft.SignedMessage) error
 		}
 	}
 
-	if quorum, _, _ := p.changeRoundQuorum(data.RoundChangeJustification); !quorum {
+	if quorum, _, _ := signedmsg.HasQuorum(p.share, data.RoundChangeJustification); !quorum {
 		return fmt.Errorf("no justifications quorum")
 	}
 
@@ -122,16 +123,4 @@ func (p *validateJustification) validateRoundChangeJustification(rcj *specqbft.S
 // Name implements pipeline.Pipeline interface
 func (p *validateJustification) Name() string {
 	return "validateJustification msg"
-}
-
-// TODO(nkryuchkov): Consider merging with all changeRoundQuorum functions.
-func (p *validateJustification) changeRoundQuorum(msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
-	uniqueSigners := make(map[spectypes.OperatorID]bool)
-	for _, msg := range msgs {
-		for _, signer := range msg.GetSigners() {
-			uniqueSigners[signer] = true
-		}
-	}
-	quorum = len(uniqueSigners)*3 >= p.share.CommitteeSize()*2
-	return quorum, len(uniqueSigners), p.share.CommitteeSize()
 }

--- a/protocol/v1/qbft/validation/changeround/validate_justification_test.go
+++ b/protocol/v1/qbft/validation/changeround/validate_justification_test.go
@@ -212,7 +212,7 @@ func TestValidateChangeRound(t *testing.T) {
 		},
 		{
 			"small justification round",
-			"round change justification invalid: msg round wrong",
+			"round change justification invalid: round is wrong",
 			SignMsg(t, 1, sks[1], &specqbft.Message{
 				MsgType:    specqbft.RoundChangeMsgType,
 				Round:      1,

--- a/protocol/v1/qbft/validation/commit/validate.go
+++ b/protocol/v1/qbft/validation/commit/validate.go
@@ -1,0 +1,41 @@
+package commit
+
+import (
+	"bytes"
+	"fmt"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+)
+
+// ValidateProposal validates message against received proposal for this round.
+func ValidateProposal(state *qbft.State) pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("validate proposal", func(signedMessage *specqbft.SignedMessage) error {
+		proposedMsg := state.GetProposalAcceptedForCurrentRound()
+		if proposedMsg == nil {
+			return fmt.Errorf("did not receive proposal for this round")
+		}
+
+		proposedData, err := proposedMsg.Message.GetProposalData()
+		if err != nil {
+			return fmt.Errorf("could not get proposed data: %w", err)
+		}
+
+		msgCommitData, err := signedMessage.Message.GetCommitData()
+		if err != nil {
+			return fmt.Errorf("could not get msg commit data: %w", err)
+		}
+
+		if err := msgCommitData.Validate(); err != nil {
+			return fmt.Errorf("msgCommitData invalid: %w", err)
+		}
+
+		if !bytes.Equal(proposedData.Data, msgCommitData.Data) {
+			return fmt.Errorf("message data is different from proposed data")
+		}
+
+		return nil
+	})
+}

--- a/protocol/v1/qbft/validation/commit/validate_test.go
+++ b/protocol/v1/qbft/validation/commit/validate_test.go
@@ -1,0 +1,105 @@
+package commit
+
+import (
+	"testing"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+)
+
+func TestValidateProposal(t *testing.T) {
+	data1, err := (&specqbft.CommitData{Data: []byte("data1")}).Encode()
+	require.NoError(t, err)
+
+	data2, err := (&specqbft.CommitData{Data: []byte("data2")}).Encode()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                            string
+		msg                             *specqbft.SignedMessage
+		proposalAcceptedForCurrentRound *specqbft.SignedMessage
+		err                             string
+	}{
+		{
+			"proposal has same value",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.CommitMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.CommitMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			"",
+		},
+		{
+			"proposal has different value",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.CommitMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.CommitMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data2,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			"message data is different from proposed data",
+		},
+		{
+			"no proposal",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.CommitMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			nil,
+			"did not receive proposal for this round",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			state := &qbft.State{}
+			state.ProposalAcceptedForCurrentRound.Store(tc.proposalAcceptedForCurrentRound)
+
+			err := ValidateProposal(state).Run(tc.msg)
+			if len(tc.err) > 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/v1/qbft/validation/prepare/validate.go
+++ b/protocol/v1/qbft/validation/prepare/validate.go
@@ -1,0 +1,56 @@
+package prepare
+
+import (
+	"bytes"
+	"fmt"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	"github.com/pkg/errors"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+)
+
+// ErrInvalidSignersNum represents an error when the number of signers is invalid.
+var ErrInvalidSignersNum = errors.New("prepare msg allows 1 signer")
+
+// ValidatePrepareMsg validates prepare message.
+func ValidatePrepareMsg() pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("validate prepare", func(signedMessage *specqbft.SignedMessage) error {
+		signers := signedMessage.GetSigners()
+		if len(signers) != 1 {
+			return ErrInvalidSignersNum
+		}
+
+		return nil
+	})
+}
+
+// ValidateProposal validates message against received proposal for this round.
+func ValidateProposal(state *qbft.State) pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("validate proposal", func(signedMessage *specqbft.SignedMessage) error {
+		proposedMsg := state.GetProposalAcceptedForCurrentRound()
+		if proposedMsg == nil {
+			return fmt.Errorf("did not receive proposal for this round")
+		}
+
+		proposedData, err := proposedMsg.Message.GetProposalData()
+		if err != nil {
+			return fmt.Errorf("could not get proposed data: %w", err)
+		}
+
+		msgPrepareData, err := signedMessage.Message.GetPrepareData()
+		if err != nil {
+			return fmt.Errorf("could not get prepare data: %w", err)
+		}
+		if err := msgPrepareData.Validate(); err != nil {
+			return fmt.Errorf("msgPrepareData invalid: %w", err)
+		}
+
+		if !bytes.Equal(proposedData.Data, msgPrepareData.Data) {
+			return fmt.Errorf("message data is different from proposed data")
+		}
+
+		return nil
+	})
+}

--- a/protocol/v1/qbft/validation/prepare/validate.go
+++ b/protocol/v1/qbft/validation/prepare/validate.go
@@ -14,8 +14,8 @@ import (
 // ErrInvalidSignersNum represents an error when the number of signers is invalid.
 var ErrInvalidSignersNum = errors.New("prepare msg allows 1 signer")
 
-// ValidatePrepareMsg validates prepare message.
-func ValidatePrepareMsg() pipelines.SignedMessagePipeline {
+// ValidatePrepareMsgSigners validates prepare message signers.
+func ValidatePrepareMsgSigners() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("validate prepare", func(signedMessage *specqbft.SignedMessage) error {
 		signers := signedMessage.GetSigners()
 		if len(signers) != 1 {

--- a/protocol/v1/qbft/validation/prepare/validate_test.go
+++ b/protocol/v1/qbft/validation/prepare/validate_test.go
@@ -1,0 +1,211 @@
+package prepare
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+	"github.com/bloxapp/ssv/protocol/v1/types"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
+
+	"github.com/herumi/bls-eth-go-binary/bls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
+)
+
+// GenerateNodes generates randomly nodes
+func GenerateNodes(cnt int) (map[uint64]*bls.SecretKey, map[uint64]*beacon.Node) {
+	_ = bls.Init(bls.BLS12_381)
+	nodes := make(map[uint64]*beacon.Node)
+	sks := make(map[uint64]*bls.SecretKey)
+	for i := 0; i < cnt; i++ {
+		sk := &bls.SecretKey{}
+		sk.SetByCSPRNG()
+
+		nodes[uint64(i)] = &beacon.Node{
+			IbftID: uint64(i),
+			Pk:     sk.GetPublicKey().Serialize(),
+		}
+		sks[uint64(i)] = sk
+	}
+	return sks, nodes
+}
+
+func signMessage(msg *specqbft.Message, sk *bls.SecretKey) (*bls.Sign, error) {
+	signatureDomain := spectypes.ComputeSignatureDomain(types.GetDefaultDomain(), spectypes.QBFTSignatureType)
+	root, err := spectypes.ComputeSigningRoot(msg, signatureDomain)
+	if err != nil {
+		return nil, err
+	}
+	return sk.SignByte(root), nil
+}
+
+// SignMsg signs the given message by the given private key
+func SignMsg(t *testing.T, id uint64, sk *bls.SecretKey, msg *specqbft.Message) *specqbft.SignedMessage {
+	bls.Init(bls.BLS12_381)
+
+	signature, err := signMessage(msg, sk)
+	require.NoError(t, err)
+	sm := &specqbft.SignedMessage{
+		Message:   msg,
+		Signature: signature.Serialize(),
+		Signers:   []spectypes.OperatorID{spectypes.OperatorID(id)},
+	}
+	return sm
+}
+
+func TestValidatePrepareMsg(t *testing.T) {
+	sks, _ := GenerateNodes(4)
+
+	tests := []struct {
+		name string
+		err  string
+		msg  *specqbft.SignedMessage
+	}{
+		{
+			"no signers",
+			"prepare msg allows 1 signer",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       []byte(time.Now().Weekday().String()),
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+		},
+		{
+			"only 2 signers",
+			"prepare msg allows 1 signer",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       []byte(time.Now().Weekday().String()),
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{1, 2},
+			},
+		},
+		{
+			"valid message",
+			"",
+			SignMsg(t, 1, sks[1], &specqbft.Message{
+				MsgType:    specqbft.PrepareMsgType,
+				Round:      1,
+				Identifier: []byte("Lambda"),
+				Data:       []byte(time.Now().Weekday().String()),
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidatePrepareMsg().Run(test.msg)
+			if len(test.err) > 0 {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateProposal(t *testing.T) {
+	data1, err := (&specqbft.PrepareData{Data: []byte("data1")}).Encode()
+	require.NoError(t, err)
+
+	data2, err := (&specqbft.PrepareData{Data: []byte("data2")}).Encode()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                            string
+		msg                             *specqbft.SignedMessage
+		proposalAcceptedForCurrentRound *specqbft.SignedMessage
+		err                             string
+	}{
+		{
+			"proposal has same value",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			"",
+		},
+		{
+			"proposal has different value",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data2,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			"message data is different from proposed data",
+		},
+		{
+			"no proposal",
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					MsgType:    specqbft.PrepareMsgType,
+					Round:      1,
+					Identifier: []byte("Lambda"),
+					Data:       data1,
+				},
+				Signature: []byte{},
+				Signers:   []spectypes.OperatorID{},
+			},
+			nil,
+			"did not receive proposal for this round",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			state := &qbft.State{}
+			state.ProposalAcceptedForCurrentRound.Store(tc.proposalAcceptedForCurrentRound)
+
+			err := ValidateProposal(state).Run(tc.msg)
+			if len(tc.err) > 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/v1/qbft/validation/prepare/validate_test.go
+++ b/protocol/v1/qbft/validation/prepare/validate_test.go
@@ -106,7 +106,7 @@ func TestValidatePrepareMsg(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidatePrepareMsg().Run(test.msg)
+			err := ValidatePrepareMsgSigners().Run(test.msg)
 			if len(test.err) > 0 {
 				require.EqualError(t, err, test.err)
 			} else {

--- a/protocol/v1/qbft/validation/preprepare/validate.go
+++ b/protocol/v1/qbft/validation/preprepare/validate.go
@@ -1,12 +1,19 @@
 package preprepare
 
 import (
+	"bytes"
 	"fmt"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
 
+	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
+	"github.com/bloxapp/ssv/protocol/v1/types"
 )
 
 // ErrInvalidSignersNum represents an error when the number of signers is invalid.
@@ -16,7 +23,7 @@ var ErrInvalidSignersNum = errors.New("proposal msg allows 1 signer")
 type LeaderResolver func(round specqbft.Round) uint64
 
 // ValidatePrePrepareMsg validates pre-prepare message
-func ValidatePrePrepareMsg(resolver LeaderResolver) pipelines.SignedMessagePipeline {
+func ValidatePrePrepareMsg(share *beacon.Share, state *qbft.State, resolver LeaderResolver) pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("validate pre-prepare", func(signedMessage *specqbft.SignedMessage) error {
 		signers := signedMessage.GetSigners()
 		if len(signers) != 1 {
@@ -27,6 +34,190 @@ func ValidatePrePrepareMsg(resolver LeaderResolver) pipelines.SignedMessagePipel
 		if uint64(signers[0]) != leader {
 			return fmt.Errorf("proposal leader invalid")
 		}
-		return nil
+
+		prepareMsg, err := signedMessage.Message.GetProposalData()
+		if err != nil {
+			return fmt.Errorf("could not get proposal data: %w", err)
+		}
+
+		if err := JustifyPrePrepare(share, state, uint64(signedMessage.Message.Round), prepareMsg); err != nil {
+			return fmt.Errorf("proposal not justified: %w", err)
+		}
+
+		proposalAcceptedForCurrentRound := state.GetProposalAcceptedForCurrentRound()
+		round := state.GetRound()
+		if (proposalAcceptedForCurrentRound == nil && signedMessage.Message.Round == round) ||
+			(proposalAcceptedForCurrentRound != nil && signedMessage.Message.Round > round) {
+			return nil
+		}
+		return errors.New("proposal is not valid with current state")
 	})
+}
+
+// JustifyPrePrepare implements:
+// predicate JustifyPrePrepare(hPRE-PREPARE, λi, round, value)
+// 	return
+// 		round = 1
+// 		∨ received a quorum Qrc of valid <ROUND-CHANGE, λi, round, prj , pvj> messages such that:
+// 			∀ <ROUND-CHANGE, λi, round, prj , pvj> ∈ Qrc : prj = ⊥ ∧ prj = ⊥
+// 			∨ received a quorum of valid <PREPARE, λi, pr, value> messages such that:
+// 				(pr, value) = HighestPrepared(Qrc)
+func JustifyPrePrepare(share *beacon.Share, state *qbft.State, round uint64, proposalData *specqbft.ProposalData) error {
+	// TODO: move its tests to this package
+	if round == 1 {
+		return nil
+	}
+
+	for _, rc := range proposalData.RoundChangeJustification {
+		// TODO: refactor
+		if err := pipelines.Combine(
+			signedmsg.BasicMsgValidation(),
+			signedmsg.MsgTypeCheck(specqbft.RoundChangeMsgType),
+			signedmsg.AuthorizeMsg(share),
+			changeround.Validate(share),
+		).Run(rc); err != nil {
+			return fmt.Errorf("change round msg not valid: %w", err)
+		}
+	}
+
+	if quorum, _, _ := signedmsg.HasQuorum(share, proposalData.RoundChangeJustification); !quorum {
+		return errors.New("change round has not quorum")
+	}
+
+	// previouslyPreparedF returns true if any on the round change messages have a prepared round and value
+	previouslyPrepared, err := func(rcMsgs []*specqbft.SignedMessage) (bool, error) {
+		for _, rc := range rcMsgs {
+			rcData, err := rc.Message.GetRoundChangeData()
+			if err != nil {
+				return false, fmt.Errorf("could not get round change data: %w", err)
+			}
+			if rcData.Prepared() {
+				return true, nil
+			}
+		}
+		return false, nil
+	}(proposalData.RoundChangeJustification)
+	if err != nil {
+		return fmt.Errorf("could not calculate if previously prepared: %w", err)
+	}
+
+	if !previouslyPrepared {
+		return nil
+	}
+
+	if quorum, _, _ := signedmsg.HasQuorum(share, proposalData.PrepareJustification); !quorum {
+		return errors.New("prepares has no quorum")
+	}
+
+	// get a round change data for which there is a justification for the highest previously prepared round
+	highest, err := highestPrepared(proposalData.RoundChangeJustification)
+	if err != nil {
+		return errors.Wrap(err, "could not get highest prepared")
+	}
+
+	if highest == nil {
+		return errors.New("no highest prepared")
+	}
+
+	highestData, err := highest.Message.GetRoundChangeData()
+	if err != nil {
+		return errors.Wrap(err, "could not get round change data")
+	}
+
+	// proposed value must equal highest prepared value
+	if !bytes.Equal(proposalData.Data, highestData.PreparedValue) {
+		return errors.New("proposed data doesn't match highest prepared")
+	}
+
+	for _, rcj := range proposalData.PrepareJustification {
+		if err := validateRoundChangeJustification(
+			rcj,
+			state.GetHeight(),
+			highestData.PreparedRound,
+			highestData.PreparedValue,
+			share,
+		); err != nil {
+			return fmt.Errorf("signed prepare not valid")
+		}
+	}
+
+	return nil
+}
+
+// highestPrepared returns a round change message with the highest prepared round, returns nil if none found
+func highestPrepared(roundChanges []*specqbft.SignedMessage) (*specqbft.SignedMessage, error) {
+	var ret *specqbft.SignedMessage
+	for _, rc := range roundChanges {
+		rcData, err := rc.Message.GetRoundChangeData()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get round change data")
+		}
+
+		if !rcData.Prepared() {
+			continue
+		}
+
+		if ret == nil {
+			ret = rc
+		} else {
+			retRCData, err := ret.Message.GetRoundChangeData()
+			if err != nil {
+				return nil, errors.Wrap(err, "could not get round change data")
+			}
+			if retRCData.PreparedRound < rcData.PreparedRound {
+				ret = rc
+			}
+		}
+	}
+	return ret, nil
+}
+
+// TODO: merge with (*validateJustification).validateRoundChangeJustification, use it everywhere where spec does
+func validateRoundChangeJustification(
+	signedPrepare *specqbft.SignedMessage,
+	height specqbft.Height,
+	round specqbft.Round,
+	value []byte,
+	share *beacon.Share,
+) error {
+	if signedPrepare.Message.MsgType != specqbft.PrepareMsgType {
+		return errors.New("prepare msg type is wrong")
+	}
+	if signedPrepare.Message.Height != height {
+		return errors.New("message height is wrong")
+	}
+	if signedPrepare.Message.Round != round {
+		return errors.New("round is wrong")
+	}
+	prepareData, err := signedPrepare.Message.GetPrepareData()
+	if err != nil {
+		return errors.Wrap(err, "could not get prepare data")
+	}
+	if err := prepareData.Validate(); err != nil {
+		return errors.Wrap(err, "prepareData invalid")
+	}
+	if !bytes.Equal(prepareData.Data, value) {
+		return errors.New("prepare data != proposed data")
+	}
+	if len(signedPrepare.GetSigners()) != 1 {
+		return errors.New("prepare msg allows 1 signer")
+	}
+
+	// validateJustification justification signature
+	pksMap, err := share.PubKeysByID(signedPrepare.GetSigners())
+	var pks beacon.PubKeys
+	for _, v := range pksMap {
+		pks = append(pks, v)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "change round could not get pubkey")
+	}
+	aggregated := pks.Aggregate()
+
+	if err = signedPrepare.Signature.Verify(signedPrepare, types.GetDefaultDomain(), spectypes.QBFTSignatureType, aggregated.Serialize()); err != nil {
+		return errors.Wrap(err, "invalid message signature")
+	}
+
+	return nil
 }

--- a/protocol/v1/qbft/validation/signedmsg/msg_round.go
+++ b/protocol/v1/qbft/validation/signedmsg/msg_round.go
@@ -1,12 +1,10 @@
 package signedmsg
 
 import (
-	"bytes"
 	"fmt"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 
-	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
 )
 
@@ -16,47 +14,6 @@ func ValidateRound(round specqbft.Round) pipelines.SignedMessagePipeline {
 		if round != signedMessage.Message.Round {
 			return fmt.Errorf("round is wrong")
 		}
-		return nil
-	})
-}
-
-// CheckProposal checks if proposal for current was received.
-func CheckProposal(state *qbft.State) pipelines.SignedMessagePipeline {
-	return pipelines.WrapFunc("validate proposal", func(signedMessage *specqbft.SignedMessage) error {
-		proposedMsg := state.GetProposalAcceptedForCurrentRound()
-		if proposedMsg == nil {
-			return fmt.Errorf("did not receive proposal for this round")
-		}
-
-		return nil
-	})
-}
-
-// ValidateProposal validates message against received proposal for this roundю
-func ValidateProposal(state *qbft.State) pipelines.SignedMessagePipeline {
-	return pipelines.WrapFunc("validate proposal", func(signedMessage *specqbft.SignedMessage) error {
-		proposedMsg := state.GetProposalAcceptedForCurrentRound()
-		if proposedMsg == nil {
-			return fmt.Errorf("did not receive proposal for this round")
-		}
-
-		proposedCommitData, err := proposedMsg.Message.GetCommitData()
-		if err != nil {
-			return fmt.Errorf("could not get proposed commit data: %w", err)
-		}
-
-		msgCommitData, err := signedMessage.Message.GetCommitData()
-		if err != nil {
-			return fmt.Errorf("could not get msg commit data: %w", err)
-		}
-		if err := msgCommitData.Validate(); err != nil {
-			return fmt.Errorf("msgCommitData invalid: %w", err)
-		}
-
-		if !bytes.Equal(proposedCommitData.Data, msgCommitData.Data) {
-			return fmt.Errorf("proposed data different than commit msg data")
-		}
-
 		return nil
 	})
 }

--- a/protocol/v1/qbft/validation/signedmsg/proposal.go
+++ b/protocol/v1/qbft/validation/signedmsg/proposal.go
@@ -1,0 +1,22 @@
+package signedmsg
+
+import (
+	"fmt"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+)
+
+// ProposalExists checks if proposal for current was received.
+func ProposalExists(state *qbft.State) pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("validate proposal", func(signedMessage *specqbft.SignedMessage) error {
+		proposedMsg := state.GetProposalAcceptedForCurrentRound()
+		if proposedMsg == nil {
+			return fmt.Errorf("did not receive proposal for this round")
+		}
+
+		return nil
+	})
+}

--- a/protocol/v1/qbft/validation/signedmsg/proposal_test.go
+++ b/protocol/v1/qbft/validation/signedmsg/proposal_test.go
@@ -1,0 +1,56 @@
+package signedmsg
+
+import (
+	"testing"
+
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
+)
+
+func TestProposalExists(t *testing.T) {
+	tests := []struct {
+		name                            string
+		round                           specqbft.Round
+		proposalAcceptedForCurrentRound *specqbft.SignedMessage
+		expectedError                   string
+	}{
+		{
+			"proposal exists",
+			1,
+			&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					Round: 1,
+				},
+			},
+			"",
+		},
+		{
+			"no proposal",
+			1,
+			nil,
+			"did not receive proposal for this round",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			state := &qbft.State{}
+			state.ProposalAcceptedForCurrentRound.Store(tc.proposalAcceptedForCurrentRound)
+			pipeline := ProposalExists(state)
+			err := pipeline.Run(&specqbft.SignedMessage{
+				Message: &specqbft.Message{
+					Round: tc.round,
+				},
+			})
+
+			if len(tc.expectedError) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}

--- a/protocol/v1/qbft/validation/signedmsg/quorum.go
+++ b/protocol/v1/qbft/validation/signedmsg/quorum.go
@@ -1,0 +1,20 @@
+package signedmsg
+
+import (
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
+
+	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
+)
+
+// HasQuorum checks if messages have a quorum.
+func HasQuorum(share *beacon.Share, msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
+	uniqueSigners := make(map[spectypes.OperatorID]bool)
+	for _, msg := range msgs {
+		for _, signer := range msg.GetSigners() {
+			uniqueSigners[signer] = true
+		}
+	}
+	quorum = len(uniqueSigners)*3 >= share.CommitteeSize()*2
+	return quorum, len(uniqueSigners), share.CommitteeSize()
+}

--- a/spectest/qbft/qbft_mapping_test.go
+++ b/spectest/qbft/qbft_mapping_test.go
@@ -123,12 +123,12 @@ func testsToRun() map[string]struct{} {
 		prepare.HappyFlow(),
 		prepare.ImparsableProposalData(),
 		prepare.InvalidPrepareData(),
-		//prepare.MultiSigner(),        // TODO(nkryuchkov): failure; need to check that message has only 1 signer
-		//prepare.NoPreviousProposal(), // TODO(nkryuchkov): failure; need to fail to process message if proposal was not received
-		//prepare.OldRound(),           // TODO(nkryuchkov): failure; need to fail to process message if its round is not equal to current one
-		//prepare.FutureRound(),        // TODO(nkryuchkov): failure; need to fail to process message if its round is not equal to current one
+		prepare.MultiSigner(),
+		prepare.NoPreviousProposal(),
+		prepare.OldRound(),
+		prepare.FutureRound(),
 		prepare.PostDecided(),
-		//prepare.WrongData(), // TODO(nkryuchkov): failure; need to check if message data is different from proposal data
+		prepare.WrongData(),
 		prepare.WrongHeight(),
 		prepare.WrongSignature(),
 

--- a/spectest/qbft/qbft_mapping_test.go
+++ b/spectest/qbft/qbft_mapping_test.go
@@ -18,11 +18,6 @@ import (
 	"github.com/bloxapp/ssv-spec/qbft/spectest"
 	spectests "github.com/bloxapp/ssv-spec/qbft/spectest/tests"
 	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/commit"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/messages"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/prepare"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/proposal"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/proposer"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/roundchange"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/bloxapp/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
@@ -35,9 +30,12 @@ import (
 	qbftprotocol "github.com/bloxapp/ssv/protocol/v1/qbft"
 	forksfactory "github.com/bloxapp/ssv/protocol/v1/qbft/controller/forks/factory"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/forks"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/leader/constant"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/msgcont"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
 	qbftstorage "github.com/bloxapp/ssv/protocol/v1/qbft/storage"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/preprepare"
 	"github.com/bloxapp/ssv/protocol/v1/types"
 	"github.com/bloxapp/ssv/protocol/v1/validator"
 	"github.com/bloxapp/ssv/storage"
@@ -47,144 +45,19 @@ import (
 
 // nolint
 func testsToRun() map[string]struct{} {
-	testList := spectest.AllTests
-	testList = []spectest.SpecTest{
-		proposer.FourOperators(),
-		proposer.SevenOperators(),
-		proposer.TenOperators(),
-		proposer.ThirteenOperators(),
+	tests := make(map[string]struct{})
 
-		messages.RoundChangeDataInvalidJustifications(),
-		messages.RoundChangeDataInvalidPreparedRound(),
-		messages.RoundChangeDataInvalidPreparedValue(),
-		messages.RoundChangePrePreparedJustifications(),
-		messages.RoundChangeNotPreparedJustifications(),
-		messages.CommitDataEncoding(),
-		messages.DecidedMsgEncoding(),
-		messages.MsgNilIdentifier(),
-		messages.MsgNonZeroIdentifier(),
-		messages.MsgTypeUnknown(),
-		messages.PrepareDataEncoding(),
-		messages.ProposeDataEncoding(),
-		messages.MsgDataNil(),
-		messages.MsgDataNonZero(),
-		messages.SignedMsgSigTooShort(),
-		messages.SignedMsgSigTooLong(),
-		messages.SignedMsgNoSigners(),
-		messages.GetRoot(),
-		messages.SignedMessageEncoding(),
-		messages.CreateProposal(),
-		messages.CreateProposalPreviouslyPrepared(),
-		messages.CreateProposalNotPreviouslyPrepared(),
-		messages.CreatePrepare(),
-		messages.CreateCommit(),
-		messages.CreateRoundChange(),
-		messages.CreateRoundChangePreviouslyPrepared(),
-		messages.RoundChangeDataEncoding(),
-
-		spectests.HappyFlow(),
-		spectests.SevenOperators(),
-		spectests.TenOperators(),
-		spectests.ThirteenOperators(),
-
-		proposal.HappyFlow(),
-		proposal.NotPreparedPreviouslyJustification(),
-		proposal.PreparedPreviouslyJustification(),
-		proposal.DifferentJustifications(),
-		//proposal.JustificationsNotHeighest(),       // TODO(nkryuchkov): failure; Check if proposal for round >1 was prepared previously with rc justification prepares at different heights but the prepare justification or value is not the highest
-		//proposal.JustificationsValueNotJustified(), // TODO(nkryuchkov): failure; Check if proposal for round >1 was prepared previously with rc justification prepares at different heights but the prepare justification or value is not the highest
-		//proposal.DuplicateMsg(),                    // TODO(nkryuchkov): failure; need to check if proposal was already accepted
-		proposal.FirstRoundJustification(),
-		//proposal.FutureRoundNoAcceptedProposal(), // TODO(nkryuchkov): failure; need to decline proposals from future rounds if no proposal was accepted for current round
-		//proposal.FutureRoundAcceptedProposal(),   // TODO(nkryuchkov): failure; need to accept proposals from future rounds if already accepted proposal for current round
-		//proposal.PastRound(),                     // TODO(nkryuchkov): failure; need to decline proposals from past rounds
-		proposal.ImparsableProposalData(),
-		//proposal.InvalidRoundChangeJustificationPrepared(),        // TODO(nkryuchkov): failure; need to handle invalid rc justification
-		//proposal.InvalidRoundChangeJustification(),                // TODO(nkryuchkov): failure; need to handle invalid rc justification
-		//proposal.PreparedPreviouslyNoRCJustificationQuorum(),      // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.NoRCJustification(),                              // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyNoPrepareJustificationQuorum(), // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyDuplicatePrepareMsg(),          // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyDuplicateRCMsg(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.DuplicateRCMsg(),                                 // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.InvalidPrepareJustificationValue(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously but one of the prepare justifications has value != highest prepared or round != highest prepared round
-		//proposal.InvalidPrepareJustificationRound(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously but one of the prepare justifications has value != highest prepared or round != highest prepared round
-		proposal.InvalidProposalData(),
-		//proposal.InvalidValueCheck(), // TODO(nkryuchkov): failure; need to check message data
-		proposal.MultiSigner(),
-		//proposal.PostDecided(),            // TODO(nkryuchkov): failure; need to avoid processing proposal message after instance became prepared or decided
-		//proposal.PostPrepared(),           // TODO(nkryuchkov): failure; need to avoid processing proposal message after instance became prepared or decided
-		//proposal.SecondProposalForRound(), // TODO(nkryuchkov): failure; need to forbid second proposal for round
-		proposal.WrongHeight(),
-		proposal.WrongProposer(),
-		proposal.WrongSignature(),
-
-		prepare.DuplicateMsg(),
-		prepare.HappyFlow(),
-		prepare.ImparsableProposalData(),
-		prepare.InvalidPrepareData(),
-		prepare.MultiSigner(),
-		prepare.NoPreviousProposal(),
-		prepare.OldRound(),
-		prepare.FutureRound(),
-		prepare.PostDecided(),
-		prepare.WrongData(),
-		prepare.WrongHeight(),
-		prepare.WrongSignature(),
-
-		commit.CurrentRound(),
-		commit.FutureRound(),
-		commit.PastRound(),
-		commit.DuplicateMsg(),
-		commit.HappyFlow(),
-		commit.InvalidCommitData(),
-		commit.PostDecided(),
-		commit.WrongData1(),
-		commit.WrongData2(),
-		commit.MultiSignerWithOverlap(),
-		commit.MultiSignerNoOverlap(),
-		commit.Decided(),
-		commit.NoPrevAcceptedProposal(),
-		commit.WrongHeight(),
-		commit.ImparsableCommitData(),
-		commit.WrongSignature(),
-
-		roundchange.HappyFlow(),
-		roundchange.F1Speedup(),
-		roundchange.F1SpeedupPrepared(),
-		roundchange.WrongHeight(),
-		roundchange.WrongSig(),
-		roundchange.MultiSigner(),
-		roundchange.NotPrepared(),
-		roundchange.Prepared(),
-		roundchange.PeerPrepared(),
-		roundchange.PeerPreparedDifferentHeights(),
-		roundchange.JustificationWrongValue(),
-		roundchange.JustificationWrongRound(),
-		roundchange.JustificationNoQuorum(),
-		roundchange.JustificationMultiSigners(),
-		roundchange.JustificationInvalidSig(),
-		roundchange.JustificationInvalidRound(),
-		roundchange.JustificationInvalidPrepareData(),
-		roundchange.JustificationDuplicateMsg(),
-		roundchange.InvalidRoundChangeData(),
-		roundchange.FutureRound(),
-		roundchange.PastRound(),
-		roundchange.F1SpeedupDifferentRounds(),
-		roundchange.DuplicateMsgQuorum(),
-		roundchange.DuplicateMsgPartialQuorum(),
-		roundchange.DuplicateMsgPrepared(),
-		roundchange.ImparsableRoundChangeData(),
+	testsBrokenInSpec := map[string]struct{}{
+		commit.FutureDecided().TestName(): {},
 	}
 
-	//testList = []spectest.SpecTest{}
-
-	result := make(map[string]struct{})
-	for _, test := range testList {
-		result[test.TestName()] = struct{}{}
+	for _, testItem := range spectest.AllTests {
+		if _, exists := testsBrokenInSpec[testItem.TestName()]; !exists {
+			tests[testItem.TestName()] = struct{}{}
+		}
 	}
 
-	return result
+	return tests
 }
 
 func TestQBFTMapping(t *testing.T) {
@@ -217,7 +90,7 @@ func TestQBFTMapping(t *testing.T) {
 		types.SetDefaultDomain(origDomain)
 	}()
 
-	testMap := testsToRun() // TODO(nkryuchkov): remove
+	testMap := testsToRun() // TODO: Remove overriding after commit.FutureDecided() is fixed in spec.
 
 	tests := make(map[string]spectest.SpecTest)
 	for name, test := range untypedTests {
@@ -400,6 +273,39 @@ func runMsgProcessingSpecTest(t *testing.T, test *spectests.MsgProcessingSpecTes
 	db.Close()
 }
 
+type forkWithValueCheck struct {
+	forks.Fork
+}
+
+func (f forkWithValueCheck) PrePrepareMsgValidationPipeline(share *beaconprotocol.Share, state *qbftprotocol.State, roundLeader preprepare.LeaderResolver) pipelines.SignedMessagePipeline {
+	return pipelines.Combine(
+		f.Fork.PrePrepareMsgValidationPipeline(share, state, roundLeader),
+		msgValueCheck(),
+	)
+}
+
+func msgValueCheck() pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("value check", func(signedMessage *specqbft.SignedMessage) error {
+		if signedMessage.Message.MsgType != specqbft.ProposalMsgType {
+			return nil
+		}
+
+		proposalData, err := signedMessage.Message.GetProposalData()
+		if err != nil {
+			return nil
+		}
+		if err := proposalData.Validate(); err != nil {
+			return nil
+		}
+
+		if err := testingutils.TestingConfig(testingutils.Testing4SharesSet()).ValueCheckF(proposalData.Data); err != nil {
+			return fmt.Errorf("proposal not justified: proposal value invalid: %w", err)
+		}
+
+		return nil
+	})
+}
+
 func runMsgSpecTest(t *testing.T, test *spectests.MsgSpecTest) {
 	var lastErr error
 
@@ -498,6 +404,7 @@ func (m roundRobinLeaderSelector) Calculate(round uint64) uint64 {
 func newQbftInstance(logger *zap.Logger, qbftStorage qbftstorage.QBFTStore, net protocolp2p.MockNetwork, beacon *validator.TestBeacon, share *beaconprotocol.Share, mappedShare *spectypes.Share, identifier []byte, forkVersion forksprotocol.ForkVersion) instance.Instancer {
 	const height = 0
 	fork := forksfactory.NewFork(forkVersion)
+
 	newInstance := instance.NewInstance(&instance.Options{
 		Logger:           logger,
 		ValidatorShare:   share,
@@ -506,7 +413,7 @@ func newQbftInstance(logger *zap.Logger, qbftStorage qbftstorage.QBFTStore, net 
 		Identifier:       identifier[:],
 		Height:           height,
 		RequireMinPeers:  false,
-		Fork:             fork.InstanceFork(),
+		Fork:             forkWithValueCheck{fork.InstanceFork()},
 		SSVSigner:        beacon.KeyManager,
 		ChangeRoundStore: qbftStorage,
 	})


### PR DESCRIPTION
Depends on https://github.com/bloxapp/ssv/pull/671 and branch `align-error-messages` of `ssv-spec`

Fixes:
- prepare.MultiSigner()
- prepare.NoPreviousProposal()
- prepare.OldRound()
- prepare.FutureRound()
- prepare.WrongData()