### PR TITLE
IO1-2584: mockgen makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,3 +142,12 @@ MONITOR_NODES=prometheus grafana
 docker-monitor:
 	@echo $(MONITOR_NODES)
 	@docker-compose up --build $(MONITOR_NODES)
+
+.PHONY: mock
+mock:
+	go generate ./...
+
+.PHONY: mock
+mockgen-install:
+	go install github.com/golang/mock/mockgen@v1.6.0
+	@which mockgen || echo "Error: ensure `go env GOPATH` is added to PATH"

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ docker-monitor:
 mock:
 	go generate ./...
 
-.PHONY: mock
+.PHONY: mockgen-install
 mockgen-install:
 	go install github.com/golang/mock/mockgen@v1.6.0
 	@which mockgen || echo "Error: ensure `go env GOPATH` is added to PATH"

--- a/eth1/mock_client.go
+++ b/eth1/mock_client.go
@@ -5,36 +5,37 @@
 package eth1
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	event "github.com/prysmaticlabs/prysm/async/event"
 	big "math/big"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	event "github.com/prysmaticlabs/prysm/async/event"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// EventsFeed mocks base method
+// EventsFeed mocks base method.
 func (m *MockClient) EventsFeed() *event.Feed {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventsFeed")
@@ -42,13 +43,13 @@ func (m *MockClient) EventsFeed() *event.Feed {
 	return ret0
 }
 
-// EventsFeed indicates an expected call of EventsFeed
+// EventsFeed indicates an expected call of EventsFeed.
 func (mr *MockClientMockRecorder) EventsFeed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventsFeed", reflect.TypeOf((*MockClient)(nil).EventsFeed))
 }
 
-// Start mocks base method
+// Start mocks base method.
 func (m *MockClient) Start() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
@@ -56,13 +57,13 @@ func (m *MockClient) Start() error {
 	return ret0
 }
 
-// Start indicates an expected call of Start
+// Start indicates an expected call of Start.
 func (mr *MockClientMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockClient)(nil).Start))
 }
 
-// Sync mocks base method
+// Sync mocks base method.
 func (m *MockClient) Sync(fromBlock *big.Int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sync", fromBlock)
@@ -70,7 +71,7 @@ func (m *MockClient) Sync(fromBlock *big.Int) error {
 	return ret0
 }
 
-// Sync indicates an expected call of Sync
+// Sync indicates an expected call of Sync.
 func (mr *MockClientMockRecorder) Sync(fromBlock interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockClient)(nil).Sync), fromBlock)

--- a/eth1/mock_sync.go
+++ b/eth1/mock_sync.go
@@ -5,48 +5,35 @@
 package eth1
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSyncOffsetStorage is a mock of SyncOffsetStorage interface
+// MockSyncOffsetStorage is a mock of SyncOffsetStorage interface.
 type MockSyncOffsetStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockSyncOffsetStorageMockRecorder
 }
 
-// MockSyncOffsetStorageMockRecorder is the mock recorder for MockSyncOffsetStorage
+// MockSyncOffsetStorageMockRecorder is the mock recorder for MockSyncOffsetStorage.
 type MockSyncOffsetStorageMockRecorder struct {
 	mock *MockSyncOffsetStorage
 }
 
-// NewMockSyncOffsetStorage creates a new mock instance
+// NewMockSyncOffsetStorage creates a new mock instance.
 func NewMockSyncOffsetStorage(ctrl *gomock.Controller) *MockSyncOffsetStorage {
 	mock := &MockSyncOffsetStorage{ctrl: ctrl}
 	mock.recorder = &MockSyncOffsetStorageMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSyncOffsetStorage) EXPECT() *MockSyncOffsetStorageMockRecorder {
 	return m.recorder
 }
 
-// SaveSyncOffset mocks base method
-func (m *MockSyncOffsetStorage) SaveSyncOffset(offset *SyncOffset) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSyncOffset", offset)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SaveSyncOffset indicates an expected call of SaveSyncOffset
-func (mr *MockSyncOffsetStorageMockRecorder) SaveSyncOffset(offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSyncOffset", reflect.TypeOf((*MockSyncOffsetStorage)(nil).SaveSyncOffset), offset)
-}
-
-// GetSyncOffset mocks base method
+// GetSyncOffset mocks base method.
 func (m *MockSyncOffsetStorage) GetSyncOffset() (*SyncOffset, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSyncOffset")
@@ -56,8 +43,22 @@ func (m *MockSyncOffsetStorage) GetSyncOffset() (*SyncOffset, bool, error) {
 	return ret0, ret1, ret2
 }
 
-// GetSyncOffset indicates an expected call of GetSyncOffset
+// GetSyncOffset indicates an expected call of GetSyncOffset.
 func (mr *MockSyncOffsetStorageMockRecorder) GetSyncOffset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncOffset", reflect.TypeOf((*MockSyncOffsetStorage)(nil).GetSyncOffset))
+}
+
+// SaveSyncOffset mocks base method.
+func (m *MockSyncOffsetStorage) SaveSyncOffset(offset *SyncOffset) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSyncOffset", offset)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSyncOffset indicates an expected call of SaveSyncOffset.
+func (mr *MockSyncOffsetStorageMockRecorder) SaveSyncOffset(offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSyncOffset", reflect.TypeOf((*MockSyncOffsetStorage)(nil).SaveSyncOffset), offset)
 }

--- a/operator/fee_recipient/mocks/controller.go
+++ b/operator/fee_recipient/mocks/controller.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	reflect "reflect"
 
-	phase0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -35,13 +34,13 @@ func (m *MockRecipientController) EXPECT() *MockRecipientControllerMockRecorder 
 }
 
 // Start mocks base method.
-func (m *MockRecipientController) Start(ticker <-chan phase0.Slot) {
+func (m *MockRecipientController) Start() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start", ticker)
+	m.ctrl.Call(m, "Start")
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockRecipientControllerMockRecorder) Start(ticker interface{}) *gomock.Call {
+func (mr *MockRecipientControllerMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRecipientController)(nil).Start), ticker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRecipientController)(nil).Start))
 }

--- a/operator/validator/mocks/controller.go
+++ b/operator/validator/mocks/controller.go
@@ -5,116 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	phase0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	eth1 "github.com/bloxapp/ssv/eth1"
 	validator "github.com/bloxapp/ssv/protocol/v2/ssv/validator"
 	types "github.com/bloxapp/ssv/protocol/v2/types"
 	gomock "github.com/golang/mock/gomock"
 	event "github.com/prysmaticlabs/prysm/async/event"
-	reflect "reflect"
 )
 
-// MockController is a mock of Controller interface
+// MockController is a mock of Controller interface.
 type MockController struct {
 	ctrl     *gomock.Controller
 	recorder *MockControllerMockRecorder
 }
 
-// MockControllerMockRecorder is the mock recorder for MockController
+// MockControllerMockRecorder is the mock recorder for MockController.
 type MockControllerMockRecorder struct {
 	mock *MockController
 }
 
-// NewMockController creates a new mock instance
+// NewMockController creates a new mock instance.
 func NewMockController(ctrl *gomock.Controller) *MockController {
 	mock := &MockController{ctrl: ctrl}
 	mock.recorder = &MockControllerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockController) EXPECT() *MockControllerMockRecorder {
 	return m.recorder
 }
 
-// ListenToEth1Events mocks base method
-func (m *MockController) ListenToEth1Events(feed *event.Feed) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ListenToEth1Events", feed)
-}
-
-// ListenToEth1Events indicates an expected call of ListenToEth1Events
-func (mr *MockControllerMockRecorder) ListenToEth1Events(feed interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListenToEth1Events", reflect.TypeOf((*MockController)(nil).ListenToEth1Events), feed)
-}
-
-// StartValidators mocks base method
-func (m *MockController) StartValidators() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartValidators")
-}
-
-// StartValidators indicates an expected call of StartValidators
-func (mr *MockControllerMockRecorder) StartValidators() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartValidators", reflect.TypeOf((*MockController)(nil).StartValidators))
-}
-
-// GetValidatorsIndices mocks base method
-func (m *MockController) GetValidatorsIndices() []phase0.ValidatorIndex {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValidatorsIndices")
-	ret0, _ := ret[0].([]phase0.ValidatorIndex)
-	return ret0
-}
-
-// GetValidatorsIndices indicates an expected call of GetValidatorsIndices
-func (mr *MockControllerMockRecorder) GetValidatorsIndices() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorsIndices", reflect.TypeOf((*MockController)(nil).GetValidatorsIndices))
-}
-
-// GetValidator mocks base method
-func (m *MockController) GetValidator(pubKey string) (*validator.Validator, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValidator", pubKey)
-	ret0, _ := ret[0].(*validator.Validator)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetValidator indicates an expected call of GetValidator
-func (mr *MockControllerMockRecorder) GetValidator(pubKey interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidator", reflect.TypeOf((*MockController)(nil).GetValidator), pubKey)
-}
-
-// UpdateValidatorMetaDataLoop mocks base method
-func (m *MockController) UpdateValidatorMetaDataLoop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateValidatorMetaDataLoop")
-}
-
-// UpdateValidatorMetaDataLoop indicates an expected call of UpdateValidatorMetaDataLoop
-func (mr *MockControllerMockRecorder) UpdateValidatorMetaDataLoop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorMetaDataLoop", reflect.TypeOf((*MockController)(nil).UpdateValidatorMetaDataLoop))
-}
-
-// StartNetworkHandlers mocks base method
-func (m *MockController) StartNetworkHandlers() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartNetworkHandlers")
-}
-
-// StartNetworkHandlers indicates an expected call of StartNetworkHandlers
-func (mr *MockControllerMockRecorder) StartNetworkHandlers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNetworkHandlers", reflect.TypeOf((*MockController)(nil).StartNetworkHandlers))
-}
-
-// Eth1EventHandler mocks base method
+// Eth1EventHandler mocks base method.
 func (m *MockController) Eth1EventHandler(ongoingSync bool) eth1.SyncEventHandler {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Eth1EventHandler", ongoingSync)
@@ -122,13 +46,13 @@ func (m *MockController) Eth1EventHandler(ongoingSync bool) eth1.SyncEventHandle
 	return ret0
 }
 
-// Eth1EventHandler indicates an expected call of Eth1EventHandler
+// Eth1EventHandler indicates an expected call of Eth1EventHandler.
 func (mr *MockControllerMockRecorder) Eth1EventHandler(ongoingSync interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eth1EventHandler", reflect.TypeOf((*MockController)(nil).Eth1EventHandler), ongoingSync)
 }
 
-// GetAllValidatorShares mocks base method
+// GetAllValidatorShares mocks base method.
 func (m *MockController) GetAllValidatorShares() ([]*types.SSVShare, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllValidatorShares")
@@ -137,13 +61,28 @@ func (m *MockController) GetAllValidatorShares() ([]*types.SSVShare, error) {
 	return ret0, ret1
 }
 
-// GetAllValidatorShares indicates an expected call of GetAllValidatorShares
+// GetAllValidatorShares indicates an expected call of GetAllValidatorShares.
 func (mr *MockControllerMockRecorder) GetAllValidatorShares() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllValidatorShares", reflect.TypeOf((*MockController)(nil).GetAllValidatorShares))
 }
 
-// GetValidatorStats mocks base method
+// GetValidator mocks base method.
+func (m *MockController) GetValidator(pubKey string) (*validator.Validator, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidator", pubKey)
+	ret0, _ := ret[0].(*validator.Validator)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetValidator indicates an expected call of GetValidator.
+func (mr *MockControllerMockRecorder) GetValidator(pubKey interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidator", reflect.TypeOf((*MockController)(nil).GetValidator), pubKey)
+}
+
+// GetValidatorStats mocks base method.
 func (m *MockController) GetValidatorStats() (uint64, uint64, uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidatorStats")
@@ -154,8 +93,70 @@ func (m *MockController) GetValidatorStats() (uint64, uint64, uint64, error) {
 	return ret0, ret1, ret2, ret3
 }
 
-// GetValidatorStats indicates an expected call of GetValidatorStats
+// GetValidatorStats indicates an expected call of GetValidatorStats.
 func (mr *MockControllerMockRecorder) GetValidatorStats() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorStats", reflect.TypeOf((*MockController)(nil).GetValidatorStats))
+}
+
+// GetValidatorsIndices mocks base method.
+func (m *MockController) GetValidatorsIndices() []phase0.ValidatorIndex {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidatorsIndices")
+	ret0, _ := ret[0].([]phase0.ValidatorIndex)
+	return ret0
+}
+
+// GetValidatorsIndices indicates an expected call of GetValidatorsIndices.
+func (mr *MockControllerMockRecorder) GetValidatorsIndices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorsIndices", reflect.TypeOf((*MockController)(nil).GetValidatorsIndices))
+}
+
+// ListenToEth1Events mocks base method.
+func (m *MockController) ListenToEth1Events(feed *event.Feed) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ListenToEth1Events", feed)
+}
+
+// ListenToEth1Events indicates an expected call of ListenToEth1Events.
+func (mr *MockControllerMockRecorder) ListenToEth1Events(feed interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListenToEth1Events", reflect.TypeOf((*MockController)(nil).ListenToEth1Events), feed)
+}
+
+// StartNetworkHandlers mocks base method.
+func (m *MockController) StartNetworkHandlers() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StartNetworkHandlers")
+}
+
+// StartNetworkHandlers indicates an expected call of StartNetworkHandlers.
+func (mr *MockControllerMockRecorder) StartNetworkHandlers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNetworkHandlers", reflect.TypeOf((*MockController)(nil).StartNetworkHandlers))
+}
+
+// StartValidators mocks base method.
+func (m *MockController) StartValidators() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StartValidators")
+}
+
+// StartValidators indicates an expected call of StartValidators.
+func (mr *MockControllerMockRecorder) StartValidators() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartValidators", reflect.TypeOf((*MockController)(nil).StartValidators))
+}
+
+// UpdateValidatorMetaDataLoop mocks base method.
+func (m *MockController) UpdateValidatorMetaDataLoop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateValidatorMetaDataLoop")
+}
+
+// UpdateValidatorMetaDataLoop indicates an expected call of UpdateValidatorMetaDataLoop.
+func (mr *MockControllerMockRecorder) UpdateValidatorMetaDataLoop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorMetaDataLoop", reflect.TypeOf((*MockController)(nil).UpdateValidatorMetaDataLoop))
 }


### PR DESCRIPTION
With the logging refactor project many interfaces will be changing. The mocks must be updated in order to stay in sync with the interface changes. 

Changes:
* Add makefile targets to install & run mockgen 1.6.0 (latest)
* Check in results of running mockgen 1.6.0 on the project