### PR TITLE
Log pubkey and role

### DIFF
--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -110,6 +110,7 @@ func (v *Validator) ProcessMessage(logger *zap.Logger, msg *queue.DecodedSSVMess
 			return errors.New("could not decode consensus message from network message")
 		}
 		logger = logger.With(fields.Height(signedMsg.Message.Height))
+		logger = logger.With(fields.PubKey(msg.MsgID.GetPubKey()), fields.Role(msg.MsgID.GetRoleType()))
 		return dutyRunner.ProcessConsensus(logger, signedMsg)
 	case spectypes.SSVPartialSignatureMsgType:
 		signedMsg, ok := msg.Body.(*specssv.SignedPartialSignatureMessage)


### PR DESCRIPTION
Currently my debugging is blocked because validator pubkey and role is not printing.

@nkryuchkov claims that logging should work without this due to logic in `validator/startup.go`. Until the bug is fixed this can be a temporary solution that later should be reverted.

This PR replaces #888 