### PR TITLE
Load Change round On startup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - change-round-process
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -68,7 +68,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - stage
+    - change-round-process
 
 
 #blox-infra-prod

--- a/protocol/v1/qbft/controller/controller_change_round.go
+++ b/protocol/v1/qbft/controller/controller_change_round.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	qbftstorage "github.com/bloxapp/ssv/protocol/v1/qbft/storage"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -13,40 +14,7 @@ func (c *Controller) ProcessChangeRound(msg *specqbft.SignedMessage) error {
 	if err := c.ValidateChangeRoundMsg(msg); err != nil {
 		return err
 	}
-	res, err := c.ChangeRoundStorage.GetLastChangeRoundMsg(c.Identifier, msg.GetSigners()...)
-	if err != nil {
-		return errors.Wrap(err, "failed to get last change round msg")
-	}
-
-	logger := c.Logger.With(zap.Any("signers", msg.GetSigners()))
-
-	if len(res) == 0 {
-		// no last changeRound msg exist, save the first one
-		c.Logger.Debug("no last change round exist. saving first one", zap.Int64("NewHeight", int64(msg.Message.Height)), zap.Int64("NewRound", int64(msg.Message.Round)))
-		return c.ChangeRoundStorage.SaveLastChangeRoundMsg(msg)
-	}
-	lastMsg := res[0]
-	logger = logger.With(
-		zap.Int64("lastHeight", int64(lastMsg.Message.Height)),
-		zap.Int64("NewHeight", int64(msg.Message.Height)),
-		zap.Int64("lastRound", int64(lastMsg.Message.Round)),
-		zap.Int64("NewRound", int64(msg.Message.Round)))
-
-	if msg.Message.Height < lastMsg.Message.Height {
-		// height is lower than the last known
-		logger.Debug("new changeRoundMsg height is lower than last changeRoundMsg")
-		return nil
-	} else if msg.Message.Height == lastMsg.Message.Height {
-		if msg.Message.Round <= lastMsg.Message.Round {
-			// round is not higher than last known
-			logger.Debug("new changeRoundMsg round is lower than last changeRoundMsg")
-			return nil
-		}
-	}
-
-	// new msg is higher than last one, save.
-	logger.Debug("last change round updated")
-	return c.ChangeRoundStorage.SaveLastChangeRoundMsg(msg)
+	return UpdateChangeRoundMessage(c.Logger, c.ChangeRoundStorage, msg)
 }
 
 // ValidateChangeRoundMsg - validation for read mode change round msg
@@ -54,4 +22,42 @@ func (c *Controller) ProcessChangeRound(msg *specqbft.SignedMessage) error {
 // basic validation, signature, changeRound data
 func (c *Controller) ValidateChangeRoundMsg(msg *specqbft.SignedMessage) error {
 	return c.Fork.ValidateChangeRoundMsg(c.ValidatorShare, message.ToMessageID(c.Identifier)).Run(msg)
+}
+
+// UpdateChangeRoundMessage if round for specific signer is higher than local msg
+func UpdateChangeRoundMessage(logger *zap.Logger, changeRoundStorage qbftstorage.ChangeRoundStore, msg *specqbft.SignedMessage) error {
+	local, err := changeRoundStorage.GetLastChangeRoundMsg(msg.Message.Identifier, msg.GetSigners()...) // assume 1 signer
+	if err != nil {
+		return errors.Wrap(err, "failed to get last change round msg")
+	}
+
+	fLogger := logger.With(zap.Any("signers", msg.GetSigners()))
+
+	if len(local) == 0 {
+		// no last changeRound msg exist, save the first one
+		fLogger.Debug("no last change round exist. saving first one", zap.Int64("NewHeight", int64(msg.Message.Height)), zap.Int64("NewRound", int64(msg.Message.Round)))
+		return changeRoundStorage.SaveLastChangeRoundMsg(msg)
+	}
+	lastMsg := local[0]
+	fLogger = fLogger.With(
+		zap.Int64("lastHeight", int64(lastMsg.Message.Height)),
+		zap.Int64("NewHeight", int64(msg.Message.Height)),
+		zap.Int64("lastRound", int64(lastMsg.Message.Round)),
+		zap.Int64("NewRound", int64(msg.Message.Round)))
+
+	if msg.Message.Height < lastMsg.Message.Height {
+		// height is lower than the last known
+		fLogger.Debug("new changeRoundMsg height is lower than last changeRoundMsg")
+		return nil
+	} else if msg.Message.Height == lastMsg.Message.Height {
+		if msg.Message.Round <= lastMsg.Message.Round {
+			// round is not higher than last known
+			fLogger.Debug("new changeRoundMsg round is lower than last changeRoundMsg")
+			return nil
+		}
+	}
+
+	// new msg is higher than last one, save.
+	logger.Debug("last change round updated")
+	return changeRoundStorage.SaveLastChangeRoundMsg(msg)
 }

--- a/protocol/v1/qbft/instance/change_round.go
+++ b/protocol/v1/qbft/instance/change_round.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/controller"
 	"math"
 	"time"
 
@@ -33,6 +34,10 @@ func (i *Instance) ChangeRoundMsgPipeline() pipelines.SignedMessagePipeline {
 				return err
 			}
 			i.containersMap[specqbft.RoundChangeMsgType].AddMessage(signedMessage, changeRoundData.PreparedValue)
+
+			if err := controller.UpdateChangeRoundMessage(i.Logger, i.changeRoundStore, signedMessage); err != nil {
+				i.Logger.Warn("failed to update change round msg in storage", zap.Error(err))
+			}
 			return nil
 		}),
 		i.ChangeRoundPartialQuorumMsgPipeline(),


### PR DESCRIPTION
**Current**
Saving change round messages only for non committee.

**New implementation** 
Save change round msg for committee validators. 
Once qbft controller init,  load change round msg’s from storage and add them to the ctrl queue.

**Why?**
Once operator preforming restart (for any reason) we need to check for the local change round msg's and if exist, add them to queue. this action can help the operator to bump to the last round before restarted and eventually speedup change round quorum.


**TBD**
Create SIP.