### PR TITLE
refactor: more flexible event parsing & handling APIs

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -555,7 +555,6 @@ func setupEventHandling(
 		validatorCtrl,
 		cfg.SSVOptions.ValidatorOptions.ShareEncryptionKeyProvider,
 		cfg.SSVOptions.ValidatorOptions.KeyManager,
-		cfg.SSVOptions.ValidatorOptions.Beacon,
 		storageMap,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger),

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -27,7 +27,6 @@ import (
 	operatorstorage "github.com/bloxapp/ssv/operator/storage"
 	"github.com/bloxapp/ssv/operator/validator"
 	"github.com/bloxapp/ssv/operator/validator/mocks"
-	"github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
 	registrystorage "github.com/bloxapp/ssv/registry/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/bloxapp/ssv/storage/kv"
@@ -180,7 +179,6 @@ func setupEventHandler(
 	}
 
 	ctrl := gomock.NewController(t)
-	bc := beacon.NewMockBeaconNode(ctrl)
 
 	contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 	if err != nil {
@@ -200,7 +198,6 @@ func setupEventHandler(
 			validatorCtrl,
 			nodeStorage.GetPrivateKey,
 			keyManager,
-			bc,
 			storageMap,
 			eventhandler.WithFullNode(),
 			eventhandler.WithLogger(logger),
@@ -234,7 +231,6 @@ func setupEventHandler(
 		validatorCtrl,
 		nodeStorage.GetPrivateKey,
 		keyManager,
-		bc,
 		storageMap,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger),

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -496,18 +496,18 @@ func (eh *EventHandler) processClusterEvent(
 	}
 
 	shares := eh.nodeStorage.Shares().List(txn, registrystorage.ByClusterID(clusterID))
-	toUpdate := make([]*ssvtypes.SSVShare, 0)
-	updatedPubKeys := make([]string, 0)
+	var toUpdate []*ssvtypes.SSVShare
+	var ownShares []*ssvtypes.SSVShare
+	var ownPubKeys []string
 
 	for _, share := range shares {
 		isOperatorShare := share.BelongsToOperator(eh.operatorData.GetOperatorData().ID)
-		if isOperatorShare || eh.fullNode {
-			updatedPubKeys = append(updatedPubKeys, hex.EncodeToString(share.ValidatorPubKey))
-		}
 		if isOperatorShare {
-			share.Liquidated = toLiquidate
-			toUpdate = append(toUpdate, share)
+			ownPubKeys = append(ownPubKeys, hex.EncodeToString(share.ValidatorPubKey))
+			ownShares = append(ownShares, share)
 		}
+		share.Liquidated = toLiquidate
+		toUpdate = append(toUpdate, share)
 	}
 
 	if len(toUpdate) > 0 {
@@ -516,7 +516,7 @@ func (eh *EventHandler) processClusterEvent(
 		}
 	}
 
-	return toUpdate, updatedPubKeys, nil
+	return ownShares, ownPubKeys, nil
 }
 
 // MalformedEventError is returned when event is malformed

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bloxapp/ssv/ekm"
 	"github.com/bloxapp/ssv/eth/contract"
+	"github.com/bloxapp/ssv/eth/eventparser"
 	"github.com/bloxapp/ssv/logging/fields"
 	qbftstorage "github.com/bloxapp/ssv/protocol/v2/qbft/storage"
 	"github.com/bloxapp/ssv/protocol/v2/types"
@@ -40,7 +41,7 @@ var (
 
 func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.ContractOperatorAdded) error {
 	logger := eh.logger.With(
-		fields.EventName(OperatorAdded),
+		fields.EventName(eventparser.OperatorAdded),
 		fields.TxHash(event.Raw.TxHash),
 		fields.OperatorID(event.OperatorId),
 		fields.Owner(event.Owner),
@@ -86,7 +87,7 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 
 func (eh *EventHandler) handleOperatorRemoved(txn basedb.Txn, event *contract.ContractOperatorRemoved) error {
 	logger := eh.logger.With(
-		fields.EventName(OperatorRemoved),
+		fields.EventName(eventparser.OperatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
 		fields.OperatorID(event.OperatorId),
 	)
@@ -125,7 +126,7 @@ func (eh *EventHandler) handleOperatorRemoved(txn basedb.Txn, event *contract.Co
 
 func (eh *EventHandler) handleValidatorAdded(txn basedb.Txn, event *contract.ContractValidatorAdded) (ownShare *ssvtypes.SSVShare, err error) {
 	logger := eh.logger.With(
-		fields.EventName(ValidatorAdded),
+		fields.EventName(eventparser.ValidatorAdded),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
 		fields.OperatorIDs(event.OperatorIds),
@@ -327,7 +328,7 @@ func validatorAddedEventToShare(
 
 func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.ContractValidatorRemoved) (spectypes.ValidatorPK, error) {
 	logger := eh.logger.With(
-		fields.EventName(ValidatorRemoved),
+		fields.EventName(eventparser.ValidatorRemoved),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
 		fields.OperatorIDs(event.OperatorIds),
@@ -389,7 +390,7 @@ func (eh *EventHandler) handleValidatorRemoved(txn basedb.Txn, event *contract.C
 
 func (eh *EventHandler) handleClusterLiquidated(txn basedb.Txn, event *contract.ContractClusterLiquidated) ([]*ssvtypes.SSVShare, error) {
 	logger := eh.logger.With(
-		fields.EventName(ClusterLiquidated),
+		fields.EventName(eventparser.ClusterLiquidated),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
 		fields.OperatorIDs(event.OperatorIds),
@@ -411,7 +412,7 @@ func (eh *EventHandler) handleClusterLiquidated(txn basedb.Txn, event *contract.
 
 func (eh *EventHandler) handleClusterReactivated(txn basedb.Txn, event *contract.ContractClusterReactivated) ([]*ssvtypes.SSVShare, error) {
 	logger := eh.logger.With(
-		fields.EventName(ClusterReactivated),
+		fields.EventName(eventparser.ClusterReactivated),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
 		fields.OperatorIDs(event.OperatorIds),
@@ -440,7 +441,7 @@ func (eh *EventHandler) handleClusterReactivated(txn basedb.Txn, event *contract
 
 func (eh *EventHandler) handleFeeRecipientAddressUpdated(txn basedb.Txn, event *contract.ContractFeeRecipientAddressUpdated) (bool, error) {
 	logger := eh.logger.With(
-		fields.EventName(FeeRecipientAddressUpdated),
+		fields.EventName(eventparser.FeeRecipientAddressUpdated),
 		fields.TxHash(event.Raw.TxHash),
 		fields.Owner(event.Owner),
 		fields.FeeRecipient(event.RecipientAddress.Bytes()),

--- a/eth/eventparser/event_parser.go
+++ b/eth/eventparser/event_parser.go
@@ -11,6 +11,21 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
+// Event names.
+const (
+	OperatorAdded              = "OperatorAdded"
+	OperatorRemoved            = "OperatorRemoved"
+	ValidatorAdded             = "ValidatorAdded"
+	ValidatorRemoved           = "ValidatorRemoved"
+	ClusterLiquidated          = "ClusterLiquidated"
+	ClusterReactivated         = "ClusterReactivated"
+	FeeRecipientAddressUpdated = "FeeRecipientAddressUpdated"
+)
+
+var (
+	ErrUnknownEvent = fmt.Errorf("unknown event")
+)
+
 type EventParser struct {
 	eventFilterer
 	eventByIDGetter
@@ -18,6 +33,7 @@ type EventParser struct {
 }
 
 type Parser interface {
+	ParseEvent(abiEvent *ethabi.Event, event ethtypes.Log) (interface{}, error)
 	eventFilterer
 	eventByIDGetter
 }
@@ -51,6 +67,27 @@ func New(eventFilterer eventFilterer) *EventParser {
 		eventFilterer:        eventFilterer,
 		eventByIDGetter:      contractABI,
 		operatorPublicKeyABI: operatorPublicKeyABI,
+	}
+}
+
+func (e *EventParser) ParseEvent(abiEvent *ethabi.Event, event ethtypes.Log) (interface{}, error) {
+	switch abiEvent.Name {
+	case OperatorAdded:
+		return e.ParseOperatorAdded(event)
+	case OperatorRemoved:
+		return e.ParseOperatorRemoved(event)
+	case ValidatorAdded:
+		return e.ParseValidatorAdded(event)
+	case ValidatorRemoved:
+		return e.ParseValidatorRemoved(event)
+	case ClusterLiquidated:
+		return e.ParseClusterLiquidated(event)
+	case ClusterReactivated:
+		return e.ParseClusterReactivated(event)
+	case FeeRecipientAddressUpdated:
+		return e.ParseFeeRecipientAddressUpdated(event)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnknownEvent, abiEvent.Name)
 	}
 }
 

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/bloxapp/ssv/eth/eventhandler"
 	"github.com/bloxapp/ssv/eth/executionclient"
 	"github.com/bloxapp/ssv/logging/fields"
 	nodestorage "github.com/bloxapp/ssv/operator/storage"
@@ -29,7 +30,7 @@ type ExecutionClient interface {
 }
 
 type EventHandler interface {
-	HandleBlockEventsStream(logs <-chan executionclient.BlockLogs, executeTasks bool) (uint64, error)
+	HandleBlockEventsStream(logs <-chan executionclient.BlockLogs, executeTasks bool, eventTraces chan<- eventhandler.EventTrace) (uint64, error)
 }
 
 // EventSyncer syncs registry contract events from the given ExecutionClient

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/bloxapp/ssv/networkconfig"
 	operatorstorage "github.com/bloxapp/ssv/operator/storage"
 	"github.com/bloxapp/ssv/operator/validator"
-	"github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
 	registrystorage "github.com/bloxapp/ssv/registry/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
 	"github.com/bloxapp/ssv/storage/kv"
@@ -147,7 +146,6 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger) *e
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	bc := beacon.NewMockBeaconNode(ctrl)
 	validatorCtrl := validator.NewController(logger, validator.ControllerOptions{
 		Context:         ctx,
 		DB:              db,
@@ -169,7 +167,6 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger) *e
 		validatorCtrl,
 		nodeStorage.GetPrivateKey,
 		keyManager,
-		bc,
 		storageMap,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger))

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -239,7 +239,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 	}
 
 	t.Run("startBlock is greater than endBlock", func(t *testing.T) {
-		logChan, errChan := client.fetchLogsInBatches(ctx, 10, 5)
+		logChan, errChan := client.FetchLogs(ctx, 10, 5)
 		select {
 		case <-logChan:
 			require.Fail(t, "Should not receive log when startBlock > endBlock")
@@ -253,7 +253,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 	t.Run("startBlock is same as endBlock", func(t *testing.T) {
 		var blockNumbers []uint64
 
-		logChan, errChan := client.fetchLogsInBatches(ctx, 5, 5)
+		logChan, errChan := client.FetchLogs(ctx, 5, 5)
 		select {
 		case block := <-logChan:
 			blockNumbers = append(blockNumbers, block.BlockNumber)
@@ -269,7 +269,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 	t.Run("startBlock is less than endBlock", func(t *testing.T) {
 		var blockNumbers []uint64
 
-		logChan, errChan := client.fetchLogsInBatches(ctx, 3, 11)
+		logChan, errChan := client.FetchLogs(ctx, 3, 11)
 		for block := range logChan {
 			blockNumbers = append(blockNumbers, block.BlockNumber)
 		}
@@ -286,7 +286,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		logChan, errChan := client.fetchLogsInBatches(canceledCtx, 0, 5)
+		logChan, errChan := client.FetchLogs(canceledCtx, 0, 5)
 		select {
 		case <-logChan:
 			require.Fail(t, "Should not receive log when context is canceled")


### PR DESCRIPTION
Since the SSV API doesn't currently provide a way to get past contract events and their validity, the only alternative is to import SSV packages.

This PR refactors the API of `eventhandler`, `eventparser` and `executionclient` packages for more granular control by external packages (and programs).

## Changes
- Expose underlying RPC in `executionclient`
- Added observability in `eventhandler` (see `EventTrace`)
- Added `eventparser.ParseEvent`
- Expose `FetchLogs` (previously `fetchLogsInBatches`)