### PR TITLE
[Audit Issue C] Limit decoded share size

### DIFF
--- a/protocol/v2/types/ssvshare.go
+++ b/protocol/v2/types/ssvshare.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	MaxPossibleShareSize = 1245
-	MaxAllowedShareSize  = MaxPossibleShareSize * 2 // Leaving some room for protocol updates and calculation mistakes.
+	MaxAllowedShareSize  = MaxPossibleShareSize * 8 // Leaving some room for protocol updates and calculation mistakes.
 )
 
 // SSVShare is a combination of spectypes.Share and its Metadata.

--- a/protocol/v2/types/ssvshare.go
+++ b/protocol/v2/types/ssvshare.go
@@ -15,7 +15,10 @@ import (
 	beaconprotocol "github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
 )
 
-const MaxPossibleShareSize = 1245
+const (
+	MaxPossibleShareSize = 1245
+	MaxAllowedShareSize  = MaxPossibleShareSize * 2 // Leaving some room for protocol updates and calculation mistakes.
+)
 
 // SSVShare is a combination of spectypes.Share and its Metadata.
 type SSVShare struct {
@@ -36,11 +39,8 @@ func (s *SSVShare) Encode() ([]byte, error) {
 
 // Decode decodes SSVShare using gob.
 func (s *SSVShare) Decode(data []byte) error {
-	// Leaving some room for protocol updates and calculation mistakes.
-	const limit = MaxPossibleShareSize * 2
-
-	if len(data) > limit {
-		return fmt.Errorf("share size is too big, got %v, max allowed %v", len(data), limit)
+	if len(data) > MaxAllowedShareSize {
+		return fmt.Errorf("share size is too big, got %v, max allowed %v", len(data), MaxAllowedShareSize)
 	}
 
 	d := gob.NewDecoder(bytes.NewReader(data))

--- a/protocol/v2/types/ssvshare.go
+++ b/protocol/v2/types/ssvshare.go
@@ -15,6 +15,8 @@ import (
 	beaconprotocol "github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
 )
 
+const MaxPossibleShareSize = 1245
+
 // SSVShare is a combination of spectypes.Share and its Metadata.
 type SSVShare struct {
 	spectypes.Share
@@ -34,6 +36,13 @@ func (s *SSVShare) Encode() ([]byte, error) {
 
 // Decode decodes SSVShare using gob.
 func (s *SSVShare) Decode(data []byte) error {
+	// Leaving some room for protocol updates and calculation mistakes.
+	const limit = MaxPossibleShareSize * 2
+
+	if len(data) > limit {
+		return fmt.Errorf("share size is too big, got %v, max allowed %v", len(data), limit)
+	}
+
 	d := gob.NewDecoder(bytes.NewReader(data))
 	if err := d.Decode(s); err != nil {
 		return fmt.Errorf("decode SSVShare: %w", err)

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -28,7 +28,7 @@ func TestValidatorSerializer(t *testing.T) {
 	sk := &bls.SecretKey{}
 	sk.SetByCSPRNG()
 
-	const keysCount = 4
+	const keysCount = 13
 
 	splitKeys, err := threshold.Create(sk.Serialize(), keysCount-1, keysCount)
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestValidatorSerializer(t *testing.T) {
 	require.Equal(t, v1.OwnerAddress, validatorShare.OwnerAddress)
 	require.Equal(t, v1.Liquidated, validatorShare.Liquidated)
 
-	tooBigEncodedShare := bytes.Repeat(obj.Value, 10)
+	tooBigEncodedShare := bytes.Repeat(obj.Value, 20)
 	require.ErrorContains(t, v1.Decode(tooBigEncodedShare),
 		"share size is too big, got "+strconv.Itoa(len(tooBigEncodedShare))+", max allowed "+strconv.Itoa(ssvtypes.MaxAllowedShareSize))
 }

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -1,18 +1,21 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/hex"
+	"sort"
 	"testing"
 
 	spectypes "github.com/bloxapp/ssv-spec/types"
-	"github.com/bloxapp/ssv/logging"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/bloxapp/ssv/logging"
+	"github.com/bloxapp/ssv/networkconfig"
 	beaconprotocol "github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
-	"github.com/bloxapp/ssv/protocol/v2/types"
+	ssvtypes "github.com/bloxapp/ssv/protocol/v2/types"
 	ssvstorage "github.com/bloxapp/ssv/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/bloxapp/ssv/utils/threshold"
@@ -37,7 +40,7 @@ func TestValidatorSerializer(t *testing.T) {
 		Key:   validatorShare.ValidatorPubKey,
 		Value: b,
 	}
-	v1 := &types.SSVShare{}
+	v1 := &ssvtypes.SSVShare{}
 	require.NoError(t, v1.Decode(obj.Value))
 	require.NotNil(t, v1.ValidatorPubKey)
 	require.Equal(t, hex.EncodeToString(v1.ValidatorPubKey), hex.EncodeToString(validatorShare.ValidatorPubKey))
@@ -46,6 +49,16 @@ func TestValidatorSerializer(t *testing.T) {
 	require.Equal(t, v1.BeaconMetadata, validatorShare.BeaconMetadata)
 	require.Equal(t, v1.OwnerAddress, validatorShare.OwnerAddress)
 	require.Equal(t, v1.Liquidated, validatorShare.Liquidated)
+}
+
+func TestMaxPossibleShareSize(t *testing.T) {
+	s, err := generateMaxPossibleShare()
+	require.NoError(t, err)
+
+	b, err := s.Encode()
+	require.NoError(t, err)
+
+	require.Equal(t, ssvtypes.MaxPossibleShareSize, len(b))
 }
 
 func TestSaveAndGetValidatorStorage(t *testing.T) {
@@ -84,7 +97,7 @@ func TestSaveAndGetValidatorStorage(t *testing.T) {
 	require.Nil(t, share)
 }
 
-func generateRandomValidatorShare(splitKeys map[uint64]*bls.SecretKey) (*types.SSVShare, *bls.SecretKey) {
+func generateRandomValidatorShare(splitKeys map[uint64]*bls.SecretKey) (*ssvtypes.SSVShare, *bls.SecretKey) {
 	threshold.Init()
 
 	sk1 := bls.SecretKey{}
@@ -93,46 +106,59 @@ func generateRandomValidatorShare(splitKeys map[uint64]*bls.SecretKey) (*types.S
 	sk2 := bls.SecretKey{}
 	sk2.SetByCSPRNG()
 
-	ibftCommittee := []*spectypes.Operator{
-		{
-			OperatorID: 1,
-			PubKey:     splitKeys[1].Serialize(),
-		},
-		{
-			OperatorID: 2,
-			PubKey:     splitKeys[2].Serialize(),
-		},
-		{
-			OperatorID: 3,
-			PubKey:     splitKeys[3].Serialize(),
-		},
-		{
-			OperatorID: 4,
-			PubKey:     splitKeys[4].Serialize(),
-		},
+	var ibftCommittee []*spectypes.Operator
+	for operatorID, sk := range splitKeys {
+		ibftCommittee = append(ibftCommittee, &spectypes.Operator{
+			OperatorID: operatorID,
+			PubKey:     sk.Serialize(),
+		})
 	}
+	sort.Slice(ibftCommittee, func(i, j int) bool {
+		return ibftCommittee[i].OperatorID < ibftCommittee[j].OperatorID
+	})
 
-	return &types.SSVShare{
+	quorum, partialQuorum := ssvtypes.ComputeQuorumAndPartialQuorum(len(splitKeys))
+
+	return &ssvtypes.SSVShare{
 		Share: spectypes.Share{
-			OperatorID:      1,
-			ValidatorPubKey: sk1.GetPublicKey().Serialize(),
-			SharePubKey:     sk2.GetPublicKey().Serialize(),
-			Committee:       ibftCommittee,
-			Quorum:          3,
-			PartialQuorum:   2,
-			DomainType:      types.GetDefaultDomain(),
-			Graffiti:        nil,
+			OperatorID:          1,
+			ValidatorPubKey:     sk1.GetPublicKey().Serialize(),
+			SharePubKey:         sk2.GetPublicKey().Serialize(),
+			Committee:           ibftCommittee,
+			Quorum:              quorum,
+			PartialQuorum:       partialQuorum,
+			DomainType:          networkconfig.TestNetwork.Domain,
+			FeeRecipientAddress: common.HexToAddress("0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e"),
+			Graffiti:            bytes.Repeat([]byte{0x01}, 32),
 		},
-		Metadata: types.Metadata{
+		Metadata: ssvtypes.Metadata{
 			BeaconMetadata: &beaconprotocol.ValidatorMetadata{
-				Balance: 1,
-				Status:  2,
-				Index:   3,
+				Balance:         1,
+				Status:          2,
+				Index:           3,
+				ActivationEpoch: 4,
 			},
 			OwnerAddress: common.HexToAddress("0xFeedB14D8b2C76FdF808C29818b06b830E8C2c0e"),
 			Liquidated:   true,
 		},
 	}, &sk1
+}
+
+func generateMaxPossibleShare() (*ssvtypes.SSVShare, error) {
+	threshold.Init()
+
+	sk := &bls.SecretKey{}
+	sk.SetByCSPRNG()
+
+	const keysCount = 13
+
+	splitKeys, err := threshold.Create(sk.Serialize(), keysCount-1, keysCount)
+	if err != nil {
+		return nil, err
+	}
+
+	validatorShare, _ := generateRandomValidatorShare(splitKeys)
+	return validatorShare, nil
 }
 
 func newShareStorageForTest(logger *zap.Logger) (Shares, func()) {

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"sort"
+	"strconv"
 	"testing"
 
 	spectypes "github.com/bloxapp/ssv-spec/types"
@@ -49,6 +50,10 @@ func TestValidatorSerializer(t *testing.T) {
 	require.Equal(t, v1.BeaconMetadata, validatorShare.BeaconMetadata)
 	require.Equal(t, v1.OwnerAddress, validatorShare.OwnerAddress)
 	require.Equal(t, v1.Liquidated, validatorShare.Liquidated)
+
+	tooBigEncodedShare := bytes.Repeat(obj.Value, 10)
+	require.ErrorContains(t, v1.Decode(tooBigEncodedShare),
+		"share size is too big, got "+strconv.Itoa(len(tooBigEncodedShare))+", max allowed "+strconv.Itoa(ssvtypes.MaxAllowedShareSize))
 }
 
 func TestMaxPossibleShareSize(t *testing.T) {


### PR DESCRIPTION
Max share size seems to be 1245. Limiting max allowed input size to twice of that