### PR TITLE
Level Beacon submission logs up to INFO

### DIFF
--- a/network/peers/conn_manager.go
+++ b/network/peers/conn_manager.go
@@ -73,7 +73,7 @@ func (c connManager) TrimPeers(ctx context.Context, logger *zap.Logger, net libp
 	for _, pid := range allPeers {
 		if !c.connManager.IsProtected(pid, protectedTag) {
 			err := net.ClosePeer(pid)
-			logger.Debug("DUMP: closing peer", zap.String("pid", pid.String()), zap.Error(err))
+			logger.Debug("closing peer", zap.String("pid", pid.String()), zap.Error(err))
 			// if err != nil {
 			//	logger.Debug("could not close trimmed peer",
 			//		zap.String("pid", pid.String()), zap.Error(err))

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -623,7 +623,7 @@ func (c *controller) onShareRemove(pk string, removeSecret bool) error {
 
 func (c *controller) onShareStart(logger *zap.Logger, share *types.SSVShare) (bool, error) {
 	if !share.HasBeaconMetadata() { // fetching index and status in case not exist
-		logger.Warn("could not start validator as metadata not found", fields.PubKey(share.ValidatorPubKey))
+		logger.Warn("skipping validator until it becomes active", fields.PubKey(share.ValidatorPubKey))
 		return false, nil
 	}
 

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -167,9 +167,7 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		// Submit it to the BN.
 		if err := r.beacon.SubmitAttestation(signedAtt); err != nil {
 			r.metrics.RoleSubmissionFailed()
-
-			logger.Error("❌ failed to submit attestation to Beacon node", fields.Slot(duty.Slot), zap.Error(err))
-
+			logger.Error("❌ failed to submit attestation", fields.Slot(duty.Slot), zap.Error(err))
 			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
 		}
 
@@ -177,10 +175,11 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		r.metrics.EndDutyFullFlow(r.GetState().RunningInstance.State.Round)
 		r.metrics.RoleSubmitted()
 
-		logger.Debug("✅ successfully submitted attestation",
+		logger.Info("✅ successfully submitted attestation",
 			fields.Slot(duty.Slot),
 			zap.String("block_root", hex.EncodeToString(signedAtt.Data.BeaconBlockRoot[:])),
 			fields.ConsensusTime(time.Since(r.started)),
+			fields.Height(r.BaseRunner.QBFTController.Height),
 			fields.Round(r.GetState().RunningInstance.State.Round))
 	}
 	r.GetState().Finished = true

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 
+	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 	"github.com/bloxapp/ssv/protocol/v2/ssv/runner/metrics"
 )
@@ -233,7 +234,10 @@ func (r *ProposerRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		r.metrics.EndDutyFullFlow(r.GetState().RunningInstance.State.Round)
 		r.metrics.RoleSubmitted()
 
-		logger.Info("✅ successfully proposed block!")
+		logger.Info("✅ successfully submitted block proposal",
+			fields.Slot(signedMsg.Message.Slot),
+			fields.Height(r.BaseRunner.QBFTController.Height),
+			fields.Round(r.GetState().RunningInstance.State.Round))
 	}
 	r.GetState().Finished = true
 	return nil

--- a/protocol/v2/ssv/runner/sync_committee.go
+++ b/protocol/v2/ssv/runner/sync_committee.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -161,7 +162,11 @@ func (r *SyncCommitteeRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg
 		r.metrics.EndDutyFullFlow(r.GetState().RunningInstance.State.Round)
 		r.metrics.RoleSubmitted()
 
-		logger.Debug("✅ successfully submitted sync committee!", fields.Slot(msg.Slot), fields.Height(r.BaseRunner.QBFTController.Height))
+		logger.Info("✅ successfully submitted sync committee",
+			fields.Slot(msg.Slot),
+			zap.String("block_root", hex.EncodeToString(msg.BeaconBlockRoot[:])),
+			fields.Height(r.BaseRunner.QBFTController.Height),
+			fields.Round(r.GetState().RunningInstance.State.Round))
 	}
 	r.GetState().Finished = true
 


### PR DESCRIPTION
Operators should see whether they're submitting attestations or not without enabling DEBUG level.