### PR TITLE
removing "who" tags from logex.GetLogger()

### DIFF
--- a/protocol/v2/blockchain/beacon/validator_metadata.go
+++ b/protocol/v2/blockchain/beacon/validator_metadata.go
@@ -65,7 +65,8 @@ type OnUpdated func(logger *zap.Logger, pk string, meta *ValidatorMetadata)
 
 // UpdateValidatorsMetadata updates validator information for the given public keys
 func UpdateValidatorsMetadata(pubKeys [][]byte, collection ValidatorMetadataStorage, bc Beacon, onUpdated OnUpdated) error {
-	logger := logex.GetLogger(zap.String("who", "UpdateValidatorsMetadata"))
+	logger := logex.GetLogger()
+	logger = logger.Named("UpdateValidatorsMetadata")
 
 	results, err := FetchValidatorsMetadata(bc, pubKeys)
 	if err != nil {

--- a/utils/tasks/exec_timeout.go
+++ b/utils/tasks/exec_timeout.go
@@ -20,9 +20,9 @@ type funcResult struct {
 // ExecWithTimeout triggers some function in the given time frame, returns true if completed
 func ExecWithTimeout(ctx context.Context, fn Func, t time.Duration) (bool, interface{}, error) {
 	c := make(chan funcResult, 1)
-	stopper := newStopper(logex.GetLogger(
-		zap.String("component", "stopper"),
-		zap.String("caller", "ExecWithTimeout")))
+	logger := logex.GetLogger(zap.String("caller", "ExecWithTimeout"))
+	logger = logger.Named("stopper")
+	stopper := newStopper(logger)
 
 	go func() {
 		defer func() {

--- a/utils/tasks/exec_timeout.go
+++ b/utils/tasks/exec_timeout.go
@@ -20,9 +20,7 @@ type funcResult struct {
 // ExecWithTimeout triggers some function in the given time frame, returns true if completed
 func ExecWithTimeout(ctx context.Context, fn Func, t time.Duration) (bool, interface{}, error) {
 	c := make(chan funcResult, 1)
-	logger := logex.GetLogger(zap.String("caller", "ExecWithTimeout"))
-	logger = logger.Named("stopper")
-	stopper := newStopper(logger)
+	stopper := newStopper(logex.GetLogger(zap.String("caller", "ExecWithTimeout")).Named("stopper"))
 
 	go func() {
 		defer func() {


### PR DESCRIPTION
change `logex.GetLogger(("who", "xxx"))` to `logex.GetLogger().Named("xxx")`