### PR TITLE
Log duty IDs instead of JSON

### DIFF
--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -269,3 +269,7 @@ func Errors(val []error) zap.Field {
 func ToBlock(val *big.Int) zap.Field {
 	return zap.Int64(FieldToBlock, val.Int64())
 }
+
+func FormatDutyID(epoch phase0.Epoch, duty *spectypes.Duty) string {
+	return fmt.Sprintf("%v-e%v-s%v-v%v", duty.Type.String(), epoch, duty.Slot, duty.ValidatorIndex)
+}

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -92,7 +92,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *spectypes.Duty) error {
 	}
 
 	// create the new dutyID for the new duty and update the dutyID map
-	v.dutyIDs.Set(duty.Type, dutyID(dutyRunner.GetBaseRunner().BeaconNetwork, duty))
+	v.dutyIDs.Set(duty.Type, fields.FormatDutyID(dutyRunner.GetBaseRunner().BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty))
 
 	logger = trySetDutyID(logger, v.dutyIDs, duty.Type)
 
@@ -151,14 +151,6 @@ func validateMessage(share spectypes.Share, msg *spectypes.SSVMessage) error {
 	}
 
 	return nil
-}
-
-func dutyID(beaconNetwork spectypes.BeaconNetwork, duty *spectypes.Duty) string {
-	dutyType := duty.Type.String()
-	epoch := beaconNetwork.EstimatedEpochAtSlot(duty.Slot)
-	slot := duty.Slot
-	validatorIndex := duty.ValidatorIndex
-	return fmt.Sprintf("%v-e%v-s%v-v%v", dutyType, epoch, slot, validatorIndex)
 }
 
 func trySetDutyID(logger *zap.Logger, dutyIDs *hashmap.Map[spectypes.BeaconRole, string], role spectypes.BeaconRole) *zap.Logger {


### PR DESCRIPTION
This PR replaces the huge JSON array in the `got duties` log with a small list of duty IDs.