### PR TITLE
Align qbft proposal message processing with spec

### DIFF
--- a/protocol/v1/qbft/instance/change_round.go
+++ b/protocol/v1/qbft/instance/change_round.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
-	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
 
@@ -63,7 +62,7 @@ func (i *Instance) uponChangeRoundFullQuorum() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("upon change round full quorum", func(signedMessage *specqbft.SignedMessage) error {
 		var err error
 		msgs := i.containersMap[specqbft.RoundChangeMsgType].ReadOnlyMessagesByRound(signedMessage.Message.Round)
-		quorum, msgsCount, committeeSize := changeround.HasQuorum(i.ValidatorShare, msgs)
+		quorum, msgsCount, committeeSize := signedmsg.HasQuorum(i.ValidatorShare, msgs)
 
 		// change round if quorum reached
 		if !quorum {

--- a/protocol/v1/qbft/instance/change_round.go
+++ b/protocol/v1/qbft/instance/change_round.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
-	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
 
@@ -63,7 +63,7 @@ func (i *Instance) uponChangeRoundFullQuorum() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("upon change round full quorum", func(signedMessage *specqbft.SignedMessage) error {
 		var err error
 		msgs := i.containersMap[specqbft.RoundChangeMsgType].ReadOnlyMessagesByRound(signedMessage.Message.Round)
-		quorum, msgsCount, committeeSize := i.changeRoundQuorum(msgs)
+		quorum, msgsCount, committeeSize := changeround.HasQuorum(i.ValidatorShare, msgs)
 
 		// change round if quorum reached
 		if !quorum {
@@ -144,17 +144,6 @@ func (i *Instance) actOnExistingPrePrepare(signedMessage *specqbft.SignedMessage
 		return nil
 	}
 	return i.UponPrePrepareMsg().Run(msg)
-}
-
-func (i *Instance) changeRoundQuorum(msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
-	uniqueSigners := make(map[spectypes.OperatorID]bool)
-	for _, msg := range msgs {
-		for _, signer := range msg.GetSigners() {
-			uniqueSigners[signer] = true
-		}
-	}
-	quorum = len(uniqueSigners)*3 >= i.ValidatorShare.CommitteeSize()*2
-	return quorum, len(uniqueSigners), i.ValidatorShare.CommitteeSize()
 }
 
 func (i *Instance) roundChangeInputValue() ([]byte, error) {

--- a/protocol/v1/qbft/instance/change_round_test.go
+++ b/protocol/v1/qbft/instance/change_round_test.go
@@ -47,7 +47,7 @@ func (v0 *testFork) PrePrepareMsgValidationPipeline(share *beacon.Share, state *
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
-		preprepare.ValidatePrePrepareMsg(roundLeader),
+		preprepare.ValidatePrePrepareMsg(share, state, roundLeader),
 	)
 }
 

--- a/protocol/v1/qbft/instance/forks/genesis/fork.go
+++ b/protocol/v1/qbft/instance/forks/genesis/fork.go
@@ -44,7 +44,7 @@ func (g *ForkGenesis) PrePrepareMsgValidationPipeline(share *beacon.Share, state
 		signedmsg.ValidateLambdas(identifier[:]),
 		signedmsg.ValidateSequenceNumber(state.GetHeight()),
 		signedmsg.AuthorizeMsg(share),
-		preprepare.ValidatePrePrepareMsg(roundLeader),
+		preprepare.ValidatePrePrepareMsg(share, state, roundLeader),
 	)
 }
 

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -49,9 +49,12 @@ func (i *Instance) UponPrePrepareMsg() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("upon pre-prepare msg", func(signedMessage *specqbft.SignedMessage) error {
 		newRound := signedMessage.Message.Round
 
-		// A future justified proposal should bump us into future round and reset timer
-		if signedMessage.Message.Round > i.State().GetRound() {
-			i.ResetRoundTimer() // TODO: make sure what is needed here is i.ResetRoundTimer(), not something else
+		if currentRound := i.State().GetRound(); signedMessage.Message.Round > currentRound {
+			i.Logger.Debug("received future justified proposal, bumping into its round and resetting timer",
+				zap.Uint64("current_round", uint64(currentRound)),
+				zap.Uint64("future_round", uint64(signedMessage.Message.Round)),
+			)
+			i.ResetRoundTimer()
 			i.bumpToRound(newRound)
 		}
 

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
 
@@ -62,7 +63,7 @@ func (i *Instance) JustifyPrePrepare(round uint64, proposalData *specqbft.Propos
 		}
 	}
 
-	if quorum, _, _ := i.changeRoundQuorum(proposalData.RoundChangeJustification); !quorum {
+	if quorum, _, _ := changeround.HasQuorum(i.ValidatorShare, proposalData.RoundChangeJustification); !quorum {
 		return errors.New("no change round quorum")
 	}
 	notPrepared, highest, err := i.HighestPrepared(specqbft.Round(round))

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"bytes"
 	"fmt"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -10,8 +9,6 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
-	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
-	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 )
 
 // PrePrepareMsgPipeline is the main pre-prepare msg pipeline
@@ -33,50 +30,12 @@ func (i *Instance) PrePrepareMsgPipeline() pipelines.SignedMessagePipeline {
 
 			return nil
 		}),
-		pipelines.CombineQuiet(
-			signedmsg.ValidateRound(i.State().GetRound()),
-			i.UponPrePrepareMsg(),
-		),
+		i.UponPrePrepareMsg(),
 	)
 }
 
 func (i *Instance) prePrepareMsgValidationPipeline() pipelines.SignedMessagePipeline {
 	return i.fork.PrePrepareMsgValidationPipeline(i.ValidatorShare, i.State(), i.RoundLeader)
-}
-
-// JustifyPrePrepare implements:
-// predicate JustifyPrePrepare(hPRE-PREPARE, λi, round, value)
-// 	return
-// 		round = 1
-// 		∨ received a quorum Qrc of valid <ROUND-CHANGE, λi, round, prj , pvj> messages such that:
-// 			∀ <ROUND-CHANGE, λi, round, prj , pvj> ∈ Qrc : prj = ⊥ ∧ prj = ⊥
-// 			∨ received a quorum of valid <PREPARE, λi, pr, value> messages such that:
-// 				(pr, value) = HighestPrepared(Qrc)
-func (i *Instance) JustifyPrePrepare(round uint64, proposalData *specqbft.ProposalData) error {
-	if round == 1 {
-		return nil
-	}
-
-	for _, rc := range proposalData.RoundChangeJustification {
-		if err := i.validateRoundChange(rc); err != nil {
-			return errors.Wrap(err, "change round msg not valid")
-		}
-	}
-
-	if quorum, _, _ := changeround.HasQuorum(i.ValidatorShare, proposalData.RoundChangeJustification); !quorum {
-		return errors.New("no change round quorum")
-	}
-	notPrepared, highest, err := i.HighestPrepared(specqbft.Round(round))
-	if err != nil {
-		return err
-	}
-	if notPrepared {
-		return nil
-	}
-	if !bytes.Equal(proposalData.Data, highest.PreparedValue) {
-		return errors.New("preparedValue different than highest prepared")
-	}
-	return nil
 }
 
 func (i *Instance) validateRoundChange(signedMsg *specqbft.SignedMessage) error {
@@ -96,15 +55,17 @@ upon receiving a valid ⟨PRE-PREPARE, λi, ri, value⟩ message m from leader(�
 */
 func (i *Instance) UponPrePrepareMsg() pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("upon pre-prepare msg", func(signedMessage *specqbft.SignedMessage) error {
+		newRound := signedMessage.Message.Round
+
+		// A future justified proposal should bump us into future round and reset timer
+		if signedMessage.Message.Round > i.State().GetRound() {
+			i.ResetRoundTimer() // TODO: make sure what is needed here is i.ResetRoundTimer(), not something else
+		}
+		i.State().Round.Store(newRound)
+
 		prepareMsg, err := signedMessage.Message.GetProposalData()
 		if err != nil {
 			return errors.Wrap(err, "failed to get prepare message")
-		}
-
-		// Pre-prepare justification
-		err = i.JustifyPrePrepare(uint64(signedMessage.Message.Round), prepareMsg)
-		if err != nil {
-			return err
 		}
 
 		// mark state

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -52,8 +52,8 @@ func (i *Instance) UponPrePrepareMsg() pipelines.SignedMessagePipeline {
 		// A future justified proposal should bump us into future round and reset timer
 		if signedMessage.Message.Round > i.State().GetRound() {
 			i.ResetRoundTimer() // TODO: make sure what is needed here is i.ResetRoundTimer(), not something else
+			i.bumpToRound(newRound)
 		}
-		i.State().Round.Store(newRound)
 
 		prepareMsg, err := signedMessage.Message.GetProposalData()
 		if err != nil {

--- a/protocol/v1/qbft/instance/pre_prepare.go
+++ b/protocol/v1/qbft/instance/pre_prepare.go
@@ -38,14 +38,6 @@ func (i *Instance) prePrepareMsgValidationPipeline() pipelines.SignedMessagePipe
 	return i.fork.PrePrepareMsgValidationPipeline(i.ValidatorShare, i.State(), i.RoundLeader)
 }
 
-func (i *Instance) validateRoundChange(signedMsg *specqbft.SignedMessage) error {
-	if len(signedMsg.GetSigners()) != 1 {
-		return errors.New("msg allows 1 signer")
-	}
-
-	return nil
-}
-
 /*
 UponPrePrepareMsg Algorithm 2 IBFTController pseudocode for process pi: normal case operation
 upon receiving a valid ⟨PRE-PREPARE, λi, ri, value⟩ message m from leader(λi, round) such that:

--- a/protocol/v1/qbft/validation/changeround/validate_justification.go
+++ b/protocol/v1/qbft/validation/changeround/validate_justification.go
@@ -57,7 +57,7 @@ func (p *validateJustification) Run(signedMessage *specqbft.SignedMessage) error
 		}
 	}
 
-	if quorum, _, _ := p.changeRoundQuorum(data.RoundChangeJustification); !quorum {
+	if quorum, _, _ := HasQuorum(p.share, data.RoundChangeJustification); !quorum {
 		return fmt.Errorf("no justifications quorum")
 	}
 
@@ -124,14 +124,14 @@ func (p *validateJustification) Name() string {
 	return "validateJustification msg"
 }
 
-// TODO(nkryuchkov): Consider merging with all changeRoundQuorum functions.
-func (p *validateJustification) changeRoundQuorum(msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
+// HasQuorum checks if messages have a quorum.
+func HasQuorum(share *beacon.Share, msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
 	uniqueSigners := make(map[spectypes.OperatorID]bool)
 	for _, msg := range msgs {
 		for _, signer := range msg.GetSigners() {
 			uniqueSigners[signer] = true
 		}
 	}
-	quorum = len(uniqueSigners)*3 >= p.share.CommitteeSize()*2
-	return quorum, len(uniqueSigners), p.share.CommitteeSize()
+	quorum = len(uniqueSigners)*3 >= share.CommitteeSize()*2
+	return quorum, len(uniqueSigners), share.CommitteeSize()
 }

--- a/protocol/v1/qbft/validation/changeround/validate_justification.go
+++ b/protocol/v1/qbft/validation/changeround/validate_justification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
 	"github.com/bloxapp/ssv/protocol/v1/types"
 )
 
@@ -57,7 +58,7 @@ func (p *validateJustification) Run(signedMessage *specqbft.SignedMessage) error
 		}
 	}
 
-	if quorum, _, _ := HasQuorum(p.share, data.RoundChangeJustification); !quorum {
+	if quorum, _, _ := signedmsg.HasQuorum(p.share, data.RoundChangeJustification); !quorum {
 		return fmt.Errorf("no justifications quorum")
 	}
 
@@ -122,16 +123,4 @@ func (p *validateJustification) validateRoundChangeJustification(rcj *specqbft.S
 // Name implements pipeline.Pipeline interface
 func (p *validateJustification) Name() string {
 	return "validateJustification msg"
-}
-
-// HasQuorum checks if messages have a quorum.
-func HasQuorum(share *beacon.Share, msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
-	uniqueSigners := make(map[spectypes.OperatorID]bool)
-	for _, msg := range msgs {
-		for _, signer := range msg.GetSigners() {
-			uniqueSigners[signer] = true
-		}
-	}
-	quorum = len(uniqueSigners)*3 >= share.CommitteeSize()*2
-	return quorum, len(uniqueSigners), share.CommitteeSize()
 }

--- a/protocol/v1/qbft/validation/preprepare/validate.go
+++ b/protocol/v1/qbft/validation/preprepare/validate.go
@@ -1,12 +1,19 @@
 package preprepare
 
 import (
+	"bytes"
 	"fmt"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
 
+	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
+	"github.com/bloxapp/ssv/protocol/v1/qbft"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/changeround"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/signedmsg"
+	"github.com/bloxapp/ssv/protocol/v1/types"
 )
 
 // ErrInvalidSignersNum represents an error when the number of signers is invalid.
@@ -16,7 +23,7 @@ var ErrInvalidSignersNum = errors.New("proposal msg allows 1 signer")
 type LeaderResolver func(round specqbft.Round) uint64
 
 // ValidatePrePrepareMsg validates pre-prepare message
-func ValidatePrePrepareMsg(resolver LeaderResolver) pipelines.SignedMessagePipeline {
+func ValidatePrePrepareMsg(share *beacon.Share, state *qbft.State, resolver LeaderResolver) pipelines.SignedMessagePipeline {
 	return pipelines.WrapFunc("validate pre-prepare", func(signedMessage *specqbft.SignedMessage) error {
 		signers := signedMessage.GetSigners()
 		if len(signers) != 1 {
@@ -27,6 +34,190 @@ func ValidatePrePrepareMsg(resolver LeaderResolver) pipelines.SignedMessagePipel
 		if uint64(signers[0]) != leader {
 			return fmt.Errorf("proposal leader invalid")
 		}
-		return nil
+
+		prepareMsg, err := signedMessage.Message.GetProposalData()
+		if err != nil {
+			return fmt.Errorf("could not get proposal data: %w", err)
+		}
+
+		if err := JustifyPrePrepare(share, state, uint64(signedMessage.Message.Round), prepareMsg); err != nil {
+			return fmt.Errorf("proposal not justified: %w", err)
+		}
+
+		proposalAcceptedForCurrentRound := state.GetProposalAcceptedForCurrentRound()
+		round := state.GetRound()
+		if (proposalAcceptedForCurrentRound == nil && signedMessage.Message.Round == round) ||
+			(proposalAcceptedForCurrentRound != nil && signedMessage.Message.Round > round) {
+			return nil
+		}
+		return errors.New("proposal is not valid with current state")
 	})
+}
+
+// JustifyPrePrepare implements:
+// predicate JustifyPrePrepare(hPRE-PREPARE, λi, round, value)
+// 	return
+// 		round = 1
+// 		∨ received a quorum Qrc of valid <ROUND-CHANGE, λi, round, prj , pvj> messages such that:
+// 			∀ <ROUND-CHANGE, λi, round, prj , pvj> ∈ Qrc : prj = ⊥ ∧ prj = ⊥
+// 			∨ received a quorum of valid <PREPARE, λi, pr, value> messages such that:
+// 				(pr, value) = HighestPrepared(Qrc)
+func JustifyPrePrepare(share *beacon.Share, state *qbft.State, round uint64, proposalData *specqbft.ProposalData) error {
+	// TODO: move its tests to this package
+	if round == 1 {
+		return nil
+	}
+
+	for _, rc := range proposalData.RoundChangeJustification {
+		// TODO: refactor
+		if err := pipelines.Combine(
+			signedmsg.BasicMsgValidation(),
+			signedmsg.MsgTypeCheck(specqbft.RoundChangeMsgType),
+			signedmsg.AuthorizeMsg(share),
+			changeround.Validate(share),
+		).Run(rc); err != nil {
+			return fmt.Errorf("change round msg not valid: %w", err)
+		}
+	}
+
+	if quorum, _, _ := signedmsg.HasQuorum(share, proposalData.RoundChangeJustification); !quorum {
+		return errors.New("change round has not quorum")
+	}
+
+	// previouslyPreparedF returns true if any on the round change messages have a prepared round and value
+	previouslyPrepared, err := func(rcMsgs []*specqbft.SignedMessage) (bool, error) {
+		for _, rc := range rcMsgs {
+			rcData, err := rc.Message.GetRoundChangeData()
+			if err != nil {
+				return false, fmt.Errorf("could not get round change data: %w", err)
+			}
+			if rcData.Prepared() {
+				return true, nil
+			}
+		}
+		return false, nil
+	}(proposalData.RoundChangeJustification)
+	if err != nil {
+		return fmt.Errorf("could not calculate if previously prepared: %w", err)
+	}
+
+	if !previouslyPrepared {
+		return nil
+	}
+
+	if quorum, _, _ := signedmsg.HasQuorum(share, proposalData.PrepareJustification); !quorum {
+		return errors.New("prepares has no quorum")
+	}
+
+	// get a round change data for which there is a justification for the highest previously prepared round
+	highest, err := highestPrepared(proposalData.RoundChangeJustification)
+	if err != nil {
+		return errors.Wrap(err, "could not get highest prepared")
+	}
+
+	if highest == nil {
+		return errors.New("no highest prepared")
+	}
+
+	highestData, err := highest.Message.GetRoundChangeData()
+	if err != nil {
+		return errors.Wrap(err, "could not get round change data")
+	}
+
+	// proposed value must equal highest prepared value
+	if !bytes.Equal(proposalData.Data, highestData.PreparedValue) {
+		return errors.New("proposed data doesn't match highest prepared")
+	}
+
+	for _, rcj := range proposalData.PrepareJustification {
+		if err := validateRoundChangeJustification(
+			rcj,
+			state.GetHeight(),
+			highestData.PreparedRound,
+			highestData.PreparedValue,
+			share,
+		); err != nil {
+			return fmt.Errorf("signed prepare not valid")
+		}
+	}
+
+	return nil
+}
+
+// highestPrepared returns a round change message with the highest prepared round, returns nil if none found
+func highestPrepared(roundChanges []*specqbft.SignedMessage) (*specqbft.SignedMessage, error) {
+	var ret *specqbft.SignedMessage
+	for _, rc := range roundChanges {
+		rcData, err := rc.Message.GetRoundChangeData()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get round change data")
+		}
+
+		if !rcData.Prepared() {
+			continue
+		}
+
+		if ret == nil {
+			ret = rc
+		} else {
+			retRCData, err := ret.Message.GetRoundChangeData()
+			if err != nil {
+				return nil, errors.Wrap(err, "could not get round change data")
+			}
+			if retRCData.PreparedRound < rcData.PreparedRound {
+				ret = rc
+			}
+		}
+	}
+	return ret, nil
+}
+
+// TODO: merge with (*validateJustification).validateRoundChangeJustification, use it everywhere where spec does
+func validateRoundChangeJustification(
+	signedPrepare *specqbft.SignedMessage,
+	height specqbft.Height,
+	round specqbft.Round,
+	value []byte,
+	share *beacon.Share,
+) error {
+	if signedPrepare.Message.MsgType != specqbft.PrepareMsgType {
+		return errors.New("prepare msg type is wrong")
+	}
+	if signedPrepare.Message.Height != height {
+		return errors.New("message height is wrong")
+	}
+	if signedPrepare.Message.Round != round {
+		return errors.New("round is wrong")
+	}
+	prepareData, err := signedPrepare.Message.GetPrepareData()
+	if err != nil {
+		return errors.Wrap(err, "could not get prepare data")
+	}
+	if err := prepareData.Validate(); err != nil {
+		return errors.Wrap(err, "prepareData invalid")
+	}
+	if !bytes.Equal(prepareData.Data, value) {
+		return errors.New("prepare data != proposed data")
+	}
+	if len(signedPrepare.GetSigners()) != 1 {
+		return errors.New("prepare msg allows 1 signer")
+	}
+
+	// validateJustification justification signature
+	pksMap, err := share.PubKeysByID(signedPrepare.GetSigners())
+	var pks beacon.PubKeys
+	for _, v := range pksMap {
+		pks = append(pks, v)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "change round could not get pubkey")
+	}
+	aggregated := pks.Aggregate()
+
+	if err = signedPrepare.Signature.Verify(signedPrepare, types.GetDefaultDomain(), spectypes.QBFTSignatureType, aggregated.Serialize()); err != nil {
+		return errors.Wrap(err, "invalid message signature")
+	}
+
+	return nil
 }

--- a/protocol/v1/qbft/validation/signedmsg/quorum.go
+++ b/protocol/v1/qbft/validation/signedmsg/quorum.go
@@ -1,0 +1,20 @@
+package signedmsg
+
+import (
+	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
+
+	"github.com/bloxapp/ssv/protocol/v1/blockchain/beacon"
+)
+
+// HasQuorum checks if messages have a quorum.
+func HasQuorum(share *beacon.Share, msgs []*specqbft.SignedMessage) (quorum bool, t int, n int) {
+	uniqueSigners := make(map[spectypes.OperatorID]bool)
+	for _, msg := range msgs {
+		for _, signer := range msg.GetSigners() {
+			uniqueSigners[signer] = true
+		}
+	}
+	quorum = len(uniqueSigners)*3 >= share.CommitteeSize()*2
+	return quorum, len(uniqueSigners), share.CommitteeSize()
+}

--- a/spectest/qbft/qbft_mapping_test.go
+++ b/spectest/qbft/qbft_mapping_test.go
@@ -18,11 +18,6 @@ import (
 	"github.com/bloxapp/ssv-spec/qbft/spectest"
 	spectests "github.com/bloxapp/ssv-spec/qbft/spectest/tests"
 	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/commit"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/messages"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/prepare"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/proposal"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/proposer"
-	"github.com/bloxapp/ssv-spec/qbft/spectest/tests/roundchange"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/bloxapp/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
@@ -35,9 +30,12 @@ import (
 	qbftprotocol "github.com/bloxapp/ssv/protocol/v1/qbft"
 	forksfactory "github.com/bloxapp/ssv/protocol/v1/qbft/controller/forks/factory"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/forks"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/leader/constant"
 	"github.com/bloxapp/ssv/protocol/v1/qbft/instance/msgcont"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/pipelines"
 	qbftstorage "github.com/bloxapp/ssv/protocol/v1/qbft/storage"
+	"github.com/bloxapp/ssv/protocol/v1/qbft/validation/preprepare"
 	"github.com/bloxapp/ssv/protocol/v1/types"
 	"github.com/bloxapp/ssv/protocol/v1/validator"
 	"github.com/bloxapp/ssv/storage"
@@ -47,144 +45,19 @@ import (
 
 // nolint
 func testsToRun() map[string]struct{} {
-	testList := spectest.AllTests
-	testList = []spectest.SpecTest{
-		proposer.FourOperators(),
-		proposer.SevenOperators(),
-		proposer.TenOperators(),
-		proposer.ThirteenOperators(),
+	tests := make(map[string]struct{})
 
-		messages.RoundChangeDataInvalidJustifications(),
-		messages.RoundChangeDataInvalidPreparedRound(),
-		messages.RoundChangeDataInvalidPreparedValue(),
-		messages.RoundChangePrePreparedJustifications(),
-		messages.RoundChangeNotPreparedJustifications(),
-		messages.CommitDataEncoding(),
-		messages.DecidedMsgEncoding(),
-		messages.MsgNilIdentifier(),
-		messages.MsgNonZeroIdentifier(),
-		messages.MsgTypeUnknown(),
-		messages.PrepareDataEncoding(),
-		messages.ProposeDataEncoding(),
-		messages.MsgDataNil(),
-		messages.MsgDataNonZero(),
-		messages.SignedMsgSigTooShort(),
-		messages.SignedMsgSigTooLong(),
-		messages.SignedMsgNoSigners(),
-		messages.GetRoot(),
-		messages.SignedMessageEncoding(),
-		messages.CreateProposal(),
-		messages.CreateProposalPreviouslyPrepared(),
-		messages.CreateProposalNotPreviouslyPrepared(),
-		messages.CreatePrepare(),
-		messages.CreateCommit(),
-		messages.CreateRoundChange(),
-		messages.CreateRoundChangePreviouslyPrepared(),
-		messages.RoundChangeDataEncoding(),
-
-		spectests.HappyFlow(),
-		spectests.SevenOperators(),
-		spectests.TenOperators(),
-		spectests.ThirteenOperators(),
-
-		proposal.HappyFlow(),
-		proposal.NotPreparedPreviouslyJustification(),
-		proposal.PreparedPreviouslyJustification(),
-		proposal.DifferentJustifications(),
-		//proposal.JustificationsNotHeighest(),       // TODO(nkryuchkov): failure; Check if proposal for round >1 was prepared previously with rc justification prepares at different heights but the prepare justification or value is not the highest
-		//proposal.JustificationsValueNotJustified(), // TODO(nkryuchkov): failure; Check if proposal for round >1 was prepared previously with rc justification prepares at different heights but the prepare justification or value is not the highest
-		//proposal.DuplicateMsg(),                    // TODO(nkryuchkov): failure; need to check if proposal was already accepted
-		proposal.FirstRoundJustification(),
-		//proposal.FutureRoundNoAcceptedProposal(), // TODO(nkryuchkov): failure; need to decline proposals from future rounds if no proposal was accepted for current round
-		//proposal.FutureRoundAcceptedProposal(),   // TODO(nkryuchkov): failure; need to accept proposals from future rounds if already accepted proposal for current round
-		//proposal.PastRound(),                     // TODO(nkryuchkov): failure; need to decline proposals from past rounds
-		proposal.ImparsableProposalData(),
-		//proposal.InvalidRoundChangeJustificationPrepared(),        // TODO(nkryuchkov): failure; need to handle invalid rc justification
-		//proposal.InvalidRoundChangeJustification(),                // TODO(nkryuchkov): failure; need to handle invalid rc justification
-		//proposal.PreparedPreviouslyNoRCJustificationQuorum(),      // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.NoRCJustification(),                              // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyNoPrepareJustificationQuorum(), // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyDuplicatePrepareMsg(),          // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.PreparedPreviouslyDuplicateRCMsg(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.DuplicateRCMsg(),                                 // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously with or without quorum of prepared or round change msgs justification
-		//proposal.InvalidPrepareJustificationValue(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously but one of the prepare justifications has value != highest prepared or round != highest prepared round
-		//proposal.InvalidPrepareJustificationRound(),               // TODO(nkryuchkov): failure; need to check if proposal for round >1 was prepared or not prepared previously but one of the prepare justifications has value != highest prepared or round != highest prepared round
-		proposal.InvalidProposalData(),
-		//proposal.InvalidValueCheck(), // TODO(nkryuchkov): failure; need to check message data
-		proposal.MultiSigner(),
-		//proposal.PostDecided(),            // TODO(nkryuchkov): failure; need to avoid processing proposal message after instance became prepared or decided
-		//proposal.PostPrepared(),           // TODO(nkryuchkov): failure; need to avoid processing proposal message after instance became prepared or decided
-		//proposal.SecondProposalForRound(), // TODO(nkryuchkov): failure; need to forbid second proposal for round
-		proposal.WrongHeight(),
-		proposal.WrongProposer(),
-		proposal.WrongSignature(),
-
-		prepare.DuplicateMsg(),
-		prepare.HappyFlow(),
-		prepare.ImparsableProposalData(),
-		prepare.InvalidPrepareData(),
-		prepare.MultiSigner(),
-		prepare.NoPreviousProposal(),
-		prepare.OldRound(),
-		prepare.FutureRound(),
-		prepare.PostDecided(),
-		prepare.WrongData(),
-		prepare.WrongHeight(),
-		prepare.WrongSignature(),
-
-		commit.CurrentRound(),
-		commit.FutureRound(),
-		commit.PastRound(),
-		commit.DuplicateMsg(),
-		commit.HappyFlow(),
-		commit.InvalidCommitData(),
-		commit.PostDecided(),
-		commit.WrongData1(),
-		commit.WrongData2(),
-		commit.MultiSignerWithOverlap(),
-		commit.MultiSignerNoOverlap(),
-		commit.Decided(),
-		commit.NoPrevAcceptedProposal(),
-		commit.WrongHeight(),
-		commit.ImparsableCommitData(),
-		commit.WrongSignature(),
-
-		roundchange.HappyFlow(),
-		roundchange.F1Speedup(),
-		roundchange.F1SpeedupPrepared(),
-		roundchange.WrongHeight(),
-		roundchange.WrongSig(),
-		roundchange.MultiSigner(),
-		roundchange.NotPrepared(),
-		roundchange.Prepared(),
-		roundchange.PeerPrepared(),
-		roundchange.PeerPreparedDifferentHeights(),
-		roundchange.JustificationWrongValue(),
-		roundchange.JustificationWrongRound(),
-		roundchange.JustificationNoQuorum(),
-		roundchange.JustificationMultiSigners(),
-		roundchange.JustificationInvalidSig(),
-		roundchange.JustificationInvalidRound(),
-		roundchange.JustificationInvalidPrepareData(),
-		roundchange.JustificationDuplicateMsg(),
-		roundchange.InvalidRoundChangeData(),
-		roundchange.FutureRound(),
-		roundchange.PastRound(),
-		roundchange.F1SpeedupDifferentRounds(),
-		roundchange.DuplicateMsgQuorum(),
-		roundchange.DuplicateMsgPartialQuorum(),
-		roundchange.DuplicateMsgPrepared(),
-		roundchange.ImparsableRoundChangeData(),
+	testsBrokenInSpec := map[string]struct{}{
+		commit.FutureDecided().TestName(): {},
 	}
 
-	//testList = []spectest.SpecTest{}
-
-	result := make(map[string]struct{})
-	for _, test := range testList {
-		result[test.TestName()] = struct{}{}
+	for _, testItem := range spectest.AllTests {
+		if _, exists := testsBrokenInSpec[testItem.TestName()]; !exists {
+			tests[testItem.TestName()] = struct{}{}
+		}
 	}
 
-	return result
+	return tests
 }
 
 func TestQBFTMapping(t *testing.T) {
@@ -217,7 +90,7 @@ func TestQBFTMapping(t *testing.T) {
 		types.SetDefaultDomain(origDomain)
 	}()
 
-	testMap := testsToRun() // TODO(nkryuchkov): remove
+	testMap := testsToRun() // TODO: Remove overriding after commit.FutureDecided() is fixed in spec.
 
 	tests := make(map[string]spectest.SpecTest)
 	for name, test := range untypedTests {
@@ -400,6 +273,39 @@ func runMsgProcessingSpecTest(t *testing.T, test *spectests.MsgProcessingSpecTes
 	db.Close()
 }
 
+type forkWithValueCheck struct {
+	forks.Fork
+}
+
+func (f forkWithValueCheck) PrePrepareMsgValidationPipeline(share *beaconprotocol.Share, state *qbftprotocol.State, roundLeader preprepare.LeaderResolver) pipelines.SignedMessagePipeline {
+	return pipelines.Combine(
+		f.Fork.PrePrepareMsgValidationPipeline(share, state, roundLeader),
+		msgValueCheck(),
+	)
+}
+
+func msgValueCheck() pipelines.SignedMessagePipeline {
+	return pipelines.WrapFunc("value check", func(signedMessage *specqbft.SignedMessage) error {
+		if signedMessage.Message.MsgType != specqbft.ProposalMsgType {
+			return nil
+		}
+
+		proposalData, err := signedMessage.Message.GetProposalData()
+		if err != nil {
+			return nil
+		}
+		if err := proposalData.Validate(); err != nil {
+			return nil
+		}
+
+		if err := testingutils.TestingConfig(testingutils.Testing4SharesSet()).ValueCheckF(proposalData.Data); err != nil {
+			return fmt.Errorf("proposal not justified: proposal value invalid: %w", err)
+		}
+
+		return nil
+	})
+}
+
 func runMsgSpecTest(t *testing.T, test *spectests.MsgSpecTest) {
 	var lastErr error
 
@@ -498,6 +404,7 @@ func (m roundRobinLeaderSelector) Calculate(round uint64) uint64 {
 func newQbftInstance(logger *zap.Logger, qbftStorage qbftstorage.QBFTStore, net protocolp2p.MockNetwork, beacon *validator.TestBeacon, share *beaconprotocol.Share, mappedShare *spectypes.Share, identifier []byte, forkVersion forksprotocol.ForkVersion) instance.Instancer {
 	const height = 0
 	fork := forksfactory.NewFork(forkVersion)
+
 	newInstance := instance.NewInstance(&instance.Options{
 		Logger:           logger,
 		ValidatorShare:   share,
@@ -506,7 +413,7 @@ func newQbftInstance(logger *zap.Logger, qbftStorage qbftstorage.QBFTStore, net 
 		Identifier:       identifier[:],
 		Height:           height,
 		RequireMinPeers:  false,
-		Fork:             fork.InstanceFork(),
+		Fork:             forkWithValueCheck{fork.InstanceFork()},
 		SSVSigner:        beacon.KeyManager,
 		ChangeRoundStore: qbftStorage,
 	})


### PR DESCRIPTION
Depends on https://github.com/bloxapp/ssv/pull/679 and branch `align-error-messages` of `ssv-spec`

Fixes:
- proposal.JustificationsNotHeighest()
- proposal.JustificationsValueNotJustified()
- proposal.DuplicateMsg()
- proposal.FutureRoundNoAcceptedProposal()
- proposal.FutureRoundAcceptedProposal()
- proposal.PastRound()
- proposal.InvalidRoundChangeJustificationPrepared()   
- proposal.InvalidRoundChangeJustification()           
- proposal.PreparedPreviouslyNoRCJustificationQuorum() 
- proposal.NoRCJustification()  
- proposal.PreparedPreviouslyNoPrepareJustificationQuorum() 
- proposal.PreparedPreviouslyDuplicatePrepareMsg()         
- proposal.PreparedPreviouslyDuplicateRCMsg()            
- proposal.DuplicateRCMsg()                           
- proposal.InvalidPrepareJustificationValue()       
- proposal.InvalidPrepareJustificationRound()         
- proposal.InvalidValueCheck()
- proposal.PostDecided()   
- proposal.PostPrepared()       
- proposal.SecondProposalForRound()