### PR TITLE
eth1/goeth, monitoring/metrics, network/p2p: crash if setup fails

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -386,8 +386,7 @@ func startMetricsHandler(ctx context.Context, logger *zap.Logger, db basedb.IDb,
 	metricsHandler := metrics.NewMetricsHandler(ctx, db, enableProf, operatorNode.(metrics.HealthCheckAgent))
 	addr := fmt.Sprintf(":%d", port)
 	if err := metricsHandler.Start(logger, http.NewServeMux(), addr); err != nil {
-		// TODO: stop node if metrics setup failed?
-		logger.Error("failed to start", zap.Error(err))
+		logger.Panic("failed to serve metrics", zap.Error(err))
 	}
 }
 

--- a/eth1/goeth/goETH.go
+++ b/eth1/goeth/goETH.go
@@ -159,8 +159,7 @@ func (ec *eth1Client) reconnect(logger *zap.Logger) {
 	}, 1*time.Second, limit+(1*time.Second))
 	logger.Debug("managed to reconnect")
 	if err := ec.streamSmartContractEvents(logger); err != nil {
-		// TODO: panic?
-		logger.Error("failed to stream events after reconnection", zap.Error(err))
+		logger.Panic("failed to stream events after reconnection", zap.Error(err))
 	}
 }
 

--- a/monitoring/metrics/handler.go
+++ b/monitoring/metrics/handler.go
@@ -11,12 +11,13 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/bloxapp/ssv/logging/fields"
-	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
+
+	"github.com/bloxapp/ssv/logging/fields"
+	"github.com/bloxapp/ssv/storage/basedb"
 )
 
 // Handler handles incoming metrics requests
@@ -84,13 +85,11 @@ func (mh *metricsHandler) Start(logger *zap.Logger, mux *http.ServeMux, addr str
 	mux.HandleFunc("/database/count-by-collection", mh.handleCountByCollection)
 	mux.HandleFunc("/health", mh.handleHealth)
 
-	go func() {
-		// TODO: enable lint (G114: Use of net/http serve function that has no support for setting timeouts (gosec))
-		// nolint: gosec
-		if err := http.ListenAndServe(addr, mux); err != nil {
-			logger.Error("failed to start http end-point", zap.Error(err))
-		}
-	}()
+	// TODO: enable lint (G114: Use of net/http serve function that has no support for setting timeouts (gosec))
+	// nolint: gosec
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		return fmt.Errorf("listen to %s: %w", addr, err)
+	}
 
 	return nil
 }

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -2,6 +2,7 @@ package p2pv1
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/rand"
 	"net"
 	"strings"
@@ -59,7 +60,9 @@ func (n *p2pNetwork) Setup(logger *zap.Logger) error {
 	rand.Seed(time.Now().UnixNano()) // nolint: staticcheck
 	logger.Info("configuring")
 
-	n.initCfg()
+	if err := n.initCfg(); err != nil {
+		return fmt.Errorf("init config: %w", err)
+	}
 
 	err := n.SetupHost(logger)
 	if err != nil {
@@ -78,7 +81,7 @@ func (n *p2pNetwork) Setup(logger *zap.Logger) error {
 	return nil
 }
 
-func (n *p2pNetwork) initCfg() {
+func (n *p2pNetwork) initCfg() error {
 	if n.cfg.RequestTimeout == 0 {
 		n.cfg.RequestTimeout = defaultReqTimeout
 	}
@@ -89,8 +92,7 @@ func (n *p2pNetwork) initCfg() {
 		s := make(records.Subnets, 0)
 		subnets, err := s.FromString(strings.Replace(n.cfg.Subnets, "0x", "", 1))
 		if err != nil {
-			// TODO: handle
-			return
+			return fmt.Errorf("parse subnet: %w", err)
 		}
 		n.subnets = subnets
 	}
@@ -100,6 +102,8 @@ func (n *p2pNetwork) initCfg() {
 	if n.cfg.TopicMaxPeers <= 0 {
 		n.cfg.TopicMaxPeers = minPeersBuffer / 2
 	}
+
+	return nil
 }
 
 // SetupHost configures a libp2p host and backoff connector utility


### PR DESCRIPTION
- If metrics server cannot be started, it likely means a configuration error which should not be hidden
- If streaming smart contract events fails, then `listenToSubscription` doesn't happen anymore, which means it's better to restart and try again. Probably we could add some code to handle this case instead.
- If `n.cfg.Subnets` cannot be parsed, then config is malformed, and crashing would show this