### PR TITLE
Change Round Fixes

### DIFF
--- a/network/forks/genesis/sync.go
+++ b/network/forks/genesis/sync.go
@@ -11,7 +11,7 @@ const (
 	historyProtocol     = "/ssv/sync/decided/history/0.0.1"
 
 	peersForSync            = 10
-	peersForLastChangeRound = 5
+	peersForLastChangeRound = 10
 )
 
 // ProtocolID returns the protocol id of the given protocol,

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -50,6 +50,8 @@ func (n *p2pNetwork) Setup() error {
 	if atomic.SwapInt32(&n.state, stateInitializing) == stateReady {
 		return errors.New("could not setup network: in ready state")
 	}
+	// set a seed for rand values
+	rand.Seed(time.Now().UnixNano())
 
 	n.logger.Info("configuring p2p network service")
 

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -177,10 +177,7 @@ func (n *p2pNetwork) getSubsetOfPeers(vpk spectypes.ValidatorPK, peerCount int, 
 	if peerCount > len(peers) {
 		peerCount = len(peers)
 	} else {
-		// TODO: remove logs
-		n.logger.Debug("peers before shuffle", zap.Any("peers", peers))
 		rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
-		n.logger.Debug("peers after shuffle", zap.Any("peers", peers))
 	}
 	return peers[:peerCount], nil
 }
@@ -212,7 +209,7 @@ func (n *p2pNetwork) makeSyncRequest(peers []peer.ID, mid spectypes.MessageID, p
 		}
 		mid := msgID(raw)
 		if distinct[mid] {
-			logger.Debug("duplicated sync msg", zap.String("mid", mid))
+			//logger.Debug("duplicated sync msg", zap.String("mid", mid))
 			continue
 		}
 		distinct[mid] = true

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -3,6 +3,7 @@ package p2pv1
 import (
 	"encoding/hex"
 	spectypes "github.com/bloxapp/ssv-spec/types"
+	"math/rand"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
@@ -173,12 +174,15 @@ func (n *p2pNetwork) getSubsetOfPeers(vpk spectypes.ValidatorPK, peerCount int, 
 		n.logger.Debug("could not find peers", zap.Any("topics", topics))
 		return nil, nil
 	}
-	// TODO: shuffle peers
-	i := peerCount
-	if i > len(peers) {
-		i = len(peers)
+	if peerCount > len(peers) {
+		peerCount = len(peers)
+	} else {
+		// TODO: remove logs
+		n.logger.Debug("peers before shuffle", zap.Any("peers", peers))
+		rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
+		n.logger.Debug("peers after shuffle", zap.Any("peers", peers))
 	}
-	return peers[:i], nil
+	return peers[:peerCount], nil
 }
 
 func (n *p2pNetwork) makeSyncRequest(peers []peer.ID, mid spectypes.MessageID, protocol libp2p_protocol.ID, syncMsg *message.SyncMessage) ([]p2pprotocol.SyncResult, error) {

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -212,6 +212,7 @@ func (n *p2pNetwork) makeSyncRequest(peers []peer.ID, mid spectypes.MessageID, p
 		}
 		mid := msgID(raw)
 		if distinct[mid] {
+			logger.Debug("duplicated sync msg", zap.String("mid", mid))
 			continue
 		}
 		distinct[mid] = true

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -199,7 +199,7 @@ func (n *p2pNetwork) makeSyncRequest(peers []peer.ID, mid spectypes.MessageID, p
 	}
 	plogger := n.logger.With(zap.String("protocol", string(protocol)), zap.String("identifier", mid.String()))
 	msgID := n.fork.MsgID()
-	distinct := make(map[string]bool, 0)
+	distinct := make(map[string]bool)
 	for _, pid := range peers {
 		logger := plogger.With(zap.String("peer", pid.String()))
 		raw, err := n.streamCtrl.Request(pid, protocol, encoded)

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -136,7 +136,8 @@ func TestP2pNetwork_Stream(t *testing.T) {
 	node := ln.Nodes[0]
 	res, err := node.LastChangeRound(mid, specqbft.Height(0))
 	require.NoError(t, err)
-	require.Len(t, res, 6)
+	require.GreaterOrEqual(t, len(res), 5)
+	require.Less(t, len(res), 7)
 	require.GreaterOrEqual(t, msgCounter, int64(9))
 }
 

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -5,21 +5,20 @@ import (
 	"encoding/hex"
 	"fmt"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	"github.com/bloxapp/ssv/network"
+	protcolp2p "github.com/bloxapp/ssv/protocol/v1/p2p"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	spectypes "github.com/bloxapp/ssv-spec/types"
+	forksfactory "github.com/bloxapp/ssv/network/forks/factory"
+	forksprotocol "github.com/bloxapp/ssv/protocol/forks"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
-
-	forksfactory "github.com/bloxapp/ssv/network/forks/factory"
-	forksprotocol "github.com/bloxapp/ssv/protocol/forks"
 )
 
 func TestGetMaxPeers(t *testing.T) {
@@ -33,7 +32,6 @@ func TestGetMaxPeers(t *testing.T) {
 	require.Equal(t, 16, n.getMaxPeers(n.fork.DecidedTopic()))
 }
 
-// TODO: fix dummy messages and check that are really sent and received by peers
 func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 	n := 4
 	ctx, cancel := context.WithCancel(context.Background())
@@ -42,7 +40,7 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 	pks := []string{"b768cdc2b2e0a859052bf04d1cd66383c96d95096a5287d08151494ce709556ba39c1300fbb902a0e2ebb7c31dc4e400",
 		"824b9024767a01b56790a72afb5f18bb0f97d5bddb946a7bd8dd35cc607c35a4d76be21f24f484d0d478b99dc63ed170"}
 
-	ln, routers, err := createNetworkAndSubscribe(ctx, t, n, pks, forksprotocol.GenesisForkVersion)
+	ln, routers, err := createNetworkAndSubscribe(ctx, t, n, forksprotocol.GenesisForkVersion, pks...)
 	require.NoError(t, err)
 	require.NotNil(t, routers)
 	require.NotNil(t, ln)
@@ -102,9 +100,78 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 	}
 }
 
-func createNetworkAndSubscribe(ctx context.Context, t *testing.T, n int, pks []string, forkVersion forksprotocol.ForkVersion) (*LocalNet, []*dummyRouter, error) {
-	logger := zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
-	//logger := zap.L()
+func TestP2pNetwork_Stream(t *testing.T) {
+	n := 12
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pkHex := "b768cdc2b2e0a859052bf04d1cd66383c96d95096a5287d08151494ce709556ba39c1300fbb902a0e2ebb7c31dc4e400"
+
+	ln, _, err := createNetworkAndSubscribe(ctx, t, n, forksprotocol.GenesisForkVersion, pkHex)
+	require.NoError(t, err)
+	require.Len(t, ln.Nodes, n)
+
+	pk, err := hex.DecodeString(pkHex)
+	require.NoError(t, err)
+	mid := spectypes.NewMsgID(pk, spectypes.BNRoleAttester)
+	rounds := []specqbft.Round{
+		1, 1, 1,
+		1, 2, 2,
+		3, 3, 1,
+		1, 1, 1,
+	}
+	heights := []specqbft.Height{
+		0, 0, 2,
+		10, 20, 20,
+		23, 23, 1,
+		1, 1, 1,
+	}
+	msgCounter := int64(0)
+	for i, node := range ln.Nodes {
+		registerHandler(node, mid, heights[i], rounds[i], &msgCounter)
+	}
+
+	<-time.After(time.Second)
+
+	node := ln.Nodes[0]
+	res, err := node.LastChangeRound(mid, specqbft.Height(0))
+	require.NoError(t, err)
+	require.Len(t, res, 6)
+	require.GreaterOrEqual(t, msgCounter, int64(9))
+}
+
+func registerHandler(node network.P2PNetwork, mid spectypes.MessageID, height specqbft.Height, round specqbft.Round, counter *int64) {
+	node.RegisterHandlers(&protcolp2p.SyncHandler{
+		Protocol: protcolp2p.LastChangeRoundProtocol,
+		Handler: func(message *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {
+			atomic.AddInt64(counter, 1)
+			sm := specqbft.SignedMessage{
+				Signature: []byte("xxx"),
+				Signers:   []spectypes.OperatorID{1, 2, 3},
+				Message: &specqbft.Message{
+					MsgType:    specqbft.RoundChangeMsgType,
+					Height:     height,
+					Round:      round,
+					Identifier: mid[:],
+					Data:       []byte("dummy change round message"),
+				},
+			}
+			data, err := sm.Encode()
+			if err != nil {
+				return nil, err
+			}
+			return &spectypes.SSVMessage{
+				MsgType: spectypes.SSVConsensusMsgType,
+				MsgID:   mid,
+				Data:    data,
+			}, nil
+		},
+	})
+}
+
+func createNetworkAndSubscribe(ctx context.Context, t *testing.T, n int, forkVersion forksprotocol.ForkVersion, pks ...string) (*LocalNet, []*dummyRouter, error) {
+	//logger := zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
+	logger := zap.L()
 	loggerFactory := func(who string) *zap.Logger {
 		return logger.With(zap.String("who", who))
 	}
@@ -119,7 +186,6 @@ func createNetworkAndSubscribe(ctx context.Context, t *testing.T, n int, pks []s
 	logger.Debug("created local network")
 
 	routers := make([]*dummyRouter, n)
-
 	// for now, skip routers for v0
 	//if forkVersion != forksprotocol.GenesisForkVersion {
 	for i, node := range ln.Nodes {

--- a/protocol/v1/sync/handlers/decided_history.go
+++ b/protocol/v1/sync/handlers/decided_history.go
@@ -15,7 +15,7 @@ import (
 )
 
 // HistoryHandler handler for decided history protocol
-// TODO: add msg validation
+// TODO: add msg validation and report scores
 func HistoryHandler(plogger *zap.Logger, store qbftstorage.DecidedMsgStore, reporting protocolp2p.ValidationReporting, maxBatchSize int) protocolp2p.RequestHandler {
 	plogger = plogger.With(zap.String("who", "last decided handler"))
 	return func(msg *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {

--- a/protocol/v1/sync/handlers/last_change_round.go
+++ b/protocol/v1/sync/handlers/last_change_round.go
@@ -14,7 +14,7 @@ import (
 )
 
 // LastChangeRoundHandler handler for last-decided protocol
-// TODO: add msg validation
+// TODO: add msg validation and report scores
 func LastChangeRoundHandler(plogger *zap.Logger, store qbftstorage.ChangeRoundStore, reporting protocolp2p.ValidationReporting) protocolp2p.RequestHandler {
 	//plogger = plogger.With(zap.String("who", "last decided handler"))
 	return func(msg *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {

--- a/protocol/v1/sync/handlers/last_decided.go
+++ b/protocol/v1/sync/handlers/last_decided.go
@@ -11,7 +11,7 @@ import (
 )
 
 // LastDecidedHandler handler for last-decided protocol
-// TODO: add msg validation
+// TODO: add msg validation and report scores
 func LastDecidedHandler(plogger *zap.Logger, store qbftstorage.DecidedMsgStore, reporting protocolp2p.ValidationReporting) protocolp2p.RequestHandler {
 	plogger = plogger.With(zap.String("who", "last decided handler"))
 	return func(msg *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {


### PR DESCRIPTION
This PR contains several enhancements and fixes to the sync components, specifically change round scenario:

* increased the number of peers for syncing change round (`5` to `10`)
* shuffle peers for all sync requests (so we'll get a different set of nodes in every request)
* filter duplicated messages for all stream protocols to avoid redundant processing
* added test for syncing change round