### PR TITLE
Include git commit/version in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 bin
 data
 docs
-.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,14 @@ FROM preparer AS builder
 # Copy files and install app
 COPY . .
 
-ARG APP_VERSION
-
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,mode=0755,target=/go/pkg \
+  COMMIT=$(git rev-parse HEAD) && \
+  BRANCH=$(git symbolic-ref --short HEAD) && \
+  VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) && \
   CGO_ENABLED=1 GOOS=linux go install \
   -tags="blst_enabled,jemalloc,allocator" \
-  -ldflags "-X main.Version='${APP_VERSION}' -linkmode external -extldflags \"-static -lm\"" \
+  -ldflags "-X main.Commit=$COMMIT -X main.Branch=$BRANCH -X main.Version=$VERSION -linkmode external -extldflags \"-static -lm\"" \
   ./cmd/ssvnode
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,10 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,mode=0755,target=/go/pkg \
   COMMIT=$(git rev-parse HEAD) && \
-  BRANCH=$(git symbolic-ref --short HEAD) && \
   VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) && \
   CGO_ENABLED=1 GOOS=linux go install \
   -tags="blst_enabled,jemalloc,allocator" \
-  -ldflags "-X main.Commit=$COMMIT -X main.Branch=$BRANCH -X main.Version=$VERSION -linkmode external -extldflags \"-static -lm\"" \
+  -ldflags "-X main.Commit=$COMMIT -X main.Version=$VERSION -linkmode external -extldflags \"-static -lm\"" \
   ./cmd/ssvnode
 
 #

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ docker-integration-test:
 #Build
 .PHONY: build
 build:
-	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Branch=`git symbolic-ref --short HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/
+	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/
 
 .PHONY: start-node
 start-node:

--- a/cmd/ssvnode/main.go
+++ b/cmd/ssvnode/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/bloxapp/ssv/cli"
 )
 
@@ -11,13 +12,10 @@ var AppName = "SSV-Node"
 // Version is the app version
 var Version = "latest"
 
-// Branch is the git branch this version was built on
-var Branch = "main"
-
 // Commit is the git commit this version was built on
 var Commit = "unknown"
 
 func main() {
-	version := fmt.Sprintf("%s-%s-%s", Version, Branch, Commit)
+	version := fmt.Sprintf("%s-%s", Version, Commit)
 	cli.Execute(AppName, version)
 }


### PR DESCRIPTION
I don't know why we had ignored `.git`. so unless we have a good reason, I suggest including it in order to be able to get git info.
the alternative is to generate this and pass to the docker build command from outside.