### PR TITLE
Remove duplicated imports

### DIFF
--- a/network/syncing/syncer.go
+++ b/network/syncing/syncer.go
@@ -5,15 +5,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bloxapp/ssv/logging/fields"
-
-	"github.com/bloxapp/ssv-spec/qbft"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
-	protocolp2p "github.com/bloxapp/ssv/protocol/v2/p2p"
-	"github.com/bloxapp/ssv/utils/tasks"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	"github.com/bloxapp/ssv/logging/fields"
+	protocolp2p "github.com/bloxapp/ssv/protocol/v2/p2p"
+	"github.com/bloxapp/ssv/utils/tasks"
 )
 
 //go:generate mockgen -package=mocks -destination=./mocks/syncer.go -source=./syncer.go
@@ -123,7 +122,7 @@ func (s *syncer) SyncDecidedByRange(
 	ctx context.Context,
 	logger *zap.Logger,
 	id spectypes.MessageID,
-	from, to qbft.Height,
+	from, to specqbft.Height,
 	handler MessageHandler,
 ) error {
 	if ctx.Err() != nil {

--- a/protocol/v2/qbft/spectest/controller_type.go
+++ b/protocol/v2/qbft/spectest/controller_type.go
@@ -6,19 +6,17 @@ import (
 	"reflect"
 	"testing"
 
-	qbfttesting "github.com/bloxapp/ssv/protocol/v2/qbft/testing"
-
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectests "github.com/bloxapp/ssv-spec/qbft/spectest/tests"
 	spectypes "github.com/bloxapp/ssv-spec/types"
-	"github.com/bloxapp/ssv-spec/types/testingutils"
 	spectestingutils "github.com/bloxapp/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/logging"
 	"github.com/bloxapp/ssv/protocol/v2/qbft"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	qbfttesting "github.com/bloxapp/ssv/protocol/v2/qbft/testing"
 )
 
 func RunControllerSpecTest(t *testing.T, test *spectests.ControllerSpecTest) {
@@ -83,7 +81,7 @@ func testProcessMsg(
 
 	// verify sync decided by range calls
 	if runData.ExpectedDecidedState.CalledSyncDecidedByRange {
-		require.EqualValues(t, runData.ExpectedDecidedState.DecidedByRangeValues, config.GetNetwork().(*testingutils.TestingNetwork).DecidedByRange)
+		require.EqualValues(t, runData.ExpectedDecidedState.DecidedByRangeValues, config.GetNetwork().(*spectestingutils.TestingNetwork).DecidedByRange)
 	} else {
 		require.EqualValues(t, [2]specqbft.Height{0, 0}, config.GetNetwork().(*spectestingutils.TestingNetwork).DecidedByRange)
 	}
@@ -99,7 +97,7 @@ func testBroadcastedDecided(
 ) {
 	if runData.ExpectedDecidedState.BroadcastedDecided != nil {
 		// test broadcasted
-		broadcastedMsgs := config.GetNetwork().(*testingutils.TestingNetwork).BroadcastedMsgs
+		broadcastedMsgs := config.GetNetwork().(*spectestingutils.TestingNetwork).BroadcastedMsgs
 		require.Greater(t, len(broadcastedMsgs), 0)
 		found := false
 		for _, msg := range broadcastedMsgs {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -6,12 +6,12 @@ import (
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	specssv "github.com/bloxapp/ssv-spec/ssv"
-	"github.com/bloxapp/ssv-spec/types"
 	spectypes "github.com/bloxapp/ssv-spec/types"
-	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	"github.com/bloxapp/ssv/protocol/v2/qbft/controller"
 )
 
 type Getters interface {
@@ -66,7 +66,7 @@ func (b *BaseRunner) SetHighestDecidedSlot(slot spec.Slot) {
 }
 
 // setupForNewDuty is sets the runner for a new duty
-func (b *BaseRunner) baseSetupForNewDuty(duty *types.Duty) {
+func (b *BaseRunner) baseSetupForNewDuty(duty *spectypes.Duty) {
 	state := NewRunnerState(b.Share.Quorum, duty)
 
 	// TODO: potentially incomplete locking of b.State. runner.Execute(duty) has access to

--- a/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
+++ b/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/bloxapp/ssv-spec/types"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	spectestingutils "github.com/bloxapp/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ import (
 type StartNewRunnerDutySpecTest struct {
 	Name                    string
 	Runner                  runner.Runner
-	Duty                    *types.Duty
+	Duty                    *spectypes.Duty
 	PostDutyRunnerStateRoot string
 	OutputMessages          []*spectypes.SignedPartialSignatureMessage
 	ExpectedError           string
@@ -39,7 +38,7 @@ func (test *StartNewRunnerDutySpecTest) Run(t *testing.T, logger *zap.Logger) {
 	if len(broadcastedMsgs) > 0 {
 		index := 0
 		for _, msg := range broadcastedMsgs {
-			if msg.MsgType != types.SSVPartialSignatureMsgType {
+			if msg.MsgType != spectypes.SSVPartialSignatureMsgType {
 				continue
 			}
 


### PR DESCRIPTION
Some imports are duplicated, e.g.:
```go
	"github.com/bloxapp/ssv-spec/qbft"
	specqbft "github.com/bloxapp/ssv-spec/qbft"
```