### PR TITLE
Version Distibution to respect $instance

### DIFF
--- a/monitoring/grafana/dashboard_ssv_operator.json
+++ b/monitoring/grafana/dashboard_ssv_operator.json
@@ -2885,7 +2885,7 @@
             {
               "datasource": "${DS_PROMETHEUS}",
               "exemplar": false,
-              "expr": "ssv:network:peers_identity{instance=~\"ssv-exporter.*\"}",
+              "expr": "ssv:network:peers_identity{instance=~\"$instance.*\"}",
               "format": "table",
               "instant": true,
               "interval": "",


### PR DESCRIPTION
Version Distibution to respect `$instance` instead of hardcoded `ssv-explorer`.