### PR TITLE
Fix qbft msgqueue concurrent map iteration and map write panic

### DIFF
--- a/protocol/v1/qbft/msgqueue/queue.go
+++ b/protocol/v1/qbft/msgqueue/queue.go
@@ -187,20 +187,24 @@ func (q *queue) Peek(n int, idx Index) []*spectypes.SSVMessage {
 
 // WithIterator looping through all indexes and return true when relevant and pop
 func (q *queue) WithIterator(n int, peek bool, iterator func(index Index) bool) []*spectypes.SSVMessage {
+	indices := make([]Index, len(q.items))
+	i := 0
 	q.itemsLock.RLock()
-
 	for k := range q.items {
-		if iterator(k) {
-			if peek {
-				q.itemsLock.RUnlock()
-				return q.Peek(n, k)
-			}
-			q.itemsLock.RUnlock()
-			return q.Pop(n, k)
+		indices[i] = k
+	}
+	q.itemsLock.RUnlock()
+
+	for _, idx := range indices {
+		if !iterator(idx) {
+			continue
 		}
+		if peek {
+			return q.Peek(n, idx)
+		}
+		return q.Pop(n, idx)
 	}
 
-	q.itemsLock.RUnlock()
 	return nil
 }
 

--- a/protocol/v1/qbft/msgqueue/queue.go
+++ b/protocol/v1/qbft/msgqueue/queue.go
@@ -187,11 +187,11 @@ func (q *queue) Peek(n int, idx Index) []*spectypes.SSVMessage {
 
 // WithIterator looping through all indexes and return true when relevant and pop
 func (q *queue) WithIterator(n int, peek bool, iterator func(index Index) bool) []*spectypes.SSVMessage {
-	indices := make([]Index, len(q.items))
-	i := 0
+	indices := make([]Index, 0, len(q.items))
+
 	q.itemsLock.RLock()
 	for k := range q.items {
-		indices[i] = k
+		indices = append(indices, k)
 	}
 	q.itemsLock.RUnlock()
 


### PR DESCRIPTION
Fix for the following issue:
```
fatal error: concurrent map iteration and map write

goroutine 291196 [running]:
runtime.throw({0x19d8450, 0xc015634010})
	/usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc020bcfb60 sp=0xc020bcfb30 pc=0x439fd1
runtime.mapiternext(0x1869148)
	/usr/local/go/src/runtime/map.go:858 +0x4eb fp=0xc020bcfbd0 sp=0xc020bcfb60 pc=0x412a6b
github.com/bloxapp/ssv/protocol/v1/qbft/msgqueue.(*queue).WithIterator(0xc0101c7710, 0xc, 0x1, 0xc010c58ae0)
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/msgqueue/queue.go:190 +0x99 fp=0xc020bcfcd8 sp=0xc020bcfbd0 pc=0xe32fb9
github.com/bloxapp/ssv/protocol/v1/qbft/controller.(*Controller).processHigherHeight(0xc001b93860, 0xc0057df540, {0xc000195650, 0x68}, 0x1988, 0xc00753a6a0)
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/controller/msgqueue_consumer.go:162 +0x103 fp=0xc020bcfda0 sp=0xc020bcfcd8 pc=0xe47903
github.com/bloxapp/ssv/protocol/v1/qbft/controller.(*Controller).ConsumeQueue(0xc001b93860, 0xc010c6c980, 0xc001b93860)
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/controller/msgqueue_consumer.go:69 +0x2de fp=0xc020bcfed0 sp=0xc020bcfda0 pc=0xe4641e
github.com/bloxapp/ssv/protocol/v1/qbft/controller.(*Controller).StartQueueConsumer(0xc001b93860, 0xc001b93860)
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/controller/msgqueue_consumer.go:28 +0xa5 fp=0xc020bcffc0 sp=0xc020bcfed0 pc=0xe45fa5
github.com/bloxapp/ssv/protocol/v1/qbft/controller.(*Controller).Init·dwrap·1()
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/controller/controller.go:185 +0x2a fp=0xc020bcffe0 sp=0xc020bcffc0 pc=0xe3d8aa
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc020bcffe8 sp=0xc020bcffe0 pc=0x46de61
created by github.com/bloxapp/ssv/protocol/v1/qbft/controller.(*Controller).Init
	/go/src/github.com/bloxapp/ssv/protocol/v1/qbft/controller/controller.go:185 +0x118
```