### PR TITLE
Migration 7: clean operator removals corruptions

### DIFF
--- a/migrations/migration_7_clean_operator_removals_corruptions.go
+++ b/migrations/migration_7_clean_operator_removals_corruptions.go
@@ -1,0 +1,16 @@
+package migrations
+
+import (
+	"context"
+)
+
+var migrationCleanOperatorRemovalCorruptions = Migration{
+	Name: "migration_7_clean_operator_removal_corruptions",
+	Run: func(ctx context.Context, opt Options, key []byte) error {
+		nodeStorage := opt.nodeStorage()
+		if err := nodeStorage.CleanRegistryData(); err != nil {
+			return err
+		}
+		return opt.Db.Set(migrationsPrefix, key, migrationCompleted)
+	},
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -25,6 +25,7 @@ var (
 		migrationCleanExporterRegistryData,
 		migrationCleanValidatorRegistryData,
 		migrationCleanSyncOffset,
+		migrationCleanOperatorRemovalCorruptions,
 	}
 )
 


### PR DESCRIPTION
A followup commit for #720

Will enforce cleanup of corrupted data