### PR TITLE
Configuration Docs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -32,4 +32,5 @@ func Execute(appName, version string) {
 func init() {
 	RootCmd.AddCommand(bootnode.StartBootNodeCmd)
 	RootCmd.AddCommand(operator.StartNodeCmd)
+	RootCmd.AddCommand(operator.GenerateDocCmd)
 }

--- a/cli/operator/generate_doc.go
+++ b/cli/operator/generate_doc.go
@@ -1,0 +1,63 @@
+package operator
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/aquasecurity/table"
+	"github.com/spf13/cobra"
+)
+
+type ArgumentDoc struct {
+	FieldName   string
+	YAMLName    string
+	EnvName     string
+	Default     string
+	Description string
+}
+
+var GenerateDocCmd = &cobra.Command{
+	Use:   "doc",
+	Short: "Generate CLI documentation for the node",
+	Run: func(cmd *cobra.Command, args []string) {
+		var cfg config
+		t := reflect.TypeOf(cfg)
+
+		var docs []ArgumentDoc
+		getAllFields(t, "", "", &docs)
+
+		tbl := table.New(os.Stdout)
+		tbl.SetHeaders("YAML", "ENV", "Default", "Description")
+		for _, doc := range docs {
+			tbl.AddRow(doc.YAMLName, doc.EnvName, doc.Default, doc.Description)
+		}
+		tbl.Render()
+	},
+}
+
+// Recursive function to get all fields with "env" or "yaml" tags.
+func getAllFields(rt reflect.Type, prefix string, yamlPrefix string, docs *[]ArgumentDoc) {
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		// Generate the full path of field names for nested fields.
+		fieldName := prefix + field.Name
+		yamlName := yamlPrefix + field.Tag.Get("yaml")
+		envTag := field.Tag.Get("env")
+
+		if yamlName != yamlPrefix || envTag != "" {
+			*docs = append(*docs, ArgumentDoc{
+				FieldName:   fieldName,
+				YAMLName:    yamlName,
+				EnvName:     envTag,
+				Default:     field.Tag.Get("env-default"),
+				Description: field.Tag.Get("env-description"),
+			})
+		}
+
+		// Recursion for nested structs.
+		if field.Type.Kind() == reflect.Struct {
+			getAllFields(field.Type, fieldName+".", yamlName+".", docs)
+		}
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,5 @@
+# Configuration
+
+You can configure the operator node by editing the `config.yaml` file or by setting environment variables.
+
+Check out the complete list of available options by running `make build && ./bin/ssvnode doc`.


### PR DESCRIPTION
This PR adds a CLI command to automatically generate documentation about the available YAML/env options.

Example output:
```
┌─────────────────────────────────────────────────┬──────────────────────────────┬──────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                      YAML                       │             ENV              │     Default      │                                             Description                                             │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ global                                          │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ global.LogLevel                                 │ LOG_LEVEL                    │ info             │ Defines logger's log level'                                                                         │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ global.LogFormat                                │ LOG_FORMAT                   │ console          │ Defines logger's encoding, valid values are 'json' (default) and 'console''                         │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ global.LogLevelFormat                           │ LOG_LEVEL_FORMAT             │ capitalColor     │ Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase'' │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ global.LogFilePath                              │ LOG_FILE_PATH                │ ./data/debug.log │ Defines a file path to write logs into                                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ db                                              │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ db.Path                                         │ DB_PATH                      │ ./data/db        │ Path for storage                                                                                    │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ db.Reporting                                    │ DB_REPORTING                 │ false            │ Flag to run on-off db size reporting                                                                │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ db.GCInterval                                   │ DB_GC_INTERVAL               │ 6m               │ Interval between garbage collection cycles. Set to 0 to disable.                                    │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv                                             │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.Network                                     │ NETWORK                      │ mainnet          │ Network is the network of this node                                                                 │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions                            │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.SignatureCollectionTimeout │ SIGNATURE_COLLECTION_TIMEOUT │ 5s               │ Timeout for signature collection after consensus                                                    │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.MetadataUpdateInterval     │ METADATA_UPDATE_INTERVAL     │ 12m              │ Interval for updating metadata                                                                      │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.HistorySyncBatchSize       │ HISTORY_SYNC_BATCH_SIZE      │ 25               │ Maximum number of messages to sync in a single batch                                                │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.MinimumPeers               │ MINIMUM_PEERS                │ 2                │ The required minimum peers for sync                                                                 │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.FullNode                   │ FULLNODE                     │ false            │ Save decided history rather than just highest messages                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.Exporter                   │ EXPORTER                     │ false            │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.BuilderProposals           │ BUILDER_PROPOSALS            │ false            │ Use external builders to produce blocks                                                             │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.MsgWorkersCount            │ MSG_WORKERS_COUNT            │ 256              │ Number of goroutines to use for message workers                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ssv.ValidatorOptions.MsgWorkerBufferSize        │ MSG_WORKER_BUFFER_SIZE       │ 1024             │ Buffer size for message workers                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ eth1                                            │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ eth1.ETH1Addr                                   │ ETH_1_ADDR                   │                  │ Execution client WebSocket address                                                                  │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ eth1.ETH1ConnectionTimeout                      │ ETH_1_CONNECTION_TIMEOUT     │ 10s              │ Execution client connection timeout                                                                 │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ eth2                                            │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ eth2.BeaconNodeAddr                             │ BEACON_NODE_ADDR             │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p                                             │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.Bootnodes                                   │ BOOTNODES                    │                  │ Bootnodes to use to start discovery, seperated with ';'                                             │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.Discovery                                   │ P2P_DISCOVERY                │ discv5           │ Discovery system to use                                                                             │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.TcpPort                                     │ TCP_PORT                     │ 13001            │ TCP port for p2p transport                                                                          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.UdpPort                                     │ UDP_PORT                     │ 12001            │ UDP port for discovery                                                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.HostAddress                                 │ HOST_ADDRESS                 │                  │ External ip node is exposed for discovery                                                           │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.HostDNS                                     │ HOST_DNS                     │                  │ External DNS node is exposed for discovery                                                          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.RequestTimeout                              │ P2P_REQUEST_TIMEOUT          │ 10s              │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.MaxBatchResponse                            │ P2P_MAX_BATCH_RESPONSE       │ 25               │ Maximum number of returned objects in a batch                                                       │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.MaxPeers                                    │ P2P_MAX_PEERS                │ 60               │ Connected peers limit for connections                                                               │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.TopicMaxPeers                               │ P2P_TOPIC_MAX_PEERS          │ 10               │ Connected peers limit per pubsub topic                                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.Subnets                                     │ SUBNETS                      │                  │ Hex string that represents the subnets that this node will join upon start                          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubSubScoring                               │ PUBSUB_SCORING               │ true             │ Flag to turn on/off pubsub scoring                                                                  │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubSubTrace                                 │ PUBSUB_TRACE                 │                  │ Flag to turn on/off pubsub tracing in logs                                                          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.DiscoveryTrace                              │ DISCOVERY_TRACE              │                  │ Flag to turn on/off discovery tracing in logs                                                       │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubsubMsgCacheTTL                           │ PUBSUB_MSG_CACHE_TTL         │                  │ How long a message ID will be remembered as seen                                                    │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubsubOutQueueSize                          │ PUBSUB_OUT_Q_SIZE            │                  │ The size that we assign to the outbound pubsub message queue                                        │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubsubValidationQueueSize                   │ PUBSUB_VAL_Q_SIZE            │                  │ The size that we assign to the pubsub validation queue                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PubsubPubsubValidateThrottle                │ PUBSUB_VAL_THROTTLE          │                  │ The amount of goroutines used for pubsub msg validation                                             │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PermissionedActivateEpoch                   │ PERMISSIONED_ACTIVE_EPOCH    │ 0                │ On which epoch to start only accepting peers that are operators registered in the contract          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.PermissionedDeactivateEpoch                 │ PERMISSIONED_DEACTIVE_EPOCH  │ 99999999999999   │ On which epoch to start accepting operators all peers                                               │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ p2p.WhitelistedOperatorKeys                     │ WHITELISTED_KEYS             │                  │ Operators' keys not registered in the contract with which the node will accept connections          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ KeyStore                                        │                              │                  │                                                                                                     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ KeyStore.PrivateKeyFile                         │ PRIVATE_KEY_FILE             │                  │ Operator private key file                                                                           │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ KeyStore.PasswordFile                           │ PASSWORD_FILE                │                  │ Password for operator private key file decryption                                                   │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ OperatorPrivateKey                              │ OPERATOR_KEY                 │                  │ Operator private key, used to decrypt contract events                                               │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ MetricsAPIPort                                  │ METRICS_API_PORT             │                  │ Port to listen on for the metrics API.                                                              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ EnableProfile                                   │ ENABLE_PROFILE               │                  │ flag that indicates whether go profiling tools are enabled                                          │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ NetworkPrivateKey                               │ NETWORK_PRIVATE_KEY          │                  │ private key for network identity                                                                    │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ WebSocketAPIPort                                │ WS_API_PORT                  │                  │ Port to listen on for the websocket API.                                                            │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ WithPing                                        │ WITH_PING                    │                  │ Whether to send websocket ping messages'                                                            │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ SSVAPIPort                                      │ SSV_API_PORT                 │                  │ Port to listen on for the SSV API.                                                                  │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ LocalEventsPath                                 │ EVENTS_PATH                  │                  │ path to local events                                                                                │
└─────────────────────────────────────────────────┴──────────────────────────────┴──────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────┘
```