### PR TITLE
Validator metadata panic

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -523,6 +523,9 @@ func (c *controller) UpdateValidatorMetadata(logger *zap.Logger, pk string, meta
 		if err != nil {
 			return errors.Wrap(err, "could not get share")
 		}
+		if share == nil {
+			return errors.New("share was not found")
+		}
 		started, err := c.onShareStart(logger, share)
 		if err != nil {
 			return errors.Wrap(err, "could not start validator")

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -318,25 +318,12 @@ func (c *controller) handleRouterMessages(logger *zap.Logger) {
 	}
 }
 
-// getShare returns the share of the given validator public key
-// TODO: optimize
-func (c *controller) getShare(pk spectypes.ValidatorPK) (*types.SSVShare, error) {
-	share, found, err := c.sharesStorage.GetShare(pk)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not read validator share [%s]", pk)
-	}
-	if !found {
-		return nil, nil
-	}
-	return share, nil
-}
-
 func (c *controller) handleWorkerMessages(logger *zap.Logger, msg *spectypes.SSVMessage) error {
-	share, err := c.getShare(msg.GetID().GetPubKey())
+	share, found, err := c.sharesStorage.GetShare(msg.GetID().GetPubKey())
 	if err != nil {
 		return err
 	}
-	if share == nil {
+	if !found {
 		return errors.Errorf("could not find validator [%s]", hex.EncodeToString(msg.GetID().GetPubKey()))
 	}
 
@@ -519,11 +506,11 @@ func (c *controller) UpdateValidatorMetadata(logger *zap.Logger, pk string, meta
 		if err != nil {
 			return errors.Wrap(err, "could not decode public key")
 		}
-		share, err := c.getShare(pkBytes)
+		share, found, err := c.sharesStorage.GetShare(pkBytes)
 		if err != nil {
 			return errors.Wrap(err, "could not get share")
 		}
-		if share == nil {
+		if !found {
 			return errors.New("share was not found")
 		}
 		started, err := c.onShareStart(logger, share)


### PR DESCRIPTION
## The bug

We had a panic happen at stage env that was a result of `ValidatorRemoved` event that was fired during 
`UpdateValidatorMetadata` this resulted in the validator not being in the `validatorMap` and yet we tried to activate it using a share from the DB, which wasn't returning an error but did return an empty share (nil) which panicked when we tried to use (log it in this case)

## Solution
on `UpdateValidatorMetadata` a new check on `Share` will make sure we wont start the share if it is empty.

## Notes

We should revamp this area, to make sure validator events are interlocked with routinely updating the validator metadata. This will probably happen as part of a bigger change in the way we receive, handle and store all the information from ETH1 node.