### PR TITLE
Conditional Popping

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,8 @@ Deploy ssv nodes to blox-infra-stage cluster:
     # +--------------------+
     # |  Deploy SSV nodes  |
     # +--------------------+
-    # - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-    # - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
     - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     #
     # +-------------------+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,8 @@ Deploy ssv nodes to blox-infra-stage cluster:
     # +--------------------+
     # |  Deploy SSV nodes  |
     # +--------------------+
-    - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
-    - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
+    # - .k8/scripts/deploy-ssv-nodes-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
+    # - .k8/scripts/deploy-ssv-node-v1-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
     - .k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     #
     # +-------------------+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - preconsensus-logging
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -56,7 +56,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - preconsensus-logging
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy
@@ -86,7 +86,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/scripts/deploy-boot-node-yaml-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - stage
+    - preconsensus-logging
 
 # +-------+
 # | Prod  |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - preconsensus-logging
+    - stage
 
 Deploy ssv exporter to blox-infra-stage cluster:
   stage: deploy
@@ -56,7 +56,7 @@ Deploy ssv exporter to blox-infra-stage cluster:
     - mv kubectl /usr/bin/
     - .k8/scripts/deploy-yamls-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - preconsensus-logging
+    - stage
 
 Deploy ssv nodes to blox-infra-stage cluster:
   stage: deploy
@@ -86,7 +86,7 @@ Deploy ssv nodes to blox-infra-stage cluster:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/scripts/deploy-boot-node-yaml-on-stage-k8s.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - preconsensus-logging
+    - stage
 
 # +-------+
 # | Prod  |

--- a/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
+++ b/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
@@ -143,7 +143,7 @@ fi
 #fi
 
 #deploy
-# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
-# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1
+kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
+# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
+# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
+kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1

--- a/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
+++ b/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
@@ -143,7 +143,7 @@ fi
 #fi
 
 #deploy
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
+# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
 kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
 kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
-kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1
+# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1

--- a/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
+++ b/.k8/scripts/deploy-ssv-node-v3-yamls-on-stage-k8s.sh
@@ -144,6 +144,6 @@ fi
 
 #deploy
 kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-1-deployment.yml || exit 1
-# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
-# kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
+kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-2-deployment.yml || exit 1
+kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-3-deployment.yml || exit 1
 kubectl --context=$K8S_CONTEXT apply -f .k8/yamls-v3-stage/ssv-node-v3-4-deployment.yml || exit 1

--- a/ekm/eth_key_manager_signer.go
+++ b/ekm/eth_key_manager_signer.go
@@ -237,7 +237,7 @@ func (km *ethKeyManagerSigner) SignRoot(data spectypes.Root, sigType spectypes.S
 		return nil, errors.Wrap(err, "could not compute signing root")
 	}
 
-	sig, err := account.ValidationKeySign(root)
+	sig, err := account.ValidationKeySign(root[:])
 	if err != nil {
 		return nil, errors.Wrap(err, "could not sign message")
 	}

--- a/go.mod
+++ b/go.mod
@@ -184,6 +184,6 @@ replace github.com/google/flatbuffers => github.com/google/flatbuffers v1.11.0
 
 replace github.com/dgraph-io/ristretto => github.com/dgraph-io/ristretto v0.1.1-0.20211108053508-297c39e6640f
 
-replace github.com/bloxapp/ssv-spec => github.com/bloxapp/ssv-spec v0.0.0-20230521155754-79016edc0974 // #mev-capella
+replace github.com/bloxapp/ssv-spec => github.com/bloxapp/ssv-spec v0.0.0-20230524104230-42bf86e3f977 // #disable-preconsensus-liveness
 
 // replace github.com/bloxapp/ssv-spec => ../ssv-spec

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bloxapp/eth2-key-manager v1.3.0-rc.0 h1:Hfq7/mdjUHmqI5Tv0Pc1TdGgXfHrgrY1tOTIz290pAg=
 github.com/bloxapp/eth2-key-manager v1.3.0-rc.0/go.mod h1:cT+qAJfnAzNz9StFoHQ8xAkyU2eyEukd6xfxvcBWuZA=
-github.com/bloxapp/ssv-spec v0.0.0-20230521155754-79016edc0974 h1:vAevyIamZpwZUhT1aWj+N64I8zvp9LSRtzQuBKSubk4=
-github.com/bloxapp/ssv-spec v0.0.0-20230521155754-79016edc0974/go.mod h1:8OAYKYxifYZ0ahWb4X+KZ6Rb49L2R3bm8lpqXt8u/2k=
+github.com/bloxapp/ssv-spec v0.0.0-20230524104230-42bf86e3f977 h1:Z4UCIz6oo6aFJYlr7Is0F2j5Uo2/9Ngm2gNJkTV9MoI=
+github.com/bloxapp/ssv-spec v0.0.0-20230524104230-42bf86e3f977/go.mod h1:8OAYKYxifYZ0ahWb4X+KZ6Rb49L2R3bm8lpqXt8u/2k=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -3,12 +3,13 @@ package fields
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/bloxapp/ssv/utils/format"
 	"math/big"
 	"net"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/bloxapp/ssv/utils/format"
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -54,8 +55,8 @@ const (
 	FieldFromBlock           = "from_block"
 	FieldHeight              = "height"
 	FieldIndexCacheMetrics   = "index_cache_metrics"
-	FieldMessageID           = "message_id"
-	FieldMessageType         = "message_type"
+	FieldMessageID           = "msg_id"
+	FieldMessageType         = "msg_type"
 	FieldName                = "name"
 	FieldNetwork             = "network"
 	FieldNetworkID           = "network_id"

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -753,7 +753,6 @@ func SetupRunners(ctx context.Context, logger *zap.Logger, options validator.Opt
 		case spectypes.BNRoleValidatorRegistration:
 			qbftCtrl := buildController(spectypes.BNRoleValidatorRegistration, nil)
 			runners[role] = runner.NewValidatorRegistrationRunner(spectypes.PraterNetwork, &options.SSVShare.Share, qbftCtrl, options.Beacon, options.Network, options.Signer)
-			runners[role].(*runner.ValidatorRegistrationRunner).GasLimit = options.GasLimit // apply gas limit
 		}
 	}
 	return runners

--- a/protocol/v2/message/msg.go
+++ b/protocol/v2/message/msg.go
@@ -19,7 +19,7 @@ func MsgTypeToString(mt spectypes.MsgType) string {
 	case spectypes.SSVConsensusMsgType:
 		return "consensus"
 	case spectypes.SSVPartialSignatureMsgType:
-		return "partialSignature"
+		return "partial_signature"
 	case spectypes.DKGMsgType:
 		return "dkg"
 	case SSVSyncMsgType:

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -67,7 +67,7 @@ func (i *Instance) Start(logger *zap.Logger, value []byte, height specqbft.Heigh
 			fields.Height(i.State.Height))
 
 		proposerID := proposer(i.State, i.GetConfig(), specqbft.FirstRound)
-		logger.Debug("ℹ️ starting QBFT instance", zap.Uint64("proposer", proposerID))
+		logger.Debug("ℹ️ starting QBFT instance", zap.Uint64("leader", proposerID))
 
 		// propose if this node is the proposer
 		if proposerID == i.State.Share.OperatorID {

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -66,10 +66,11 @@ func (i *Instance) Start(logger *zap.Logger, value []byte, height specqbft.Heigh
 			fields.Round(i.State.Round),
 			fields.Height(i.State.Height))
 
-		logger.Debug("ℹ️ starting QBFT instance")
+		proposerID := proposer(i.State, i.GetConfig(), specqbft.FirstRound)
+		logger.Debug("ℹ️ starting QBFT instance", zap.Uint64("proposer", proposerID))
 
 		// propose if this node is the proposer
-		if proposer(i.State, i.GetConfig(), specqbft.FirstRound) == i.State.Share.OperatorID {
+		if proposerID == i.State.Share.OperatorID {
 			proposal, err := CreateProposal(i.State, i.config, i.StartValue, nil, nil)
 			// nolint
 			if err != nil {

--- a/protocol/v2/qbft/instance/round_change.go
+++ b/protocol/v2/qbft/instance/round_change.go
@@ -61,11 +61,9 @@ func (i *Instance) uponRoundChange(
 			return errors.Wrap(err, "failed to create proposal")
 		}
 
-		roundchangeSigners := allSigners(roundChangeMsgContainer.MessagesForRound(i.State.Round))
-
 		logger.Debug("🔄 got justified round change, broadcasting proposal message",
 			fields.Round(i.State.Round),
-			zap.Any("round-change-signers", roundchangeSigners),
+			zap.Any("round-change-signers", allSigners(roundChangeMsgContainer.MessagesForRound(i.State.Round))),
 			fields.Root(proposal.Message.Root))
 
 		if err := i.Broadcast(logger, proposal); err != nil {

--- a/protocol/v2/qbft/testing_utils.go
+++ b/protocol/v2/qbft/testing_utils.go
@@ -25,7 +25,7 @@ var SignMsg = func(sk *bls.SecretKey, id types.OperatorID, msg *specqbft.Message
 	sigType := types.QBFTSignatureType
 
 	r, _ := types.ComputeSigningRoot(msg, types.ComputeSignatureDomain(domain, sigType))
-	sig := sk.SignByte(r)
+	sig := sk.SignByte(r[:])
 
 	return &specqbft.SignedMessage{
 		Message:   *msg,

--- a/protocol/v2/ssv/queue/message_prioritizer_test.go
+++ b/protocol/v2/ssv/queue/message_prioritizer_test.go
@@ -40,37 +40,37 @@ var messagePriorityTests = []struct {
 			// 1.2. Events/Timeout
 			mockTimeoutMessage{Height: 98, Role: spectypes.BNRoleProposer},
 
-			// 2. Current height/slot:
-			// 2.1. Consensus
-			// 2.1.1. Consensus/Proposal
+			// 1. Current height/slot:
+			// 1.1. Consensus
+			// 1.1.1. Consensus/Proposal
 			mockConsensusMessage{Height: 100, Type: qbft.ProposalMsgType},
-			// 2.1.2. Consensus/Prepare
+			// 1.1.2. Consensus/Prepare
 			mockConsensusMessage{Height: 100, Type: qbft.PrepareMsgType},
-			// 2.1.3. Consensus/Commit
+			// 1.1.3. Consensus/Commit
 			mockConsensusMessage{Height: 100, Type: qbft.CommitMsgType},
-			// 2.1.4. Consensus/<Other>
+			// 1.1.4. Consensus/<Other>
 			mockConsensusMessage{Height: 100, Type: qbft.RoundChangeMsgType},
-			// 2.2. Pre-consensus
+			// 1.2. Pre-consensus
 			mockNonConsensusMessage{Slot: 64, Type: spectypes.SelectionProofPartialSig},
-			// 2.3. Post-consensus
+			// 1.3. Post-consensus
 			mockNonConsensusMessage{Slot: 64, Type: spectypes.PostConsensusPartialSig},
 
-			// 3. Higher height/slot:
-			// 3.1 Decided
+			// 2. Higher height/slot:
+			// 2.1 Decided
 			mockConsensusMessage{Height: 101, Decided: true},
-			// 3.2. Pre-consensus
+			// 2.2. Pre-consensus
 			mockNonConsensusMessage{Slot: 65, Type: spectypes.SelectionProofPartialSig},
-			// 3.3. Consensus
+			// 2.3. Consensus
 			mockConsensusMessage{Height: 101},
-			// 3.4. Post-consensus
+			// 2.4. Post-consensus
 			mockNonConsensusMessage{Slot: 65, Type: spectypes.PostConsensusPartialSig},
 
-			// 4. Lower height/slot:
-			// 4.1 Decided
+			// 3. Lower height/slot:
+			// 3.1 Decided
 			mockConsensusMessage{Height: 99, Decided: true},
-			// 4.2. Commit
+			// 3.2. Commit
 			mockConsensusMessage{Height: 99, Type: qbft.CommitMsgType},
-			// 4.3. Pre-consensus
+			// 3.3. Pre-consensus
 			mockNonConsensusMessage{Slot: 63, Type: spectypes.SelectionProofPartialSig},
 		},
 	},

--- a/protocol/v2/ssv/queue/message_prioritizer_test.go
+++ b/protocol/v2/ssv/queue/message_prioritizer_test.go
@@ -40,37 +40,37 @@ var messagePriorityTests = []struct {
 			// 1.2. Events/Timeout
 			mockTimeoutMessage{Height: 98, Role: spectypes.BNRoleProposer},
 
-			// 1. Current height/slot:
-			// 1.1. Consensus
-			// 1.1.1. Consensus/Proposal
+			// 2. Current height/slot:
+			// 2.1. Consensus
+			// 2.1.1. Consensus/Proposal
 			mockConsensusMessage{Height: 100, Type: qbft.ProposalMsgType},
-			// 1.1.2. Consensus/Prepare
+			// 2.1.2. Consensus/Prepare
 			mockConsensusMessage{Height: 100, Type: qbft.PrepareMsgType},
-			// 1.1.3. Consensus/Commit
+			// 2.1.3. Consensus/Commit
 			mockConsensusMessage{Height: 100, Type: qbft.CommitMsgType},
-			// 1.1.4. Consensus/<Other>
+			// 2.1.4. Consensus/<Other>
 			mockConsensusMessage{Height: 100, Type: qbft.RoundChangeMsgType},
-			// 1.2. Pre-consensus
+			// 2.2. Pre-consensus
 			mockNonConsensusMessage{Slot: 64, Type: spectypes.SelectionProofPartialSig},
-			// 1.3. Post-consensus
+			// 2.3. Post-consensus
 			mockNonConsensusMessage{Slot: 64, Type: spectypes.PostConsensusPartialSig},
 
-			// 2. Higher height/slot:
-			// 2.1 Decided
+			// 3. Higher height/slot:
+			// 3.1 Decided
 			mockConsensusMessage{Height: 101, Decided: true},
-			// 2.2. Pre-consensus
+			// 3.2. Pre-consensus
 			mockNonConsensusMessage{Slot: 65, Type: spectypes.SelectionProofPartialSig},
-			// 2.3. Consensus
+			// 3.3. Consensus
 			mockConsensusMessage{Height: 101},
-			// 2.4. Post-consensus
+			// 3.4. Post-consensus
 			mockNonConsensusMessage{Slot: 65, Type: spectypes.PostConsensusPartialSig},
 
-			// 3. Lower height/slot:
-			// 3.1 Decided
+			// 4. Lower height/slot:
+			// 4.1 Decided
 			mockConsensusMessage{Height: 99, Decided: true},
-			// 3.2. Commit
+			// 4.2. Commit
 			mockConsensusMessage{Height: 99, Type: qbft.CommitMsgType},
-			// 3.3. Pre-consensus
+			// 4.3. Pre-consensus
 			mockNonConsensusMessage{Slot: 63, Type: spectypes.SelectionProofPartialSig},
 		},
 	},

--- a/protocol/v2/ssv/queue/messages.go
+++ b/protocol/v2/ssv/queue/messages.go
@@ -58,14 +58,13 @@ func compareHeightOrSlot(state *State, m *DecodedSSVMessage) int {
 		if mm.Message.Height > state.Height {
 			return 1
 		}
-		// TODO
-		// } else if mm, ok := m.Body.(*ssv.SignedPartialSignatureMessage); ok {
-		// 	if mm.Message.Messages[0].Slot == state.Slot {
-		// 		return 0
-		// 	}
-		// 	if mm.Message.Messages[0].Slot > state.Slot {
-		// 		return 1
-		// 	}
+	} else if mm, ok := m.Body.(*spectypes.SignedPartialSignatureMessage); ok {
+		if mm.Message.Slot == state.Slot {
+			return 0
+		}
+		if mm.Message.Slot > state.Slot {
+			return 1
+		}
 	}
 	return -1
 }

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -13,6 +13,9 @@ const (
 // Filter is a function that returns true if the message should be popped.
 type Filter func(*DecodedSSVMessage) bool
 
+// FilterAny returns a Filter that returns true for any message.
+func FilterAny(*DecodedSSVMessage) bool { return true }
+
 // Queue is a queue of DecodedSSVMessage with dynamic (per-pop) prioritization.
 type Queue interface {
 	// Push blocks until the message is pushed to the queue.
@@ -24,10 +27,10 @@ type Queue interface {
 
 	// Pop returns and removes the next message in the queue, or blocks until a message is available.
 	// When the context is canceled, Pop returns immediately with any leftover message or nil.
-	Pop(context.Context, MessagePrioritizer) *DecodedSSVMessage
+	Pop(context.Context, MessagePrioritizer, Filter) *DecodedSSVMessage
 
 	// TryPop returns immediately with the next message in the queue, or nil if there is none.
-	TryPop(MessagePrioritizer) *DecodedSSVMessage
+	TryPop(MessagePrioritizer, Filter) *DecodedSSVMessage
 
 	// Empty returns true if the queue is empty.
 	Empty() bool
@@ -66,19 +69,19 @@ func (q *priorityQueue) TryPush(msg *DecodedSSVMessage) bool {
 	}
 }
 
-func (q *priorityQueue) TryPop(prioritizer MessagePrioritizer) *DecodedSSVMessage {
+func (q *priorityQueue) TryPop(prioritizer MessagePrioritizer, filter Filter) *DecodedSSVMessage {
 	// Read any pending messages from the inbox.
 	q.readInbox()
 
 	// Pop the highest priority message.
 	if q.head != nil {
-		return q.pop(prioritizer)
+		return q.pop(prioritizer, filter)
 	}
 
 	return nil
 }
 
-func (q *priorityQueue) Pop(ctx context.Context, prioritizer MessagePrioritizer) *DecodedSSVMessage {
+func (q *priorityQueue) Pop(ctx context.Context, prioritizer MessagePrioritizer, filter Filter) *DecodedSSVMessage {
 	// Read any pending messages from the inbox, if enough time has passed.
 	// inboxReadFrequency is a tradeoff between responsiveness and computational cost,
 	// since reading the inbox is more expensive than just reading the head.
@@ -88,13 +91,23 @@ func (q *priorityQueue) Pop(ctx context.Context, prioritizer MessagePrioritizer)
 
 	// Try to pop immediately.
 	if q.head != nil {
-		return q.pop(prioritizer)
+		if m := q.pop(prioritizer, filter); m != nil {
+			return m
+		}
 	}
 
 	// Wait for a message to be pushed.
+Wait:
 	select {
 	case msg := <-q.inbox:
-		q.head = &item{message: msg}
+		if q.head == nil {
+			q.head = &item{message: msg}
+		} else {
+			q.head = &item{message: msg, next: q.head}
+		}
+		if !filter(msg) {
+			goto Wait
+		}
 	case <-ctx.Done():
 	}
 
@@ -103,7 +116,7 @@ func (q *priorityQueue) Pop(ctx context.Context, prioritizer MessagePrioritizer)
 
 	// Pop the highest priority message.
 	if q.head != nil {
-		return q.pop(prioritizer)
+		return q.pop(prioritizer, filter)
 	}
 
 	return nil
@@ -126,11 +139,13 @@ func (q *priorityQueue) readInbox() {
 	}
 }
 
-func (q *priorityQueue) pop(prioritizer MessagePrioritizer) *DecodedSSVMessage {
+func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *DecodedSSVMessage {
 	if q.head.next == nil {
 		m := q.head.message
-		q.head = nil
-		return m
+		if filter(m) {
+			q.head = nil
+			return m
+		}
 	}
 
 	// Remove the highest priority message and return it.
@@ -154,7 +169,10 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer) *DecodedSSVMessage {
 	} else {
 		prior.next = highest.next
 	}
-	return highest.message
+	if filter(highest.message) {
+		return highest.message
+	}
+	return nil
 }
 
 func (q *priorityQueue) Empty() bool {

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -34,6 +34,9 @@ type Queue interface {
 
 	// Empty returns true if the queue is empty.
 	Empty() bool
+
+	// Len returns the number of messages in the queue.
+	Len() int
 }
 
 type priorityQueue struct {
@@ -177,6 +180,14 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *Deco
 
 func (q *priorityQueue) Empty() bool {
 	return q.head == nil && len(q.inbox) == 0
+}
+
+func (q *priorityQueue) Len() int {
+	n := len(q.inbox)
+	for i := q.head; i != nil; i = i.next {
+		n++
+	}
+	return n
 }
 
 // item is a node in a linked list of DecodedSSVMessage.

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -141,11 +141,11 @@ func (q *priorityQueue) readInbox() {
 
 func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *DecodedSSVMessage {
 	if q.head.next == nil {
-		m := q.head.message
-		if filter(m) {
+		if m := q.head.message; filter(m) {
 			q.head = nil
 			return m
 		}
+		return nil
 	}
 
 	// Remove the highest priority message and return it.
@@ -155,7 +155,7 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *Deco
 		current = q.head
 	)
 	for {
-		if prioritizer.Prior(current.next.message, highest.message) {
+		if prioritizer.Prior(current.next.message, highest.message) && filter(current.next.message) {
 			highest = current.next
 			prior = current
 		}

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -10,6 +10,9 @@ const (
 	inboxReadFrequency = 1 * time.Millisecond
 )
 
+// Filter is a function that returns true if the message should be popped.
+type Filter func(*DecodedSSVMessage) bool
+
 // Queue is a queue of DecodedSSVMessage with dynamic (per-pop) prioritization.
 type Queue interface {
 	// Push blocks until the message is pushed to the queue.

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -34,17 +34,17 @@ func TestPriorityQueue_TryPop(t *testing.T) {
 	require.False(t, queue.Empty())
 
 	// Pop 1st message.
-	popped := queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
+	popped := queue.TryPop(NewMessagePrioritizer(mockState))
 	require.Equal(t, msg, popped)
 
 	// Pop 2nd message.
-	popped = queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
+	popped = queue.TryPop(NewMessagePrioritizer(mockState))
 	require.True(t, queue.Empty())
 	require.NotNil(t, popped)
 	require.Equal(t, msg2, popped)
 
 	// Pop nil.
-	popped = queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
+	popped = queue.TryPop(NewMessagePrioritizer(mockState))
 	require.Nil(t, popped)
 }
 
@@ -72,7 +72,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 
 	// Should pop everything immediately.
 	for i := 0; i < capacity; i++ {
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
 		require.Equal(t, msg, popped)
 	}
 	require.True(t, queue.Empty())
@@ -82,7 +82,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 		defer cancel()
 		expectedEnd := time.Now().Add(contextTimeout)
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
 		require.Nil(t, popped)
 		require.WithinDuration(t, expectedEnd, time.Now(), precision)
 	}
@@ -98,7 +98,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 	// Should wait for the messages to be pushed.
 	expectedEnd := time.Now().Add(pushDelay * time.Duration(capacity))
 	for i := 0; i < capacity; i++ {
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
 		require.Equal(t, msg, popped)
 	}
 	require.True(t, queue.Empty())
@@ -128,7 +128,7 @@ func TestPriorityQueue_Order(t *testing.T) {
 
 				// Pop messages from the queue and compare to the expected order.
 				for i, excepted := range messages {
-					actual := q.TryPop(NewMessagePrioritizer(test.state), FilterAny)
+					actual := q.TryPop(NewMessagePrioritizer(test.state))
 					require.Equal(t, excepted, actual, "incorrect message at index %d", i)
 				}
 			}
@@ -251,7 +251,7 @@ func benchmarkPriorityQueueParallel(b *testing.B, factory func() Queue, lossy bo
 			go func() {
 				defer poppersWg.Done()
 				for {
-					msg := queue.Pop(poppingCtx, NewMessagePrioritizer(mockState), FilterAny)
+					msg := queue.Pop(poppingCtx, NewMessagePrioritizer(mockState))
 					if msg == nil {
 						return
 					}
@@ -349,7 +349,7 @@ func BenchmarkPriorityQueue_Concurrent(b *testing.B) {
 	go func() {
 		defer popperWg.Done()
 		for n := b.N; n > 0; n-- {
-			msg := queue.Pop(pushersCtx, prioritizer, FilterAny)
+			msg := queue.Pop(pushersCtx, prioritizer)
 			if msg == nil {
 				return
 			}

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -34,17 +34,17 @@ func TestPriorityQueue_TryPop(t *testing.T) {
 	require.False(t, queue.Empty())
 
 	// Pop 1st message.
-	popped := queue.TryPop(NewMessagePrioritizer(mockState))
+	popped := queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
 	require.Equal(t, msg, popped)
 
 	// Pop 2nd message.
-	popped = queue.TryPop(NewMessagePrioritizer(mockState))
+	popped = queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
 	require.True(t, queue.Empty())
 	require.NotNil(t, popped)
 	require.Equal(t, msg2, popped)
 
 	// Pop nil.
-	popped = queue.TryPop(NewMessagePrioritizer(mockState))
+	popped = queue.TryPop(NewMessagePrioritizer(mockState), FilterAny)
 	require.Nil(t, popped)
 }
 
@@ -72,7 +72,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 
 	// Should pop everything immediately.
 	for i := 0; i < capacity; i++ {
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
 		require.Equal(t, msg, popped)
 	}
 	require.True(t, queue.Empty())
@@ -82,7 +82,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 		defer cancel()
 		expectedEnd := time.Now().Add(contextTimeout)
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
 		require.Nil(t, popped)
 		require.WithinDuration(t, expectedEnd, time.Now(), precision)
 	}
@@ -98,7 +98,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 	// Should wait for the messages to be pushed.
 	expectedEnd := time.Now().Add(pushDelay * time.Duration(capacity))
 	for i := 0; i < capacity; i++ {
-		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState))
+		popped := queue.Pop(ctx, NewMessagePrioritizer(mockState), FilterAny)
 		require.Equal(t, msg, popped)
 	}
 	require.True(t, queue.Empty())
@@ -128,7 +128,7 @@ func TestPriorityQueue_Order(t *testing.T) {
 
 				// Pop messages from the queue and compare to the expected order.
 				for i, excepted := range messages {
-					actual := q.TryPop(NewMessagePrioritizer(test.state))
+					actual := q.TryPop(NewMessagePrioritizer(test.state), FilterAny)
 					require.Equal(t, excepted, actual, "incorrect message at index %d", i)
 				}
 			}
@@ -251,7 +251,7 @@ func benchmarkPriorityQueueParallel(b *testing.B, factory func() Queue, lossy bo
 			go func() {
 				defer poppersWg.Done()
 				for {
-					msg := queue.Pop(poppingCtx, NewMessagePrioritizer(mockState))
+					msg := queue.Pop(poppingCtx, NewMessagePrioritizer(mockState), FilterAny)
 					if msg == nil {
 						return
 					}
@@ -349,7 +349,7 @@ func BenchmarkPriorityQueue_Concurrent(b *testing.B) {
 	go func() {
 		defer popperWg.Done()
 		for n := b.N; n > 0; n-- {
-			msg := queue.Pop(pushersCtx, prioritizer)
+			msg := queue.Pop(pushersCtx, prioritizer, FilterAny)
 			if msg == nil {
 				return
 			}

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -77,7 +77,6 @@ func TestPriorityQueue_Filter(t *testing.T) {
 
 	// Pop 2nd message.
 	popped = queue.TryPop(NewMessagePrioritizer(mockState), func(msg *DecodedSSVMessage) bool {
-		log.Printf("height: %d", msg.Body.(*qbft.SignedMessage).Message.Height)
 		return msg.Body.(*qbft.SignedMessage).Message.Height == 101
 	})
 	require.NotNil(t, popped)

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -3,7 +3,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"sync"
 	"sync/atomic"

--- a/protocol/v2/ssv/runner/attester.go
+++ b/protocol/v2/ssv/runner/attester.go
@@ -131,7 +131,10 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		return errors.Wrap(err, "failed processing post consensus message")
 	}
 
-	logger.Debug("🧩 got partial signatures", zap.Any("signer", signedMsg.Signer), fields.Slot(r.GetState().DecidedValue.Duty.Slot))
+	duty := r.GetState().DecidedValue.Duty
+	logger = logger.With(fields.Slot(duty.Slot))
+	logger.Debug("🧩 got partial signatures",
+		zap.Uint64("signer", signedMsg.Signer))
 
 	if !quorum {
 		return nil
@@ -152,9 +155,8 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		specSig := phase0.BLSSignature{}
 		copy(specSig[:], sig)
 
-		duty := r.GetState().DecidedValue.Duty
-
-		logger.Debug("🧩 reconstructed partial signatures", zap.Any("signers", getPostConsensusSigners(r.GetState(), root)), fields.Slot(duty.Slot))
+		logger.Debug("🧩 reconstructed partial signatures",
+			zap.Uint64s("signers", getPostConsensusSigners(r.GetState(), root)))
 
 		aggregationBitfield := bitfield.NewBitlist(r.GetState().DecidedValue.Duty.CommitteeLength)
 		aggregationBitfield.SetBitAt(duty.ValidatorCommitteeIndex, true)
@@ -169,7 +171,7 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		// Submit it to the BN.
 		if err := r.beacon.SubmitAttestation(signedAtt); err != nil {
 			r.metrics.RoleSubmissionFailed()
-			logger.Error("❌ failed to submit attestation", fields.Slot(duty.Slot), zap.Error(err))
+			logger.Error("❌ failed to submit attestation", zap.Error(err))
 			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
 		}
 
@@ -178,7 +180,6 @@ func (r *AttesterRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *spe
 		r.metrics.RoleSubmitted()
 
 		logger.Info("✅ successfully submitted attestation",
-			fields.Slot(duty.Slot),
 			zap.String("block_root", hex.EncodeToString(signedAtt.Data.BeaconBlockRoot[:])),
 			fields.ConsensusTime(time.Since(r.started)),
 			fields.Height(r.BaseRunner.QBFTController.Height),

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -324,6 +324,12 @@ func (r *ProposerRunner) executeDuty(logger *zap.Logger, duty *spectypes.Duty) e
 	if err := r.GetNetwork().Broadcast(msgToBroadcast); err != nil {
 		return errors.Wrap(err, "can't broadcast partial randao sig")
 	}
+
+	logger.Debug("🔏 signed & broadcasted partial randao signature",
+		fields.Slot(duty.Slot),
+		fields.Height(r.BaseRunner.QBFTController.Height),
+		fields.Round(r.GetState().RunningInstance.State.Round))
+
 	return nil
 }
 

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -325,10 +325,7 @@ func (r *ProposerRunner) executeDuty(logger *zap.Logger, duty *spectypes.Duty) e
 		return errors.Wrap(err, "can't broadcast partial randao sig")
 	}
 
-	logger.Debug("🔏 signed & broadcasted partial randao signature",
-		fields.Slot(duty.Slot),
-		fields.Height(r.BaseRunner.QBFTController.Height),
-		fields.Round(r.GetState().RunningInstance.State.Round))
+	logger.Debug("🔏 signed & broadcasted partial RANDAO signature")
 
 	return nil
 }

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -74,7 +74,7 @@ func (r *ProposerRunner) ProcessPreConsensus(logger *zap.Logger, signedMsg *spec
 		return errors.Wrap(err, "failed processing randao message")
 	}
 
-	logger.Debug("got partial RANDAO sig",
+	logger.Debug("RVRT got partial RANDAO sig",
 		zap.Uint64s("signers", signedMsg.GetSigners()),
 		zap.Bool("quorum", quorum),
 	)

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -104,13 +104,13 @@ func (r *ProposerRunner) ProcessPreConsensus(logger *zap.Logger, signedMsg *spec
 		if err != nil {
 			// Prysm currently doesn’t support MEV.
 			// TODO: Check Prysm MEV support after https://github.com/prysmaticlabs/prysm/issues/12103 is resolved.
-			return errors.Wrap(err, "failed to get blinded beacon block")
+			return errors.Wrap(err, "failed to get Beacon block")
 		}
 	} else {
 		// get block data
 		obj, ver, err = r.GetBeaconNode().GetBeaconBlock(duty.Slot, r.GetShare().Graffiti, fullSig)
 		if err != nil {
-			return errors.Wrap(err, "failed to get beacon block")
+			return errors.Wrap(err, "failed to get Beacon block")
 		}
 	}
 

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -74,6 +74,11 @@ func (r *ProposerRunner) ProcessPreConsensus(logger *zap.Logger, signedMsg *spec
 		return errors.Wrap(err, "failed processing randao message")
 	}
 
+	logger.Debug("got partial RANDAO sig",
+		zap.Uint64s("signers", signedMsg.GetSigners()),
+		zap.Bool("quorum", quorum),
+	)
+
 	// quorum returns true only once (first time quorum achieved)
 	if !quorum {
 		return nil

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -69,6 +69,8 @@ func (b *BaseRunner) SetHighestDecidedSlot(slot spec.Slot) {
 func (b *BaseRunner) baseSetupForNewDuty(duty *types.Duty) {
 	state := NewRunnerState(b.Share.Quorum, duty)
 
+	// TODO: potentially incomplete locking of b.State. runner.Execute(duty) has access to
+	// b.State but currently does not write to it
 	b.mtx.Lock() // writes to b.State
 	b.State = state
 	b.mtx.Unlock()
@@ -98,8 +100,6 @@ func (b *BaseRunner) baseStartNewDuty(logger *zap.Logger, runner Runner, duty *s
 		return err
 	}
 
-	// potentially incomplete locking of b.State. runner.Execute(duty) has access to
-	// b.State but currently does not write to it
 	b.baseSetupForNewDuty(duty)
 	return runner.executeDuty(logger, duty)
 }

--- a/protocol/v2/ssv/runner/runner_state_helpers.go
+++ b/protocol/v2/ssv/runner/runner_state_helpers.go
@@ -6,6 +6,15 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 )
 
+func getPreConsensusSigners(state *State, root [32]byte) []spectypes.OperatorID {
+	sigs := state.PreConsensusContainer.Signatures[hex.EncodeToString(root[:])]
+	var signers []spectypes.OperatorID
+	for op := range sigs {
+		signers = append(signers, op)
+	}
+	return signers
+}
+
 func getPostConsensusSigners(state *State, root [32]byte) []spectypes.OperatorID {
 	sigs := state.PostConsensusContainer.Signatures[hex.EncodeToString(root[:])]
 	var signers []spectypes.OperatorID

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 
-	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/bloxapp/ssv-spec/qbft"
 	specssv "github.com/bloxapp/ssv-spec/ssv"
@@ -20,7 +20,6 @@ import (
 
 type ValidatorRegistrationRunner struct {
 	BaseRunner *BaseRunner
-	GasLimit   uint64
 
 	beacon   specssv.BeaconNode
 	network  specssv.Network
@@ -158,15 +157,15 @@ func (r *ValidatorRegistrationRunner) executeDuty(logger *zap.Logger, duty *spec
 	return nil
 }
 
-func (r *ValidatorRegistrationRunner) calculateValidatorRegistration() (*eth2apiv1.ValidatorRegistration, error) {
+func (r *ValidatorRegistrationRunner) calculateValidatorRegistration() (*v1.ValidatorRegistration, error) {
 	pk := phase0.BLSPubKey{}
 	copy(pk[:], r.BaseRunner.Share.ValidatorPubKey)
 
 	epoch := r.BaseRunner.BeaconNetwork.EstimatedEpochAtSlot(r.BaseRunner.State.StartingDuty.Slot)
 
-	return &eth2apiv1.ValidatorRegistration{
+	return &v1.ValidatorRegistration{
 		FeeRecipient: r.BaseRunner.Share.FeeRecipientAddress,
-		GasLimit:     r.GasLimit,
+		GasLimit:     spectypes.DefaultGasLimit,
 		Timestamp:    r.BaseRunner.BeaconNetwork.EpochStartTime(epoch),
 		Pubkey:       pk,
 	}, nil

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -239,10 +239,6 @@ func fixRunnerForRun(t *testing.T, runnerMap map[string]interface{}, ks *testing
 		ret.(*runner.ProposerRunner).ProducesBlindedBlocks = blindedBlocks.(bool)
 	}
 
-	if gasLimit, ok := runnerMap["GasLimit"]; ok {
-		ret.(*runner.ValidatorRegistrationRunner).GasLimit = uint64(gasLimit.(float64))
-	}
-
 	if ret.GetBaseRunner().QBFTController != nil {
 		ret.GetBaseRunner().QBFTController = fixControllerForRun(t, logger, ret, ret.GetBaseRunner().QBFTController, ks)
 		if ret.GetBaseRunner().State != nil {

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -51,7 +51,6 @@ var SyncCommitteeContributionRunner = func(logger *zap.Logger, keySet *spectesti
 
 var ValidatorRegistrationRunner = func(logger *zap.Logger, keySet *spectestingutils.TestKeySet) runner.Runner {
 	ret := baseRunner(logger, spectypes.BNRoleValidatorRegistration, nil, keySet)
-	ret.(*runner.ValidatorRegistrationRunner).GasLimit = 1
 	return ret
 }
 

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -129,6 +129,9 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 			logger.Error("❗ got nil message from queue, but context is not done!")
 			break
 		}
+		logger.Debug("📬 popped message from queue",
+			fields.MessageID(msg.MsgID), fields.MessageType(msg.MsgType),
+			zap.Int("queue_len", q.Q.Len()))
 
 		// Handle the message.
 		if err := handler(logger, msg); err != nil {

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/message"
 	"github.com/bloxapp/ssv/protocol/v2/ssv/queue"
-	"github.com/bloxapp/ssv/protocol/v2/types"
 )
 
 // MessageHandler process the msg. return error if exist
@@ -108,19 +107,9 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 		state.Round = v.GetLastRound(msgID)
 		state.Quorum = v.Share.Quorum
 
-		filter := queue.FilterAny
-		if !state.HasRunningInstance {
-			filter = func(m *queue.DecodedSSVMessage) bool {
-				e, ok := m.Body.(*types.EventMsg)
-				if !ok {
-					return false
-				}
-				return e.Type == types.ExecuteDuty
-			}
-		}
-
 		// Pop the highest priority message for the current state.
-		msg := q.Q.Pop(ctx, queue.NewMessagePrioritizer(&state), filter)
+		msg := q.Q.Pop(ctx, queue.NewMessagePrioritizer(&state))
+		// logger.Debug("📬 queue: pop message", fields.MessageID(msg.MsgID), fields.MessageType(msg.MsgType))
 		if ctx.Err() != nil {
 			break
 		}

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/message"
 	"github.com/bloxapp/ssv/protocol/v2/ssv/queue"
+	"github.com/bloxapp/ssv/protocol/v2/types"
 )
 
 // MessageHandler process the msg. return error if exist
@@ -107,9 +108,19 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 		state.Round = v.GetLastRound(msgID)
 		state.Quorum = v.Share.Quorum
 
+		filter := queue.FilterAny
+		if !state.HasRunningInstance {
+			filter = func(m *queue.DecodedSSVMessage) bool {
+				e, ok := m.Body.(*types.EventMsg)
+				if !ok {
+					return false
+				}
+				return e.Type == types.ExecuteDuty
+			}
+		}
+
 		// Pop the highest priority message for the current state.
-		msg := q.Q.Pop(ctx, queue.NewMessagePrioritizer(&state))
-		// logger.Debug("📬 queue: pop message", fields.MessageID(msg.MsgID), fields.MessageType(msg.MsgType))
+		msg := q.Q.Pop(ctx, queue.NewMessagePrioritizer(&state), filter)
 		if ctx.Err() != nil {
 			break
 		}

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -108,6 +108,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 		state.Round = v.GetLastRound(msgID)
 		state.Quorum = v.Share.Quorum
 
+		// Pop only ExecuteDuty messages if there is no running instance.
 		filter := queue.FilterAny
 		if !state.HasRunningInstance {
 			filter = func(m *queue.DecodedSSVMessage) bool {

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -110,7 +110,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 
 		// Pop only ExecuteDuty messages if there is no running instance.
 		filter := queue.FilterAny
-		if runner != nil && runner.HasRunningDuty() {
+		if runner != nil && !runner.HasRunningDuty() {
 			filter = func(m *queue.DecodedSSVMessage) bool {
 				e, ok := m.Body.(*types.EventMsg)
 				if !ok {

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -120,7 +120,8 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 
 		// Handle the message.
 		if err := handler(logger, msg); err != nil {
-			v.logMsg(logger, msg, "❗ could not handle message", zap.Any("type", msg.SSVMessage.MsgType), zap.Error(err))
+			v.logMsg(logger, msg, "❗ could not handle message",
+				fields.MessageType(msg.SSVMessage.MsgType), zap.Error(err))
 		}
 	}
 

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -112,6 +112,8 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 		filter := queue.FilterAny
 		if !state.HasRunningInstance {
 			filter = func(m *queue.DecodedSSVMessage) bool {
+				return true
+
 				e, ok := m.Body.(*types.EventMsg)
 				if !ok {
 					return false

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -126,7 +126,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 				return e.Type == types.ExecuteDuty
 			}
 		} else if runningInstance != nil && runningInstance.State.ProposalAcceptedForCurrentRound == nil {
-			// If no proposal was accepted for the current round, skip non-proposal consensus messages
+			// If no proposal was accepted for the current round, skip prepare & commit messages
 			// for the current height and round.
 			filter = func(m *queue.DecodedSSVMessage) bool {
 				sm, ok := m.Body.(*specqbft.SignedMessage)
@@ -136,7 +136,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 				if sm.Message.Height != state.Height || sm.Message.Round != state.Round {
 					return true
 				}
-				return sm.Message.MsgType == specqbft.ProposalMsgType
+				return sm.Message.MsgType != specqbft.PrepareMsgType && sm.Message.MsgType != specqbft.CommitMsgType
 			}
 		}
 

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -151,9 +151,9 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 		}
 		lens = append(lens, q.Q.Len())
 		if len(lens) >= 10 {
-			logger.Debug("📬 popped message from queue",
+			logger.Debug("📬 [TEMPORARY] queue statistics",
 				fields.MessageID(msg.MsgID), fields.MessageType(msg.MsgType),
-				zap.Ints("queue_lens", lens))
+				zap.Ints("past_10_lengths", lens))
 			lens = lens[:0]
 		}
 

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -110,10 +110,8 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 
 		// Pop only ExecuteDuty messages if there is no running instance.
 		filter := queue.FilterAny
-		if !state.HasRunningInstance {
+		if runner != nil && runner.HasRunningDuty() {
 			filter = func(m *queue.DecodedSSVMessage) bool {
-				return true
-
 				e, ok := m.Body.(*types.EventMsg)
 				if !ok {
 					return false

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -125,7 +125,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 				}
 				return e.Type == types.ExecuteDuty
 			}
-		} else if runningInstance.State.ProposalAcceptedForCurrentRound == nil {
+		} else if runningInstance != nil && runningInstance.State.ProposalAcceptedForCurrentRound == nil {
 			// If no proposal was accepted for the current round, skip non-proposal consensus messages
 			// for the current height and round.
 			filter = func(m *queue.DecodedSSVMessage) bool {

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -98,11 +98,15 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *spectypes.Duty) error {
 
 	// Attach height and round to logger.
 	round := specqbft.NoRound
+	var height specqbft.Height
 	if baseRunner.State != nil && baseRunner.State.RunningInstance != nil {
 		round = baseRunner.State.RunningInstance.State.Round
 	}
+	if baseRunner.QBFTController != nil {
+		height = baseRunner.QBFTController.Height
+	}
 	logger = logger.With(
-		fields.Height(baseRunner.QBFTController.Height),
+		fields.Height(height),
 		fields.Round(round),
 	)
 

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -98,7 +98,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *spectypes.Duty) error {
 
 	// Attach height and round to logger.
 	round := specqbft.NoRound
-	if baseRunner.State.RunningInstance != nil {
+	if baseRunner.State != nil && baseRunner.State.RunningInstance != nil {
 		round = baseRunner.State.RunningInstance.State.Round
 	}
 	logger = logger.With(

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -91,24 +91,15 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *spectypes.Duty) error {
 		return errors.Errorf("no runner for duty type %s", duty.Type.String())
 	}
 
-	// Attach duty ID to logger.
+	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
 	v.dutyIDs.Set(duty.Type, fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty))
 	logger = trySetDutyID(logger, v.dutyIDs, duty.Type)
 
-	// Attach height and round to logger.
-	round := specqbft.NoRound
-	var height specqbft.Height
-	if baseRunner.State != nil && baseRunner.State.RunningInstance != nil {
-		round = baseRunner.State.RunningInstance.State.Round
-	}
+	// Log with height.
 	if baseRunner.QBFTController != nil {
-		height = baseRunner.QBFTController.Height
+		logger = logger.With(fields.Height(baseRunner.QBFTController.Height))
 	}
-	logger = logger.With(
-		fields.Height(height),
-		fields.Round(round),
-	)
 
 	logger.Info("ℹ️ starting duty processing")
 

--- a/protocol/v2/testing/test_utils.go
+++ b/protocol/v2/testing/test_utils.go
@@ -96,7 +96,7 @@ func signMessage(msg *specqbft.Message, sk *bls.SecretKey) (*bls.Sign, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sk.SignByte(root), nil
+	return sk.SignByte(root[:]), nil
 }
 
 // MultiSignMsg signs a msg with multiple signers

--- a/protocol/v2/types/crypto.go
+++ b/protocol/v2/types/crypto.go
@@ -48,7 +48,7 @@ func VerifyByOperators(s spectypes.Signature, data spectypes.MessageSignature, d
 	}
 
 	// verify
-	if res := sign.FastAggregateVerify(pks, computedRoot); !res {
+	if res := sign.FastAggregateVerify(pks, computedRoot[:]); !res {
 		return errors.New("failed to verify signature")
 	}
 	return nil


### PR DESCRIPTION
### Problem
Sometimes messages are being processed prematurely which leads to them being rejected, for example:
1. Prepares/commits for a proposal that wasn't yet received
2. Proposal for a duty that wasn't yet started

This PR refactors `priorityQueue` to support popping messages with a filter, and uses this new ability to avoid popping certain messages too early, specifically:
1. **If no duty is running, pop only ExecuteDuty messages**
  *This keeps pre-consensus/consensus messages in the queue, until we're ready to process them.*
2. **If no proposal was accepted for the current round, skip prepare & commit messages for the current height and round**
  *This helps handle network-layer asynchrony. While prepares & commits are sent after proposals, they're sometimes received before.*