### PR TITLE
test: add slashing tests

### DIFF
--- a/ekm/eth_key_manager_signer.go
+++ b/ekm/eth_key_manager_signer.go
@@ -260,7 +260,8 @@ func (km *ethKeyManagerSigner) AddShare(shareKey *bls.SecretKey) error {
 		return errors.Wrap(err, "could not check share existence")
 	}
 	if acc == nil {
-		if err := km.saveMinimalSlashingProtection(shareKey.GetPublicKey().Serialize()); err != nil {
+		currentSlot := km.storage.Network().EstimatedCurrentSlot()
+		if err := km.saveMinimalSlashingProtection(shareKey.GetPublicKey().Serialize(), currentSlot); err != nil {
 			return errors.Wrap(err, "could not save minimal slashing protection")
 		}
 		if err := km.saveShare(shareKey); err != nil {
@@ -271,8 +272,7 @@ func (km *ethKeyManagerSigner) AddShare(shareKey *bls.SecretKey) error {
 	return nil
 }
 
-func (km *ethKeyManagerSigner) saveMinimalSlashingProtection(pk []byte) error {
-	currentSlot := km.storage.Network().EstimatedCurrentSlot()
+func (km *ethKeyManagerSigner) saveMinimalSlashingProtection(pk []byte, currentSlot phase0.Slot) error {
 	currentEpoch := km.storage.Network().EstimatedEpochAtSlot(currentSlot)
 	highestTarget := currentEpoch + minimalAttSlashingProtectionEpochDistance
 	highestSource := highestTarget - 1

--- a/ekm/signer_key_manager_test.go
+++ b/ekm/signer_key_manager_test.go
@@ -323,7 +323,7 @@ func TestSlashing_Attestation(t *testing.T) {
 	// 1. Check a valid attestation.
 	signAttestation(secretKeys[1], phase0.Root{1}, createAttestationData(3, 4), false, "")
 
-	// 2. Same signing root -> slashing (stricter than spec).
+	// 2. Same signing root -> slashing (stricter than Eth spec).
 	signAttestation(secretKeys[1], phase0.Root{1}, createAttestationData(3, 4), true, "")
 
 	// 3. Lower than minimum source epoch -> expect slashing.
@@ -338,14 +338,14 @@ func TestSlashing_Attestation(t *testing.T) {
 	// 6. Different signing root, higher source epoch, higher target epoch -> no slashing.
 	signAttestation(secretKeys[1], phase0.Root{3}, createAttestationData(4, 5), false, "")
 
-	// 7. Different signing root, lower source epoch, higher target epoch -> slashing (stricter than spec).
+	// 7. Different signing root, lower source epoch, higher target epoch -> slashing (stricter than Eth spec).
 	signAttestation(secretKeys[1], phase0.Root{3}, createAttestationData(3, 5), true, "")
 
 	// 8. Different signing root, higher source epoch, higher target epoch (again) -> expect slashing (double vote).
 	signAttestation(secretKeys[1], phase0.Root{byte(4)}, createAttestationData(3, 5), true, "HighestAttestationVote")
 
 	// 9. Lower source epoch, higher target epoch -> expect slashing. Should fail due to surrounding,
-	// but since check 7 is stricter than spec, this will fail due to double vote.
+	// but since check 7 is stricter than Eth spec, this will fail due to double vote.
 	for root := 1; root <= 5; root++ {
 		signAttestation(secretKeys[1], phase0.Root{byte(root)}, createAttestationData(3, 6), true, "HighestAttestationVote")
 	}

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -58,7 +58,8 @@ diffLoop:
 						si.subnets[subnet] = make([]peer.ID, 0)
 					} else {
 						// #nosec
-						// False positive by the linter, it says potential out of bounds, but it can't be because we're inside a for on `peers`.
+						// False positive by the linter, it says potential out of bounds,
+						// but it can't be because we're inside a for on `peers`.
 						si.subnets[subnet] = peers[1:]
 					}
 					continue diffLoop

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -57,7 +57,7 @@ diffLoop:
 					if len(peers) == 1 {
 						si.subnets[subnet] = make([]peer.ID, 0)
 					} else {
-// #nosec
+						// #nosec
 						// The slice operation is safe here because we're checking that the length of peers is not 1.
 						// In Go, slicing beyond the end of an array yields an empty slice, which is acceptable in this context.
 						si.subnets[subnet] = peers[1:]

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -57,7 +57,7 @@ diffLoop:
 					if len(peers) == 1 {
 						si.subnets[subnet] = make([]peer.ID, 0)
 					} else {
-						si.subnets[subnet] = peers[1:]
+						si.subnets[subnet] = peers[1:] //nolint:all
 					}
 					continue diffLoop
 				}

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -57,7 +57,10 @@ diffLoop:
 					if len(peers) == 1 {
 						si.subnets[subnet] = make([]peer.ID, 0)
 					} else {
-						si.subnets[subnet] = peers[1:] //nolint:all
+// #nosec
+						// The slice operation is safe here because we're checking that the length of peers is not 1.
+						// In Go, slicing beyond the end of an array yields an empty slice, which is acceptable in this context.
+						si.subnets[subnet] = peers[1:]
 					}
 					continue diffLoop
 				}

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -58,8 +58,7 @@ diffLoop:
 						si.subnets[subnet] = make([]peer.ID, 0)
 					} else {
 						// #nosec
-						// The slice operation is safe here because we're checking that the length of peers is not 1.
-						// In Go, slicing beyond the end of an array yields an empty slice, which is acceptable in this context.
+						// False positive by the linter, it says potential out of bounds, but it can't be because we're inside a for on `peers`.
 						si.subnets[subnet] = peers[1:]
 					}
 					continue diffLoop


### PR DESCRIPTION
This PR adds various slashing tests which attempt to prove that the slashing protection would block double & surrounding votes.