### PR TITLE
feat: (api) provide status, index and owner address at `/v1/validators`

### DIFF
--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -20,6 +20,7 @@ type Validators struct {
 
 func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	var request struct {
+		Owners    api.HexSlice    `json:"owners" form:"owners"`
 		Operators api.Uint64Slice `json:"operators" form:"operators"`
 		Clusters  requestClusters `json:"clusters" form:"clusters"`
 		PubKeys   api.HexSlice    `json:"pubkeys" form:"pubkeys"`
@@ -34,6 +35,9 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var filters []registrystorage.SharesFilter
+	if len(request.Owners) > 0 {
+		filters = append(filters, byOwners(request.Owners))
+	}
 	if len(request.Operators) > 0 {
 		filters = append(filters, byOperators(request.Operators))
 	}
@@ -53,6 +57,17 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 		response.Data[i] = validatorFromShare(share)
 	}
 	return api.Render(w, r, response)
+}
+
+func byOwners(owners []api.Hex) registrystorage.SharesFilter {
+	return func(share *types.SSVShare) bool {
+		for _, a := range owners {
+			if bytes.Equal(a, share.OwnerAddress[:]) {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 func byOperators(operators []uint64) registrystorage.SharesFilter {
@@ -132,6 +147,9 @@ func (c *requestClusters) Bind(value string) error {
 
 type validatorJSON struct {
 	PubKey        api.Hex                `json:"public_key"`
+	Index         phase0.ValidatorIndex  `json:"index"`
+	Status        string                 `json:"status"`
+	Owner         api.Hex                `json:"owner"`
 	Committee     []spectypes.OperatorID `json:"committee"`
 	Quorum        uint64                 `json:"quorum"`
 	PartialQuorum uint64                 `json:"partial_quorum"`
@@ -142,6 +160,7 @@ type validatorJSON struct {
 func validatorFromShare(share *types.SSVShare) *validatorJSON {
 	v := &validatorJSON{
 		PubKey: api.Hex(share.ValidatorPubKey),
+		Owner:  api.Hex(share.OwnerAddress[:]),
 		Committee: func() []spectypes.OperatorID {
 			committee := make([]spectypes.OperatorID, len(share.Committee))
 			for i, op := range share.Committee {
@@ -153,6 +172,10 @@ func validatorFromShare(share *types.SSVShare) *validatorJSON {
 		PartialQuorum: share.PartialQuorum,
 		Grafitti:      string(share.Graffiti),
 		Liquidated:    share.Liquidated,
+	}
+	if share.HasBeaconMetadata() {
+		v.Index = share.Metadata.BeaconMetadata.Index
+		v.Status = share.Metadata.BeaconMetadata.Status.String()
 	}
 	return v
 }

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -699,6 +699,7 @@ func (c *controller) UpdateValidatorMetaDataLoop(logger *zap.Logger) {
 
 		filters := []registrystorage.SharesFilter{registrystorage.ByNotLiquidated()}
 		if !c.validatorOptions.Exporter {
+			// If we're not an exporter node, fetch only for validators of our operator.
 			filters = append(filters, registrystorage.ByOperatorID(c.operatorData.ID))
 		}
 		shares := c.sharesStorage.List(filters...)

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -463,7 +463,10 @@ func (c *controller) setupNonCommitteeValidators(logger *zap.Logger) {
 		return
 	}
 
+	pubKeys := make([][]byte, 0, len(nonCommitteeShares))
 	for _, validatorShare := range nonCommitteeShares {
+		pubKeys = append(pubKeys, validatorShare.ValidatorPubKey)
+
 		opts := *c.validatorOptions
 		opts.SSVShare = validatorShare
 		allRoles := []spectypes.BeaconRole{
@@ -479,6 +482,13 @@ func (c *controller) setupNonCommitteeValidators(logger *zap.Logger) {
 			if err != nil {
 				logger.Error("failed to sync highest decided", zap.Error(err))
 			}
+		}
+	}
+
+	if len(pubKeys) > 0 {
+		logger.Debug("updating metadata for non-committee validators", zap.Int("count", len(pubKeys)))
+		if err := beaconprotocol.UpdateValidatorsMetadata(logger, pubKeys, c, c.beacon, c.onMetadataUpdated); err != nil {
+			logger.Warn("could not update all validators", zap.Error(err))
 		}
 	}
 }
@@ -687,7 +697,11 @@ func (c *controller) UpdateValidatorMetaDataLoop(logger *zap.Logger) {
 	for {
 		time.Sleep(c.metadataUpdateInterval)
 
-		shares := c.sharesStorage.List(registrystorage.ByOperatorID(c.operatorData.ID), registrystorage.ByNotLiquidated())
+		filters := []registrystorage.SharesFilter{registrystorage.ByNotLiquidated()}
+		if !c.validatorOptions.Exporter {
+			filters = append(filters, registrystorage.ByOperatorID(c.operatorData.ID))
+		}
+		shares := c.sharesStorage.List(filters...)
 		var pks [][]byte
 		for _, share := range shares {
 			pks = append(pks, share.ValidatorPubKey)


### PR DESCRIPTION
- Respond with the validator's status, index and Eth1 owner address in `/v1/validators`
- Exporter nodes now fetch metadata for all validators so they can provide their statuses & indices