### PR TITLE
Fix builtin shadowing

### DIFF
--- a/protocol/v2/qbft/instance/compact.go
+++ b/protocol/v2/qbft/instance/compact.go
@@ -23,9 +23,9 @@ func Compact(state *specqbft.State, decidedMessage *specqbft.SignedMessage) {
 //
 // See Compact for more details.
 func CompactCopy(state *specqbft.State, decidedMessage *specqbft.SignedMessage) *specqbft.State {
-	copy := *state
-	compact(&copy, decidedMessage, compactContainerCopy)
-	return &copy
+	stateCopy := *state
+	compact(&stateCopy, decidedMessage, compactContainerCopy)
+	return &stateCopy
 }
 
 func compact(state *specqbft.State, decidedMessage *specqbft.SignedMessage, compactContainer compactContainerFunc) {

--- a/protocol/v2/qbft/instance/compact_test.go
+++ b/protocol/v2/qbft/instance/compact_test.go
@@ -153,8 +153,8 @@ func TestCompact(t *testing.T) {
 			}
 
 			// Test CompactCopy.
-			copy := CompactCopy(tt.inputState, tt.inputMsg)
-			require.Equal(t, tt.expected, copy)
+			stateCopy := CompactCopy(tt.inputState, tt.inputMsg)
+			require.Equal(t, tt.expected, stateCopy)
 
 			// Verify that input state was not modified by CompactCopy.
 			inputStateAfter, err := tt.inputState.Encode()


### PR DESCRIPTION
`copy` is a builtin and should not be shadowed