### PR TITLE
fix: (SlotTicker) potential double tick

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -140,7 +140,7 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		slotTickerProvider := func() slotticker.SlotTicker {
-			return slotticker.New(networkConfig)
+			return slotticker.New(logger, networkConfig)
 		}
 
 		cfg.ConsensusClient.Context = cmd.Context()

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -140,7 +140,10 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		slotTickerProvider := func() slotticker.SlotTicker {
-			return slotticker.New(logger, networkConfig)
+			return slotticker.New(logger, slotticker.Config{
+				SlotDuration: networkConfig.SlotDurationSec(),
+				GenesisTime:  networkConfig.GetGenesisTime(),
+			})
 		}
 
 		cfg.ConsensusClient.Context = cmd.Context()

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/ilyakaznacheev/cleanenv v1.4.2
-	github.com/jamiealquiza/tachymeter v2.0.0+incompatible
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/libp2p/go-libp2p v0.28.2
 	github.com/libp2p/go-libp2p-kad-dht v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,6 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
-github.com/jamiealquiza/tachymeter v2.0.0+incompatible h1:mGiF1DGo8l6vnGT8FXNNcIXht/YmjzfraiUprXYwJ6g=
-github.com/jamiealquiza/tachymeter v2.0.0+incompatible/go.mod h1:Ayf6zPZKEnLsc3winWEXJRkTBhdHo58HODAu1oFJkYU=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=

--- a/operator/slotticker/slotticker.go
+++ b/operator/slotticker/slotticker.go
@@ -21,26 +21,6 @@ type Config struct {
 	GenesisTime  time.Time
 }
 
-type TimerProvider func(d time.Duration) Timer
-
-type Timer interface {
-	Stop() bool
-	Reset(d time.Duration) bool
-	C() <-chan time.Time
-}
-
-type timer struct {
-	*time.Timer
-}
-
-func NewTimer(d time.Duration) Timer {
-	return &timer{time.NewTimer(d)}
-}
-
-func (t *timer) C() <-chan time.Time {
-	return t.Timer.C
-}
-
 type slotTicker struct {
 	logger       *zap.Logger
 	timer        Timer
@@ -51,10 +31,10 @@ type slotTicker struct {
 
 // New returns a goroutine-free SlotTicker implementation which is not thread-safe.
 func New(logger *zap.Logger, cfg Config) *slotTicker {
-	return NewWithCustomTimer(logger, cfg, NewTimer)
+	return newWithCustomTimer(logger, cfg, NewTimer)
 }
 
-func NewWithCustomTimer(logger *zap.Logger, cfg Config, timerProvider TimerProvider) *slotTicker {
+func newWithCustomTimer(logger *zap.Logger, cfg Config, timerProvider TimerProvider) *slotTicker {
 	now := time.Now()
 	timeSinceGenesis := now.Sub(cfg.GenesisTime)
 

--- a/operator/slotticker/slotticker.go
+++ b/operator/slotticker/slotticker.go
@@ -16,74 +16,63 @@ type SlotTicker interface {
 	Slot() phase0.Slot
 }
 
-type ConfigProvider interface {
-	SlotDurationSec() time.Duration
-	GetGenesisTime() time.Time
-}
-
 type Config struct {
-	slotDuration time.Duration
-	genesisTime  time.Time
+	SlotDuration time.Duration
+	GenesisTime  time.Time
 }
 
-func (cfg Config) SlotDurationSec() time.Duration {
-	return cfg.slotDuration
+type TimerProvider func(d time.Duration) Timer
+
+type Timer interface {
+	Stop() bool
+	Reset(d time.Duration) bool
+	C() <-chan time.Time
 }
 
-func (cfg Config) GetGenesisTime() time.Time {
-	return cfg.genesisTime
+type timer struct {
+	*time.Timer
 }
 
-type TimerProvider interface {
-	NewTimer(d time.Duration) *time.Timer
+func NewTimer(d time.Duration) Timer {
+	return &timer{time.NewTimer(d)}
 }
 
-// realTimerProvider is an implementation of TimerProvider that uses real timers.
-type realTimerProvider struct{}
-
-func (rtp *realTimerProvider) NewTimer(d time.Duration) *time.Timer {
-	return time.NewTimer(d)
+func (t *timer) C() <-chan time.Time {
+	return t.Timer.C
 }
 
 type slotTicker struct {
 	logger       *zap.Logger
-	timer        *time.Timer
+	timer        Timer
 	slotDuration time.Duration
 	genesisTime  time.Time
 	slot         phase0.Slot
 }
 
 // New returns a goroutine-free SlotTicker implementation which is not thread-safe.
-func New(logger *zap.Logger, cfgProvider ConfigProvider) *slotTicker {
-	return NewWithCustomTimer(logger, cfgProvider, &realTimerProvider{})
+func New(logger *zap.Logger, cfg Config) *slotTicker {
+	return NewWithCustomTimer(logger, cfg, NewTimer)
 }
 
-func NewWithCustomTimer(logger *zap.Logger, cfgProvider ConfigProvider, timerProvider TimerProvider) *slotTicker {
-	genesisTime := cfgProvider.GetGenesisTime()
-	slotDuration := cfgProvider.SlotDurationSec()
-
+func NewWithCustomTimer(logger *zap.Logger, cfg Config, timerProvider TimerProvider) *slotTicker {
 	now := time.Now()
-	timeSinceGenesis := now.Sub(genesisTime)
+	timeSinceGenesis := now.Sub(cfg.GenesisTime)
 
 	var initialDelay time.Duration
 	if timeSinceGenesis < 0 {
 		// Genesis time is in the future
 		initialDelay = -timeSinceGenesis // Wait until the genesis time
 	} else {
-		slotsSinceGenesis := timeSinceGenesis / slotDuration
-		nextSlotStartTime := genesisTime.Add((slotsSinceGenesis + 1) * slotDuration)
+		slotsSinceGenesis := timeSinceGenesis / cfg.SlotDuration
+		nextSlotStartTime := cfg.GenesisTime.Add((slotsSinceGenesis + 1) * cfg.SlotDuration)
 		initialDelay = time.Until(nextSlotStartTime)
-	}
-
-	if timerProvider == nil {
-		timerProvider = &realTimerProvider{}
 	}
 
 	return &slotTicker{
 		logger:       logger,
-		timer:        timerProvider.NewTimer(initialDelay),
-		slotDuration: slotDuration,
-		genesisTime:  genesisTime,
+		timer:        timerProvider(initialDelay),
+		slotDuration: cfg.SlotDuration,
+		genesisTime:  cfg.GenesisTime,
 		slot:         0,
 	}
 }
@@ -94,12 +83,12 @@ func NewWithCustomTimer(logger *zap.Logger, cfgProvider ConfigProvider, timerPro
 func (s *slotTicker) Next() <-chan time.Time {
 	timeSinceGenesis := time.Since(s.genesisTime)
 	if timeSinceGenesis < 0 {
-		return s.timer.C
+		return s.timer.C()
 	}
 	if !s.timer.Stop() {
 		// try to drain the channel, but don't block if there's no value
 		select {
-		case <-s.timer.C:
+		case <-s.timer.C():
 		default:
 		}
 	}
@@ -107,12 +96,12 @@ func (s *slotTicker) Next() <-chan time.Time {
 	if nextSlot <= s.slot {
 		// We've already ticked for this slot, so we need to wait for the next one.
 		nextSlot = s.slot + 1
-		s.logger.Warn("double tick", zap.Uint64("slot", uint64(s.slot)))
+		s.logger.Debug("double tick", zap.Uint64("slot", uint64(s.slot)))
 	}
 	nextSlotStartTime := s.genesisTime.Add(time.Duration(nextSlot) * s.slotDuration)
 	s.timer.Reset(time.Until(nextSlotStartTime))
 	s.slot = nextSlot
-	return s.timer.C
+	return s.timer.C()
 }
 
 // Slot returns the current slot number.

--- a/operator/slotticker/slotticker_test.go
+++ b/operator/slotticker/slotticker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cornelk/hashmap/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestSlotTicker(t *testing.T) {
@@ -20,7 +21,7 @@ func TestSlotTicker(t *testing.T) {
 	timeSinceGenesis := time.Since(genesisTime)
 	expectedSlot := phase0.Slot(timeSinceGenesis/slotDuration) + 1
 
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 
 	for i := 0; i < numTicks; i++ {
 		<-ticker.Next()
@@ -34,7 +35,7 @@ func TestSlotTicker(t *testing.T) {
 func TestTickerInitialization(t *testing.T) {
 	slotDuration := 200 * time.Millisecond
 	genesisTime := time.Now()
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 
 	start := time.Now()
 	<-ticker.Next()
@@ -52,7 +53,7 @@ func TestSlotNumberConsistency(t *testing.T) {
 	slotDuration := 200 * time.Millisecond
 	genesisTime := time.Now()
 
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 	var lastSlot phase0.Slot
 
 	for i := 0; i < 10; i++ {
@@ -68,7 +69,7 @@ func TestGenesisInFuture(t *testing.T) {
 	slotDuration := 200 * time.Millisecond
 	genesisTime := time.Now().Add(1 * time.Second) // Setting genesis time 1s in the future
 
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 	start := time.Now()
 
 	<-ticker.Next()
@@ -87,7 +88,7 @@ func TestBoundedDrift(t *testing.T) {
 	slotDuration := 20 * time.Millisecond
 	genesisTime := time.Now()
 
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 	ticks := 100
 
 	start := time.Now()
@@ -120,7 +121,7 @@ func TestMultipleSlotTickers(t *testing.T) {
 	for i := 0; i < numTickers; i++ {
 		go func() {
 			defer wg.Done()
-			ticker := New(Config{slotDuration, genesisTime})
+			ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 			for j := 0; j < ticksPerTimer; j++ {
 				<-ticker.Next()
 			}
@@ -146,7 +147,7 @@ func TestSlotSkipping(t *testing.T) {
 	)
 
 	genesisTime := time.Now()
-	ticker := New(Config{slotDuration, genesisTime})
+	ticker := New(zap.NewNop(), Config{slotDuration, genesisTime})
 
 	var lastSlot phase0.Slot
 	for i := 1; i <= numTicks; i++ { // Starting loop from 1 for ease of skipInterval check

--- a/operator/slotticker/slotticker_test.go
+++ b/operator/slotticker/slotticker_test.go
@@ -219,7 +219,7 @@ func TestDoubleTickWarning(t *testing.T) {
 	logger := zap.New(core)
 
 	// Initialize the slotTicker with the mock timer provider
-	ticker := NewWithCustomTimer(logger, Config{
+	ticker := newWithCustomTimer(logger, Config{
 		SlotDuration: 200 * time.Millisecond,
 		GenesisTime:  time.Now(),
 	}, func(d time.Duration) Timer {
@@ -267,7 +267,7 @@ func TestDoubleTickRealTimer(t *testing.T) {
 	mockTimer := &mockTimer{timer: NewTimer(time.Hour).(*timer)}
 	slotTime := 200 * time.Millisecond
 	firstSlotTime := time.Now()
-	ticker := NewWithCustomTimer(logger, Config{
+	ticker := newWithCustomTimer(logger, Config{
 		SlotDuration: slotTime,
 		GenesisTime:  time.Now(),
 	}, (&mockTimeProvider{timer: mockTimer}).NewTimer)

--- a/operator/slotticker/timer.go
+++ b/operator/slotticker/timer.go
@@ -1,0 +1,23 @@
+package slotticker
+
+import "time"
+
+type TimerProvider func(d time.Duration) Timer
+
+type Timer interface {
+	Stop() bool
+	Reset(d time.Duration) bool
+	C() <-chan time.Time
+}
+
+type timer struct {
+	*time.Timer
+}
+
+func NewTimer(d time.Duration) Timer {
+	return &timer{time.NewTimer(d)}
+}
+
+func (t *timer) C() <-chan time.Time {
+	return t.Timer.C
+}


### PR DESCRIPTION
This PR fixes a bug where the SlotTicker wakes up earlier than planned, for example 11.999 seconds into the same slot it already ticked on, and ends up ticking the same slot again.

See https://github.com/bloxapp/ssv/pull/1244#discussion_r1431331559 for more explanation.