### PR TITLE
refactor: node health API

### DIFF
--- a/api/handling.go
+++ b/api/handling.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -8,8 +9,8 @@ import (
 )
 
 const (
-	ContentTypePlainText = "text/plain"
-	ContentTypeJSON      = "application/json"
+	contentTypePlainText = "text/plain"
+	contentTypeJSON      = "application/json"
 )
 
 type HandlerFunc func(http.ResponseWriter, *http.Request) error
@@ -28,21 +29,26 @@ func Handler(h HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// Render negotiates the content type and renders the response, defaulting to JSON.
+// Response must implement fmt.Stringer to be rendered as plain text.
 func Render(w http.ResponseWriter, r *http.Request, response any) error {
-	switch NegotiateContentType(r) {
-	case ContentTypePlainText:
-		render.PlainText(w, r, response.(string))
-	case ContentTypeJSON:
-		render.JSON(w, r, response)
-	}
-	return nil
-}
+	// Negotiate content type, defaulting to JSON.
+	contentType := httputil.NegotiateContentType(
+		r,
+		[]string{contentTypePlainText, contentTypeJSON},
+		contentTypeJSON,
+	)
 
-// negotiateContentType parses "Accept:" header and returns preferred content type string.
-func NegotiateContentType(r *http.Request) string {
-	contentTypes := []string{
-		ContentTypePlainText,
-		ContentTypeJSON,
+	switch contentType {
+	case contentTypePlainText:
+		// Try rendering as a string, otherwise fallback to JSON.
+		if stringer, ok := response.(fmt.Stringer); ok {
+			render.PlainText(w, r, stringer.String())
+			return nil
+		}
+		fallthrough
+	default:
+		render.JSON(w, r, response)
+		return nil
 	}
-	return httputil.NegotiateContentType(r, contentTypes, ContentTypePlainText)
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -45,8 +45,8 @@ func (s *Server) Run() error {
 	router.Get("/v1/node/identity", api.Handler(s.node.Identity))
 	router.Get("/v1/node/peers", api.Handler(s.node.Peers))
 	router.Get("/v1/node/topics", api.Handler(s.node.Topics))
-	router.Get("/v1/validators", api.Handler(s.validators.List))
 	router.Get("/v1/node/health", api.Handler(s.node.Health))
+	router.Get("/v1/validators", api.Handler(s.validators.List))
 
 	s.logger.Info("Serving SSV API", zap.String("addr", s.addr))
 


### PR DESCRIPTION
- Fix `api.Render` — other routes were panicing because default content type of browser request is text/plain, but they didn't return a string.
- For text/plain requests, encode indented JSON instead of fmt.Printf (looks nearly the same, but more maintainable than custom format)
- Extract special fields to "advanced" struct

Example response:
```json
{
  "p2p": "bad: no peers are connected",
  "beacon_node": "good",
  "execution_node": "good",
  "event_syncer": "good",
  "advanced": {
    "peers": 0,
    "inbound_conns": 0,
    "outbound_conns": 0,
    "p2p_listen_addresses": [
      "192.168.1.112:13001"
    ]
  }
}
```