### PR TITLE
Add structured logging to file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.7.0
 	google.golang.org/grpc v1.40.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2043,6 +2043,8 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=

--- a/logging/global.go
+++ b/logging/global.go
@@ -1,12 +1,30 @@
 package logging
 
 import (
-	"fmt"
+	"io"
+	"os"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+var logFileWriter io.Writer
+
+// TODO: Log rotation out of the app
+func getFileWriter(logFileName string) io.Writer {
+	fileLogger := &lumberjack.Logger{
+		Filename:   logFileName,
+		MaxSize:    500, // megabytes
+		MaxBackups: 3,
+		MaxAge:     28, // days
+		Compress:   false,
+	}
+
+	return fileLogger
+}
 
 func parseConfigLevel(levelName string) (zapcore.Level, error) {
 	return zapcore.ParseLevel(levelName)
@@ -25,6 +43,10 @@ func parseConfigLevelEncoder(levelEncoderName string) zapcore.LevelEncoder {
 	}
 }
 
+func SetLogFilename(name string) {
+	logFileWriter = getFileWriter(name)
+}
+
 func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string) error {
 	level, err := parseConfigLevel(levelName)
 	if err != nil {
@@ -32,6 +54,10 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 	}
 
 	levelEncoder := parseConfigLevelEncoder(levelEncoderName)
+
+	lv := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl >= level
+	})
 
 	cfg := zap.Config{
 		Encoding:    logFormat,
@@ -53,12 +79,20 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 		},
 	}
 
-	globalLogger, err := cfg.Build()
-	if err != nil {
-		return fmt.Errorf("err making logger: %w", err)
+	consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(cfg.EncoderConfig), os.Stdout, lv)
+
+	if logFileWriter == nil {
+		SetLogFilename("debug.log")
 	}
 
-	zap.ReplaceGlobals(globalLogger)
+	lv2 := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return true // debug log returns all logs
+	})
+
+	dev := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
+	fileCore := zapcore.NewCore(dev, zapcore.AddSync(logFileWriter), lv2)
+
+	zap.ReplaceGlobals(zap.New(zapcore.NewTee(consoleCore, fileCore)))
 
 	return nil
 }


### PR DESCRIPTION
- add file writer with rotation
- log to file and console at the same file

Default file path is `./debug.log` right now, it's changeable using `SetLogFilename` we should probably (#todo) add a config param.