### PR TITLE
chore: change order of go get cmds

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -10,13 +10,14 @@ RUN apt-get update && apt upgrade -y && \
 
 RUN go version
 ENV GO111MODULE=on
-RUN go get github.com/go-delve/delve/cmd/dlv
-RUN go get -u github.com/cosmtrek/air@v1.27.8
 
 WORKDIR /go/src/github.com/bloxapp/ssv/
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/cosmtrek/air@v1.27.8
 
 COPY . .
 


### PR DESCRIPTION
Changed order of `go get` cmd because it failed with 
```
ERROR: failed to solve: process "/bin/sh -c go get github.com/go-delve/delve/cmd/dlv" did not complete successfully: exit code: 1
```