### PR TITLE
Fix: Use Share PublicKey for Share Removal

### DIFF
--- a/ekm/signer_storage.go
+++ b/ekm/signer_storage.go
@@ -47,17 +47,19 @@ type Storage interface {
 	SetEncryptionKey(newKey string) error
 	ListAccountsTxn(r basedb.Reader) ([]core.ValidatorAccount, error)
 	SaveAccountTxn(rw basedb.ReadWriter, account core.ValidatorAccount) error
+
+	BeaconNetwork() beacon.BeaconNetwork
 }
 
 type storage struct {
 	db            basedb.Database
-	network       beacon.Network
+	network       beacon.BeaconNetwork
 	encryptionKey []byte
 	logger        *zap.Logger // struct logger is used because core.Storage does not support passing a logger
 	lock          sync.RWMutex
 }
 
-func NewSignerStorage(db basedb.Database, network beacon.Network, logger *zap.Logger) Storage {
+func NewSignerStorage(db basedb.Database, network beacon.BeaconNetwork, logger *zap.Logger) Storage {
 	return &storage{
 		db:      db,
 		network: network,
@@ -87,7 +89,7 @@ func (s *storage) DropRegistryData() error {
 }
 
 func (s *storage) objPrefix(obj string) []byte {
-	return []byte(string(s.network.BeaconNetwork) + obj)
+	return []byte(string(s.network.GetBeaconNetwork()) + obj)
 }
 
 // Name returns storage name.
@@ -97,7 +99,7 @@ func (s *storage) Name() string {
 
 // Network returns the network storage is related to.
 func (s *storage) Network() core.Network {
-	return core.Network(s.network.BeaconNetwork)
+	return core.Network(s.network.GetBeaconNetwork())
 }
 
 // SaveWallet stores the given wallet.
@@ -405,4 +407,8 @@ func (s *storage) decrypt(data []byte) ([]byte, error) {
 
 	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
 	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+
+func (s *storage) BeaconNetwork() beacon.BeaconNetwork {
+	return s.network
 }

--- a/eth/eventhandler/event_handler.go
+++ b/eth/eventhandler/event_handler.go
@@ -46,7 +46,7 @@ var (
 
 type taskExecutor interface {
 	StartValidator(share *ssvtypes.SSVShare) error
-	StopValidator(share *ssvtypes.SSVShare) error
+	StopValidator(pubKey spectypes.ValidatorPK) error
 	LiquidateCluster(owner ethcommon.Address, operatorIDs []uint64, toLiquidate []*ssvtypes.SSVShare) error
 	ReactivateCluster(owner ethcommon.Address, operatorIDs []uint64, toReactivate []*ssvtypes.SSVShare) error
 	UpdateFeeRecipient(owner, recipient ethcommon.Address) error
@@ -285,7 +285,7 @@ func (eh *EventHandler) processEvent(txn basedb.Txn, event ethtypes.Log) (Task, 
 			return nil, nil
 		}
 
-		share, err := eh.handleValidatorRemoved(txn, validatorRemovedEvent)
+		validatorPubKey, err := eh.handleValidatorRemoved(txn, validatorRemovedEvent)
 		if err != nil {
 			eh.metrics.EventProcessingFailed(abiEvent.Name)
 
@@ -298,8 +298,8 @@ func (eh *EventHandler) processEvent(txn basedb.Txn, event ethtypes.Log) (Task, 
 
 		defer eh.metrics.EventProcessed(abiEvent.Name)
 
-		if share != nil {
-			return NewStopValidatorTask(eh.taskExecutor, share), nil
+		if validatorPubKey != nil {
+			return NewStopValidatorTask(eh.taskExecutor, validatorPubKey), nil
 		}
 
 		return nil, nil

--- a/eth/eventhandler/event_handler.go
+++ b/eth/eventhandler/event_handler.go
@@ -46,7 +46,7 @@ var (
 
 type taskExecutor interface {
 	StartValidator(share *ssvtypes.SSVShare) error
-	StopValidator(publicKey []byte) error
+	StopValidator(share *ssvtypes.SSVShare) error
 	LiquidateCluster(owner ethcommon.Address, operatorIDs []uint64, toLiquidate []*ssvtypes.SSVShare) error
 	ReactivateCluster(owner ethcommon.Address, operatorIDs []uint64, toReactivate []*ssvtypes.SSVShare) error
 	UpdateFeeRecipient(owner, recipient ethcommon.Address) error
@@ -285,7 +285,7 @@ func (eh *EventHandler) processEvent(txn basedb.Txn, event ethtypes.Log) (Task, 
 			return nil, nil
 		}
 
-		sharePK, err := eh.handleValidatorRemoved(txn, validatorRemovedEvent)
+		share, err := eh.handleValidatorRemoved(txn, validatorRemovedEvent)
 		if err != nil {
 			eh.metrics.EventProcessingFailed(abiEvent.Name)
 
@@ -298,13 +298,11 @@ func (eh *EventHandler) processEvent(txn basedb.Txn, event ethtypes.Log) (Task, 
 
 		defer eh.metrics.EventProcessed(abiEvent.Name)
 
-		if sharePK == nil {
-			return nil, nil
+		if share != nil {
+			return NewStopValidatorTask(eh.taskExecutor, share), nil
 		}
 
-		task := NewStopValidatorTask(eh.taskExecutor, validatorRemovedEvent.PublicKey)
-
-		return task, nil
+		return nil, nil
 
 	case ClusterLiquidated:
 		clusterLiquidatedEvent, err := eh.eventParser.ParseClusterLiquidated(event)

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -236,26 +236,13 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			eventsCh <- block
 		}()
 
-		sharePubKey := validatorData1.operatorsShares[0].sec.GetPublicKey().Serialize()
 		lastProcessedBlock, err := eh.HandleBlockEventsStream(eventsCh, false)
 		require.NoError(t, err)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
-
-		accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(accounts))
-		require.True(t, shareExist(accounts, sharePubKey))
-
-		highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-		require.NoError(t, err)
-		require.True(t, found)
-		require.NotNil(t, highestAttestation)
-
-		_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-		require.NoError(t, err)
-		require.True(t, found)
-
 		blockNum++
+
+		requireKeyManagerDataToExist(t, eh, 1, validatorData1)
+
 		// Check that validator was registered
 		shares := eh.nodeStorage.Shares().List(nil)
 		require.Equal(t, 1, len(shares))
@@ -301,26 +288,12 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			sharePubKey := validatorData2.operatorsShares[0].sec.GetPublicKey().Serialize()
 			lastProcessedBlock, err = eh.HandleBlockEventsStream(eventsCh, false)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
-
-			accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-			require.NoError(t, err)
-			require.Equal(t, 1, len(accounts))
-			require.False(t, shareExist(accounts, sharePubKey))
-
-			highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-			require.NoError(t, err)
-			require.False(t, found)
-			require.Nil(t, highestAttestation)
-
-			_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-			require.NoError(t, err)
-			require.False(t, found)
-
 			blockNum++
+
+			requireKeyManagerDataToNotExist(t, eh, 1, validatorData2)
 
 			// Check that validator was not registered,
 			shares = eh.nodeStorage.Shares().List(nil)
@@ -364,26 +337,12 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			sharePubKey := validatorData2.operatorsShares[0].sec.GetPublicKey().Serialize()
 			lastProcessedBlock, err = eh.HandleBlockEventsStream(eventsCh, false)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
-
-			accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-			require.NoError(t, err)
-			require.Equal(t, 2, len(accounts))
-			require.True(t, shareExist(accounts, sharePubKey))
-
-			highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-			require.NoError(t, err)
-			require.True(t, found)
-			require.NotNil(t, highestAttestation)
-
-			_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-			require.NoError(t, err)
-			require.True(t, found)
-
 			blockNum++
+
+			requireKeyManagerDataToExist(t, eh, 2, validatorData2)
 
 			// Check that validator was registered for op1,
 			shares = eh.nodeStorage.Shares().List(nil)
@@ -437,26 +396,12 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			sharePubKey := validatorData3.operatorsShares[0].sec.GetPublicKey().Serialize()
 			lastProcessedBlock, err = eh.HandleBlockEventsStream(eventsCh, false)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
-
-			accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-			require.NoError(t, err)
-			require.Equal(t, 2, len(accounts))
-			require.False(t, shareExist(accounts, sharePubKey))
-
-			highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-			require.NoError(t, err)
-			require.False(t, found)
-			require.Nil(t, highestAttestation)
-
-			_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-			require.NoError(t, err)
-			require.False(t, found)
-
 			blockNum++
+
+			requireKeyManagerDataToNotExist(t, eh, 2, validatorData3)
 
 			// Check that validator was not registered
 			shares = eh.nodeStorage.Shares().List(nil)
@@ -499,26 +444,12 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			sharePubKey := validatorData3.operatorsShares[0].sec.GetPublicKey().Serialize()
 			lastProcessedBlock, err = eh.HandleBlockEventsStream(eventsCh, false)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
-
-			accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-			require.NoError(t, err)
-			require.Equal(t, 3, len(accounts))
-			require.True(t, shareExist(accounts, sharePubKey))
-
-			highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-			require.NoError(t, err)
-			require.True(t, found)
-			require.NotNil(t, highestAttestation)
-
-			_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-			require.NoError(t, err)
-			require.True(t, found)
-
 			blockNum++
+
+			requireKeyManagerDataToExist(t, eh, 3, validatorData3)
 
 			// Check that validator was registered
 			shares = eh.nodeStorage.Shares().List(nil)
@@ -557,26 +488,14 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			eventsCh <- block
 		}()
 
-		sharePubKey := validatorData1.operatorsShares[0].sec.GetPublicKey().Serialize()
+		requireKeyManagerDataToExist(t, eh, 3, validatorData1)
+
 		lastProcessedBlock, err := eh.HandleBlockEventsStream(eventsCh, true)
 		require.NoError(t, err)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
-
-		accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
-		require.NoError(t, err)
-		require.Equal(t, 2, len(accounts))
-		require.False(t, shareExist(accounts, sharePubKey))
-
-		highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
-		require.NoError(t, err)
-		require.False(t, found)
-		require.Nil(t, highestAttestation)
-
-		_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
-		require.NoError(t, err)
-		require.False(t, found)
-
 		blockNum++
+
+		requireKeyManagerDataToNotExist(t, eh, 2, validatorData1)
 	})
 
 	// Receive event, unmarshall, parse, check parse event is not nil or with an error, owner is correct, operator ids are correct
@@ -996,4 +915,38 @@ func generateSharesData(validatorData *testValidatorData, operators []*testOpera
 	sharesDataSigned := append(sig, sharesData...)
 
 	return sharesDataSigned, nil
+}
+
+func requireKeyManagerDataToExist(t *testing.T, eh *EventHandler, expectedAccounts int, validatorData *testValidatorData) {
+	sharePubKey := validatorData.operatorsShares[0].sec.GetPublicKey().Serialize()
+	accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
+	require.NoError(t, err)
+	require.Equal(t, expectedAccounts, len(accounts))
+	require.True(t, shareExist(accounts, sharePubKey))
+
+	highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, highestAttestation)
+
+	_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
+	require.NoError(t, err)
+	require.True(t, found)
+}
+
+func requireKeyManagerDataToNotExist(t *testing.T, eh *EventHandler, expectedAccounts int, validatorData *testValidatorData) {
+	sharePubKey := validatorData.operatorsShares[0].sec.GetPublicKey().Serialize()
+	accounts, err := eh.keyManager.(ekm.StorageProvider).ListAccounts()
+	require.NoError(t, err)
+	require.Equal(t, expectedAccounts, len(accounts))
+	require.False(t, shareExist(accounts, sharePubKey))
+
+	highestAttestation, found, err := eh.keyManager.(ekm.StorageProvider).RetrieveHighestAttestation(sharePubKey)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, highestAttestation)
+
+	_, found, err = eh.keyManager.(ekm.StorageProvider).RetrieveHighestProposal(sharePubKey)
+	require.NoError(t, err)
+	require.False(t, found)
 }

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -324,11 +324,11 @@ func validatorAddedEventToShare(
 	return &validatorShare, shareSecret, nil
 }
 
-func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) ([]byte, error) {
+func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) (*types.SSVShare, error) {
 	logger := eh.logger.With(
 		zap.String("event_type", ValidatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
-		zap.String("owner_address", event.Owner.String()),
+		fields.Owner(event.Owner),
 		zap.Uint64s("operator_ids", event.OperatorIds),
 		fields.PubKey(event.PublicKey),
 	)
@@ -374,7 +374,7 @@ func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.C
 	if isOperatorShare {
 		eh.metrics.ValidatorRemoved(event.PublicKey)
 		logger.Debug("processed event")
-		return share.ValidatorPubKey, nil
+		return share, nil
 	}
 
 	logger.Debug("processed event")

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -39,10 +39,10 @@ var (
 
 func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.ContractOperatorAdded) error {
 	logger := eh.logger.With(
-		zap.String("event_type", OperatorAdded),
+		fields.EventName(OperatorAdded),
 		fields.TxHash(event.Raw.TxHash),
 		fields.OperatorID(event.OperatorId),
-		zap.String("owner_address", event.Owner.String()),
+		fields.Owner(event.Owner),
 		fields.OperatorPubKey(event.PublicKey),
 	)
 	logger.Debug("processing event")
@@ -85,7 +85,7 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 
 func (eh *EventHandler) handleOperatorRemoved(txn basedb.Txn, event *contract.ContractOperatorRemoved) error {
 	logger := eh.logger.With(
-		zap.String("event_type", OperatorRemoved),
+		fields.EventName(OperatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
 		fields.OperatorID(event.OperatorId),
 	)
@@ -101,8 +101,8 @@ func (eh *EventHandler) handleOperatorRemoved(txn basedb.Txn, event *contract.Co
 	}
 
 	logger = logger.With(
-		zap.String("operator_pub_key", ethcommon.Bytes2Hex(od.PublicKey)),
-		zap.String("owner_address", od.OwnerAddress.String()),
+		fields.OperatorPubKey(od.PublicKey),
+		fields.Owner(od.OwnerAddress),
 	)
 
 	// TODO: In original handler we didn't delete operator data, so this behavior was preserved. However we likely need to.
@@ -124,10 +124,10 @@ func (eh *EventHandler) handleOperatorRemoved(txn basedb.Txn, event *contract.Co
 
 func (eh *EventHandler) handleValidatorAdded(txn basedb.Txn, event *contract.ContractValidatorAdded) (ownShare *ssvtypes.SSVShare, err error) {
 	logger := eh.logger.With(
-		zap.String("event_type", ValidatorAdded),
+		fields.EventName(ValidatorAdded),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
-		zap.Uint64s("operator_ids", event.OperatorIds),
+		fields.OperatorIDs(event.OperatorIds),
 		fields.Validator(event.PublicKey),
 	)
 
@@ -326,10 +326,10 @@ func validatorAddedEventToShare(
 
 func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) (*types.SSVShare, error) {
 	logger := eh.logger.With(
-		zap.String("event_type", ValidatorRemoved),
+		fields.EventName(ValidatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
-		zap.Uint64s("operator_ids", event.OperatorIds),
+		fields.OperatorIDs(event.OperatorIds),
 		fields.PubKey(event.PublicKey),
 	)
 	logger.Debug("processing event")
@@ -372,6 +372,11 @@ func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.C
 		logger = logger.With(zap.String("validator_pubkey", hex.EncodeToString(share.ValidatorPubKey)))
 	}
 	if isOperatorShare {
+		err = eh.keyManager.RemoveShare(hex.EncodeToString(share.SharePubKey))
+		if err != nil {
+			return nil, fmt.Errorf("could not remove share from ekm storage: %w", err)
+		}
+
 		eh.metrics.ValidatorRemoved(event.PublicKey)
 		logger.Debug("processed event")
 		return share, nil
@@ -383,10 +388,10 @@ func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.C
 
 func (eh *EventHandler) handleClusterLiquidated(txn basedb.Txn, event *contract.ContractClusterLiquidated) ([]*ssvtypes.SSVShare, error) {
 	logger := eh.logger.With(
-		zap.String("event_type", ClusterLiquidated),
+		fields.EventName(ClusterLiquidated),
 		fields.TxHash(event.Raw.TxHash),
-		zap.String("owner_address", event.Owner.String()),
-		zap.Uint64s("operator_ids", event.OperatorIds),
+		fields.Owner(event.Owner),
+		fields.OperatorIDs(event.OperatorIds),
 	)
 	logger.Debug("processing event")
 
@@ -405,10 +410,10 @@ func (eh *EventHandler) handleClusterLiquidated(txn basedb.Txn, event *contract.
 
 func (eh *EventHandler) handleClusterReactivated(txn basedb.Txn, event *contract.ContractClusterReactivated) ([]*ssvtypes.SSVShare, error) {
 	logger := eh.logger.With(
-		zap.String("event_type", ClusterReactivated),
+		fields.EventName(ClusterReactivated),
 		fields.TxHash(event.Raw.TxHash),
-		zap.String("owner_address", event.Owner.String()),
-		zap.Uint64s("operator_ids", event.OperatorIds),
+		fields.Owner(event.Owner),
+		fields.OperatorIDs(event.OperatorIds),
 	)
 	logger.Debug("processing event")
 
@@ -427,9 +432,9 @@ func (eh *EventHandler) handleClusterReactivated(txn basedb.Txn, event *contract
 
 func (eh *EventHandler) handleFeeRecipientAddressUpdated(txn basedb.Txn, event *contract.ContractFeeRecipientAddressUpdated) (bool, error) {
 	logger := eh.logger.With(
-		zap.String("event_type", FeeRecipientAddressUpdated),
+		fields.EventName(FeeRecipientAddressUpdated),
 		fields.TxHash(event.Raw.TxHash),
-		zap.String("owner_address", event.Owner.String()),
+		fields.Owner(event.Owner),
 		fields.FeeRecipient(event.RecipientAddress.Bytes()),
 	)
 	logger.Debug("processing event")

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -324,7 +324,7 @@ func validatorAddedEventToShare(
 	return &validatorShare, shareSecret, nil
 }
 
-func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) (*types.SSVShare, error) {
+func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) (spectypes.ValidatorPK, error) {
 	logger := eh.logger.With(
 		fields.EventName(ValidatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
@@ -379,7 +379,7 @@ func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.C
 
 		eh.metrics.ValidatorRemoved(event.PublicKey)
 		logger.Debug("processed event")
-		return share, nil
+		return share.ValidatorPubKey, nil
 	}
 
 	logger.Debug("processed event")

--- a/eth/eventhandler/task.go
+++ b/eth/eventhandler/task.go
@@ -1,9 +1,10 @@
 package eventhandler
 
 import (
+	spectypes "github.com/bloxapp/ssv-spec/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
-	ssvtypes "github.com/bloxapp/ssv/protocol/v2/types"
+	"github.com/bloxapp/ssv/protocol/v2/types"
 )
 
 type Task interface {
@@ -11,15 +12,15 @@ type Task interface {
 }
 
 type startValidatorExecutor interface {
-	StartValidator(share *ssvtypes.SSVShare) error
+	StartValidator(share *types.SSVShare) error
 }
 
 type StartValidatorTask struct {
 	executor startValidatorExecutor
-	share    *ssvtypes.SSVShare
+	share    *types.SSVShare
 }
 
-func NewStartValidatorTask(executor startValidatorExecutor, share *ssvtypes.SSVShare) *StartValidatorTask {
+func NewStartValidatorTask(executor startValidatorExecutor, share *types.SSVShare) *StartValidatorTask {
 	return &StartValidatorTask{
 		executor: executor,
 		share:    share,
@@ -31,15 +32,15 @@ func (t StartValidatorTask) Execute() error {
 }
 
 type stopValidatorExecutor interface {
-	StopValidator(share *ssvtypes.SSVShare) error
+	StopValidator(share *types.SSVShare) error
 }
 
 type StopValidatorTask struct {
 	executor stopValidatorExecutor
-	share    *ssvtypes.SSVShare
+	share    *types.SSVShare
 }
 
-func NewStopValidatorTask(executor stopValidatorExecutor, share *ssvtypes.SSVShare) *StopValidatorTask {
+func NewStopValidatorTask(executor stopValidatorExecutor, share *types.SSVShare) *StopValidatorTask {
 	return &StopValidatorTask{
 		executor: executor,
 		share:    share,
@@ -51,21 +52,21 @@ func (t StopValidatorTask) Execute() error {
 }
 
 type liquidateClusterExecutor interface {
-	LiquidateCluster(owner ethcommon.Address, operatorIDs []uint64, toLiquidate []*ssvtypes.SSVShare) error
+	LiquidateCluster(owner ethcommon.Address, operatorIDs []spectypes.OperatorID, toLiquidate []*types.SSVShare) error
 }
 
 type LiquidateClusterTask struct {
 	executor    liquidateClusterExecutor
 	owner       ethcommon.Address
-	operatorIDs []uint64
-	toLiquidate []*ssvtypes.SSVShare
+	operatorIDs []spectypes.OperatorID
+	toLiquidate []*types.SSVShare
 }
 
 func NewLiquidateClusterTask(
 	executor liquidateClusterExecutor,
 	owner ethcommon.Address,
-	operatorIDs []uint64,
-	toLiquidate []*ssvtypes.SSVShare,
+	operatorIDs []spectypes.OperatorID,
+	toLiquidate []*types.SSVShare,
 ) *LiquidateClusterTask {
 	return &LiquidateClusterTask{
 		executor:    executor,
@@ -80,21 +81,21 @@ func (t LiquidateClusterTask) Execute() error {
 }
 
 type reactivateClusterExecutor interface {
-	ReactivateCluster(owner ethcommon.Address, operatorIDs []uint64, toReactivate []*ssvtypes.SSVShare) error
+	ReactivateCluster(owner ethcommon.Address, operatorIDs []spectypes.OperatorID, toReactivate []*types.SSVShare) error
 }
 
 type ReactivateClusterTask struct {
 	executor     reactivateClusterExecutor
 	owner        ethcommon.Address
-	operatorIDs  []uint64
-	toReactivate []*ssvtypes.SSVShare
+	operatorIDs  []spectypes.OperatorID
+	toReactivate []*types.SSVShare
 }
 
 func NewReactivateClusterTask(
 	executor reactivateClusterExecutor,
 	owner ethcommon.Address,
-	operatorIDs []uint64,
-	toReactivate []*ssvtypes.SSVShare,
+	operatorIDs []spectypes.OperatorID,
+	toReactivate []*types.SSVShare,
 ) *ReactivateClusterTask {
 	return &ReactivateClusterTask{
 		executor:     executor,

--- a/eth/eventhandler/task.go
+++ b/eth/eventhandler/task.go
@@ -32,23 +32,23 @@ func (t StartValidatorTask) Execute() error {
 }
 
 type stopValidatorExecutor interface {
-	StopValidator(share *types.SSVShare) error
+	StopValidator(pubKey spectypes.ValidatorPK) error
 }
 
 type StopValidatorTask struct {
 	executor stopValidatorExecutor
-	share    *types.SSVShare
+	pubKey   spectypes.ValidatorPK
 }
 
-func NewStopValidatorTask(executor stopValidatorExecutor, share *types.SSVShare) *StopValidatorTask {
+func NewStopValidatorTask(executor stopValidatorExecutor, pubKey spectypes.ValidatorPK) *StopValidatorTask {
 	return &StopValidatorTask{
 		executor: executor,
-		share:    share,
+		pubKey:   pubKey,
 	}
 }
 
 func (t StopValidatorTask) Execute() error {
-	return t.executor.StopValidator(t.share)
+	return t.executor.StopValidator(t.pubKey)
 }
 
 type liquidateClusterExecutor interface {

--- a/eth/eventhandler/task.go
+++ b/eth/eventhandler/task.go
@@ -31,23 +31,23 @@ func (t StartValidatorTask) Execute() error {
 }
 
 type stopValidatorExecutor interface {
-	StopValidator(publicKey []byte) error
+	StopValidator(share *ssvtypes.SSVShare) error
 }
 
 type StopValidatorTask struct {
-	executor  stopValidatorExecutor
-	publicKey []byte
+	executor stopValidatorExecutor
+	share    *ssvtypes.SSVShare
 }
 
-func NewStopValidatorTask(executor stopValidatorExecutor, publicKey []byte) *StopValidatorTask {
+func NewStopValidatorTask(executor stopValidatorExecutor, share *ssvtypes.SSVShare) *StopValidatorTask {
 	return &StopValidatorTask{
-		executor:  executor,
-		publicKey: publicKey,
+		executor: executor,
+		share:    share,
 	}
 }
 
 func (t StopValidatorTask) Execute() error {
-	return t.executor.StopValidator(t.publicKey)
+	return t.executor.StopValidator(t.share)
 }
 
 type liquidateClusterExecutor interface {

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -99,7 +99,7 @@ func TestExecuteTask(t *testing.T) {
 	t.Run("test StopValidator task execution", func(t *testing.T) {
 		validatorCtrl.EXPECT().StopValidator(gomock.Any()).Return(nil).AnyTimes()
 
-		task := NewStopValidatorTask(eh.taskExecutor, &ssvtypes.SSVShare{})
+		task := NewStopValidatorTask(eh.taskExecutor, ethcommon.Hex2Bytes(valPk))
 		require.NoError(t, task.Execute())
 	})
 

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -3,8 +3,9 @@ package eventhandler
 import (
 	"context"
 	"encoding/binary"
-	"github.com/golang/mock/gomock"
 	"testing"
+
+	"github.com/golang/mock/gomock"
 
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -98,7 +99,7 @@ func TestExecuteTask(t *testing.T) {
 	t.Run("test StopValidator task execution", func(t *testing.T) {
 		validatorCtrl.EXPECT().StopValidator(gomock.Any()).Return(nil).AnyTimes()
 
-		task := NewStopValidatorTask(eh.taskExecutor, ethcommon.Hex2Bytes(valPk))
+		task := NewStopValidatorTask(eh.taskExecutor, &ssvtypes.SSVShare{})
 		require.NoError(t, task.Execute())
 	})
 

--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -64,6 +64,7 @@ const (
 	FieldName                = "name"
 	FieldNetwork             = "network"
 	FieldOperatorId          = "operator_id"
+	FieldOperatorIDs         = "operator_ids"
 	FieldOperatorPubKey      = "operator_pubkey"
 	FieldOwnerAddress        = "owner_address"
 	FieldPeerID              = "peer_id"
@@ -188,6 +189,10 @@ func SyncResults(msgs protocolp2p.SyncResults) zapcore.Field {
 
 func OperatorID(operatorId spectypes.OperatorID) zap.Field {
 	return zap.Uint64(FieldOperatorId, operatorId)
+}
+
+func OperatorIDs(operatorIDs []spectypes.OperatorID) zap.Field {
+	return zap.Uint64s(FieldOperatorIDs, operatorIDs)
 }
 
 func OperatorIDStr(operatorId string) zap.Field {

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -104,7 +104,7 @@ type Controller interface {
 	IndicesChangeChan() chan struct{}
 
 	StartValidator(share *ssvtypes.SSVShare) error
-	StopValidator(share *ssvtypes.SSVShare) error
+	StopValidator(pubKey spectypes.ValidatorPK) error
 	LiquidateCluster(owner common.Address, operatorIDs []uint64, toLiquidate []*ssvtypes.SSVShare) error
 	ReactivateCluster(owner common.Address, operatorIDs []uint64, toReactivate []*ssvtypes.SSVShare) error
 	UpdateFeeRecipient(owner, recipient common.Address) error

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -104,7 +104,7 @@ type Controller interface {
 	IndicesChangeChan() chan struct{}
 
 	StartValidator(share *ssvtypes.SSVShare) error
-	StopValidator(publicKey []byte) error
+	StopValidator(share *ssvtypes.SSVShare) error
 	LiquidateCluster(owner common.Address, operatorIDs []uint64, toLiquidate []*ssvtypes.SSVShare) error
 	ReactivateCluster(owner common.Address, operatorIDs []uint64, toReactivate []*ssvtypes.SSVShare) error
 	UpdateFeeRecipient(owner, recipient common.Address) error
@@ -647,9 +647,9 @@ func (c *controller) onMetadataUpdated(pk string, meta *beaconprotocol.Validator
 
 // onShareRemove is called when a validator was removed
 // TODO: think how we can make this function atomic (i.e. failing wouldn't stop the removal of the share)
-func (c *controller) onShareRemove(pk string, removeSecret bool) error {
+func (c *controller) onShareRemove(share *ssvtypes.SSVShare, removeSecret bool) error {
 	// remove from validatorsMap
-	v := c.validatorsMap.RemoveValidator(pk)
+	v := c.validatorsMap.RemoveValidator(hex.EncodeToString(share.ValidatorPubKey))
 
 	// stop instance
 	if v != nil {
@@ -657,7 +657,7 @@ func (c *controller) onShareRemove(pk string, removeSecret bool) error {
 	}
 	// remove the share secret from key-manager
 	if removeSecret {
-		if err := c.keyManager.RemoveShare(pk); err != nil {
+		if err := c.keyManager.RemoveShare(hex.EncodeToString(share.SharePubKey)); err != nil {
 			return errors.Wrap(err, "could not remove share secret from key manager")
 		}
 	}

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -645,24 +645,15 @@ func (c *controller) onMetadataUpdated(pk string, meta *beaconprotocol.Validator
 	}
 }
 
-// onShareRemove is called when a validator was removed
-// TODO: think how we can make this function atomic (i.e. failing wouldn't stop the removal of the share)
-func (c *controller) onShareRemove(share *ssvtypes.SSVShare, removeSecret bool) error {
+// onShareStop is called when a validator was removed or liquidated
+func (c *controller) onShareStop(pubKey spectypes.ValidatorPK) {
 	// remove from validatorsMap
-	v := c.validatorsMap.RemoveValidator(hex.EncodeToString(share.ValidatorPubKey))
+	v := c.validatorsMap.RemoveValidator(hex.EncodeToString(pubKey))
 
 	// stop instance
 	if v != nil {
 		v.Stop()
 	}
-	// remove the share secret from key-manager
-	if removeSecret {
-		if err := c.keyManager.RemoveShare(hex.EncodeToString(share.SharePubKey)); err != nil {
-			return errors.Wrap(err, "could not remove share secret from key manager")
-		}
-	}
-
-	return nil
 }
 
 func (c *controller) onShareStart(share *ssvtypes.SSVShare) (bool, error) {

--- a/operator/validator/mocks/controller.go
+++ b/operator/validator/mocks/controller.go
@@ -219,17 +219,17 @@ func (mr *MockControllerMockRecorder) StartValidators() *gomock.Call {
 }
 
 // StopValidator mocks base method.
-func (m *MockController) StopValidator(share *types0.SSVShare) error {
+func (m *MockController) StopValidator(pubKey types.ValidatorPK) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopValidator", share)
+	ret := m.ctrl.Call(m, "StopValidator", pubKey)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StopValidator indicates an expected call of StopValidator.
-func (mr *MockControllerMockRecorder) StopValidator(share interface{}) *gomock.Call {
+func (mr *MockControllerMockRecorder) StopValidator(pubKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopValidator", reflect.TypeOf((*MockController)(nil).StopValidator), share)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopValidator", reflect.TypeOf((*MockController)(nil).StopValidator), pubKey)
 }
 
 // UpdateFeeRecipient mocks base method.

--- a/operator/validator/mocks/controller.go
+++ b/operator/validator/mocks/controller.go
@@ -219,17 +219,17 @@ func (mr *MockControllerMockRecorder) StartValidators() *gomock.Call {
 }
 
 // StopValidator mocks base method.
-func (m *MockController) StopValidator(publicKey []byte) error {
+func (m *MockController) StopValidator(share *types0.SSVShare) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopValidator", publicKey)
+	ret := m.ctrl.Call(m, "StopValidator", share)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StopValidator indicates an expected call of StopValidator.
-func (mr *MockControllerMockRecorder) StopValidator(publicKey interface{}) *gomock.Call {
+func (mr *MockControllerMockRecorder) StopValidator(share interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopValidator", reflect.TypeOf((*MockController)(nil).StopValidator), publicKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopValidator", reflect.TypeOf((*MockController)(nil).StopValidator), share)
 }
 
 // UpdateFeeRecipient mocks base method.

--- a/operator/validator/task_executor.go
+++ b/operator/validator/task_executor.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -30,11 +29,11 @@ func (c *controller) StartValidator(share *ssvtypes.SSVShare) error {
 	return nil
 }
 
-func (c *controller) StopValidator(publicKey []byte) error {
-	logger := c.taskLogger("StopValidator", fields.PubKey(publicKey))
+func (c *controller) StopValidator(share *ssvtypes.SSVShare) error {
+	logger := c.taskLogger("StopValidator", fields.PubKey(share.ValidatorPubKey))
 
-	c.metrics.ValidatorRemoved(publicKey)
-	if err := c.onShareRemove(hex.EncodeToString(publicKey), true); err != nil {
+	c.metrics.ValidatorRemoved(share.ValidatorPubKey)
+	if err := c.onShareRemove(share, true); err != nil {
 		return err
 	}
 
@@ -52,7 +51,7 @@ func (c *controller) LiquidateCluster(owner common.Address, operatorIDs []uint64
 		// we can't remove the share secret from key-manager
 		// due to the fact that after activating the validators (ClusterReactivated)
 		// we don't have the encrypted keys to decrypt the secret, but only the owner address
-		if err := c.onShareRemove(hex.EncodeToString(share.ValidatorPubKey), false); err != nil {
+		if err := c.onShareRemove(share, false); err != nil {
 			return err
 		}
 		logger.With(fields.PubKey(share.ValidatorPubKey)).Debug("removed share")

--- a/operator/validator/task_executor.go
+++ b/operator/validator/task_executor.go
@@ -30,11 +30,11 @@ func (c *controller) StartValidator(share *types.SSVShare) error {
 	return nil
 }
 
-func (c *controller) StopValidator(share *types.SSVShare) error {
-	logger := c.taskLogger("StopValidator", fields.PubKey(share.ValidatorPubKey))
+func (c *controller) StopValidator(pubKey spectypes.ValidatorPK) error {
+	logger := c.taskLogger("StopValidator", fields.PubKey(pubKey))
 
-	c.metrics.ValidatorRemoved(share.ValidatorPubKey)
-	c.onShareStop(share.ValidatorPubKey)
+	c.metrics.ValidatorRemoved(pubKey)
+	c.onShareStop(pubKey)
 
 	logger.Info("removed validator")
 


### PR DESCRIPTION
### Problem

Previously, shares were being removed based on the validator's public key, which was incorrect.

### Solution

This fix introduces the proper way to delete a share by using the share's public key instead of the validator's public key. This ensures that the correct share is removed from the EKM (ETH Key Manager) storage.

UPD: based on @moshe-blox [comment](https://github.com/bloxapp/ssv/pull/1140#pullrequestreview-1618840674)
added a logic that interact with database to be as part of the tx in eventhandler.