### PR TITLE
Hotfix permissioned rollout

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -99,11 +99,15 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		cfg.P2pNetworkConfig.Ctx = cmd.Context()
-		currentSlot := uint64(eth2Network.EstimatedCurrentSlot())
-		if currentSlot >= cfg.P2pNetworkConfig.PermissionedActivateSlot && currentSlot < cfg.P2pNetworkConfig.PermissionedDeactivateSlot {
-			cfg.P2pNetworkConfig.Permissioned = true
-			cfg.P2pNetworkConfig.WhitelistedOperatorKeys = append(cfg.P2pNetworkConfig.WhitelistedOperatorKeys, p2pv1.StageExporterPubkeys...) // TODO: get whitelisted from network config
+
+		permissioned := func() bool {
+			currentSlot := uint64(eth2Network.EstimatedCurrentSlot())
+			return currentSlot >= cfg.P2pNetworkConfig.PermissionedActivateSlot && currentSlot < cfg.P2pNetworkConfig.PermissionedDeactivateSlot
 		}
+
+		cfg.P2pNetworkConfig.Permissioned = permissioned
+		cfg.P2pNetworkConfig.WhitelistedOperatorKeys = append(cfg.P2pNetworkConfig.WhitelistedOperatorKeys, p2pv1.StageExporterPubkeys...) // TODO: get whitelisted from network config
+
 		p2pNetwork := setupP2P(forkVersion, operatorData, db, logger)
 
 		ctx := cmd.Context()

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -101,8 +101,8 @@ var StartNodeCmd = &cobra.Command{
 		cfg.P2pNetworkConfig.Ctx = cmd.Context()
 
 		permissioned := func() bool {
-			currentSlot := uint64(eth2Network.EstimatedCurrentSlot())
-			return currentSlot >= cfg.P2pNetworkConfig.PermissionedActivateSlot && currentSlot < cfg.P2pNetworkConfig.PermissionedDeactivateSlot
+			currentEpoch := uint64(eth2Network.EstimatedCurrentEpoch())
+			return currentEpoch >= cfg.P2pNetworkConfig.PermissionedActivateEpoch && currentEpoch < cfg.P2pNetworkConfig.PermissionedDeactivateEpoch
 		}
 
 		cfg.P2pNetworkConfig.Permissioned = permissioned

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	PermissionedActivateSlot   uint64 `yaml:"PermissionedActivateSlot" env:"PERMISSIONED_ACTIVE_SLOT" env-default:"99999999999999" env-description:"On which slot to start only accepting peers that are operators registered in the contract"`
 	PermissionedDeactivateSlot uint64 `yaml:"PermissionedDeactivateSlot" env:"PERMISSIONED_DEACTIVE_SLOT" env-default:"0" env-description:"On which slot to start accepting operators all peers"`
 
-	Permissioned bool // this is not loaded from config file but set up in full node setup
+	Permissioned func() bool // this is not loaded from config file but set up in full node setup
 	// WhitelistedOperatorKeys is an array of Operator Public Key PEMs not registered in the contract with which the node will accept connections
 	WhitelistedOperatorKeys []string `yaml:"WhitelistedOperatorKeys" env:"WHITELISTED_KEYS" env-description:"Operators' keys not registered in the contract with which the node will accept connections"`
 }

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -78,8 +78,8 @@ type Config struct {
 
 	GetValidatorStats network.GetValidatorStats
 
-	PermissionedActivateSlot   uint64 `yaml:"PermissionedActivateSlot" env:"PERMISSIONED_ACTIVE_SLOT" env-default:"99999999999999" env-description:"On which slot to start only accepting peers that are operators registered in the contract"`
-	PermissionedDeactivateSlot uint64 `yaml:"PermissionedDeactivateSlot" env:"PERMISSIONED_DEACTIVE_SLOT" env-default:"0" env-description:"On which slot to start accepting operators all peers"`
+	PermissionedActivateEpoch   uint64 `yaml:"PermissionedActivateEpoch" env:"PERMISSIONED_ACTIVE_EPOCH" env-default:"99999999999999" env-description:"On which epoch to start only accepting peers that are operators registered in the contract"`
+	PermissionedDeactivateEpoch uint64 `yaml:"PermissionedDeactivateEpoch" env:"PERMISSIONED_DEACTIVE_EPOCH" env-default:"0" env-description:"On which epoch to start accepting operators all peers"`
 
 	Permissioned func() bool // this is not loaded from config file but set up in full node setup
 	// WhitelistedOperatorKeys is an array of Operator Public Key PEMs not registered in the contract with which the node will accept connections

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -188,15 +188,18 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 		return n.subnets
 	}
 
-	filters := []connections.HandshakeFilter{
-		connections.NetworkIDFilter(n.cfg.NetworkID),
-	}
+	filters := func() []connections.HandshakeFilter {
+		filters := []connections.HandshakeFilter{
+			connections.NetworkIDFilter(n.cfg.NetworkID),
+		}
 
-	if n.cfg.Permissioned {
-		filters = append(filters,
-			connections.SenderRecipientIPsCheckFilter(n.host.ID()),
-			connections.SignatureCheckFilter(),
-			connections.RegisteredOperatorsFilter(logger, n.nodeStorage, n.cfg.WhitelistedOperatorKeys))
+		if n.cfg.Permissioned() {
+			filters = append(filters,
+				connections.SenderRecipientIPsCheckFilter(n.host.ID()),
+				connections.SignatureCheckFilter(),
+				connections.RegisteredOperatorsFilter(logger, n.nodeStorage, n.cfg.WhitelistedOperatorKeys))
+		}
+		return filters
 	}
 
 	handshaker := connections.NewHandshaker(n.ctx, &connections.HandshakerCfg{
@@ -210,7 +213,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 		SubnetsProvider: subnetsProvider,
 		NodeStorage:     n.nodeStorage,
 		Permissioned:    n.cfg.Permissioned,
-	}, filters...)
+	}, filters)
 
 	n.host.SetStreamHandler(peers.NodeInfoProtocol, handshaker.Handler(logger))
 	logger.Debug("handshaker is ready")

--- a/network/p2p/test_utils.go
+++ b/network/p2p/test_utils.go
@@ -195,5 +195,8 @@ func NewNetConfig(netPrivKey *ecdsa.PrivateKey, operatorID string, forkVersion f
 		UserAgent:         ua,
 		NetworkID:         "ssv-testnet",
 		Discovery:         discT,
+		Permissioned: func() bool {
+			return false
+		},
 	}
 }

--- a/network/peers/connections/helpers_test.go
+++ b/network/peers/connections/helpers_test.go
@@ -126,8 +126,8 @@ func getTestingData(t *testing.T) TestData {
 		net:          net,
 		nodeStorage:  nst,
 		streams:      sc,
-		filters:      []HandshakeFilter{},
-		Permissioned: false,
+		filters:      func() []HandshakeFilter { return []HandshakeFilter{} },
+		Permissioned: func() bool { return false },
 	}
 
 	mockConn := mock.Conn{


### PR DESCRIPTION
# Abstract

The permissioned feature previously only checked for the slot in the startup of the node. we want to enable nodes to change accordingly during operation hence this change.