### PR TITLE
chore: increase timeout to allow for long-running pprof requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - stage
+    - metrics-server-timeout
 
 Deploy nodes to stage:
   stage: deploy
@@ -71,7 +71,7 @@ Deploy nodes to stage:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/stage/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - stage
+    - metrics-server-timeout
 
 Deploy exporter to stage:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_BUILD_REF $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_BUILD_REF
   only:
-    - metrics-server-timeout
+    - stage
 
 Deploy nodes to stage:
   stage: deploy
@@ -71,7 +71,7 @@ Deploy nodes to stage:
     # █▓▒░ Keep commented unless you're testing the bootnode ░▒▓█
     # - .k8/stage/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_STAGE $CI_BUILD_REF ssv $APP_REPLICAS_INFRA_STAGE blox-infra-stage kubernetes-admin@blox-infra stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V1 $SSV_NODES_MEM_LIMIT_V1
   only:
-    - metrics-server-timeout
+    - stage
 
 Deploy exporter to stage:
   stage: deploy

--- a/monitoring/metrics/handler.go
+++ b/monitoring/metrics/handler.go
@@ -86,7 +86,8 @@ func (mh *metricsHandler) Start(logger *zap.Logger, mux *http.ServeMux, addr str
 	mux.HandleFunc("/database/count-by-collection", mh.handleCountByCollection)
 	mux.HandleFunc("/health", mh.handleHealth)
 
-	const timeout = 3 * time.Second
+	// Set a high timeout to allow for long-running pprof requests.
+	const timeout = 600 * time.Second
 
 	httpServer := &http.Server{
 		Addr:         addr,


### PR DESCRIPTION
Ever since #991 we can't request pprof profiles fora duration >3 seconds. This PR increases the timeout.