### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.20.7 AS preparer
 
 RUN apt-get update                                                        && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-  curl=7.88.1-10+deb12u1 \
+  curl=7.88.1-10+deb12u4 \
   git=1:2.39.2-1.1 \
   zip=3.0-13 \
   unzip=6.0-28 \


### PR DESCRIPTION
Introduces a little bit of flexibility in the package dependencies and bumps bind-tools to 9.18.19 .

By the way, with these changes I was able to build the image and successfully run the SSV node on arm64.