### PR TITLE
Log Panics

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -76,11 +76,12 @@ var StartNodeCmd = &cobra.Command{
 	Use:   "start-node",
 	Short: "Starts an instance of SSV node",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		logger, err := setupGlobal(cmd)
 		if err != nil {
 			log.Fatal("could not create logger", err)
 		}
+
+		defer logging.CapturePanic(logger)
 
 		networkConfig, forkVersion, err := setupSSVNetwork(logger)
 		if err != nil {

--- a/logging/global.go
+++ b/logging/global.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"io"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -92,4 +93,11 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 	zap.ReplaceGlobals(zap.New(zapcore.NewTee(consoleCore, fileCore)))
 
 	return nil
+}
+
+func CapturePanic(logger *zap.Logger) {
+	if r := recover(); r != nil {
+		stackTrace := string(debug.Stack())
+		logger.Panic("Recovered from panic", zap.Any("panic", r), zap.String("stackTrace", stackTrace))
+	}
 }

--- a/logging/global.go
+++ b/logging/global.go
@@ -97,6 +97,7 @@ func SetGlobalLogger(levelName string, levelEncoderName string, logFormat string
 
 func CapturePanic(logger *zap.Logger) {
 	if r := recover(); r != nil {
+		defer logger.Sync()
 		stackTrace := string(debug.Stack())
 		logger.Panic("Recovered from panic", zap.Any("panic", r), zap.String("stackTrace", stackTrace))
 	}


### PR DESCRIPTION
This PR recovers from panics to log them with zap, and then re-panics to preserve existing behavior.

Example:
```bash
2023-05-31T20:11:20.101180Z     PANIC   Recovered from panic    {"panic": "not implemented", "stackTrace": "...full-stack-trace..."}
```