### PR TITLE
ship logs into a file and stdout at the same time.

### DIFF
--- a/cli/bootnode/boot_node.go
+++ b/cli/bootnode/boot_node.go
@@ -30,7 +30,7 @@ var StartBootNodeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat); err != nil {
+		if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat, cfg.LogFilePath); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,7 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'json' (default) and 'console''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
-	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./debug.log" env-description:"Defines a file path to write logs into"`
+	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./data/debug.log" env-description:"Defines a file path to write logs into"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,6 +16,7 @@ type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level'"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'json' (default) and 'console''"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase''"`
+	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./debug.log" env-description:"Defines a file path to write logs into"`
 }
 
 // ProcessArgs processes and handles CLI arguments

--- a/cli/export_keys_from_mnemonic.go
+++ b/cli/export_keys_from_mnemonic.go
@@ -19,7 +19,7 @@ var exportKeysCmd = &cobra.Command{
 	Use:   "export-keys",
 	Short: "exports private/public keys based on given mnemonic",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("dpanic", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("dpanic", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cli/generate_operator_keys.go
+++ b/cli/generate_operator_keys.go
@@ -15,7 +15,7 @@ var generateOperatorKeysCmd = &cobra.Command{
 	Use:   "generate-operator-keys",
 	Short: "generates ssv operator keys",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("debug", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("debug", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 		logger := zap.L().Named(RootCmd.Short)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -192,7 +192,7 @@ func setupGlobal(cmd *cobra.Command) (*zap.Logger, error) {
 		}
 	}
 
-	if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat); err != nil {
+	if err := logging.SetGlobalLogger(cfg.LogLevel, cfg.LogLevelFormat, cfg.LogFormat, cfg.LogFilePath); err != nil {
 		return nil, fmt.Errorf("logging.SetGlobalLogger: %w", err)
 	}
 

--- a/cli/threshold.go
+++ b/cli/threshold.go
@@ -18,7 +18,7 @@ var createThresholdCmd = &cobra.Command{
 	Use:   "create-threshold",
 	Short: "Turns a private key into a threshold key",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := logging.SetGlobalLogger("debug", "capital", "console"); err != nil {
+		if err := logging.SetGlobalLogger("debug", "capital", "console", ""); err != nil {
 			log.Fatal(err)
 		}
 		logger := zap.L().Named(logging.NameCreateThreshold)

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,5 +1,6 @@
 global:
   LogLevel: info
+  LogFilePath: ./data/debug.log
 
 db:
   Path: ./data/db

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.7.0
 	google.golang.org/grpc v1.40.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2041,6 +2041,8 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=

--- a/integration/qbft/tests/setup_test.go
+++ b/integration/qbft/tests/setup_test.go
@@ -34,7 +34,7 @@ func GetSharedData(t *testing.T) SharedData { //singleton B-)
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-	if err := logging.SetGlobalLogger("debug", "capital", "console"); err != nil {
+	if err := logging.SetGlobalLogger("debug", "capital", "console", ""); err != nil {
 		panic(err)
 	}
 

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestLogger(t *testing.T) *zap.Logger {
-	err := SetGlobalLogger("debug", "capital", "console")
+	err := SetGlobalLogger("debug", "capital", "console", "")
 	require.NoError(t, err)
 	return zap.L().Named(t.Name())
 }
 
 func BenchLogger(b *testing.B) *zap.Logger {
-	err := SetGlobalLogger("debug", "capital", "console")
+	err := SetGlobalLogger("debug", "capital", "console", "")
 	require.NoError(b, err)
 	return zap.L().Named(b.Name())
 }


### PR DESCRIPTION
rotate log files using `lumberjack`. send all debug logs into a file in json format.

### Old pr description
This PR adds functionality that lets you write structured logs ( json formatted logs { "L": level, "M": msg, "T": time, "field": field}.
This way indexing services like Elastic can easily index these lines and give us nice features in Kibana or KQL to search the logs.
note about log file rotation

currently I added in-code log file rotation using lumberjack lib, the best practice is that the env will take care of it and our app won't be concerned with compressing and moving files. this is temporary so we won't explode our cloud nodes with endless logs.

we'll need to do some research and consult @zevzek and come with a better rotation solution.