### PR TITLE
Streams Deadline

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	libp2pdiscbackoff "github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/async"
@@ -103,12 +104,13 @@ func (n *p2pNetwork) SetupHost() error {
 		return errors.Wrap(err, "could not create libp2p options")
 	}
 
+	limitsCfg := rcmgr.DefaultLimits.AutoScale()
 	// TODO: enable and extract resource manager params as config
-	// rmgr, err := rcmgr.NewResourceManager(rcmgr.NewDefaultDynamicLimiter(0.2, 128<<20, 1<<29)) // 134-536MB
-	// if err != nil {
-	//	return errors.Wrap(err, "could not create resource manager")
-	//}
-	// opts = append(opts, libp2p.ResourceManager(rmgr))
+	rmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(limitsCfg))
+	if err != nil {
+		return errors.Wrap(err, "could not create resource manager")
+	}
+	opts = append(opts, libp2p.ResourceManager(rmgr))
 	host, err := libp2p.New(opts...)
 	if err != nil {
 		return errors.Wrap(err, "could not create p2p host")

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -2,6 +2,7 @@ package p2pv1
 
 import (
 	"encoding/hex"
+	"github.com/multiformats/go-multistream"
 	"math/rand"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -220,12 +221,13 @@ func (n *p2pNetwork) makeSyncRequest(peers []peer.ID, mid spectypes.MessageID, p
 		logger := plogger.With(zap.String("peer", pid.String()))
 		raw, err := n.streamCtrl.Request(pid, protocol, encoded)
 		if err != nil {
-			logger.Debug("could not make stream request", zap.Error(err))
+			if err != multistream.ErrNotSupported {
+				logger.Debug("could not make stream request", zap.Error(err))
+			}
 			continue
 		}
 		mid := msgID(raw)
 		if distinct[mid] {
-			// logger.Debug("duplicated sync msg", zap.String("mid", mid))
 			continue
 		}
 		distinct[mid] = true

--- a/network/p2p/p2p_sync.go
+++ b/network/p2p/p2p_sync.go
@@ -141,26 +141,26 @@ func (n *p2pNetwork) registerHandlers(pid libp2p_protocol.ID, handlers ...p2ppro
 		req, respond, done, err := n.streamCtrl.HandleStream(stream)
 		defer done()
 		if err != nil {
-			n.logger.Warn("could not handle stream", zap.Error(err))
+			n.logger.Debug("could not handle stream", zap.Error(err))
 			return
 		}
 		smsg, err := n.fork.DecodeNetworkMsg(req)
 		if err != nil {
-			n.logger.Warn("could not decode msg from stream", zap.Error(err))
+			n.logger.Debug("could not decode msg from stream", zap.Error(err))
 			return
 		}
 		result, err := handler(smsg)
 		if err != nil {
-			n.logger.Warn("could not handle msg from stream", zap.Error(err))
+			n.logger.Debug("could not handle msg from stream", zap.Error(err))
 			return
 		}
 		resultBytes, err := n.fork.EncodeNetworkMsg(result)
 		if err != nil {
-			n.logger.Warn("could not encode msg", zap.Error(err))
+			n.logger.Debug("could not encode msg", zap.Error(err))
 			return
 		}
 		if err := respond(resultBytes); err != nil {
-			n.logger.Warn("could not respond to stream", zap.Error(err))
+			n.logger.Debug("could not respond to stream", zap.Error(err))
 			return
 		}
 	})

--- a/network/p2p/test_utils.go
+++ b/network/p2p/test_utils.go
@@ -77,7 +77,7 @@ func CreateAndStartLocalNet(pctx context.Context, loggerFactory LoggerFactory, f
 		go func(node network.P2PNetwork, i int) {
 			logger := loggerFactory(fmt.Sprintf("node-%d", i))
 			if err := node.Start(); err != nil {
-				logger.Error("could not start node", zap.Error(err))
+				logger.Warn("could not start node", zap.Error(err))
 				wg.Done()
 				return
 			}
@@ -94,7 +94,7 @@ func CreateAndStartLocalNet(pctx context.Context, loggerFactory LoggerFactory, f
 					logger.Fatal("could not find enough peers", zap.Int("n", n), zap.Int("found", len(peers)))
 					return
 				}
-				// logger.Debug("found enough peers", zap.Int("n", n), zap.Int("found", len(peers)))
+				logger.Debug("found enough peers", zap.Int("n", n), zap.Int("found", len(peers)))
 			}(node, logger)
 		}(node, i)
 	}

--- a/network/peers/connections/conn_handler.go
+++ b/network/peers/connections/conn_handler.go
@@ -64,10 +64,10 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 
 	onNewConnection := func(net libp2pnetwork.Network, conn libp2pnetwork.Conn) error {
 		id := conn.RemotePeer()
-		_logger := ch.logger.With(zap.String("targetPeer", id.String()))
+		logger := ch.logger.With(zap.String("targetPeer", id.String()))
 		ok, err := ch.handshake(conn)
 		if err != nil {
-			_logger.Debug("could not handshake with peer", zap.Error(err))
+			logger.Debug("could not handshake with peer", zap.Error(err))
 		}
 		if !ok {
 			disconnect(net, conn)
@@ -81,7 +81,7 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 			disconnect(net, conn)
 			return errors.New("peer doesn't share enough subnets")
 		}
-		_logger.Debug("new connection is ready",
+		logger.Debug("new connection is ready",
 			zap.String("dir", conn.Stat().Direction.String()))
 		metricsConnections.Inc()
 		return nil
@@ -127,10 +127,10 @@ func (ch *connHandler) handshake(conn libp2pnetwork.Conn) (bool, error) {
 		switch err {
 		case peers.ErrIndexingInProcess, errHandshakeInProcess, peerstore.ErrNotFound:
 			// ignored errors
-			return true, err
+			return true, nil
 		case errPeerWasFiltered, errUnknownUserAgent:
 			// ignored errors but we still close connection
-			return false, err
+			return false, nil
 		default:
 		}
 		return false, err

--- a/network/peers/connections/conn_handler.go
+++ b/network/peers/connections/conn_handler.go
@@ -81,8 +81,8 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 			disconnect(net, conn)
 			return errors.New("peer doesn't share enough subnets")
 		}
-		logger.Debug("new connection is ready",
-			zap.String("dir", conn.Stat().Direction.String()))
+		//logger.Debug("new connection is ready",
+		//	zap.String("dir", conn.Stat().Direction.String()))
 		metricsConnections.Inc()
 		return nil
 	}

--- a/network/peers/connections/handshaker.go
+++ b/network/peers/connections/handshaker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -62,8 +61,6 @@ type handshaker struct {
 	ids         identify.IDService
 	net         libp2pnetwork.Network
 
-	pending *sync.Map
-
 	subnetsProvider SubnetsProvider
 }
 
@@ -91,7 +88,6 @@ func NewHandshaker(ctx context.Context, cfg *HandshakerCfg, filters ...Handshake
 		subnetsIdx:      cfg.SubnetsIdx,
 		ids:             cfg.IDService,
 		filters:         filters,
-		pending:         &sync.Map{},
 		states:          cfg.States,
 		subnetsProvider: cfg.SubnetsProvider,
 		net:             cfg.Network,
@@ -105,11 +101,6 @@ func (h *handshaker) Handler() libp2pnetwork.StreamHandler {
 		// start by marking the peer as pending
 		pid := stream.Conn().RemotePeer()
 		pidStr := pid.String()
-		//_, pending := h.pending.LoadOrStore(pidStr, true)
-		//if pending {
-		//	return
-		//}
-		//defer h.pending.Delete(pidStr)
 
 		req, res, done, err := h.streams.HandleStream(stream)
 		defer done()
@@ -177,10 +168,6 @@ func (h *handshaker) preHandshake(conn libp2pnetwork.Conn) error {
 // Handshake initiates handshake with the given conn
 func (h *handshaker) Handshake(conn libp2pnetwork.Conn) error {
 	pid := conn.RemotePeer()
-	if _, loaded := h.pending.LoadOrStore(pid.String(), true); loaded {
-		return errHandshakeInProcess
-	}
-	defer h.pending.Delete(pid.String())
 	// check if the peer is known before we continue
 	ni, err := h.getNodeInfo(pid)
 	if err != nil || ni != nil {

--- a/network/peers/connections/handshaker.go
+++ b/network/peers/connections/handshaker.go
@@ -105,11 +105,11 @@ func (h *handshaker) Handler() libp2pnetwork.StreamHandler {
 		// start by marking the peer as pending
 		pid := stream.Conn().RemotePeer()
 		pidStr := pid.String()
-		_, pending := h.pending.LoadOrStore(pidStr, true)
-		if pending {
-			return
-		}
-		defer h.pending.Delete(pidStr)
+		//_, pending := h.pending.LoadOrStore(pidStr, true)
+		//if pending {
+		//	return
+		//}
+		//defer h.pending.Delete(pidStr)
 
 		req, res, done, err := h.streams.HandleStream(stream)
 		defer done()

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -68,10 +68,8 @@ func (n *streamCtrl) Request(peerID peer.ID, protocol protocol.ID, data []byte) 
 	defer metricsStreamRequestsActive.WithLabelValues(string(protocol)).Dec()
 
 	if err := stream.WriteWithTimeout(data, n.requestTimeout); err != nil {
+		_ = s.Reset()
 		return nil, errors.Wrap(err, "could not write to stream")
-	}
-	if err := s.CloseWrite(); err != nil {
-		return nil, errors.Wrap(err, "could not close write stream")
 	}
 	res, err := stream.ReadWithTimeout(n.requestTimeout)
 	if err != nil {
@@ -96,6 +94,7 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 	}
 	data, err := s.ReadWithTimeout(n.requestTimeout)
 	if err != nil {
+		_ = stream.Reset()
 		return nil, nil, done, errors.Wrap(err, "could not read stream msg")
 	}
 

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -68,8 +68,10 @@ func (n *streamCtrl) Request(peerID peer.ID, protocol protocol.ID, data []byte) 
 	defer metricsStreamRequestsActive.WithLabelValues(string(protocol)).Dec()
 
 	if err := stream.WriteWithTimeout(data, n.requestTimeout); err != nil {
-		_ = s.Reset()
 		return nil, errors.Wrap(err, "could not write to stream")
+	}
+	if err := s.CloseWrite(); err != nil {
+		return nil, errors.Wrap(err, "could not close write stream")
 	}
 	res, err := stream.ReadWithTimeout(n.requestTimeout)
 	if err != nil {
@@ -94,7 +96,6 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 	}
 	data, err := s.ReadWithTimeout(n.requestTimeout)
 	if err != nil {
-		_ = stream.Reset()
 		return nil, nil, done, errors.Wrap(err, "could not read stream msg")
 	}
 

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"context"
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core"
@@ -57,7 +58,10 @@ func (n *streamCtrl) Request(peerID peer.ID, protocol protocol.ID, data []byte) 
 	}
 	stream := NewStream(s)
 	defer func() {
-		_ = stream.Close()
+		err := stream.Close()
+		if err != nil && err.Error() != libp2pnetwork.ErrReset.Error() {
+			n.logger.Debug("failed to close stream (request)", zap.String("s_id", stream.ID()), zap.Error(err))
+		}
 	}()
 	metricsStreamOutgoingRequests.WithLabelValues(string(protocol)).Inc()
 	metricsStreamRequestsActive.WithLabelValues(string(protocol)).Inc()
@@ -86,16 +90,12 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 	metricsStreamRequests.WithLabelValues(string(protocolID)).Inc()
 	// logger := n.logger.With(zap.String("protocol", string(protocolID)), zap.String("streamID", streamID))
 	done := func() {
-		//TODO: remove line below after TODO inside the if-statement is resolved
-		// nolint: staticcheck
-		if err := s.Close(); err != nil {
-			// TODO (amir): investigate
-			// logger.Warn("could not close stream", zap.Error(err))
+		if err := s.Close(); err != nil && err.Error() != libp2pnetwork.ErrReset.Error() {
+			n.logger.Debug("failed to close stream (handler)", zap.String("s_id", stream.ID()), zap.Error(err))
 		}
 	}
 	data, err := s.ReadWithTimeout(n.requestTimeout)
 	if err != nil {
-		// logger.Warn("could not read stream msg", zap.Error(err))
 		return nil, nil, done, errors.Wrap(err, "could not read stream msg")
 	}
 
@@ -103,7 +103,7 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 		cp := make([]byte, len(res))
 		copy(cp, res)
 		if err := s.WriteWithTimeout(cp, n.requestTimeout); err != nil {
-			// logger.Warn("could not write to stream", zap.Error(err))
+			// logger.Debug("could not write to stream", zap.Error(err))
 			return errors.Wrap(err, "could not write to stream")
 		}
 		metricsStreamResponses.WithLabelValues(string(protocolID)).Inc()

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -100,7 +100,9 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 	}
 
 	return data, func(res []byte) error {
-		if err := s.WriteWithTimeout(res, n.requestTimeout); err != nil {
+		cp := make([]byte, len(res), len(res))
+		copy(cp, res)
+		if err := s.WriteWithTimeout(cp, n.requestTimeout); err != nil {
 			// logger.Warn("could not write to stream", zap.Error(err))
 			return errors.Wrap(err, "could not write to stream")
 		}

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -100,7 +100,7 @@ func (n *streamCtrl) HandleStream(stream core.Stream) ([]byte, StreamResponder, 
 	}
 
 	return data, func(res []byte) error {
-		cp := make([]byte, len(res), len(res))
+		cp := make([]byte, len(res))
 		copy(cp, res)
 		if err := s.WriteWithTimeout(cp, n.requestTimeout); err != nil {
 			// logger.Warn("could not write to stream", zap.Error(err))


### PR DESCRIPTION
Fixing some issues with libp2p streams, that lead to disconnections and multiple warning logs.

- remove pending cache for handshake 
(caused deadlines in case of multiple handshake attempts)
- logs alignment
- added resource manager to apply stream limits (TODO: check in scale)
see [libp2p: dos mitigation](https://docs.libp2p.io/concepts/security/dos-mitigation/#leverage-the-resource-manager-to-limit-resource-usage-go-libp2p-only)