### PR TITLE
Keep Go mod cache across Docker builds (superfast builds: part 2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ Build stage Docker image:
   tags:
     - blox-infra-stage
   script:
-    - apk add --no-cache curl jq python py-pip
+    - apk add --no-cache py-pip
     - pip install pyyaml==5.3.1
     - pip install awscli
     - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ Build stage Docker image:
   tags:
     - blox-infra-stage
   script:
-    - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
+    - DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_STAGE_REPO=`$ECRLOGIN_INFRA_STAGE`
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
@@ -81,7 +81,7 @@ Build prod Docker image:
   tags:
     - blox-infra-prod
   script:
-    - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
+    - DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_PROD_REPO=`$ECRLOGIN_INFRA_PROD`
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - docker-build-cache
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - docker-build-cache
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ variables:
 # | STAGE |
 # ---------
 Build stage Docker image:
+  image: docker:20.10.23
   stage: build
   tags:
     - blox-infra-stage
@@ -36,7 +37,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - docker-build-cache
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - docker-build-cache
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ Build stage Docker image:
   stage: build
   tags:
     - blox-infra-stage
-  script
+  script:
     - apk add --no-cache curl jq python py-pip
     - pip install pyyaml==5.3.1
     - pip install awscli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,10 @@ Build stage Docker image:
   stage: build
   tags:
     - blox-infra-stage
-  script:
+  script
+    - apk add --no-cache curl jq python py-pip
+    - pip install pyyaml==5.3.1
+    - pip install awscli
     - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_STAGE_REPO=`$ECRLOGIN_INFRA_STAGE`
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ Build prod Docker image:
   tags:
     - blox-infra-prod
   script:
-    - DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
+    - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_PROD_REPO=`$ECRLOGIN_INFRA_PROD`
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_BUILD_REF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,10 @@ Build stage Docker image:
   stage: build
   tags:
     - blox-infra-stage
+  variables:
+    DOCKER_BUILDKIT: 1
   script:
-    - DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
+    - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_STAGE_REPO=`$ECRLOGIN_INFRA_STAGE`
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
 variables:
   #GLOBAL
   IMAGE_NAME: ssv-node
+  DOCKER_BUILDKIT: 1
 
   #STAGE
   ACCOUNT_ID_INFRA_STAGE: 121827225315
@@ -29,8 +30,6 @@ Build stage Docker image:
   stage: build
   tags:
     - blox-infra-stage
-  variables:
-    DOCKER_BUILDKIT: 1
   script:
     - docker build -t $IMAGE_NAME:$CI_BUILD_REF -f Dockerfile .
     - DOCKER_LOGIN_TO_INFRA_STAGE_REPO=`$ECRLOGIN_INFRA_STAGE`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax = docker/dockerfile:experimental
 #
 # STEP 1: Prepare environment
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:experimental
 #
 # STEP 1: Prepare environment
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ FROM golang:1.19 AS preparer
 
 RUN apt-get update                                                        && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl git zip unzip wget g++ python gcc-aarch64-linux-gnu bzip2 make      \
+  curl git zip unzip wget g++ python gcc-aarch64-linux-gnu bzip2 make      \
   && rm -rf /var/lib/apt/lists/*
 # install jemalloc
 WORKDIR /tmp/jemalloc-temp
 RUN curl -s -L "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2" -o jemalloc.tar.bz2 \
-      && tar xjf ./jemalloc.tar.bz2
+  && tar xjf ./jemalloc.tar.bz2
 RUN cd jemalloc-5.2.1 \
-      && ./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto' \
-      && make && make install
+  && ./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto' \
+  && make && make install
 
 RUN go version
 RUN python --version
@@ -31,11 +31,14 @@ FROM preparer AS builder
 
 # Copy files and install app
 COPY . .
-RUN go get -d -v ./...
 
 ARG APP_VERSION
 
-RUN CGO_ENABLED=1 GOOS=linux go install -tags="blst_enabled,jemalloc,allocator" -ldflags "-X main.Version=`if [ ! -z "${APP_VERSION}" ]; then echo $APP_VERSION; else git describe --tags $(git rev-list --tags --max-count=1); fi` -linkmode external -extldflags \"-static -lm\"" ./cmd/ssvnode
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=1 GOOS=linux go install \
+  -tags="blst_enabled,jemalloc,allocator" \
+  -ldflags "-X main.Version=`if [ ! -z "${APP_VERSION}" ]; then echo $APP_VERSION; else git describe --tags $(git rev-list --tags --max-count=1); fi` -linkmode external -extldflags \"-static -lm\"" \
+  ./cmd/ssvnode
 
 #
 # STEP 3: Prepare image to run the binary
@@ -44,7 +47,7 @@ FROM alpine:3.12 AS runner
 
 # Install ca-certificates, bash
 RUN apk -v --update add ca-certificates bash make  bind-tools && \
-    rm /var/cache/apk/*
+  rm /var/cache/apk/*
 
 COPY --from=builder /go/bin/ssvnode /go/bin/ssvnode
 COPY ./Makefile .env* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN go version
 WORKDIR /go/src/github.com/bloxapp/ssv/
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,mode=0755,target=/go/pkg \
+  go mod download
 
 ARG APP_VERSION
 #
@@ -34,6 +36,7 @@ COPY . .
 ARG APP_VERSION
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,mode=0755,target=/go/pkg \
   CGO_ENABLED=1 GOOS=linux go install \
   -tags="blst_enabled,jemalloc,allocator" \
   -ldflags "-X main.Version=`if [ ! -z "${APP_VERSION}" ]; then echo $APP_VERSION; else git describe --tags $(git rev-list --tags --max-count=1); fi` -linkmode external -extldflags \"-static -lm\"" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.19 AS preparer
 
 RUN apt-get update                                                        && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-  curl git zip unzip wget g++ python gcc-aarch64-linux-gnu bzip2 make      \
+  curl git zip unzip wget g++ gcc-aarch64-linux-gnu bzip2 make      \
   && rm -rf /var/lib/apt/lists/*
 # install jemalloc
 WORKDIR /tmp/jemalloc-temp
@@ -16,7 +16,6 @@ RUN cd jemalloc-5.2.1 \
   && make && make install
 
 RUN go version
-RUN python --version
 
 WORKDIR /go/src/github.com/bloxapp/ssv/
 COPY go.mod .


### PR DESCRIPTION
After #835 which caches `go build`, this PR adds cache for `go mod download` 💪