### PR TITLE
fix: jammed `indicesChange` channel

### DIFF
--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -270,13 +270,12 @@ func TestScheduler_Regression_IndiciesChangeStuck(t *testing.T) {
 	err := s.Start(ctx, logger)
 	require.NoError(t, err)
 
+	s.indicesChg <- struct{}{} // first time make fanout stuck
 	select {
-	case s.indicesChg <- struct{}{}: // first time make fanout stuck
-		select {
-		case s.indicesChg <- struct{}{}: // second send should hang
-			break
-		default:
-			t.Fatal("Channel is jammed")
-		}
+	case s.indicesChg <- struct{}{}: // second send should hang
+		break
+	default:
+		t.Fatal("Channel is jammed")
 	}
+
 }

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -242,7 +242,8 @@ func TestScheduler_Regression_IndiciesChangeStuck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	logger := logging.TestLogger(t)
 
 	mockBeaconNode := mocks.NewMockBeaconNode(ctrl)

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -237,3 +237,46 @@ func TestScheduler_Run(t *testing.T) {
 	cancel()
 	require.NoError(t, s.Wait())
 }
+
+func TestScheduler_Regression_IndiciesChangeStuck(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, _ := context.WithCancel(context.Background())
+	logger := logging.TestLogger(t)
+
+	mockBeaconNode := mocks.NewMockBeaconNode(ctrl)
+	mockValidatorController := mocks.NewMockValidatorController(ctrl)
+	mockTicker := mockslotticker.NewMockTicker(ctrl)
+	// create multiple mock duty handlers
+
+	opts := &SchedulerOptions{
+		Ctx:                 ctx,
+		BeaconNode:          mockBeaconNode,
+		Network:             networkconfig.TestNetwork,
+		ValidatorController: mockValidatorController,
+		Ticker:              mockTicker,
+		IndicesChg:          make(chan struct{}),
+
+		BuilderProposals: true,
+	}
+
+	s := NewScheduler(opts)
+
+	// add multiple mock duty handlers
+	s.handlers = []dutyHandler{NewValidatorRegistrationHandler()}
+	mockBeaconNode.EXPECT().Events(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockTicker.EXPECT().Subscribe(gomock.Any()).Return(nil).Times(len(s.handlers) + 1)
+	err := s.Start(ctx, logger)
+	require.NoError(t, err)
+
+	select {
+	case s.indicesChg <- struct{}{}: // first time make fanout stuck
+		select {
+		case s.indicesChg <- struct{}{}: // second send should hang
+			break
+		default:
+			t.Fatal("Channel is jammed")
+		}
+	}
+}

--- a/operator/duties/validatorregistration.go
+++ b/operator/duties/validatorregistration.go
@@ -70,6 +70,12 @@ func (h *ValidatorRegistrationHandler) HandleDuties(ctx context.Context) {
 				h.validatorsPassedFirstRegistration[string(share.ValidatorPubKey)] = struct{}{}
 			}
 			h.logger.Debug("validator registration duties sent", zap.Uint64("slot", uint64(slot)), fields.Count(sent))
+
+		case <-h.indicesChange:
+			continue
+
+		case <-h.reorg:
+			continue
 		}
 	}
 }


### PR DESCRIPTION
One of the subscribers of that channel was not reading messages from it, which caused the `event.Feed` to get stuck on it's `Send` method for eternity.