### PR TITLE
Write sturctured logs to a file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
 #    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
     - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
-    - stage
+    - log_file_structured
 
 # ---------
 # | Prod  |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - log_file_structured
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -72,8 +72,8 @@ Deploy ssv nodes to blox-infra-stage cluster:
     - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
     - chmod 755 kubectl
     - mv kubectl /usr/bin/
-    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+#    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+#    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
     - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
     - stage

--- a/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
+++ b/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
@@ -144,6 +144,6 @@ fi
 
 #deploy
 kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1
+#kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
+#kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
+#kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1

--- a/cli/bootnode/boot_node.go
+++ b/cli/bootnode/boot_node.go
@@ -30,7 +30,7 @@ var StartBootNodeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat); err != nil {
+		if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat, cfg.LogFilePath); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,6 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'json' (default) and 'console''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
+	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./data/debug.log" env-description:"Defines a file path to write logs into"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,7 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'json' (default) and 'console''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
-	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./data/debug.log" env-description:"Defines a file path to write logs into"`
+	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./debug.log" env-description:"Defines a file path to write logs into"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/export_keys_from_mnemonic.go
+++ b/cli/export_keys_from_mnemonic.go
@@ -19,7 +19,7 @@ var exportKeysCmd = &cobra.Command{
 	Use:   "export-keys",
 	Short: "exports private/public keys based on given mnemonic",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("dpanic", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("dpanic", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cli/generate_operator_keys.go
+++ b/cli/generate_operator_keys.go
@@ -15,7 +15,7 @@ var generateOperatorKeysCmd = &cobra.Command{
 	Use:   "generate-operator-keys",
 	Short: "generates ssv operator keys",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("debug", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("debug", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 		logger := zap.L().Named(RootCmd.Short)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -192,7 +192,7 @@ func setupGlobal(cmd *cobra.Command) (*zap.Logger, error) {
 		}
 	}
 
-	if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat); err != nil {
+	if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat, cfg.LogFilePath); err != nil {
 		return nil, fmt.Errorf("logging.SetGlobalLogger: %w", err)
 	}
 

--- a/cli/threshold.go
+++ b/cli/threshold.go
@@ -18,7 +18,7 @@ var createThresholdCmd = &cobra.Command{
 	Use:   "create-threshold",
 	Short: "Turns a private key into a threshold key",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("debug", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("debug", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 		logger := zap.L().Named(logging.NameCreateThreshold)

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,5 +1,6 @@
 global:
   LogLevel: info
+  LogFilePath: ./data/debug.log
 
 db:
   Path: ./data/db

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,6 @@
 global:
   LogLevel: info
-  LogFilePath: ./data/debug.log
+  LogFilePath: ./debug.log
 
 db:
   Path: ./data/db

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,6 @@
 global:
   LogLevel: info
-  LogFilePath: .data/debug.log
+  LogFilePath: ./data/debug.log
 
 db:
   Path: ./data/db

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,6 @@
 global:
   LogLevel: info
-  LogFilePath: ./debug.log
+  LogFilePath: .data/debug.log
 
 db:
   Path: ./data/db

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.7.0
 	google.golang.org/grpc v1.40.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2043,6 +2043,8 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=

--- a/logging/global.go
+++ b/logging/global.go
@@ -1,12 +1,30 @@
 package logging
 
 import (
-	"fmt"
+	"io"
+	"os"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+var logFileWriter io.Writer
+
+// TODO: Log rotation out of the app
+func getFileWriter(logFileName string) io.Writer {
+	fileLogger := &lumberjack.Logger{
+		Filename:   logFileName,
+		MaxSize:    500, // megabytes
+		MaxBackups: 3,
+		MaxAge:     28, // days
+		Compress:   false,
+	}
+
+	return fileLogger
+}
 
 func parseConfigLevel(levelName string) (zapcore.Level, error) {
 	return zapcore.ParseLevel(levelName)
@@ -25,6 +43,10 @@ func parseConfigLevelEncoder(levelEncoderName string) zapcore.LevelEncoder {
 	}
 }
 
+func SetLogFilename(name string) {
+	logFileWriter = getFileWriter(name)
+}
+
 func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string) error {
 	level, err := parseConfigLevel(levelName)
 	if err != nil {
@@ -32,6 +54,10 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 	}
 
 	levelEncoder := parseConfigLevelEncoder(levelEncoderName)
+
+	lv := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl >= level
+	})
 
 	cfg := zap.Config{
 		Encoding:    logFormat,
@@ -53,12 +79,20 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 		},
 	}
 
-	globalLogger, err := cfg.Build()
-	if err != nil {
-		return fmt.Errorf("err making logger: %w", err)
+	consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(cfg.EncoderConfig), os.Stdout, lv)
+
+	if logFileWriter == nil {
+		SetLogFilename("debug.log")
 	}
 
-	zap.ReplaceGlobals(globalLogger)
+	lv2 := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return true // debug log returns all logs
+	})
+
+	dev := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
+	fileCore := zapcore.NewCore(dev, zapcore.AddSync(logFileWriter), lv2)
+
+	zap.ReplaceGlobals(zap.New(zapcore.NewTee(consoleCore, fileCore)))
 
 	return nil
 }

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestLogger(t *testing.T) *zap.Logger {
-	err := SetGlobalLogger("debug", "capital", "console")
+	err := SetGlobalLogger("debug", "capital", "console", "")
 	require.NoError(t, err)
 	return zap.L().Named(t.Name())
 }
 
 func BenchLogger(b *testing.B) *zap.Logger {
-	err := SetGlobalLogger("debug", "capital", "console")
+	err := SetGlobalLogger("debug", "capital", "console", "")
 	require.NoError(b, err)
 	return zap.L().Named(b.Name())
 }


### PR DESCRIPTION
This PR adds functionality that lets you write structured logs ( json formatted logs `{ "L": level, "M": msg, "T": time, "field": field}`. 
This way indexing services like Elastic can easily index these lines and give us nice features in Kibana or KQL to search the logs.

## note about log file rotation
currently I added in-code log file rotation using `lumberjack` lib, the best practice is that the env will take care of it and our app won't be concerned with compressing and moving files. this is temporary so we won't explode our cloud nodes with endless logs. 

we'll need to do some research and consult @zevzek and come with a better rotation solution.

## reminder 
- [ ] - change deploy code back before merging 
