### PR TITLE
Fix: health route host addres

### DIFF
--- a/api/handlers/node.go
+++ b/api/handlers/node.go
@@ -128,9 +128,7 @@ func (h *Node) Health(w http.ResponseWriter, r *http.Request) error {
 	var resp healthCheckJSON
 
 	// Retrieve P2P listen addresses.
-	for _, addr := range h.ListenAddresses {
-		resp.Advanced.ListenAddresses = append(resp.Advanced.ListenAddresses, addr)
-	}
+	resp.Advanced.ListenAddresses = h.ListenAddresses
 
 	// Count peers and connections.
 	peers := h.Network.Peers()

--- a/api/handlers/node.go
+++ b/api/handlers/node.go
@@ -7,14 +7,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr/net"
-
 	"github.com/bloxapp/ssv/api"
 	networkpeers "github.com/bloxapp/ssv/network/peers"
 	"github.com/bloxapp/ssv/nodeprobe"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const healthyPeerCount = 30
@@ -87,10 +84,11 @@ func (hc healthCheckJSON) String() string {
 }
 
 type Node struct {
-	PeersIndex networkpeers.Index
-	TopicIndex TopicIndex
-	Network    network.Network
-	NodeProber *nodeprobe.Prober
+	ListenAddresses []string
+	PeersIndex      networkpeers.Index
+	TopicIndex      TopicIndex
+	Network         network.Network
+	NodeProber      *nodeprobe.Prober
 }
 
 func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
@@ -130,16 +128,8 @@ func (h *Node) Health(w http.ResponseWriter, r *http.Request) error {
 	var resp healthCheckJSON
 
 	// Retrieve P2P listen addresses.
-	for _, addr := range h.Network.ListenAddresses() {
-		if addr.String() == "/p2p-circuit" || addr.Decapsulate(ma.StringCast("/ip4/0.0.0.0")) == nil {
-			// Skip circuit and non-IP4 addresses.
-			continue
-		}
-		netAddr, err := manet.ToNetAddr(addr)
-		if err != nil {
-			return fmt.Errorf("failed to convert multiaddr to net.Addr: %w", err)
-		}
-		resp.Advanced.ListenAddresses = append(resp.Advanced.ListenAddresses, netAddr.String())
+	for _, addr := range h.ListenAddresses {
+		resp.Advanced.ListenAddresses = append(resp.Advanced.ListenAddresses, addr)
 	}
 
 	// Count peers and connections.

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -300,10 +300,11 @@ var StartNodeCmd = &cobra.Command{
 				fmt.Sprintf(":%d", cfg.SSVAPIPort),
 				&handlers.Node{
 					// TODO: replace with narrower interface! (instead of accessing the entire PeersIndex)
-					PeersIndex: p2pNetwork.(p2pv1.PeersIndexProvider).PeersIndex(),
-					Network:    p2pNetwork.(p2pv1.HostProvider).Host().Network(),
-					TopicIndex: p2pNetwork.(handlers.TopicIndex),
-					NodeProber: nodeProber,
+					ListenAddresses: []string{fmt.Sprintf("tcp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.TCPPort), fmt.Sprintf("udp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.UDPPort)},
+					PeersIndex:      p2pNetwork.(p2pv1.PeersIndexProvider).PeersIndex(),
+					Network:         p2pNetwork.(p2pv1.HostProvider).Host().Network(),
+					TopicIndex:      p2pNetwork.(handlers.TopicIndex),
+					NodeProber:      nodeProber,
 				},
 				&handlers.Validators{
 					Shares: nodeStorage.Shares(),


### PR DESCRIPTION
we were using libp2p to get the addresses to show in the health route, while this works in K8S, local node will publish their local IP, so now we are passing in the host address and advertising it.
found with @moshe-blox 