### PR TITLE
Implement Slashing Protection Data Update for Reactivated Validators

### DIFF
--- a/ekm/eth_key_manager_signer.go
+++ b/ekm/eth_key_manager_signer.go
@@ -29,9 +29,16 @@ import (
 	"github.com/bloxapp/ssv/storage/basedb"
 )
 
-// minimal att&block epoch/slot distance to protect slashing
-var minimalAttSlashingProtectionEpochDistance = phase0.Epoch(0)
-var minimalBlockSlashingProtectionSlotDistance = phase0.Slot(0)
+const (
+	// minSPAttestationEpochGap is the minimum epoch distance used for slashing protection in attestations.
+	// It defines the smallest allowable gap between the source and target epochs in an existing attestation
+	// and those in a new attestation, helping to prevent slashable offenses.
+	minSPAttestationEpochGap = phase0.Epoch(0)
+	// minSPProposalSlotGap is the minimum slot distance used for slashing protection in block proposals.
+	// It defines the smallest allowable gap between the current slot and the slot of a new block proposal,
+	// helping to prevent slashable offenses.
+	minSPProposalSlotGap = phase0.Slot(0)
+)
 
 type ethKeyManagerSigner struct {
 	wallet            core.Wallet
@@ -48,6 +55,7 @@ type StorageProvider interface {
 	ListAccounts() ([]core.ValidatorAccount, error)
 	RetrieveHighestAttestation(pubKey []byte) (*phase0.AttestationData, bool, error)
 	RetrieveHighestProposal(pubKey []byte) (phase0.Slot, bool, error)
+	BumpSlashingProtection(pubKey []byte) error
 }
 
 // NewETHKeyManagerSigner returns a new instance of ethKeyManagerSigner
@@ -279,32 +287,14 @@ func (km *ethKeyManagerSigner) AddShare(shareKey *bls.SecretKey) error {
 		return errors.Wrap(err, "could not check share existence")
 	}
 	if acc == nil {
-		currentSlot := km.storage.BeaconNetwork().EstimatedCurrentSlot()
-		if err := km.saveMinimalSlashingProtection(shareKey.GetPublicKey().Serialize(), currentSlot); err != nil {
-			return errors.Wrap(err, "could not save minimal slashing protection")
+		if err := km.BumpSlashingProtection(shareKey.GetPublicKey().Serialize()); err != nil {
+			return errors.Wrap(err, "could not bump slashing protection")
 		}
 		if err := km.saveShare(shareKey); err != nil {
 			return errors.Wrap(err, "could not save share")
 		}
 	}
 
-	return nil
-}
-
-func (km *ethKeyManagerSigner) saveMinimalSlashingProtection(pk []byte, currentSlot phase0.Slot) error {
-	currentEpoch := km.storage.BeaconNetwork().EstimatedEpochAtSlot(currentSlot)
-	highestTarget := currentEpoch + minimalAttSlashingProtectionEpochDistance
-	highestSource := highestTarget - 1
-	highestProposal := currentSlot + minimalBlockSlashingProtectionSlotDistance
-
-	minAttData := minimalAttProtectionData(highestSource, highestTarget)
-
-	if err := km.storage.SaveHighestAttestation(pk, minAttData); err != nil {
-		return errors.Wrapf(err, "could not save minimal highest attestation for %s", string(pk))
-	}
-	if err := km.storage.SaveHighestProposal(pk, highestProposal); err != nil {
-		return errors.Wrapf(err, "could not save minimal highest proposal for %s", string(pk))
-	}
 	return nil
 }
 
@@ -334,6 +324,117 @@ func (km *ethKeyManagerSigner) RemoveShare(pubKey string) error {
 	return nil
 }
 
+// BumpSlashingProtection updates the slashing protection data for a given public key.
+func (km *ethKeyManagerSigner) BumpSlashingProtection(pubKey []byte) error {
+	currentSlot := km.storage.BeaconNetwork().EstimatedCurrentSlot()
+
+	// Update highest attestation data for slashing protection.
+	if err := km.updateHighestAttestation(pubKey, currentSlot); err != nil {
+		return err
+	}
+
+	// Update highest proposal data for slashing protection.
+	if err := km.updateHighestProposal(pubKey, currentSlot); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// updateHighestAttestation updates the highest attestation data for slashing protection.
+func (km *ethKeyManagerSigner) updateHighestAttestation(pubKey []byte, slot phase0.Slot) error {
+	var highAtt *phase0.AttestationData
+
+	// Retrieve the highest attestation data stored for the given public key.
+	retrievedHighAtt, found, err := km.RetrieveHighestAttestation(pubKey)
+	if err != nil {
+		return fmt.Errorf("could not retrieve highest attestation: %w", err)
+	}
+
+	currentEpoch := km.storage.BeaconNetwork().EstimatedEpochAtSlot(slot)
+
+	// Validate the retrieved highest attestation data.
+	if found && retrievedHighAtt != nil {
+		if retrievedHighAtt.Source.Epoch < currentEpoch-1 && retrievedHighAtt.Target.Epoch < currentEpoch {
+			found = false
+		} else {
+			// The retrieved highest attestation data is far in the future.
+			return nil
+		}
+	}
+
+	// Compute new highest attestation if not found or invalidated.
+	if !found || retrievedHighAtt == nil {
+		highAtt = km.computeMinimalAttestationSP(currentEpoch)
+	}
+
+	// Save the new highest attestation data.
+	if err := km.storage.SaveHighestAttestation(pubKey, highAtt); err != nil {
+		return fmt.Errorf("could not save highest attestation: %w", err)
+	}
+
+	return nil
+}
+
+// updateHighestProposal updates the highest proposal slot for slashing protection.
+func (km *ethKeyManagerSigner) updateHighestProposal(pubKey []byte, slot phase0.Slot) error {
+	var highProp phase0.Slot
+
+	// Retrieve the highest proposal slot stored for the given public key.
+	retrievedHighProp, found, err := km.RetrieveHighestProposal(pubKey)
+	if err != nil {
+		return fmt.Errorf("could not retrieve highest proposal: %w", err)
+	}
+
+	// Validate the retrieved highest proposal slot.
+	if found && retrievedHighProp != 0 {
+		if retrievedHighProp < slot {
+			found = false
+		} else {
+			// The retrieved highest proposal slot is far in the future.
+			return nil
+		}
+	}
+
+	// Compute new highest proposal if not found or invalidated.
+	if !found || retrievedHighProp == 0 {
+		highProp = km.computeMinimalProposerSP(slot)
+	}
+
+	// Save the new highest proposal slot.
+	if err := km.storage.SaveHighestProposal(pubKey, highProp); err != nil {
+		return fmt.Errorf("could not save highest proposal: %w", err)
+	}
+
+	return nil
+}
+
+// computeMinimalAttestationSP calculates the minimal safe attestation data for slashing protection.
+// It takes the current epoch as an argument and returns an AttestationData object with the minimal safe source and target epochs.
+func (km *ethKeyManagerSigner) computeMinimalAttestationSP(epoch phase0.Epoch) *phase0.AttestationData {
+	// Calculate the highest safe target epoch based on the current epoch and a predefined minimum distance.
+	highestTarget := epoch + minSPAttestationEpochGap
+	// The highest safe source epoch is one less than the highest target epoch.
+	highestSource := highestTarget - 1
+
+	// Return a new AttestationData object with the calculated source and target epochs.
+	return &phase0.AttestationData{
+		Source: &phase0.Checkpoint{
+			Epoch: highestSource,
+		},
+		Target: &phase0.Checkpoint{
+			Epoch: highestTarget,
+		},
+	}
+}
+
+// computeMinimalProposerSP calculates the minimal safe slot for a block proposal to avoid slashing.
+// It takes the current slot as an argument and returns the minimal safe slot.
+func (km *ethKeyManagerSigner) computeMinimalProposerSP(slot phase0.Slot) phase0.Slot {
+	// Calculate the highest safe proposal slot based on the current slot and a predefined minimum distance.
+	return slot + minSPProposalSlotGap
+}
+
 func (km *ethKeyManagerSigner) saveShare(shareKey *bls.SecretKey) error {
 	key, err := core.NewHDKeyFromPrivateKey(shareKey.Serialize(), "")
 	if err != nil {
@@ -344,18 +445,4 @@ func (km *ethKeyManagerSigner) saveShare(shareKey *bls.SecretKey) error {
 		return errors.Wrap(err, "could not save new account")
 	}
 	return nil
-}
-
-func minimalAttProtectionData(source, target phase0.Epoch) *phase0.AttestationData {
-	return &phase0.AttestationData{
-		BeaconBlockRoot: [32]byte{},
-		Source: &phase0.Checkpoint{
-			Epoch: source,
-			Root:  [32]byte{},
-		},
-		Target: &phase0.Checkpoint{
-			Epoch: target,
-			Root:  [32]byte{},
-		},
-	}
 }

--- a/ekm/signer_key_manager_test.go
+++ b/ekm/signer_key_manager_test.go
@@ -7,26 +7,25 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/bloxapp/eth2-key-manager/core"
-	"github.com/bloxapp/eth2-key-manager/wallets/hd"
-	"github.com/bloxapp/ssv/utils/rsaencryption"
-
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
-	"github.com/bloxapp/ssv/storage/basedb"
-
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/bloxapp/eth2-key-manager/core"
+	"github.com/bloxapp/eth2-key-manager/wallets/hd"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
-	"github.com/bloxapp/ssv/logging"
-	"github.com/bloxapp/ssv/networkconfig"
-	"github.com/bloxapp/ssv/utils/threshold"
 	"github.com/herumi/bls-eth-go-binary/bls"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/bloxapp/ssv/logging"
+	"github.com/bloxapp/ssv/networkconfig"
+	"github.com/bloxapp/ssv/storage/basedb"
+	"github.com/bloxapp/ssv/utils"
+	"github.com/bloxapp/ssv/utils/rsaencryption"
+	"github.com/bloxapp/ssv/utils/threshold"
 )
 
 const (
@@ -36,7 +35,7 @@ const (
 	pk2Str = "8796fafa576051372030a75c41caafea149e4368aebaca21c9f90d9974b3973d5cee7d7874e4ec9ec59fb2c8945b3e01"
 )
 
-func testKeyManager(t *testing.T) spectypes.KeyManager {
+func testKeyManager(t *testing.T, network *networkconfig.NetworkConfig) spectypes.KeyManager {
 	threshold.Init()
 
 	logger := logging.TestLogger(t)
@@ -44,7 +43,13 @@ func testKeyManager(t *testing.T) spectypes.KeyManager {
 	db, err := getBaseStorage(logger)
 	require.NoError(t, err)
 
-	km, err := NewETHKeyManagerSigner(logger, db, networkconfig.TestNetwork, true, "")
+	if network == nil {
+		network = &networkconfig.NetworkConfig{
+			Beacon: utils.SetupMockBeaconNetwork(t, nil),
+		}
+	}
+
+	km, err := NewETHKeyManagerSigner(logger, db, *network, true, "")
 	require.NoError(t, err)
 
 	sk1 := &bls.SecretKey{}
@@ -120,7 +125,7 @@ func TestEncryptedKeyManager(t *testing.T) {
 }
 
 func TestSlashing(t *testing.T) {
-	km := testKeyManager(t)
+	km := testKeyManager(t, nil)
 
 	sk1 := &bls.SecretKey{}
 	require.NoError(t, sk1.SetHexString(sk1Str))
@@ -129,12 +134,12 @@ func TestSlashing(t *testing.T) {
 	currentSlot := km.(*ethKeyManagerSigner).storage.Network().EstimatedCurrentSlot()
 	currentEpoch := km.(*ethKeyManagerSigner).storage.Network().EstimatedEpochAtSlot(currentSlot)
 
-	highestTarget := currentEpoch + minimalAttSlashingProtectionEpochDistance + 1
+	highestTarget := currentEpoch + minSPAttestationEpochGap + 1
 	highestSource := highestTarget - 1
-	highestProposal := currentSlot + minimalBlockSlashingProtectionSlotDistance + 1
+	highestProposal := currentSlot + minSPProposalSlotGap + 1
 
 	attestationData := &phase0.AttestationData{
-		Slot:            30,
+		Slot:            currentSlot,
 		Index:           1,
 		BeaconBlockRoot: [32]byte{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2},
 		Source: &phase0.Checkpoint{
@@ -272,7 +277,7 @@ func TestSlashing(t *testing.T) {
 }
 
 func TestSlashing_Attestation(t *testing.T) {
-	km := testKeyManager(t)
+	km := testKeyManager(t, nil)
 
 	var secretKeys [4]*bls.SecretKey
 	for i := range secretKeys {
@@ -280,8 +285,7 @@ func TestSlashing_Attestation(t *testing.T) {
 		secretKeys[i].SetByCSPRNG()
 
 		// Equivalent to AddShare but with a custom slot for minimal slashing protection.
-		minimalSlot := phase0.Slot(64)
-		err := km.(*ethKeyManagerSigner).saveMinimalSlashingProtection(secretKeys[i].GetPublicKey().Serialize(), minimalSlot)
+		err := km.(*ethKeyManagerSigner).BumpSlashingProtection(secretKeys[i].GetPublicKey().Serialize())
 		require.NoError(t, err)
 		err = km.(*ethKeyManagerSigner).saveShare(secretKeys[i])
 		require.NoError(t, err)
@@ -317,6 +321,12 @@ func TestSlashing_Attestation(t *testing.T) {
 			require.NoError(t, err, "expected no slashing")
 			require.NotZero(t, sig, "expected non-zero signature")
 			require.NotZero(t, root, "expected non-zero root")
+
+			highAtt, found, err := km.(*ethKeyManagerSigner).storage.RetrieveHighestAttestation(sk.GetPublicKey().Serialize())
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, attestation.Source.Epoch, highAtt.Source.Epoch)
+			require.Equal(t, attestation.Target.Epoch, highAtt.Target.Epoch)
 		}
 	}
 
@@ -360,7 +370,7 @@ func TestSlashing_Attestation(t *testing.T) {
 func TestSignRoot(t *testing.T) {
 	require.NoError(t, bls.Init(bls.BLS12_381))
 
-	km := testKeyManager(t)
+	km := testKeyManager(t, nil)
 
 	t.Run("pk 1", func(t *testing.T) {
 		pk := &bls.PublicKey{}

--- a/ekm/signer_key_manager_test.go
+++ b/ekm/signer_key_manager_test.go
@@ -46,6 +46,7 @@ func testKeyManager(t *testing.T, network *networkconfig.NetworkConfig) spectype
 	if network == nil {
 		network = &networkconfig.NetworkConfig{
 			Beacon: utils.SetupMockBeaconNetwork(t, nil),
+			Domain: networkconfig.TestNetwork.Domain,
 		}
 	}
 

--- a/eth/eventhandler/local_events_test.go
+++ b/eth/eventhandler/local_events_test.go
@@ -46,7 +46,7 @@ func TestHandleLocalEvent(t *testing.T) {
 		defer cancel()
 
 		logger := zaptest.NewLogger(t)
-		eh, _, err := setupEventHandler(t, ctx, logger, ops[0], false)
+		eh, _, err := setupEventHandler(t, ctx, logger, nil, ops[0], false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +73,7 @@ func TestHandleLocalEvent(t *testing.T) {
 		defer cancel()
 
 		logger := zaptest.NewLogger(t)
-		eh, _, err := setupEventHandler(t, ctx, logger, ops[0], false)
+		eh, _, err := setupEventHandler(t, ctx, logger, nil, ops[0], false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -52,7 +52,7 @@ func TestExecuteTask(t *testing.T) {
 	ops, err := createOperators(1)
 	require.NoError(t, err)
 
-	eh, validatorCtrl, err := setupEventHandler(t, ctx, logger, ops[0], true)
+	eh, validatorCtrl, err := setupEventHandler(t, ctx, logger, nil, ops[0], true)
 	require.NoError(t, err)
 
 	t.Run("test AddValidator task execution - not started", func(t *testing.T) {
@@ -149,7 +149,7 @@ func TestHandleBlockEventsStreamWithExecution(t *testing.T) {
 	ops, err := createOperators(1)
 	require.NoError(t, err)
 
-	eh, _, err := setupEventHandler(t, ctx, logger, ops[0], false)
+	eh, _, err := setupEventHandler(t, ctx, logger, nil, ops[0], false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -99,7 +99,7 @@ func TestExecuteTask(t *testing.T) {
 	t.Run("test StopValidator task execution", func(t *testing.T) {
 		validatorCtrl.EXPECT().StopValidator(gomock.Any()).Return(nil).AnyTimes()
 
-		task := NewStopValidatorTask(eh.taskExecutor, &ssvtypes.SSVShare{})
+		task := NewStopValidatorTask(eh.taskExecutor, ethcommon.Hex2Bytes(valPk))
 		require.NoError(t, task.Execute())
 	})
 

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -99,7 +99,7 @@ func TestExecuteTask(t *testing.T) {
 	t.Run("test StopValidator task execution", func(t *testing.T) {
 		validatorCtrl.EXPECT().StopValidator(gomock.Any()).Return(nil).AnyTimes()
 
-		task := NewStopValidatorTask(eh.taskExecutor, ethcommon.Hex2Bytes(valPk))
+		task := NewStopValidatorTask(eh.taskExecutor, &ssvtypes.SSVShare{})
 		require.NoError(t, task.Execute())
 	})
 

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/golang/mock/gomock"
+
+	"github.com/bloxapp/ssv/networkconfig"
+	mocknetwork "github.com/bloxapp/ssv/protocol/v2/blockchain/beacon/mocks"
+)
+
+type SlotValue struct {
+	mu   sync.Mutex
+	slot phase0.Slot
+}
+
+func (sv *SlotValue) SetSlot(s phase0.Slot) {
+	sv.mu.Lock()
+	defer sv.mu.Unlock()
+	sv.slot = s
+}
+
+func (sv *SlotValue) GetSlot() phase0.Slot {
+	sv.mu.Lock()
+	defer sv.mu.Unlock()
+	return sv.slot
+}
+
+func SetupMockBeaconNetwork(t *testing.T, currentSlot *SlotValue) *mocknetwork.MockBeaconNetwork {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	if currentSlot == nil {
+		currentSlot = &SlotValue{}
+		currentSlot.SetSlot(32)
+	}
+
+	mockBeaconNetwork := mocknetwork.NewMockBeaconNetwork(ctrl)
+	mockBeaconNetwork.EXPECT().GetBeaconNetwork().Return(networkconfig.TestNetwork.Beacon.GetBeaconNetwork()).AnyTimes()
+
+	mockBeaconNetwork.EXPECT().EstimatedCurrentSlot().DoAndReturn(
+		func() phase0.Slot {
+			return currentSlot.GetSlot()
+		},
+	).AnyTimes()
+	mockBeaconNetwork.EXPECT().EstimatedEpochAtSlot(gomock.Any()).DoAndReturn(
+		func(slot phase0.Slot) phase0.Epoch {
+			return phase0.Epoch(slot / 32)
+		},
+	).AnyTimes()
+
+	return mockBeaconNetwork
+}


### PR DESCRIPTION
#### Description:

This PR addresses the issue of outdated slashing protection data for reactivated validators in the EKM (Ethereum Key Manager). Specifically, it aims to prevent the signing of slashable attestations or proposals by ensuring that the slashing protection data is updated appropriately when a validator is reactivated.

#### Changes:

- Added logic to update slashing protection data for reactivated validators.
- The slashing protection data is "bumped" to the next epoch & slot only if the stored values are lower. This ensures that we do not overwrite higher stored values.

```go
# Pseudo-code to demonstrate the bump logic
storedEpoch = max(nextEpoch, storedEpoch)
```

#### Testing:

- Added unit tests to verify that the slashing protection data is updated correctly.
