### PR TITLE
Share Caching Patches

### DIFF
--- a/operator/fee_recipient/controller_test.go
+++ b/operator/fee_recipient/controller_test.go
@@ -139,11 +139,11 @@ func populateStorage(t *testing.T, logger *zap.Logger, storage registrystorage.S
 	}
 
 	for i := 0; i < 1000; i++ {
-		require.NoError(t, storage.Save(logger, createShare(i, operatorData.ID)))
+		require.NoError(t, storage.Save(createShare(i, operatorData.ID)))
 	}
 
 	// add none committee share
-	require.NoError(t, storage.Save(logger, createShare(2000, spectypes.OperatorID(1))))
+	require.NoError(t, storage.Save(createShare(2000, spectypes.OperatorID(1))))
 
 	all := storage.List(registrystorage.ByOperatorID(operatorData.ID), registrystorage.ByNotLiquidated())
 	require.Equal(t, 1000, len(all))

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -620,7 +620,7 @@ func (c *controller) onShareCreate(logger *zap.Logger, validatorEvent abiparser.
 	}
 
 	// save validator data
-	if err := c.sharesStorage.Save(logger, share); err != nil {
+	if err := c.sharesStorage.Save(share); err != nil {
 		return nil, errors.Wrap(err, "could not save validator share")
 	}
 

--- a/operator/validator/event_handler.go
+++ b/operator/validator/event_handler.go
@@ -427,7 +427,7 @@ func (c *controller) processClusterEvent(
 	}
 
 	if len(toUpdate) > 0 {
-		if err = c.sharesStorage.Save(logger, toUpdate...); err != nil {
+		if err = c.sharesStorage.Save(toUpdate...); err != nil {
 			return nil, nil, errors.Wrapf(err, "could not save validator shares")
 		}
 	}

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -64,10 +64,10 @@ func TestSaveAndGetValidatorStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	validatorShare, _ := generateRandomValidatorShare(splitKeys)
-	require.NoError(t, shareStorage.Save(logger, validatorShare))
+	require.NoError(t, shareStorage.Save(validatorShare))
 
 	validatorShare2, _ := generateRandomValidatorShare(splitKeys)
-	require.NoError(t, shareStorage.Save(logger, validatorShare2))
+	require.NoError(t, shareStorage.Save(validatorShare2))
 
 	validatorShareByKey := shareStorage.Get(validatorShare.ValidatorPubKey)
 	require.NotNil(t, validatorShareByKey)


### PR DESCRIPTION
This PR primarily improves the integrity of the in-memory replica.

- Update database first in `Save` & `Delete` (to prevent updating in-memory if database update failed)
- Remove `logger` parameter from `Save` because it isn't needed anymore