### PR TITLE
fix: (`handleValidatorAdded`) bump nonce on share decryption error

### DIFF
--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -183,10 +183,6 @@ func (eh *EventHandler) handleValidatorAdded(txn basedb.Txn, event *contract.Con
 			if errors.As(err, &malformedEventError) {
 				logger.Warn("malformed event", zap.Error(err))
 
-				if err := eh.nodeStorage.BumpNonce(txn, event.Owner); err != nil {
-					return nil, fmt.Errorf("bump nonce: %w", err)
-				}
-
 				return nil, err
 			}
 

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -138,7 +138,7 @@ func (eh *EventHandler) handleValidatorAdded(txn basedb.Txn, event *contract.Con
 		return nil, fmt.Errorf("failed to get next nonce: %w", nonceErr)
 	}
 
-	// Bump nonce. This would be reverted later if the handling fails,
+	// Bump nonce. This transaction would be reverted later if the handling fails,
 	// unless the failure is due to a malformed event.
 	if err := eh.nodeStorage.BumpNonce(txn, event.Owner); err != nil {
 		return nil, err

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -184,6 +184,11 @@ func (eh *EventHandler) handleValidatorAdded(txn basedb.Txn, event *contract.Con
 			var malformedEventError *MalformedEventError
 			if errors.As(err, &malformedEventError) {
 				logger.Warn("malformed event", zap.Error(err))
+
+				if err := eh.nodeStorage.BumpNonce(txn, event.Owner); err != nil {
+					return nil, fmt.Errorf("bump nonce: %w", err)
+				}
+
 				return nil, err
 			}
 

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -166,10 +166,10 @@ func TestWaitSubsetOfPeers(t *testing.T) {
 		expectedPeersLen int
 		expectedErr      string
 	}{
-		{"Valid input", 5, 5, time.Millisecond * 50, 5, ""},
-		{"Zero minPeers", 0, 10, time.Millisecond * 50, 0, ""},
-		{"maxPeers less than minPeers", 10, 5, time.Millisecond * 50, 0, "minPeers should not be greater than maxPeers"},
-		{"Negative minPeers", -1, 10, time.Millisecond * 50, 0, "minPeers and maxPeers should not be negative"},
+		{"Valid input", 5, 5, time.Millisecond * 30, 5, ""},
+		{"Zero minPeers", 0, 10, time.Millisecond * 30, 0, ""},
+		{"maxPeers less than minPeers", 10, 5, time.Millisecond * 30, 0, "minPeers should not be greater than maxPeers"},
+		{"Negative minPeers", -1, 10, time.Millisecond * 30, 0, "minPeers and maxPeers should not be negative"},
 		{"Negative timeout", 10, 50, time.Duration(-1), 0, "timeout should be positive"},
 	}
 
@@ -181,13 +181,14 @@ func TestWaitSubsetOfPeers(t *testing.T) {
 			vpk := spectypes.ValidatorPK{} // replace with a valid value
 			// The mock function increments the number of peers by 1 for each call, up to maxPeers
 			peersCount := 0
+			start := time.Now()
 			mockGetSubsetOfPeers := func(logger *zap.Logger, vpk spectypes.ValidatorPK, maxPeers int, filter func(peer.ID) bool) (peers []peer.ID, err error) {
 				if tt.minPeers == 0 {
 					return []peer.ID{}, nil
 				}
 
 				peersCount++
-				if peersCount > maxPeers {
+				if peersCount > maxPeers || time.Since(start) > (tt.timeout-tt.timeout/5) {
 					peersCount = maxPeers
 				}
 				peers = make([]peer.ID, peersCount)


### PR DESCRIPTION
This PR fixes a bug where operators wouldn't bump the owner's nonce when the share belongs to them and is not encrypted correctly.

NOTE: the other operators (who couldn't verify the encryption) will still save the share to their database, so there will be a discrepancy between the owning operator and the others.