### PR TITLE
`ExecuteDuty` Without CGO

### DIFF
--- a/integration/qbft/tests/scenario_test.go
+++ b/integration/qbft/tests/scenario_test.go
@@ -81,8 +81,9 @@ func (s *Scenario) Run(t *testing.T, role spectypes.BeaconRole) {
 				time.Sleep(dutyProp.Delay)
 
 				duty := createDuty(getKeySet(s.Committee).ValidatorPK.Serialize(), dutyProp.Slot, dutyProp.ValidatorIndex, role)
-
-				ssvMsg, err := duties.CreateDutyExecuteMsg(duty, getKeySet(s.Committee).ValidatorPK)
+				var pk spec.BLSPubKey
+				copy(pk[:], getKeySet(s.Committee).ValidatorPK.Serialize())
+				ssvMsg, err := duties.CreateDutyExecuteMsg(duty, pk)
 				require.NoError(t, err)
 				dec, err := queue.DecodeSSVMessage(logger, ssvMsg)
 				require.NoError(t, err)

--- a/operator/duties/controller.go
+++ b/operator/duties/controller.go
@@ -3,6 +3,7 @@ package duties
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/cornelk/hashmap"
-	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -146,12 +146,8 @@ func (dc *dutyController) ExecuteDuty(logger *zap.Logger, duty *spectypes.Duty) 
 	var pk phase0.BLSPubKey
 	copy(pk[:], duty.PubKey[:])
 
-	pubKey, err := types.DeserializeBLSPublicKey(pk[:])
-	if err != nil {
-		return errors.Wrap(err, "failed to deserialize pubkey from duty")
-	}
-	if v, ok := dc.validatorController.GetValidator(pubKey.SerializeToHexStr()); ok {
-		ssvMsg, err := CreateDutyExecuteMsg(duty, &pubKey)
+	if v, ok := dc.validatorController.GetValidator(hex.EncodeToString(pk[:])); ok {
+		ssvMsg, err := CreateDutyExecuteMsg(duty, pk)
 		if err != nil {
 			return err
 		}
@@ -171,7 +167,7 @@ func (dc *dutyController) ExecuteDuty(logger *zap.Logger, duty *spectypes.Duty) 
 }
 
 // CreateDutyExecuteMsg returns ssvMsg with event type of duty execute
-func CreateDutyExecuteMsg(duty *spectypes.Duty, pubKey *bls.PublicKey) (*spectypes.SSVMessage, error) {
+func CreateDutyExecuteMsg(duty *spectypes.Duty, pubKey phase0.BLSPubKey) (*spectypes.SSVMessage, error) {
 	executeDutyData := types.ExecuteDutyData{Duty: duty}
 	edd, err := json.Marshal(executeDutyData)
 	if err != nil {
@@ -187,7 +183,7 @@ func CreateDutyExecuteMsg(duty *spectypes.Duty, pubKey *bls.PublicKey) (*spectyp
 	}
 	return &spectypes.SSVMessage{
 		MsgType: message.SSVEventMsgType,
-		MsgID:   spectypes.NewMsgID(types.GetDefaultDomain(), pubKey.Serialize(), duty.Type),
+		MsgID:   spectypes.NewMsgID(types.GetDefaultDomain(), pubKey[:], duty.Type),
 		Data:    data,
 	}, nil
 }


### PR DESCRIPTION
This PR removes useless CGO calls to deserialize & serialize public keys in `ExecuteDuty`.