### PR TITLE
kv: fix lack of badger DB report

### DIFF
--- a/storage/kv/badger.go
+++ b/storage/kv/badger.go
@@ -250,17 +250,15 @@ func (b *BadgerDb) Close(logger *zap.Logger) error {
 }
 
 // report the db size and metrics
-func (b *BadgerDb) report(logger *zap.Logger) func() {
+func (b *BadgerDb) report(logger *zap.Logger) {
 	logger = logger.Named(logging.NameBadgerDBReporting)
-	return func() {
-		lsm, vlog := b.db.Size()
-		blockCache := b.db.BlockCacheMetrics()
-		indexCache := b.db.IndexCacheMetrics()
+	lsm, vlog := b.db.Size()
+	blockCache := b.db.BlockCacheMetrics()
+	indexCache := b.db.IndexCacheMetrics()
 
-		logger.Debug("BadgerDBReport", zap.Int64("lsm", lsm), zap.Int64("vlog", vlog),
-			fields.BlockCacheMetrics(blockCache),
-			fields.IndexCacheMetrics(indexCache))
-	}
+	logger.Debug("BadgerDBReport", zap.Int64("lsm", lsm), zap.Int64("vlog", vlog),
+		fields.BlockCacheMetrics(blockCache),
+		fields.IndexCacheMetrics(indexCache))
 }
 
 func (b *BadgerDb) periodicallyReport(logger *zap.Logger, interval time.Duration) {


### PR DESCRIPTION
`report` is being used as `report(logger)` instead of `report(logger)()`, so it should report but not return a function that reports