### PR TITLE
Deprecate decided topic

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - deprecate-decided-topic
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -48,7 +48,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - deprecate-decided-topic
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,9 @@ variables:
   ECRLOGIN_INFRA_PROD: "aws ecr get-login --registry-ids $ACCOUNT_ID_INFRA_PROD --region $AWS_REGION_INFRA_PROD --no-include-email"
   PROD_HEALTH_CHECK_IMAGE: 764289642555.dkr.ecr.us-west-2.amazonaws.com/infra-prod-repo:ubuntu20
 
+# ---------
+# | STAGE |
+# ---------
 Build stage Docker image:
   stage: build
   tags:
@@ -70,7 +73,9 @@ Deploy ssv nodes to blox-infra-stage cluster:
   only:
     - stage
 
-#blox-infra-prod
+# ---------
+# | Prod  |
+# ---------
 Build prod Docker image:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - deprecate-decided-topic
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -51,7 +51,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - deprecate-decided-topic
+    - stage
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy

--- a/network/forks/fork.go
+++ b/network/forks/fork.go
@@ -27,9 +27,6 @@ type nodeRecord interface {
 type pubSubMapping interface {
 	// ValidatorTopicID maps the given validator public key to the corresponding pubsub topic
 	ValidatorTopicID(pk []byte) []string
-	// DecidedTopic returns the name used for main/decided topic,
-	// or empty string if the fork doesn't include a decided topic
-	DecidedTopic() string
 	// GetTopicFullName returns the topic full name, including prefix
 	GetTopicFullName(baseName string) string
 	// GetTopicBaseName return the base topic name of the topic, w/o ssv prefix

--- a/network/forks/genesis/pubsub_mapping.go
+++ b/network/forks/genesis/pubsub_mapping.go
@@ -10,7 +10,6 @@ import (
 const (
 	// UnknownSubnet is used when a validator public key is invalid
 	UnknownSubnet = "unknown"
-	decidedTopic  = "decided"
 
 	topicPrefix = "ssv.v2"
 )
@@ -33,11 +32,6 @@ func (genesis *ForkGenesis) GetTopicFullName(baseName string) string {
 // GetTopicBaseName return the base topic name of the topic, w/o ssv prefix
 func (genesis *ForkGenesis) GetTopicBaseName(topicName string) string {
 	return strings.Replace(topicName, fmt.Sprintf("%s.", topicPrefix), "", 1)
-}
-
-// DecidedTopic returns decided topic name for v1
-func (genesis *ForkGenesis) DecidedTopic() string {
-	return decidedTopic
 }
 
 // topicOf returns the topic for the given subnet

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	RequestTimeout   time.Duration `yaml:"RequestTimeout" env:"P2P_REQUEST_TIMEOUT"  env-default:"7s"`
 	MaxBatchResponse uint64        `yaml:"MaxBatchResponse" env:"P2P_MAX_BATCH_RESPONSE" env-default:"25" env-description:"Maximum number of returned objects in a batch"`
 	MaxPeers         int           `yaml:"MaxPeers" env:"P2P_MAX_PEERS" env-default:"60" env-description:"Connected peers limit for connections"`
-	TopicMaxPeers    int           `yaml:"TopicMaxPeers" env:"P2P_TOPIC_MAX_PEERS" env-default:"5" env-description:"Connected peers limit per pubsub topic"`
+	TopicMaxPeers    int           `yaml:"TopicMaxPeers" env:"P2P_TOPIC_MAX_PEERS" env-default:"8" env-description:"Connected peers limit per pubsub topic"`
 
 	// Subnets is a static bit list of subnets that this node will register upon start.
 	Subnets string `yaml:"Subnets" env:"SUBNETS" env-description:"Hex string that represents the subnets that this node will join upon start"`

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -30,7 +30,6 @@ func TestGetMaxPeers(t *testing.T) {
 
 	require.Equal(t, 40, n.getMaxPeers(""))
 	require.Equal(t, 8, n.getMaxPeers("100"))
-	require.Equal(t, 16, n.getMaxPeers(n.fork.DecidedTopic()))
 }
 
 func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -239,9 +239,7 @@ func (ctrl *topicsCtrl) setupTopicValidator(name string) error {
 		// first try to unregister in case there is already a msg validator for that topic (e.g. fork scenario)
 		_ = ctrl.ps.UnregisterTopicValidator(name)
 		var opts []pubsub.ValidatorOpt
-		if ctrl.fork.GetTopicBaseName(name) == ctrl.fork.DecidedTopic() {
-			opts = append(opts, pubsub.WithValidatorTimeout(time.Second))
-		}
+		// opts = append(opts, pubsub.WithValidatorTimeout(time.Second))
 		err := ctrl.ps.RegisterTopicValidator(name, ctrl.msgValidatorFactory(name), opts...)
 		if err != nil {
 			return errors.Wrap(err, "could not register topic validator")

--- a/network/topics/msg_validator.go
+++ b/network/topics/msg_validator.go
@@ -38,7 +38,8 @@ func NewSSVMsgValidator(plogger *zap.Logger, fork forks.Fork, self peer.ID) func
 		}
 		pmsg.ValidatorData = *msg
 		return pubsub.ValidationAccept
-		// check decided topic
+
+		// Check if the message was sent on the right topic.
 		// currentTopic := pmsg.GetTopic()
 		// currentTopicBaseName := fork.GetTopicBaseName(currentTopic)
 		// topics := fork.ValidatorTopicID(msg.GetID().GetPubKey())

--- a/network/topics/params/peer_score.go
+++ b/network/topics/params/peer_score.go
@@ -1,10 +1,11 @@
 package params
 
 import (
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"net"
 	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const (
@@ -29,7 +30,7 @@ func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, ipColocationWeight f
 		oneEpoch = oneEpochDuration
 	}
 
-	maxPositiveScore := (maxInMeshScore + maxFirstDeliveryScore) * (decidedTopicWeight + subnetTopicsWeight)
+	maxPositiveScore := (maxInMeshScore + maxFirstDeliveryScore) * (subnetTopicsWeight)
 	topicScoreCap := maxPositiveScore / 4.0 // ETH divides by 2, we use lower value to reduce cap
 
 	behaviourPenaltyThreshold := 10.0 // using a larger threshold than ETH (6) to reduce the effect of behavioural penalty

--- a/network/topics/params/scores_test.go
+++ b/network/topics/params/scores_test.go
@@ -17,30 +17,6 @@ func TestTopicScoreParams(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			"decided topic 1k validators",
-			func() *Options {
-				opts := NewDecidedTopicOpts(1000, 128)
-				return &opts
-			},
-			nil,
-		},
-		{
-			"decided topic 10k validators",
-			func() *Options {
-				opts := NewDecidedTopicOpts(10000, 128)
-				return &opts
-			},
-			nil,
-		},
-		{
-			"decided topic 51k validators",
-			func() *Options {
-				opts := NewDecidedTopicOpts(51000, 128)
-				return &opts
-			},
-			nil,
-		},
-		{
 			"subnet topic 1k validators",
 			func() *Options {
 				opts := NewSubnetTopicOpts(1000, 128)

--- a/network/topics/params/topic_score.go
+++ b/network/topics/params/topic_score.go
@@ -1,10 +1,11 @@
 package params
 
 import (
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/pkg/errors"
 	"math"
 	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -22,7 +23,6 @@ const (
 	dampeningFactor = 50
 
 	subnetTopicsWeight = 4.0
-	decidedTopicWeight = 0.5
 )
 
 const (
@@ -75,7 +75,7 @@ func (o *Options) defaults() {
 		o.Network.OneEpochDuration = oneEpochDuration
 	}
 	if o.Network.TotalTopicsWeight == 0 {
-		o.Network.TotalTopicsWeight = decidedTopicWeight + subnetTopicsWeight
+		o.Network.TotalTopicsWeight = subnetTopicsWeight // + ...
 	}
 	if o.Topic.D == 0 {
 		o.Topic.D = gossipSubD
@@ -103,19 +103,6 @@ func NewOpts(activeValidators, subnets int) Options {
 		},
 		Topic: TopicOpts{},
 	}
-}
-
-// NewDecidedTopicOpts creates new TopicOpts for decided topic
-func NewDecidedTopicOpts(activeValidators, subnets int) Options {
-	opts := NewOpts(activeValidators, subnets)
-	opts.defaults()
-	opts.Topic.TopicWeight = decidedTopicWeight
-	opts.Topic.ExpectedMsgRate = float64(opts.Network.ActiveValidators) / float64(slotsPerEpoch)
-	opts.Topic.FirstMsgDecayTime = time.Duration(1)
-	opts.Topic.MeshMsgDecayTime = time.Duration(16)
-	opts.Topic.MeshMsgCapFactor = 32.0 // using a large factor until we have more accurate values
-	opts.Topic.MeshMsgActivationTime = opts.Network.OneEpochDuration
-	return opts
 }
 
 // NewSubnetTopicOpts creates new TopicOpts for a subnet topic

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -2,6 +2,9 @@ package topics
 
 import (
 	"context"
+	"net"
+	"time"
+
 	"github.com/bloxapp/ssv/network"
 	"github.com/bloxapp/ssv/network/forks"
 	"github.com/bloxapp/ssv/network/peers"
@@ -13,13 +16,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"net"
-	"time"
 )
 
 const (
 	// subscriptionRequestLimit sets an upper bound for the number of topic we are allowed to subscribe to.
-	// 128 subnets + decided topic
+	// 128 subnets + 1 safety buffer
 	subscriptionRequestLimit = 128 + 1
 )
 

--- a/network/topics/scoring.go
+++ b/network/topics/scoring.go
@@ -1,13 +1,14 @@
 package topics
 
 import (
+	"time"
+
 	"github.com/bloxapp/ssv/network/forks"
 	"github.com/bloxapp/ssv/network/peers"
 	"github.com/bloxapp/ssv/network/topics/params"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
-	"time"
 )
 
 // DefaultScoringConfig returns the default scoring config
@@ -51,7 +52,6 @@ func scoreInspector(logger *zap.Logger, scoreIdx peers.ScoreIndex) pubsub.Extend
 
 // topicScoreParams factory for creating scoring params for topics
 func topicScoreParams(cfg *PububConfig, f forks.Fork) func(string) *pubsub.TopicScoreParams {
-	decidedTopic := f.GetTopicFullName(f.DecidedTopic())
 	return func(t string) *pubsub.TopicScoreParams {
 		totalValidators, activeValidators, myValidators, err := cfg.GetValidatorStats()
 		if err != nil {
@@ -61,13 +61,7 @@ func topicScoreParams(cfg *PububConfig, f forks.Fork) func(string) *pubsub.Topic
 		logger := cfg.Logger.With(zap.String("topic", t), zap.Uint64("totalValidators", totalValidators),
 			zap.Uint64("activeValidators", activeValidators), zap.Uint64("myValidators", myValidators))
 		logger.Debug("got validator stats for score params")
-		var opts params.Options
-		switch t {
-		case decidedTopic:
-			opts = params.NewDecidedTopicOpts(int(totalValidators), f.Subnets())
-		default:
-			opts = params.NewSubnetTopicOpts(int(totalValidators), f.Subnets())
-		}
+		opts := params.NewSubnetTopicOpts(int(totalValidators), f.Subnets())
 		tp, err := params.TopicParams(opts)
 		if err != nil {
 			logger.Debug("ignoring topic score params", zap.Error(err))


### PR DESCRIPTION
Today we're sending decided messages in 2 topics: the validator's subnet and the decided topic.

This PR deprecates the decided topic to avoid this duplication, in hopes to reduce overall network load.