### PR TITLE
Fix Runtime Subscriptions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - fix-subnet-subscriptions
+    - stage
 
 Deploy nodes to stage:
   stage: deploy
@@ -71,7 +71,7 @@ Deploy nodes to stage:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/stage/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - fix-subnet-subscriptions
+    - stage
 
 Deploy exporter to stage:
   stage: deploy
@@ -87,7 +87,7 @@ Deploy exporter to stage:
     - mv kubectl /usr/bin/
     - .k8/stage/scripts/deploy-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - fix-subnet-subscriptions
+    - stage
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - fix-subnet-subscriptions
 
 Deploy nodes to stage:
   stage: deploy
@@ -71,7 +71,7 @@ Deploy nodes to stage:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/stage/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - stage
+    - fix-subnet-subscriptions
 
 Deploy exporter to stage:
   stage: deploy
@@ -87,7 +87,7 @@ Deploy exporter to stage:
     - mv kubectl /usr/bin/
     - .k8/stage/scripts/deploy-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - fix-subnet-subscriptions
 
 
 

--- a/eth1/goeth/goETH.go
+++ b/eth1/goeth/goETH.go
@@ -174,7 +174,12 @@ func (ec *eth1Client) fireEvent(log types.Log, name string, data interface{}) {
 
 // streamSmartContractEvents sync events history of the given contract
 func (ec *eth1Client) streamSmartContractEvents(logger *zap.Logger) error {
-	logger.Debug("streaming smart contract events")
+	currentBlock, err := ec.conn.BlockNumber(ec.ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get current block")
+	}
+	logger.Debug("streaming smart contract events",
+		zap.Uint64("current_block", currentBlock))
 
 	contractAbi, err := abi.JSON(strings.NewReader(ec.contractABI))
 	if err != nil {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -215,13 +215,10 @@ func (n *p2pNetwork) isReady() bool {
 func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 	// TODO: this is a temporary fix to update subnets when validators are added/removed,
 	// there is a pending PR to replace this: https://github.com/bloxapp/ssv/pull/990
+	logger = logger.Named(logging.NameP2PNetwork)
 	for {
-		time.Sleep(time.Second * 4)
-
 		start := time.Now()
-		logger := logger.Named(logging.NameP2PNetwork)
 
-		visited := make(map[int]bool)
 		last := make([]byte, len(n.subnets))
 		if len(n.subnets) > 0 {
 			copy(last, n.subnets)
@@ -232,9 +229,6 @@ func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 				return true
 			}
 			subnet := n.fork.ValidatorSubnet(pkHex)
-			if _, ok := visited[subnet]; ok {
-				return true
-			}
 			newSubnets[subnet] = byte(1)
 			return true
 		})
@@ -267,6 +261,8 @@ func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 			zap.Any("subnets", subnetsList),
 			zap.Duration("took", time.Since(start)),
 		)
+
+		time.Sleep(time.Second * 4)
 	}
 }
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -213,60 +213,61 @@ func (n *p2pNetwork) isReady() bool {
 // UpdateSubnets will update the registered subnets according to active validators
 // NOTE: it won't subscribe to the subnets (use subscribeToSubnets for that)
 func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
-	go func() {
-		for {
-			time.Sleep(time.Second * 4)
-			start := time.Now()
-			logger := logger.Named(logging.NameP2PNetwork)
+	// TODO: this is a temporary fix to update subnets when validators are added/removed,
+	// there is a pending PR to replace this: https://github.com/bloxapp/ssv/pull/990
+	for {
+		time.Sleep(time.Second * 4)
 
-			visited := make(map[int]bool)
-			last := make([]byte, len(n.subnets))
-			if len(n.subnets) > 0 {
-				copy(last, n.subnets)
-			}
-			newSubnets := make([]byte, n.fork.Subnets())
-			n.activeValidators.Range(func(pkHex string, status validatorStatus) bool {
-				if status == validatorStatusInactive {
-					return true
-				}
-				subnet := n.fork.ValidatorSubnet(pkHex)
-				if _, ok := visited[subnet]; ok {
-					return true
-				}
-				newSubnets[subnet] = byte(1)
-				return true
-			})
-			subnetsToAdd := make([]int, 0)
-			if !bytes.Equal(newSubnets, last) { // have changes
-				n.subnets = newSubnets
-				for i, b := range newSubnets {
-					if b == byte(1) {
-						subnetsToAdd = append(subnetsToAdd, i)
-					}
-				}
-			}
+		start := time.Now()
+		logger := logger.Named(logging.NameP2PNetwork)
 
-			if len(subnetsToAdd) == 0 {
-				continue
-			}
-
-			self := n.idx.Self()
-			self.Metadata.Subnets = records.Subnets(n.subnets).String()
-			n.idx.UpdateSelfRecord(self)
-
-			err := n.disc.RegisterSubnets(logger.Named(logging.NameDiscoveryService), subnetsToAdd...)
-			if err != nil {
-				logger.Warn("could not register subnets", zap.Error(err))
-				continue
-			}
-			allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
-			subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
-			logger.Debug("updated subnets (node-info)",
-				zap.Any("subnets", subnetsList),
-				zap.Duration("took", time.Since(start)),
-			)
+		visited := make(map[int]bool)
+		last := make([]byte, len(n.subnets))
+		if len(n.subnets) > 0 {
+			copy(last, n.subnets)
 		}
-	}()
+		newSubnets := make([]byte, n.fork.Subnets())
+		n.activeValidators.Range(func(pkHex string, status validatorStatus) bool {
+			if status == validatorStatusInactive {
+				return true
+			}
+			subnet := n.fork.ValidatorSubnet(pkHex)
+			if _, ok := visited[subnet]; ok {
+				return true
+			}
+			newSubnets[subnet] = byte(1)
+			return true
+		})
+		subnetsToAdd := make([]int, 0)
+		if !bytes.Equal(newSubnets, last) { // have changes
+			n.subnets = newSubnets
+			for i, b := range newSubnets {
+				if b == byte(1) {
+					subnetsToAdd = append(subnetsToAdd, i)
+				}
+			}
+		}
+
+		if len(subnetsToAdd) == 0 {
+			continue
+		}
+
+		self := n.idx.Self()
+		self.Metadata.Subnets = records.Subnets(n.subnets).String()
+		n.idx.UpdateSelfRecord(self)
+
+		err := n.disc.RegisterSubnets(logger.Named(logging.NameDiscoveryService), subnetsToAdd...)
+		if err != nil {
+			logger.Warn("could not register subnets", zap.Error(err))
+			continue
+		}
+		allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
+		subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
+		logger.Debug("updated subnets (node-info)",
+			zap.Any("subnets", subnetsList),
+			zap.Duration("took", time.Since(start)),
+		)
+	}
 }
 
 // getMaxPeers returns max peers of the given topic.

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -213,51 +213,60 @@ func (n *p2pNetwork) isReady() bool {
 // UpdateSubnets will update the registered subnets according to active validators
 // NOTE: it won't subscribe to the subnets (use subscribeToSubnets for that)
 func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
-	logger = logger.Named(logging.NameP2PNetwork)
+	go func() {
+		for {
+			time.Sleep(time.Second * 4)
+			start := time.Now()
+			logger = logger.Named(logging.NameP2PNetwork)
 
-	visited := make(map[int]bool)
-	last := make([]byte, len(n.subnets))
-	if len(n.subnets) > 0 {
-		copy(last, n.subnets)
-	}
-	newSubnets := make([]byte, n.fork.Subnets())
-	n.activeValidators.Range(func(pkHex string, status validatorStatus) bool {
-		if status == validatorStatusInactive {
-			return true
-		}
-		subnet := n.fork.ValidatorSubnet(pkHex)
-		if _, ok := visited[subnet]; ok {
-			return true
-		}
-		newSubnets[subnet] = byte(1)
-		return true
-	})
-	subnetsToAdd := make([]int, 0)
-	if !bytes.Equal(newSubnets, last) { // have changes
-		n.subnets = newSubnets
-		for i, b := range newSubnets {
-			if b == byte(1) {
-				subnetsToAdd = append(subnetsToAdd, i)
+			visited := make(map[int]bool)
+			last := make([]byte, len(n.subnets))
+			if len(n.subnets) > 0 {
+				copy(last, n.subnets)
 			}
+			newSubnets := make([]byte, n.fork.Subnets())
+			n.activeValidators.Range(func(pkHex string, status validatorStatus) bool {
+				if status == validatorStatusInactive {
+					return true
+				}
+				subnet := n.fork.ValidatorSubnet(pkHex)
+				if _, ok := visited[subnet]; ok {
+					return true
+				}
+				newSubnets[subnet] = byte(1)
+				return true
+			})
+			subnetsToAdd := make([]int, 0)
+			if !bytes.Equal(newSubnets, last) { // have changes
+				n.subnets = newSubnets
+				for i, b := range newSubnets {
+					if b == byte(1) {
+						subnetsToAdd = append(subnetsToAdd, i)
+					}
+				}
+			}
+
+			if len(subnetsToAdd) == 0 {
+				return
+			}
+
+			self := n.idx.Self()
+			self.Metadata.Subnets = records.Subnets(n.subnets).String()
+			n.idx.UpdateSelfRecord(self)
+
+			err := n.disc.RegisterSubnets(logger.Named(logging.NameDiscoveryService), subnetsToAdd...)
+			if err != nil {
+				logger.Warn("could not register subnets", zap.Error(err))
+				return
+			}
+			allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
+			subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
+			logger.Debug("updated subnets (node-info)",
+				zap.Any("subnets", subnetsList),
+				zap.Duration("took", time.Since(start)),
+			)
 		}
-	}
-
-	if len(subnetsToAdd) == 0 {
-		return
-	}
-
-	self := n.idx.Self()
-	self.Metadata.Subnets = records.Subnets(n.subnets).String()
-	n.idx.UpdateSelfRecord(self)
-
-	err := n.disc.RegisterSubnets(logger.Named(logging.NameDiscoveryService), subnetsToAdd...)
-	if err != nil {
-		logger.Warn("could not register subnets", zap.Error(err))
-		return
-	}
-	allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
-	subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)
-	logger.Debug("updated subnets (node-info)", zap.Any("subnets", subnetsList))
+	}()
 }
 
 // getMaxPeers returns max peers of the given topic.

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -247,7 +247,7 @@ func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 			}
 
 			if len(subnetsToAdd) == 0 {
-				return
+				continue
 			}
 
 			self := n.idx.Self()
@@ -257,7 +257,7 @@ func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 			err := n.disc.RegisterSubnets(logger.Named(logging.NameDiscoveryService), subnetsToAdd...)
 			if err != nil {
 				logger.Warn("could not register subnets", zap.Error(err))
-				return
+				continue
 			}
 			allSubs, _ := records.Subnets{}.FromString(records.AllSubnets)
 			subnetsList := records.SharedSubnets(allSubs, n.subnets, 0)

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -217,7 +217,7 @@ func (n *p2pNetwork) UpdateSubnets(logger *zap.Logger) {
 		for {
 			time.Sleep(time.Second * 4)
 			start := time.Now()
-			logger = logger.Named(logging.NameP2PNetwork)
+			logger := logger.Named(logging.NameP2PNetwork)
 
 			visited := make(map[int]bool)
 			last := make([]byte, len(n.subnets))


### PR DESCRIPTION
This PR fixes a case where `p2pNetwork.Subscribe` is being called in runtime as new validators join, but the subnets record isn't updated neither in the node's metadata and the new topics aren't being registered to.

This is a temporary PR until https://github.com/bloxapp/ssv/pull/990 for until is ready.