### PR TITLE
fix build fail on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update                                                        && \
   git=1:2.39.2-1.1 \
   zip=3.0-13 \
   unzip=6.0-28 \
-  wget=1.21.3-1+b2 \
+  wget="1.21.3*" \
   g++=4:12.2.0-3 \
   gcc-aarch64-linux-gnu=4:12.2.0-3 \
   bzip2=1.0.8-5+b1 \


### PR DESCRIPTION
wget is missing at the declared version. Build fails.

1.21.3-1+**b1** on arm64
1.21.3-1+**b2** on amd64



```

$ uname -a
Linux xyz 5.15.0-1021-oracle #27-Ubuntu SMP Fri Oct 14 20:04:20 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
$ docker run -ti golang:1.20.7 sh
# apt update
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main arm64 Packages [8681 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main arm64 Packages [6408 B]
Get:6 http://deb.debian.org/debian-security bookworm-security/main arm64 Packages [77.0 kB]
Fetched 9015 kB in 1s (9121 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
24 packages can be upgraded. Run 'apt list --upgradable' to see them.
# apt search wget
Sorting... Done
Full Text Search... Done
libcupt4-2-downloadmethod-wget/stable 2.10.4+nmu1+b1 arm64
  flexible package manager -- wget download method

libwget0/stable 1.99.1-2.2 arm64
  Download library for files and recursive websites

pwget/stable 2016.1019+git75c6e3e-8 all
  downloader utility which resembles wget (implemented in Perl)

python3-wget/stable 3.2-4 all
  pure Python download utility for Python 3

wget/stable,now 1.21.3-1+b1 arm64 [installed]
  retrieves files from the web

wget2/stable 1.99.1-2.2 arm64
  file and recursive website downloader

wget2-dev/stable 1.99.1-2.2 arm64
  development file for libwget2

wput/stable 0.6.2+git20130413-11 arm64
  tiny wget-like ftp-client for uploading files
```