### PR TITLE
Revised logging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,9 +64,9 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
     - chmod 755 kubectl
     - mv kubectl /usr/bin/
-    #    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-    #    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
-    - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+#    - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
     - spec-align-qbft
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,6 @@ stages:
   - deploy
 
 variables:
-
   #GLOBAL
   IMAGE_NAME: ssv-node
 
@@ -14,7 +13,7 @@ variables:
   APP_REPLICAS_INFRA_STAGE: "1"
   ECRLOGIN_INFRA_STAGE: "aws ecr get-login --registry-ids $ACCOUNT_ID_INFRA_STAGE --region $AWS_REGION_INFRA_STAGE --no-include-email"
   STAGE_HEALTH_CHECK_IMAGE: 121827225315.dkr.ecr.us-west-2.amazonaws.com/infra-stage-repo:ubuntu20
- 
+
   #PRODUCTION
   ACCOUNT_ID_INFRA_PROD: 764289642555
   AWS_REGION_INFRA_PROD: "us-west-2"
@@ -33,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - spec-align-qbft-logging
+    - spec-align-qbft
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -65,12 +64,11 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
     - chmod 755 kubectl
     - mv kubectl /usr/bin/
-    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
-#    - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    #    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    #    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+    - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
-    - spec-align-qbft-logging
-
+    - spec-align-qbft
 
 #blox-infra-prod
 Build prod Docker image:
@@ -84,7 +82,6 @@ Build prod Docker image:
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
   only:
     - main
-
 
 Deploy ssv exporter to blox-infra-prod cluster:
   stage: deploy
@@ -114,13 +111,13 @@ Deploy ssv-nodes to blox-infra-prod cluster:
     - export SSV_NODES_CPU_LIMIT_V1=$PROD_SSV_NODES_CPU_LIMIT_V1
     - export SSV_NODES_MEM_LIMIT_V1=$PROD_SSV_NODES_MEM_LIMIT_V1
     - export SSV_NODES_CPU_LIMIT_V3=$PROD_SSV_NODES_CPU_LIMIT_V3
-    - export SSV_NODES_MEM_LIMIT_V3=$PROD_SSV_NODES_MEM_LIMIT_V3      
+    - export SSV_NODES_MEM_LIMIT_V3=$PROD_SSV_NODES_MEM_LIMIT_V3
     - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
     - chmod +x ./kubectl
     - mv ./kubectl /usr/bin/kubectl
     - .k8/scripts/deploy-ssv-nodes-yamls-on-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-#    - .k8/scripts/deploy-paul-lh-yml-on-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-#    - .k8/scripts/deploy-ssv-node-v1-yamls-on-prod-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
-#    - .k8/scripts/deploy-ssv-node-v3-yamls-on-prod-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
+  #    - .k8/scripts/deploy-paul-lh-yml-on-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+  #    - .k8/scripts/deploy-ssv-node-v1-yamls-on-prod-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+  #    - .k8/scripts/deploy-ssv-node-v3-yamls-on-prod-k8s.sh $DOCKER_REPO_INFRA_PROD $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
   only:
     - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - spec-align-qbft
+    - spec-align-qbft-logging
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -69,7 +69,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
 #    - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
-    - spec-align-qbft
+    - spec-align-qbft-logging
 
 
 #blox-infra-prod

--- a/.k8/yamls-stage-v1/ssv-node-v2-1-deployment.yml
+++ b/.k8/yamls-stage-v1/ssv-node-v2-1-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-10-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-10-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-11-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-11-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-12-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-12-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-9-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-9-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-2-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-2-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-3-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-3-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-4-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-4-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-5-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-5-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-6-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-6-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-7-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-7-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-stage/ssv-node-v2-8-deployment.yml
+++ b/.k8/yamls-stage/ssv-node-v2-8-deployment.yml
@@ -109,6 +109,8 @@ spec:
               optional: true
         - name: LOG_LEVEL
           value: "debug"
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: DISCOVERY_TYPE_KEY
           value: "discv5"
         - name: NETWORK

--- a/.k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml
+++ b/.k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml
@@ -107,6 +107,8 @@ spec:
               name: config-secrets
               key: abi_version
               optional: true
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: LOG_LEVEL
           value: "debug"
         - name: DB_REPORTING

--- a/.k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml
+++ b/.k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml
@@ -107,6 +107,8 @@ spec:
               name: config-secrets
               key: abi_version
               optional: true
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: LOG_LEVEL
           value: "debug"
         - name: DB_REPORTING

--- a/.k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml
+++ b/.k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml
@@ -107,6 +107,8 @@ spec:
               name: config-secrets
               key: abi_version
               optional: true
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: LOG_LEVEL
           value: "debug"
         - name: DB_REPORTING

--- a/.k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml
+++ b/.k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml
@@ -107,6 +107,8 @@ spec:
               name: config-secrets
               key: abi_version
               optional: true
+        - name: DEBUG_SERVICES
+          value: "ssv/protocol/*."
         - name: LOG_LEVEL
           value: "debug"
         - name: DB_REPORTING

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,7 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'console' (default) and 'json''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
-	DebugRegexp    string `yaml:"DebugRegexp" env:"DEBUG_REGEXP" env-default:"ssv/protocol/*" env-description:"Defines components that will have debug level log"`
+	DebugServices  string `yaml:"DebugServices" env:"DEBUG_SERVICES" env-default:"" env-description:"Defines components that will have debug level log"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,6 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'console' (default) and 'json''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
+	DebugRegexp    string `yaml:"DebugRegexp" env:"DEBUG_REGEXP" env-default:"ssv/protocol/*" env-description:"Defines components that will have debug level log"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -91,7 +91,9 @@ var StartNodeCmd = &cobra.Command{
 		if errLogLevel != nil {
 			Logger.Warn(fmt.Sprintf("Default log level set to %s", loggerLevel), zap.Error(errLogLevel))
 		}
-		_ = logging.SetLogLevelRegex(cfg.DebugRegexp, "debug")
+		if len(cfg.DebugServices) > 0 {
+			_ = logging.SetLogLevelRegex(cfg.DebugServices, "debug")
+		}
 
 		cfg.DBOptions.Logger = Logger
 		cfg.DBOptions.Ctx = cmd.Context()

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	logging "github.com/ipfs/go-log"
 	"log"
 	"net/http"
 	"time"
@@ -90,6 +91,7 @@ var StartNodeCmd = &cobra.Command{
 		if errLogLevel != nil {
 			Logger.Warn(fmt.Sprintf("Default log level set to %s", loggerLevel), zap.Error(errLogLevel))
 		}
+		_ = logging.SetLogLevelRegex(cfg.DebugRegexp, "debug")
 
 		cfg.DBOptions.Logger = Logger
 		cfg.DBOptions.Ctx = cmd.Context()

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -139,9 +139,14 @@ $ make build
    2. fill the validator registration event with the data generated in section 4
 6. Place the `events.yaml` file in the `./config` directory (`./config/events.yaml`)
 7. Add the local events path to [config.yaml](../config/config.yaml) file `LocalEventsPath: ./config/events.yaml`
-8. Override the Bootnodes default value to empty string in [network config](../network/p2p/config.go) in order to use MDNS network. \
+8. Add debug services to [config.yaml](../config/config.yaml) file, use the following to debug all components: 
+```yaml 
+global:
+    DebugServices: ssv/.*
+```
+9. Override the Bootnodes default value to empty string in [network config](../network/p2p/config.go) in order to use MDNS network. \
    Validate you are not passing Bootnodes param in [config.yaml](../config/config.yaml)
-9. Build and run 4 local nodes ```docker-compose up --build ssv-node-1 ssv-node-2 ssv-node-3 ssv-node-4```
+10. Build and run 4 local nodes ```docker-compose up --build ssv-node-1 ssv-node-2 ssv-node-3 ssv-node-4```
 
 ### Run
 

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -1,0 +1,23 @@
+[<img src="./resources/bloxstaking_header_image.png" >](https://www.bloxstaking.com/)
+
+<br>
+<br>
+
+# Logs for Operators
+
+In order to minimize clutter, SSV periodically logs statistics at every slot and epoch. For example:
+```log
+INFO  Epoch started  {epoch: 1, duties: {proposals: 3, attestations: 2170, sync_committee: 3072}}
+ERROR  Failed to submit sync committee message  {error: "rpc error: code = Unavailable desc = connection error"}
+ERROR  Failed to submit attestation  {error: "rpc error: code = Unavailable desc = connection error"}
+INFO  Slot advanced  {epoch: 1, slot: 32, proposals: "2/2", attestations: "187/190", sync_committee: "88/96"}
+...
+INFO  Slot advanced  {epoch: 1, slot: 63, proposals: "0/0", attestations: "161/165", sync_committee: "93/96"}
+INFO  Epoch completed  {epoch: 0, proposals: "3/3", attestations: "2161/2170", sync_committee: "2882/3072"}
+```
+
+# Logs for Developers
+
+Debug logs can be enabled with the `--debug-services` flag or `DebugServices` environment variable.
+
+🚧 TODO

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -3,9 +3,20 @@
 <br>
 <br>
 
-# Logs for Operators
+# SSV - Logging
 
-In order to minimize clutter, SSV periodically logs statistics at every slot and epoch. For example:
+This document describes the logging standards and strategies used in ssv node. 
+
+## Logs for Operators
+
+In order to minimize clutter, SSV periodically logs statistics at every slot and epoch.
+
+Errors in logs can be of the following types:
+* `ERROR` - means the operator should take action
+* `WARN` - means the operator should pay attention
+
+For example:
+
 ```log
 INFO  Epoch started  {epoch: 1, duties: {proposals: 3, attestations: 2170, sync_committee: 3072}}
 ERROR  Failed to submit sync committee message  {error: "rpc error: code = Unavailable desc = connection error"}
@@ -16,7 +27,7 @@ INFO  Slot advanced  {epoch: 1, slot: 63, proposals: "0/0", attestations: "161/1
 INFO  Epoch completed  {epoch: 0, proposals: "3/3", attestations: "2161/2170", sync_committee: "2882/3072"}
 ```
 
-# Logs for Developers
+## Logs for Developers
 
 Debug logs can be enabled with the `--debug-services` flag or `DebugServices` environment variable.
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/attestantio/go-eth2-client v0.11.3
 	github.com/bloxapp/eth2-key-manager v1.1.3-0.20211102055147-c66d220973fd
-	github.com/bloxapp/ssv-spec v0.2.8-0.20221205114417-675c93af14b3
+	github.com/bloxapp/ssv-spec v0.2.8-0.20221215130920-8065017bd80d
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/ethereum/go-ethereum v1.10.18

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bloxapp/eth2-key-manager v1.1.3-0.20211102055147-c66d220973fd h1:EknWTnR7eSYFfH0GpQDn8+6naP4lV8pQPpnDFo59KhM=
 github.com/bloxapp/eth2-key-manager v1.1.3-0.20211102055147-c66d220973fd/go.mod h1:5Q4nQePS4jMbmO9J4qED+rxKcfHv0GNoFm6IkD2HRog=
-github.com/bloxapp/ssv-spec v0.2.8-0.20221205114417-675c93af14b3 h1:uZWEWDzBk5R1AgCf76A8H8swPQRfOdAFq7Yb72/YLV4=
-github.com/bloxapp/ssv-spec v0.2.8-0.20221205114417-675c93af14b3/go.mod h1:V/fCzJJ1+c+6IDF5y5UfwU6tZPLrg/6O8tyHUfSnpGw=
+github.com/bloxapp/ssv-spec v0.2.8-0.20221215130920-8065017bd80d h1:37uiqnu79tSPCD8+dZCYfmxdzKRQMSUTB+rrOXIl6y4=
+github.com/bloxapp/ssv-spec v0.2.8-0.20221215130920-8065017bd80d/go.mod h1:V/fCzJJ1+c+6IDF5y5UfwU6tZPLrg/6O8tyHUfSnpGw=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -187,7 +187,7 @@ func (n *p2pNetwork) clearValidatorState(pkHex string) {
 // handleIncomingMessages reads messages from the given channel and calls the router, note that this function blocks.
 func (n *p2pNetwork) handlePubsubMessages(topic string, msg *pubsub.Message) error {
 	if n.msgRouter == nil {
-		n.logger.Warn("msg router is not configured")
+		n.logger.Debug("msg router is not configured")
 		return nil
 	}
 	if msg == nil {

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -148,7 +148,6 @@ func NewController(options ControllerOptions) Controller {
 	}
 
 	validatorOptions := &validator.Options{ //TODO add vars
-		Logger:  options.Logger,
 		Network: options.Network,
 		Beacon:  commons.NewBeaconAdapter(options.Beacon),
 		Storage: storageMap,
@@ -551,9 +550,9 @@ func (c *controller) UpdateValidatorMetaDataLoop() {
 	}
 }
 
-func setupRunners(ctx context.Context, options validator.Options) runner.DutyRunners {
+func setupRunners(ctx context.Context, logger *zap.Logger, options validator.Options) runner.DutyRunners {
 	if options.SSVShare == nil || options.SSVShare.BeaconMetadata == nil {
-		options.Logger.Error("validator missing metadata", zap.String("pk", hex.EncodeToString(options.SSVShare.ValidatorPubKey)))
+		logger.Error("missing validator metadata", zap.String("validator", hex.EncodeToString(options.SSVShare.ValidatorPubKey)))
 		return runner.DutyRunners{} // TODO need to find better way to fix it
 	}
 
@@ -574,12 +573,12 @@ func setupRunners(ctx context.Context, options validator.Options) runner.DutyRun
 			ValueCheckF: nil, // sets per role type
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
 				leader := specqbft.RoundRobinProposer(state, round)
-				options.Logger.Debug("leader", zap.Int("", int(leader)))
+				logger.Debug("leader", zap.Int("", int(leader)))
 				return leader
 			},
 			Storage: options.Storage.Get(role),
 			Network: options.Network,
-			Timer:   roundtimer.New(ctx, options.Logger, nil),
+			Timer:   roundtimer.New(ctx, logger, nil),
 		}
 	}
 

--- a/operator/validator/validators_map.go
+++ b/operator/validator/validators_map.go
@@ -31,7 +31,7 @@ type validatorsMap struct {
 
 func newValidatorsMap(ctx context.Context, logger *zap.Logger, db basedb.IDb, optsTemplate *validator.Options) *validatorsMap {
 	vm := validatorsMap{
-		logger:        logger.With(zap.String("component", "validatorsMap")),
+		logger:        logger.With(zap.String("who", "validatorsMap")),
 		ctx:           ctx,
 		db:            db,
 		lock:          sync.RWMutex{},
@@ -108,12 +108,12 @@ func (vm *validatorsMap) Size() int {
 }
 
 func printShare(s *types.SSVShare, logger *zap.Logger, msg string) {
-	var committee []string
-	for _, c := range s.Committee {
-		committee = append(committee, fmt.Sprintf(`[OperatorID=%d, PubKey=%x]`, c.OperatorID, c.PubKey))
+	committee := make([]string, len(s.Committee))
+	for i, c := range s.Committee {
+		committee[i] = fmt.Sprintf(`[OperatorID=%d, PubKey=%x]`, c.OperatorID, c.PubKey)
 	}
 	logger.Debug(msg,
-		zap.String("pubKey", hex.EncodeToString(s.ValidatorPubKey)),
-		zap.Uint64("nodeID", uint64(s.OperatorID)),
+		zap.String("pub_key", hex.EncodeToString(s.ValidatorPubKey)),
+		zap.Uint64("node_id", uint64(s.OperatorID)),
 		zap.Strings("committee", committee))
 }

--- a/operator/validator/validators_map.go
+++ b/operator/validator/validators_map.go
@@ -76,7 +76,7 @@ func (vm *validatorsMap) GetOrCreateValidator(share *types.SSVShare) *validator.
 	if v, ok := vm.validatorsMap[pubKey]; !ok {
 		opts := *vm.optsTemplate
 		opts.SSVShare = share
-		opts.DutyRunners = setupRunners(vm.ctx, opts)
+		opts.DutyRunners = setupRunners(vm.ctx, vm.logger, opts)
 		vm.validatorsMap[pubKey] = validator.NewValidator(vm.ctx, opts)
 		printShare(share, vm.logger, "setup validator done")
 		opts.SSVShare = nil

--- a/protocol/v2/blockchain/beacon/validator_metadata.go
+++ b/protocol/v2/blockchain/beacon/validator_metadata.go
@@ -69,28 +69,28 @@ func UpdateValidatorsMetadata(pubKeys [][]byte, collection ValidatorMetadataStor
 
 	results, err := FetchValidatorsMetadata(bc, pubKeys)
 	if err != nil {
-		return errors.Wrap(err, "failed to get validator data from Beacon")
+		return errors.Wrap(err, "failed to get validator data from Beacon node")
 	}
-	logger.Debug("got validators metadata", zap.Int("pks count", len(pubKeys)),
-		zap.Int("results count", len(results)))
+	logger.Debug("got validators metadata", zap.Int("requested", len(pubKeys)),
+		zap.Int("received", len(results)))
 
 	var errs []error
 	for pk, meta := range results {
 		if err := collection.UpdateValidatorMetadata(pk, meta); err != nil {
 			logger.Error("failed to update validator metadata",
-				zap.String("pk", pk), zap.Error(err))
+				zap.String("validator", pk), zap.Error(err))
 			errs = append(errs, err)
 		}
 		if onUpdated != nil {
 			onUpdated(pk, meta)
 		}
-		logger.Debug("managed to update validator metadata",
+		logger.Debug("successfully updated validator metadata",
 			zap.String("pk", pk), zap.Any("metadata", meta))
 	}
 	if len(errs) > 0 {
-		logger.Error("could not process validators returned from beacon",
-			zap.Int("count", len(errs)), zap.Any("errs", errs))
-		return errors.Errorf("could not process %d validators returned from beacon", len(errs))
+		logger.Error("failed to process validators returned from Beacon node",
+			zap.Int("count", len(errs)), zap.Errors("errors", errs))
+		return errors.Errorf("failed to process %d validators returned from Beacon node", len(errs))
 	}
 
 	return nil

--- a/protocol/v2/blockchain/beacon/validator_metadata.go
+++ b/protocol/v2/blockchain/beacon/validator_metadata.go
@@ -69,7 +69,7 @@ func UpdateValidatorsMetadata(pubKeys [][]byte, collection ValidatorMetadataStor
 
 	results, err := FetchValidatorsMetadata(bc, pubKeys)
 	if err != nil {
-		return errors.Wrap(err, "failed to get validator data from Beacon node")
+		return errors.Wrap(err, "failed to get validator data from Beacon")
 	}
 	logger.Debug("got validators metadata", zap.Int("requested", len(pubKeys)),
 		zap.Int("received", len(results)))
@@ -90,7 +90,7 @@ func UpdateValidatorsMetadata(pubKeys [][]byte, collection ValidatorMetadataStor
 	if len(errs) > 0 {
 		logger.Error("failed to process validators returned from Beacon node",
 			zap.Int("count", len(errs)), zap.Errors("errors", errs))
-		return errors.Errorf("failed to process %d validators returned from Beacon node", len(errs))
+		return errors.Errorf("could not process %d validators returned from beacon", len(errs))
 	}
 
 	return nil

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -139,7 +139,7 @@ func (c *Controller) UponExistingInstanceMsg(msg *specqbft.SignedMessage) (*spec
 
 	if err := c.broadcastDecided(decidedMsg); err != nil {
 		// no need to fail processing instance deciding if failed to save/ broadcast
-		c.logger.Warn("failed to broadcast decided msg", zap.Error(err))
+		c.logger.Debug("failed to broadcast decided message", zap.Error(err))
 	}
 	return msg, nil
 }

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -71,7 +70,7 @@ func NewController(
 		StoredInstances:     InstanceContainer{},
 		FutureMsgsContainer: make(map[spectypes.OperatorID]specqbft.Height),
 		config:              config,
-		logger:              logger.With(zap.String("identifier", hex.EncodeToString(identifier))),
+		logger:              logger.With(zap.String("identifier", spectypes.MessageIDFromBytes(identifier).String())),
 	}
 }
 

--- a/protocol/v2/qbft/controller/decided.go
+++ b/protocol/v2/qbft/controller/decided.go
@@ -59,11 +59,11 @@ func (c *Controller) UponDecided(msg *specqbft.SignedMessage) (*specqbft.SignedM
 	if !prevDecided {
 		if futureInstance := c.StoredInstances.FindInstance(msg.Message.Height); futureInstance != nil {
 			if err = c.SaveHighestInstance(futureInstance, msg); err != nil {
-				c.logger.Warn("failed to save instance",
+				c.logger.Debug("failed to save instance",
 					zap.Uint64("height", uint64(msg.Message.Height)),
 					zap.Error(err))
 			} else {
-				c.logger.Info("saved instance upon decided", zap.Uint64("height", uint64(msg.Message.Height)))
+				c.logger.Debug("saved instance upon decided", zap.Uint64("height", uint64(msg.Message.Height)))
 			}
 		}
 		return msg, nil

--- a/protocol/v2/qbft/controller/decided.go
+++ b/protocol/v2/qbft/controller/decided.go
@@ -1,11 +1,10 @@
 package controller
 
 import (
-	"fmt"
-
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/instance"
 	"github.com/bloxapp/ssv/protocol/v2/types"
@@ -60,7 +59,11 @@ func (c *Controller) UponDecided(msg *specqbft.SignedMessage) (*specqbft.SignedM
 	if !prevDecided {
 		if futureInstance := c.StoredInstances.FindInstance(msg.Message.Height); futureInstance != nil {
 			if err = c.SaveHighestInstance(futureInstance, msg); err != nil {
-				fmt.Printf("failed to save instance: %s\n", err.Error())
+				c.logger.Warn("failed to save instance",
+					zap.Uint64("height", uint64(msg.Message.Height)),
+					zap.Error(err))
+			} else {
+				c.logger.Info("saved instance upon decided", zap.Uint64("height", uint64(msg.Message.Height)))
 			}
 		}
 		return msg, nil

--- a/protocol/v2/qbft/controller/future_msg.go
+++ b/protocol/v2/qbft/controller/future_msg.go
@@ -4,6 +4,7 @@ import (
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/types"
 )
@@ -16,6 +17,9 @@ func (c *Controller) UponFutureMsg(msg *specqbft.SignedMessage) (*specqbft.Signe
 		return nil, errors.New("discarded future msg")
 	}
 	if c.f1SyncTrigger() {
+		c.logger.Debug("triggered f+1 sync",
+			zap.Uint64("ctrl_height", uint64(c.Height)),
+			zap.Uint64("msg_height", uint64(msg.Message.Height)))
 		return nil, c.GetConfig().GetNetwork().SyncHighestDecided(spectypes.MessageIDFromBytes(c.Identifier))
 	}
 	return nil, nil

--- a/protocol/v2/qbft/instance/commit.go
+++ b/protocol/v2/qbft/instance/commit.go
@@ -6,6 +6,7 @@ import (
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/types"
 )
@@ -49,6 +50,9 @@ func (i *Instance) UponCommit(signedCommit *specqbft.SignedMessage, commitMsgCon
 		if err != nil {
 			return false, nil, nil, errors.Wrap(err, "could not aggregate commit msgs")
 		}
+
+		i.logger.Debug("got commit quorum", zap.Any("signers", agg.Signers))
+
 		return true, msgCommitData.Data, agg, nil
 	}
 	return false, nil, nil, nil

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -3,9 +3,10 @@ package instance
 import (
 	"encoding/hex"
 	"encoding/json"
+	"sync"
+
 	logging "github.com/ipfs/go-log"
 	"go.uber.org/zap"
-	"sync"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
@@ -66,17 +67,17 @@ func (i *Instance) Start(value []byte, height specqbft.Height) {
 		// propose if this node is the proposer
 		leader := proposer(i.State, i.GetConfig(), specqbft.FirstRound)
 
-		i.logger.Debug("starting instance")
+		i.logger.Debug("starting QBFT instance")
 		if leader == i.State.Share.OperatorID {
 			proposal, err := CreateProposal(i.State, i.config, i.StartValue, nil, nil)
 			// nolint
 			if err != nil {
-				i.logger.Warn("could not create proposal", zap.Error(err))
+				i.logger.Warn("failed to create proposal", zap.Error(err))
 				// TODO align spec to add else to avoid broadcast errored proposal
 			} else {
 				// nolint
 				if err := i.Broadcast(proposal); err != nil {
-					i.logger.Warn("could not broadcast proposal", zap.Error(err))
+					i.logger.Warn("failed to broadcast proposal", zap.Error(err))
 				}
 			}
 		}

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"sync"
 
@@ -50,8 +49,8 @@ func NewInstance(
 		},
 		config:      config,
 		processMsgF: spectypes.NewThreadSafeF(),
-		logger: logger.With(zap.String("identifier",
-			hex.EncodeToString(identifier)), zap.Uint64("height", uint64(height))),
+		logger: logger.With(zap.String("identifier", spectypes.MessageIDFromBytes(identifier).String()),
+			zap.Uint64("height", uint64(height))),
 	}
 }
 

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -116,7 +116,6 @@ func (i *Instance) ProcessMsg(msg *specqbft.SignedMessage) (decided bool, decide
 		case specqbft.CommitMsgType:
 			decided, decidedValue, aggregatedCommit, err = i.UponCommit(msg, i.State.CommitContainer)
 			if decided {
-				i.logger.Debug("decided instance upon commit quorum")
 				i.State.Decided = decided
 				i.State.DecidedValue = decidedValue
 			}

--- a/protocol/v2/qbft/instance/prepare.go
+++ b/protocol/v2/qbft/instance/prepare.go
@@ -2,10 +2,10 @@ package instance
 
 import (
 	"bytes"
-
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/types"
 )
@@ -59,9 +59,12 @@ func (i *Instance) uponPrepare(
 		return errors.Wrap(err, "could not create commit msg")
 	}
 
+	i.logger.Debug("got prepare quorum, broadcasting commit message", zap.Uint64("round", uint64(i.State.Round)))
+
 	if err := i.Broadcast(commitMsg); err != nil {
 		return errors.Wrap(err, "failed to broadcast commit message")
 	}
+
 	return nil
 }
 

--- a/protocol/v2/qbft/instance/prepare.go
+++ b/protocol/v2/qbft/instance/prepare.go
@@ -62,7 +62,7 @@ func (i *Instance) uponPrepare(
 
 	i.logger.Debug("got prepare quorum, broadcasting commit message",
 		zap.Uint64("round", uint64(i.State.Round)),
-		zap.Any("signers", signedPrepare.Signers))
+		zap.Any("signers", commitMsg.Signers))
 
 	if err := i.Broadcast(commitMsg); err != nil {
 		return errors.Wrap(err, "failed to broadcast commit message")

--- a/protocol/v2/qbft/instance/prepare.go
+++ b/protocol/v2/qbft/instance/prepare.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"bytes"
+
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
@@ -59,7 +60,9 @@ func (i *Instance) uponPrepare(
 		return errors.Wrap(err, "could not create commit msg")
 	}
 
-	i.logger.Debug("got prepare quorum, broadcasting commit message", zap.Uint64("round", uint64(i.State.Round)))
+	i.logger.Debug("got prepare quorum, broadcasting commit message",
+		zap.Uint64("round", uint64(i.State.Round)),
+		zap.Any("signers", signedPrepare.Signers))
 
 	if err := i.Broadcast(commitMsg); err != nil {
 		return errors.Wrap(err, "failed to broadcast commit message")

--- a/protocol/v2/qbft/instance/proposal.go
+++ b/protocol/v2/qbft/instance/proposal.go
@@ -2,10 +2,10 @@ package instance
 
 import (
 	"bytes"
-
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/types"
 )
@@ -41,6 +41,8 @@ func (i *Instance) uponProposal(signedProposal *specqbft.SignedMessage, proposeM
 	if err != nil {
 		return errors.Wrap(err, "could not create prepare msg")
 	}
+
+	i.logger.Debug("got proposal quorum, broadcasting prepare message", zap.Uint64("round", uint64(i.State.Round)))
 
 	if err := i.Broadcast(prepare); err != nil {
 		return errors.Wrap(err, "failed to broadcast prepare message")

--- a/protocol/v2/qbft/instance/proposal.go
+++ b/protocol/v2/qbft/instance/proposal.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"bytes"
+
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
@@ -42,7 +43,9 @@ func (i *Instance) uponProposal(signedProposal *specqbft.SignedMessage, proposeM
 		return errors.Wrap(err, "could not create prepare msg")
 	}
 
-	i.logger.Debug("got proposal quorum, broadcasting prepare message", zap.Uint64("round", uint64(i.State.Round)))
+	i.logger.Debug("got proposal, broadcasting prepare message",
+		zap.Uint64("round", uint64(i.State.Round)),
+		zap.Any("signers", prepare.Signers))
 
 	if err := i.Broadcast(prepare); err != nil {
 		return errors.Wrap(err, "failed to broadcast prepare message")

--- a/protocol/v2/qbft/instance/round_change.go
+++ b/protocol/v2/qbft/instance/round_change.go
@@ -15,7 +15,7 @@ func (i *Instance) uponRoundChange(
 	roundChangeMsgContainer *specqbft.MsgContainer,
 	valCheck specqbft.ProposedValueCheckF,
 ) error {
-	if err := validRoundChange(i.State, i.config, signedRoundChange, i.State.Height, signedRoundChange.Message.Round); err != nil {
+	if err := validRoundChange(i.State, i.config, signedRoundChange, i.State.Height, i.State.Round); err != nil {
 		return errors.Wrap(err, "round change msg invalid")
 	}
 
@@ -224,7 +224,7 @@ func validRoundChange(state *specqbft.State, config types.IConfig, signedMsg *sp
 	if signedMsg.Message.Height != height {
 		return errors.New("round change Height is wrong")
 	}
-	if signedMsg.Message.Round != round {
+	if signedMsg.Message.Round < round {
 		return errors.New("msg round wrong")
 	}
 	if len(signedMsg.GetSigners()) != 1 {

--- a/protocol/v2/qbft/instance/round_change.go
+++ b/protocol/v2/qbft/instance/round_change.go
@@ -15,7 +15,7 @@ func (i *Instance) uponRoundChange(
 	roundChangeMsgContainer *specqbft.MsgContainer,
 	valCheck specqbft.ProposedValueCheckF,
 ) error {
-	if err := validRoundChange(i.State, i.config, signedRoundChange, i.State.Height, i.State.Round); err != nil {
+	if err := validRoundChange(i.State, i.config, signedRoundChange, i.State.Height, signedRoundChange.Message.Round); err != nil {
 		return errors.Wrap(err, "round change msg invalid")
 	}
 
@@ -224,7 +224,7 @@ func validRoundChange(state *specqbft.State, config types.IConfig, signedMsg *sp
 	if signedMsg.Message.Height != height {
 		return errors.New("round change Height is wrong")
 	}
-	if signedMsg.Message.Round < round {
+	if signedMsg.Message.Round != round {
 		return errors.New("msg round wrong")
 	}
 	if len(signedMsg.GetSigners()) != 1 {

--- a/protocol/v2/qbft/instance/round_change.go
+++ b/protocol/v2/qbft/instance/round_change.go
@@ -83,8 +83,10 @@ func (i *Instance) uponChangeRoundPartialQuorum(newRound specqbft.Round, instanc
 		return errors.Wrap(err, "failed to create round change message")
 	}
 
-	i.logger.Debug("got change round partial quorum, broadcasting change round message",
-		zap.Uint64("new_round", uint64(newRound)), zap.Uint64("old_round", uint64(oldRound)))
+	if newRound%10 == 0 {
+		i.logger.Debug("got change round partial quorum, broadcasting change round message",
+			zap.Uint64("new_round", uint64(newRound)), zap.Uint64("old_round", uint64(oldRound)))
+	}
 
 	if err := i.Broadcast(roundChange); err != nil {
 		return errors.Wrap(err, "failed to broadcast round change message")

--- a/protocol/v2/qbft/instance/timeout.go
+++ b/protocol/v2/qbft/instance/timeout.go
@@ -7,7 +7,9 @@ import (
 
 func (i *Instance) UponRoundTimeout() error {
 	newRound := i.State.Round + 1
-	i.logger.Debug("round timed out", zap.Uint64("round", uint64(newRound)))
+	if newRound%10 == 0 {
+		i.logger.Debug("round timed out", zap.Uint64("round", uint64(newRound)))
+	}
 	i.State.Round = newRound
 	i.State.ProposalAcceptedForCurrentRound = nil
 	i.config.GetTimer().TimeoutForRound(i.State.Round)

--- a/protocol/v2/qbft/instance/timeout.go
+++ b/protocol/v2/qbft/instance/timeout.go
@@ -1,13 +1,13 @@
 package instance
 
 import (
-	"fmt"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 func (i *Instance) UponRoundTimeout() error {
 	newRound := i.State.Round + 1
-	fmt.Println("UponRoundTimeout:", newRound)
+	i.logger.Debug("upon round timeout", zap.Uint64("round", uint64(newRound)))
 	i.State.Round = newRound
 	i.State.ProposalAcceptedForCurrentRound = nil
 	i.config.GetTimer().TimeoutForRound(i.State.Round)

--- a/protocol/v2/qbft/instance/timeout.go
+++ b/protocol/v2/qbft/instance/timeout.go
@@ -7,7 +7,7 @@ import (
 
 func (i *Instance) UponRoundTimeout() error {
 	newRound := i.State.Round + 1
-	i.logger.Debug("upon round timeout", zap.Uint64("round", uint64(newRound)))
+	i.logger.Debug("round timed out", zap.Uint64("round", uint64(newRound)))
 	i.State.Round = newRound
 	i.State.ProposalAcceptedForCurrentRound = nil
 	i.config.GetTimer().TimeoutForRound(i.State.Round)

--- a/protocol/v2/queue/worker/message_worker.go
+++ b/protocol/v2/queue/worker/message_worker.go
@@ -136,7 +136,7 @@ func (w *Worker) process(msg *spectypes.SSVMessage) {
 	}
 	if err := w.handler(msg); err != nil {
 		if handlerErr := w.errHandler(msg, err); handlerErr != nil {
-			w.logger.Warn("could not handle message", zap.Error(handlerErr))
+			w.logger.Warn("failed to handle message", zap.Error(handlerErr))
 			return
 		}
 	}

--- a/protocol/v2/queue/worker/message_worker.go
+++ b/protocol/v2/queue/worker/message_worker.go
@@ -136,7 +136,7 @@ func (w *Worker) process(msg *spectypes.SSVMessage) {
 	}
 	if err := w.handler(msg); err != nil {
 		if handlerErr := w.errHandler(msg, err); handlerErr != nil {
-			w.logger.Warn("failed to handle message", zap.Error(handlerErr))
+			w.logger.Debug("failed to handle message", zap.Error(handlerErr))
 			return
 		}
 	}

--- a/protocol/v2/queue/worker/message_worker.go
+++ b/protocol/v2/queue/worker/message_worker.go
@@ -2,8 +2,9 @@ package worker
 
 import (
 	"context"
-	spectypes "github.com/bloxapp/ssv-spec/types"
 	"log"
+
+	spectypes "github.com/bloxapp/ssv-spec/types"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/protocol/v2/ssv/msgqueue/queue.go
+++ b/protocol/v2/ssv/msgqueue/queue.go
@@ -61,8 +61,6 @@ func New(logger *zap.Logger, opt ...Option) (MsgQueue, error) {
 		return nil, err
 	}
 
-	logger.Debug("queue configuration", zap.Any("indexers", len(opts.Indexers)))
-
 	return &queue{
 		logger:    logger,
 		indexers:  opts.Indexers,
@@ -124,7 +122,6 @@ func (q *queue) Add(msg *spectypes.SSVMessage) {
 		q.items[idx] = msgs
 		metricsMsgQRatio.WithLabelValues(idx.ID, idx.Name, message.MsgTypeToString(idx.Mt), strconv.Itoa(int(idx.Cmt))).Inc()
 	}
-	q.logger.Debug("message added to queue", zap.Any("indices", indices))
 }
 
 func (q *queue) Purge(idx Index) int64 {

--- a/protocol/v2/ssv/msgqueue/sort.go
+++ b/protocol/v2/ssv/msgqueue/sort.go
@@ -41,7 +41,7 @@ func (by By) Add(msgs []*MsgContainer, msg *MsgContainer) []*MsgContainer {
 	return newMsgs
 }
 
-// ByRound implements By for round based priority
+// ByRound implements By for round based priority, in descending order
 func ByRound() By {
 	return func(a, b *spectypes.SSVMessage) bool {
 		aRound, ok := getRound(a)
@@ -52,7 +52,7 @@ func ByRound() By {
 		if !ok {
 			return true
 		}
-		return aRound > bRound
+		return aRound < bRound
 	}
 }
 

--- a/protocol/v2/ssv/msgqueue/sort.go
+++ b/protocol/v2/ssv/msgqueue/sort.go
@@ -41,7 +41,7 @@ func (by By) Add(msgs []*MsgContainer, msg *MsgContainer) []*MsgContainer {
 	return newMsgs
 }
 
-// ByRound implements By for round based priority, in descending order
+// ByRound implements By for round based priority
 func ByRound() By {
 	return func(a, b *spectypes.SSVMessage) bool {
 		aRound, ok := getRound(a)
@@ -52,7 +52,7 @@ func ByRound() By {
 		if !ok {
 			return true
 		}
-		return aRound < bRound
+		return aRound > bRound
 	}
 }
 

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -10,6 +11,7 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
@@ -21,6 +23,7 @@ type AggregatorRunner struct {
 	network  specssv.Network
 	signer   spectypes.KeyManager
 	valCheck specqbft.ProposedValueCheckF
+	logger   *zap.Logger
 }
 
 func NewAggregatorRunner(
@@ -32,18 +35,21 @@ func NewAggregatorRunner(
 	signer spectypes.KeyManager,
 	valCheck specqbft.ProposedValueCheckF,
 ) Runner {
+	logger := logger.With(zap.String("validator", hex.EncodeToString(share.ValidatorPubKey)))
 	return &AggregatorRunner{
 		BaseRunner: &BaseRunner{
 			BeaconRoleType: spectypes.BNRoleAggregator,
 			BeaconNetwork:  beaconNetwork,
 			Share:          share,
 			QBFTController: qbftController,
+			logger:         logger.With(zap.String("who", "BaseRunner")),
 		},
 
 		beacon:   beacon,
 		network:  network,
 		signer:   signer,
 		valCheck: valCheck,
+		logger:   logger.With(zap.String("who", "AggregatorRunner")),
 	}
 }
 

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -151,7 +151,7 @@ func (r *AttesterRunner) ProcessPostConsensus(signedMsg *specssv.SignedPartialSi
 			return errors.Wrap(err, "failed to publish attestation to Beacon node")
 		}
 
-		r.logger.Debug("submitted attestation", zap.Int64("slot", int64(duty.Slot)))
+		r.logger.Debug("successfully published attestation", zap.Int64("slot", int64(duty.Slot)))
 	}
 	r.GetState().Finished = true
 

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -144,14 +144,14 @@ func (r *AttesterRunner) ProcessPostConsensus(signedMsg *specssv.SignedPartialSi
 			AggregationBits: aggregationBitfield,
 		}
 
-		// Publish it to the BN.
+		// Submit it to the BN.
 		if err := r.beacon.SubmitAttestation(signedAtt); err != nil {
-			r.logger.Error("failed to publish attestation to Beacon node",
+			r.logger.Error("failed to submit attestation to Beacon node",
 				zap.Int64("slot", int64(duty.Slot)), zap.Error(err))
 			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
 		}
 
-		r.logger.Debug("successfully published attestation", zap.Int64("slot", int64(duty.Slot)))
+		r.logger.Debug("successfully submitted attestation", zap.Int64("slot", int64(duty.Slot)))
 	}
 	r.GetState().Finished = true
 

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -133,7 +133,9 @@ func (r *AttesterRunner) ProcessPostConsensus(signedMsg *specssv.SignedPartialSi
 
 		duty := r.GetState().DecidedValue.Duty
 
-		r.logger.Debug("reconstructed partial signature", zap.Int64("slot", int64(duty.Slot)))
+		r.logger.Debug("reconstructed partial signatures",
+			zap.Any("signers", getPostConsensusSigners(r.GetState(), root)),
+			zap.Int64("slot", int64(duty.Slot)))
 
 		// Produce signed Attestation.
 		aggregationBitfield := bitfield.NewBitlist(r.GetState().DecidedValue.Duty.CommitteeLength)

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -126,7 +126,7 @@ func (r *AttesterRunner) ProcessPostConsensus(signedMsg *specssv.SignedPartialSi
 		// Reconstruct signature.
 		sig, err := r.GetState().ReconstructBeaconSig(r.GetState().PostConsensusContainer, root, r.GetShare().ValidatorPubKey)
 		if err != nil {
-			return errors.Wrap(err, "failed to reconstruct post consensus signature")
+			return errors.Wrap(err, "could not reconstruct post consensus signature")
 		}
 		specSig := phase0.BLSSignature{}
 		copy(specSig[:], sig)
@@ -148,7 +148,7 @@ func (r *AttesterRunner) ProcessPostConsensus(signedMsg *specssv.SignedPartialSi
 		if err := r.beacon.SubmitAttestation(signedAtt); err != nil {
 			r.logger.Error("failed to publish attestation to Beacon node",
 				zap.Int64("slot", int64(duty.Slot)), zap.Error(err))
-			return errors.Wrap(err, "failed to publish attestation to Beacon node")
+			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
 		}
 
 		r.logger.Debug("successfully published attestation", zap.Int64("slot", int64(duty.Slot)))

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -10,6 +12,7 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
@@ -21,6 +24,7 @@ type ProposerRunner struct {
 	network  specssv.Network
 	signer   spectypes.KeyManager
 	valCheck specqbft.ProposedValueCheckF
+	logger   *zap.Logger
 }
 
 func NewProposerRunner(
@@ -32,18 +36,21 @@ func NewProposerRunner(
 	signer spectypes.KeyManager,
 	valCheck specqbft.ProposedValueCheckF,
 ) Runner {
+	logger := logger.With(zap.String("validator", hex.EncodeToString(share.ValidatorPubKey)))
 	return &ProposerRunner{
 		BaseRunner: &BaseRunner{
 			BeaconRoleType: spectypes.BNRoleProposer,
 			BeaconNetwork:  beaconNetwork,
 			Share:          share,
 			QBFTController: qbftController,
+			logger:         logger.With(zap.String("who", "BaseRunner")),
 		},
 
 		beacon:   beacon,
 		network:  network,
 		signer:   signer,
 		valCheck: valCheck,
+		logger:   logger.With(zap.String("who", "ProposerRunner")),
 	}
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -114,7 +114,7 @@ func (b *BaseRunner) baseConsensusMsgProcessing(runner Runner, msg *specqbft.Sig
 	} else {
 		if inst := b.QBFTController.StoredInstances.FindInstance(decidedMsg.Message.Height); inst != nil {
 			if err = b.QBFTController.SaveHighestInstance(inst, decidedMsg); err != nil {
-				b.logger.Warn("Failed to save instance",
+				b.logger.Warn("failed to save instance",
 					zap.Uint64("height", uint64(decidedMsg.Message.Height)),
 					zap.Error(err))
 			}

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/hex"
 	logging "github.com/ipfs/go-log"
 	"go.uber.org/zap"
 
@@ -228,4 +229,13 @@ func (b *BaseRunner) hasRunningDuty() bool {
 		return false
 	}
 	return !b.State.Finished
+}
+
+func getPostConsensusSigners(state *State, root []byte) []spectypes.OperatorID {
+	sigs := state.PostConsensusContainer.Signatures[hex.EncodeToString(root)]
+	var signers []spectypes.OperatorID
+	for op := range sigs {
+		signers = append(signers, op)
+	}
+	return signers
 }

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	logging "github.com/ipfs/go-log"
 
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
+
+var logger = logging.Logger("ssv/protocol/ssv/runner").Desugar()
 
 type Getters interface {
 	GetBaseRunner() *BaseRunner

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -1,8 +1,8 @@
 package runner
 
 import (
-	"fmt"
 	logging "github.com/ipfs/go-log"
+	"go.uber.org/zap"
 
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -54,6 +54,7 @@ type BaseRunner struct {
 	QBFTController *controller.Controller
 	BeaconNetwork  spectypes.BeaconNetwork
 	BeaconRoleType spectypes.BeaconRole
+	logger         *zap.Logger
 }
 
 // baseStartNewDuty is a base func that all runner implementation can call to start a duty
@@ -113,7 +114,9 @@ func (b *BaseRunner) baseConsensusMsgProcessing(runner Runner, msg *specqbft.Sig
 	} else {
 		if inst := b.QBFTController.StoredInstances.FindInstance(decidedMsg.Message.Height); inst != nil {
 			if err = b.QBFTController.SaveHighestInstance(inst, decidedMsg); err != nil {
-				fmt.Printf("failed to save instance: %s\n", err.Error())
+				b.logger.Warn("Failed to save instance",
+					zap.Uint64("height", uint64(decidedMsg.Message.Height)),
+					zap.Error(err))
 			}
 		}
 	}

--- a/protocol/v2/ssv/runner/sync_committee.go
+++ b/protocol/v2/ssv/runner/sync_committee.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -10,6 +12,7 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
@@ -21,6 +24,7 @@ type SyncCommitteeRunner struct {
 	network  specssv.Network
 	signer   spectypes.KeyManager
 	valCheck specqbft.ProposedValueCheckF
+	logger   *zap.Logger
 }
 
 func NewSyncCommitteeRunner(
@@ -32,18 +36,21 @@ func NewSyncCommitteeRunner(
 	signer spectypes.KeyManager,
 	valCheck specqbft.ProposedValueCheckF,
 ) Runner {
+	logger := logger.With(zap.String("validator", hex.EncodeToString(share.ValidatorPubKey)))
 	return &SyncCommitteeRunner{
 		BaseRunner: &BaseRunner{
 			BeaconRoleType: spectypes.BNRoleSyncCommittee,
 			BeaconNetwork:  beaconNetwork,
 			Share:          share,
 			QBFTController: qbftController,
+			logger:         logger.With(zap.String("who", "BaseRunner")),
 		},
 
 		beacon:   beacon,
 		network:  network,
 		signer:   signer,
 		valCheck: valCheck,
+		logger:   logger.With(zap.String("who", "SyncCommitteeRunner")),
 	}
 }
 

--- a/protocol/v2/ssv/runner/sync_committee_aggregator.go
+++ b/protocol/v2/ssv/runner/sync_committee_aggregator.go
@@ -3,7 +3,9 @@ package runner
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -11,6 +13,7 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
@@ -22,6 +25,7 @@ type SyncCommitteeAggregatorRunner struct {
 	network  specssv.Network
 	signer   spectypes.KeyManager
 	valCheck specqbft.ProposedValueCheckF
+	logger   *zap.Logger
 }
 
 func NewSyncCommitteeAggregatorRunner(
@@ -33,18 +37,21 @@ func NewSyncCommitteeAggregatorRunner(
 	signer spectypes.KeyManager,
 	valCheck specqbft.ProposedValueCheckF,
 ) Runner {
+	logger := logger.With(zap.String("validator", hex.EncodeToString(share.ValidatorPubKey)))
 	return &SyncCommitteeAggregatorRunner{
 		BaseRunner: &BaseRunner{
 			BeaconRoleType: spectypes.BNRoleSyncCommitteeContribution,
 			BeaconNetwork:  beaconNetwork,
 			Share:          share,
 			QBFTController: qbftController,
+			logger:         logger.With(zap.String("who", "BaseRunner")),
 		},
 
 		beacon:   beacon,
 		network:  network,
 		signer:   signer,
 		valCheck: valCheck,
+		logger:   logger.With(zap.String("who", "SyncCommitteeAggregatorRunner")),
 	}
 }
 

--- a/protocol/v2/ssv/runner/timer.go
+++ b/protocol/v2/ssv/runner/timer.go
@@ -1,10 +1,10 @@
 package runner
 
 import (
-	"fmt"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/instance"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/roundtimer"
+	"go.uber.org/zap"
 )
 
 func (b *BaseRunner) registerTimeoutHandler(instance *instance.Instance, height specqbft.Height) {
@@ -31,7 +31,7 @@ func (b *BaseRunner) onTimeout(h specqbft.Height) func() {
 		err := instance.UponRoundTimeout()
 		if err != nil {
 			// TODO: handle?
-			fmt.Println("failed to handle timeout:", err.Error())
+			b.logger.Warn("failed to handle timeout", zap.Error(err))
 		}
 	}
 }

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -45,8 +45,7 @@ func (v *Validator) ConsumeQueue(msgID spectypes.MessageID, handler MessageHandl
 	ctx, cancel := context.WithCancel(v.ctx)
 	defer cancel()
 
-	identifier := msgID.String()
-	logger := v.logger.With(zap.String("identifier", identifier))
+	logger := v.logger.With(zap.String("identifier", msgID.String()))
 	higherCache := cache.New(time.Second*12, time.Second*24)
 
 	for ctx.Err() == nil {

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -17,12 +17,6 @@ type MessageHandler func(msg *spectypes.SSVMessage) error
 
 // HandleMessage handles a spectypes.SSVMessage.
 func (v *Validator) HandleMessage(msg *spectypes.SSVMessage) {
-	// fields := []zap.Field{
-	// 	zap.Int("queue_len", v.Q.Len()),
-	// 	zap.String("msgType", message.MsgTypeToString(msg.MsgType)),
-	// 	zap.String("msgID", msg.MsgID.String()),
-	// }
-	// v.logger.Debug("got message, add to queue", fields...)
 	v.Q.Add(msg)
 }
 
@@ -79,14 +73,10 @@ func (v *Validator) ConsumeQueue(msgID spectypes.MessageID, handler MessageHandl
 		}
 
 		// clean all old messages. (when stuck on change round stage, msgs not deleted)
-		cleaned := v.Q.Clean(func(index msgqueue.Index) bool {
+		v.Q.Clean(func(index msgqueue.Index) bool {
 			// remove all msg's that are 2 heights old, besides height 0
 			return int64(index.H) <= int64(lastHeight-2) // remove all msg's that are 2 heights old. not post consensus & decided
 		})
-		_ = cleaned
-		// if cleaned > 0 {
-		// 	logger.Debug("indexes cleaned from queue", zap.Int64("count", cleaned))
-		// }
 	}
 
 	logger.Warn("queue consumer is closed")
@@ -100,11 +90,6 @@ func (v *Validator) GetLastHeight(identifier spectypes.MessageID) specqbft.Heigh
 	if r == nil {
 		return specqbft.Height(0)
 	}
-	// ctrl := r.GetBaseRunner().QBFTController
-	// if ctrl == nil {
-	//	return specqbft.Height(0)
-	//}
-	// return state.LastHeight
 	return r.GetBaseRunner().QBFTController.Height
 }
 
@@ -160,11 +145,6 @@ func (v *Validator) processByState(handler MessageHandler, msgID spectypes.Messa
 	if msg == nil {
 		return false // no msg found
 	}
-	// v.logger.Debug("queue found message for state",
-	//	zap.Int32("stage", currentState.Stage.Load()),
-	//	zap.Int32("seq", int32(currentState.GetHeight())),
-	//	zap.Int32("round", int32(currentState.GetRound())),
-	//)
 
 	err := handler(msg)
 	if err != nil {

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -124,7 +124,7 @@ func (v *Validator) processNoRunningInstance(handler MessageHandler, msgID spect
 
 	err := handler(msgs[0])
 	if err != nil {
-		logger.Debug("could not handle message", zap.Error(err))
+		logger.Debug("could not handle message", zap.String("error", err.Error()))
 	}
 	return true // msg processed
 }
@@ -215,7 +215,6 @@ func (v *Validator) getNextMsgForState(identifier string, height specqbft.Height
 	for _, idx := range idxs {
 		iterator.AddIndex(idx)
 	}
-
 	iterator.
 		Add(func() msgqueue.Index {
 			return msgqueue.DecidedMsgIndex(identifier)

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -35,7 +35,7 @@ func (v *Validator) StartQueueConsumer(msgID spectypes.MessageID, handler Messag
 	for ctx.Err() == nil {
 		err := v.ConsumeQueue(msgID, handler, time.Millisecond*50)
 		if err != nil {
-			v.logger.Warn("could not consume queue", zap.Error(err))
+			v.logger.Debug("failed consuming queue", zap.Error(err))
 		}
 	}
 }
@@ -146,7 +146,7 @@ func (v *Validator) processNoRunningInstance(handler MessageHandler, msgID spect
 
 	err := handler(msgs[0])
 	if err != nil {
-		logger.Warn("could not handle msg", zap.Error(err))
+		logger.Warn("could not handle message", zap.Error(err))
 	}
 	return true // msg processed
 }

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -23,7 +23,7 @@ func (v *Validator) HandleMessage(msg *spectypes.SSVMessage) {
 		zap.String("msgType", message.MsgTypeToString(msg.MsgType)),
 		zap.String("msgID", msg.MsgID.String()),
 	}
-	v.logger.Debug("got message, add to queue", fields...)
+	v.logger.Debug("got message, adding to queue", fields...)
 	v.Q.Add(msg)
 }
 

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -63,6 +63,7 @@ func (v *Validator) ConsumeQueue(msgID spectypes.MessageID, handler MessageHandl
 		//	continue
 		//}
 		lastHeight := v.GetLastHeight(msgID)
+		identifier := msgID.String()
 
 		if processed := v.processHigherHeight(handler, identifier, lastHeight, higherCache); processed {
 			continue

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"fmt"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/bloxapp/ssv/ibft/storage"
@@ -18,6 +17,9 @@ type NonCommitteeValidator struct {
 }
 
 func NewNonCommitteeValidator(identifier spectypes.MessageID, opts Options) *NonCommitteeValidator {
+	logger := logger.With(zap.String("who", "NonCommitteeValidator"),
+		zap.String("identifier", identifier.String()))
+
 	// currently, only need domain & storage
 	config := &types.Config{
 		Domain:  types.GetDefaultDomain(),
@@ -25,11 +27,11 @@ func NewNonCommitteeValidator(identifier spectypes.MessageID, opts Options) *Non
 	}
 	ctrl := qbftcontroller.NewController(identifier[:], &opts.SSVShare.Share, types.GetDefaultDomain(), config)
 	if err := ctrl.LoadHighestInstance(identifier[:]); err != nil {
-		fmt.Printf("failed to load highest instance: %e", err)
+		logger.Debug("failed to load highest instance", zap.Error(err))
 	}
 
 	return &NonCommitteeValidator{
-		logger:         opts.Logger,
+		logger:         logger,
 		Share:          opts.SSVShare,
 		Storage:        opts.Storage,
 		qbftController: ctrl,
@@ -39,7 +41,7 @@ func NewNonCommitteeValidator(identifier spectypes.MessageID, opts Options) *Non
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *spectypes.SSVMessage) {
 	logger := ncv.logger.With(zap.String("id", msg.GetID().String()))
 	if err := validateMessage(ncv.Share.Share, msg); err != nil {
-		logger.Warn("Message invalid", zap.Error(err))
+		logger.Debug("invalid message", zap.Error(err))
 		return
 	}
 
@@ -47,7 +49,7 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *spectypes.SSVMessage) {
 	case spectypes.SSVConsensusMsgType:
 		signedMsg := &specqbft.SignedMessage{}
 		if err := signedMsg.Decode(msg.GetData()); err != nil {
-			logger.Warn("could not get consensus Message from network Message", zap.Error(err))
+			logger.Debug("could not get consensus Message from network Message", zap.Error(err))
 			return
 		}
 		// only supports decided msg's
@@ -56,11 +58,11 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *spectypes.SSVMessage) {
 		}
 
 		if decided, err := ncv.qbftController.ProcessMsg(signedMsg); err != nil {
-			logger.Warn("failed to process message", zap.Error(err))
+			logger.Debug("failed to process message", zap.Error(err))
 		} else if decided != nil {
 			if inst := ncv.qbftController.StoredInstances.FindInstance(signedMsg.Message.Height); inst != nil {
 				if err = ncv.qbftController.SaveHighestInstance(inst, signedMsg); err != nil {
-					fmt.Printf("failed to save instance: %s\n", err.Error())
+					ncv.logger.Debug("failed to save instance", zap.Error(err))
 				}
 			}
 		}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -41,7 +41,7 @@ func NewNonCommitteeValidator(identifier spectypes.MessageID, opts Options) *Non
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *spectypes.SSVMessage) {
 	logger := ncv.logger.With(zap.String("id", msg.GetID().String()))
 	if err := validateMessage(ncv.Share.Share, msg); err != nil {
-		logger.Debug("invalid message", zap.Error(err))
+		logger.Debug("got invalid message", zap.Error(err))
 		return
 	}
 
@@ -49,7 +49,7 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *spectypes.SSVMessage) {
 	case spectypes.SSVConsensusMsgType:
 		signedMsg := &specqbft.SignedMessage{}
 		if err := signedMsg.Decode(msg.GetData()); err != nil {
-			logger.Debug("could not get consensus Message from network Message", zap.Error(err))
+			logger.Debug("failed to get consensus Message from network Message", zap.Error(err))
 			return
 		}
 		// only supports decided msg's

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -7,12 +7,10 @@ import (
 	"github.com/bloxapp/ssv/ibft/storage"
 	"github.com/bloxapp/ssv/protocol/v2/ssv/runner"
 	"github.com/bloxapp/ssv/protocol/v2/types"
-	"go.uber.org/zap"
 )
 
 // Options represents options that should be passed to a new instance of Validator.
 type Options struct {
-	Logger      *zap.Logger
 	Network     specqbft.Network
 	Beacon      specssv.BeaconNode
 	Storage     *storage.QBFTStores
@@ -23,9 +21,7 @@ type Options struct {
 }
 
 func (o *Options) defaults() {
-	if o.Logger == nil {
-		o.Logger = zap.L()
-	}
+	// Nothing to set yet.
 }
 
 // State of the validator

--- a/protocol/v2/ssv/validator/startup.go
+++ b/protocol/v2/ssv/validator/startup.go
@@ -26,7 +26,9 @@ func (v *Validator) Start() error {
 			}
 			identifier := spectypes.NewMsgID(r.GetBaseRunner().Share.ValidatorPubKey, role)
 			if err := r.GetBaseRunner().QBFTController.LoadHighestInstance(identifier[:]); err != nil {
-				v.logger.Warn("could not load highest", zap.String("identifier", identifier.String()), zap.Error(err))
+				v.logger.Warn("failed to load highest instance",
+					zap.String("identifier", identifier.String()),
+					zap.Error(err))
 			}
 			if err := n.Subscribe(identifier.GetPubKey()); err != nil {
 				return err
@@ -60,7 +62,9 @@ func (v *Validator) sync(mid spectypes.MessageID) {
 	for ctx.Err() == nil {
 		err := v.Network.SyncHighestDecided(mid)
 		if err != nil {
-			v.logger.Debug("could not sync highest decided", zap.String("identifier", mid.String()))
+			v.logger.Debug("failed to sync highest decided",
+				zap.String("identifier", mid.String()),
+				zap.Error(err))
 			retries--
 			if retries > 0 {
 				interval *= 2

--- a/protocol/v2/sync/commons.go
+++ b/protocol/v2/sync/commons.go
@@ -19,7 +19,7 @@ func GetHighest(logger *zap.Logger, remoteMsgs ...p2pprotocol.SyncResult) (highe
 	for _, remoteMsg := range remoteMsgs {
 		sm, err := ExtractSyncMsg(remoteMsg.Msg)
 		if err != nil {
-			logger.Warn("bad sync message", zap.Error(err))
+			logger.Warn("failed to extract sync message", zap.Error(err))
 			continue
 		}
 		if sm == nil {

--- a/protocol/v2/sync/handlers/decided_history.go
+++ b/protocol/v2/sync/handlers/decided_history.go
@@ -18,11 +18,11 @@ import (
 func HistoryHandler(plogger *zap.Logger, storeMap *storage.QBFTStores, reporting protocolp2p.ValidationReporting, maxBatchSize int) protocolp2p.RequestHandler {
 	plogger = plogger.With(zap.String("who", "last decided handler"))
 	return func(msg *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {
-		logger := plogger.With(zap.String("msg_id_hex", fmt.Sprintf("%x", msg.MsgID)))
+		logger := plogger.With(zap.String("msg_id", fmt.Sprintf("%x", msg.MsgID)))
 		sm := &message.SyncMessage{}
 		err := sm.Decode(msg.Data)
 		if err != nil {
-			logger.Debug("could not decode msg data", zap.Error(err))
+			logger.Debug("failed to decode message data", zap.Error(err))
 			reporting.ReportValidation(msg, protocolp2p.ValidationRejectLow)
 			sm.Status = message.StatusBadRequest
 		} else if sm.Protocol != message.DecidedHistoryType {

--- a/protocol/v2/sync/handlers/last_decided.go
+++ b/protocol/v2/sync/handlers/last_decided.go
@@ -15,13 +15,13 @@ import (
 // LastDecidedHandler handler for last-decided protocol
 // TODO: add msg validation and report scores
 func LastDecidedHandler(plogger *zap.Logger, storeMap *storage.QBFTStores, reporting protocolp2p.ValidationReporting) protocolp2p.RequestHandler {
-	plogger = plogger.With(zap.String("who", "last decided handler"))
+	plogger = plogger.With(zap.String("who", "LastDecidedHandler"))
 	return func(msg *spectypes.SSVMessage) (*spectypes.SSVMessage, error) {
 		logger := plogger.With(zap.String("identifier", msg.MsgID.String()))
 		sm := &message.SyncMessage{}
 		err := sm.Decode(msg.Data)
 		if err != nil {
-			logger.Debug("could not decode msg data", zap.Error(err))
+			logger.Debug("failed to decode message data", zap.Error(err))
 			reporting.ReportValidation(msg, protocolp2p.ValidationRejectLow)
 			sm.Status = message.StatusBadRequest
 		} else if sm.Protocol != message.LastDecidedType {
@@ -36,7 +36,7 @@ func LastDecidedHandler(plogger *zap.Logger, storeMap *storage.QBFTStores, repor
 			}
 			instance, err := store.GetHighestInstance(msgID[:])
 			if err != nil {
-				logger.Debug("could not get highest instance", zap.Error(err))
+				logger.Debug("failed to get highest instance", zap.Error(err))
 			} else if instance != nil {
 				logger.Debug("last decided results", zap.Any("res", instance.DecidedMessage), zap.Error(err))
 				sm.UpdateResults(err, instance.DecidedMessage)

--- a/protocol/v2/sync/history/syncer.go
+++ b/protocol/v2/sync/history/syncer.go
@@ -69,7 +69,7 @@ func (s syncer) SyncRange(ctx context.Context, identifier spectypes.MessageID, h
 		zap.Uint64("from", uint64(from)))
 	// if we didn't visit all messages in range > log warning
 	if len(visited) < int(to-from) {
-		logger.Warn("not all messages in range were saved", zap.Any("visited", visited))
+		logger.Warn("failed to save all messages in range", zap.Any("visited", visited))
 		// return errors.Errorf("not all messages in range were saved (%d out of %d)", len(visited), int(to-from))
 	}
 	logger.Debug("done with range history sync")
@@ -98,10 +98,10 @@ func (s syncer) processMessages(ctx context.Context, msgs []p2pprotocol.SyncResu
 				continue signedMsgLoop
 			}
 			if err := handler(signedMsg); err != nil {
-				s.logger.Warn("could not add decided with handler", zap.Error(err), zap.Int64("height", int64(height)))
+				s.logger.Warn("failed to add decided with handler", zap.Error(err), zap.Int64("height", int64(height)))
 				continue
 			}
-			s.logger.Debug("mark sync msg as visited", zap.Int64("h", int64(height)))
+			s.logger.Debug("marked sync message as visited", zap.Int64("h", int64(height)))
 			visited[height] = true
 		}
 	}


### PR DESCRIPTION
This PR tries to make logs:
- Quiet, to avoid spamming log indexers (such as Kibana)
- User-friendly, to help operators understand how their node is doing (or failing) with digestible messages

See more information in https://github.com/bloxapp/ssv/issues/676

**Changes**

- Package-level loggers (instead of passing loggers by dependency injection)
- Log levels are configurable per package with the `DebugServices` parameter (using https://github.com/ipfs/go-log)

From now on, the following rules should be applied to logs:

- Levels reserved for operators:
  - ERROR: operator should take action
  - WARN: operator should pay attention
- DEBUG is reserved for developers:
  - Non-critical errors (such as 'failed to broadcast' or 'invalid message from peer')
  - High-level tracing of consensus flow (instead of per p2p message)