### PR TITLE
fix: switch endpoint in `checkPrysmDebugEndpoints`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - fix-prysm-debug-check
+    - stage
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - fix-prysm-debug-check
+    - stage
 
 # +---------------+
 # |     Prod      |
@@ -120,7 +120,7 @@ Build prod Docker image:
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_COMMIT_SHA
 
   only:
-    - fix-prysm-debug-check
+    - main
 
 Deploy nodes to prod:
   stage: deploy
@@ -139,7 +139,7 @@ Deploy nodes to prod:
     # +-------------------------------+
     # |  🟠 Deploy SSV Holesky nodes  |
     # +-------------------------------+
-    # - .k8/production/holesky/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
+    - .k8/production/holesky/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
     #
     # +-------------------------------+
     # │  🟠 Deploy Holesky Bootnode   |
@@ -150,7 +150,7 @@ Deploy nodes to prod:
     # +---------------------------+
     # |  🟠 Deploy SSV Prater nodes  |
     # +---------------------------+
-    # - .k8/production/prater/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
+    - .k8/production/prater/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
     #
     # +----------------------------+
     # |  🔴 Deploy SSV Mainnet nodes  |
@@ -171,7 +171,7 @@ Deploy nodes to prod:
     # - .k8/production/mainnet/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
 
   only:
-    - fix-prysm-debug-check
+    - main
 
 Deploy exporter to prod:
   stage: deploy
@@ -204,5 +204,5 @@ Deploy exporter to prod:
     # - .k8/production/mainnet/scripts/deploy-exporters.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
 
   only:
-    - fix-prysm-debug-check
+    - main
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - stage
+    - fix-prysm-debug-check
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - fix-prysm-debug-check
 
 # +---------------+
 # |     Prod      |
@@ -120,7 +120,7 @@ Build prod Docker image:
     - $DOCKER_LOGIN_TO_INFRA_PROD_REPO && docker push $DOCKER_REPO_INFRA_PROD:$CI_COMMIT_SHA
 
   only:
-    - main
+    - fix-prysm-debug-check
 
 Deploy nodes to prod:
   stage: deploy
@@ -139,7 +139,7 @@ Deploy nodes to prod:
     # +-------------------------------+
     # |  🟠 Deploy SSV Holesky nodes  |
     # +-------------------------------+
-    - .k8/production/holesky/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
+    # - .k8/production/holesky/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
     #
     # +-------------------------------+
     # │  🟠 Deploy Holesky Bootnode   |
@@ -150,7 +150,7 @@ Deploy nodes to prod:
     # +---------------------------+
     # |  🟠 Deploy SSV Prater nodes  |
     # +---------------------------+
-    - .k8/production/prater/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
+    # - .k8/production/prater/scripts/deploy-cluster-1--4.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
     #
     # +----------------------------+
     # |  🔴 Deploy SSV Mainnet nodes  |
@@ -171,7 +171,7 @@ Deploy nodes to prod:
     # - .k8/production/mainnet/scripts/deploy-boot-nodes.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $PROD_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT_V3 $SSV_NODES_MEM_LIMIT_V3
 
   only:
-    - main
+    - fix-prysm-debug-check
 
 Deploy exporter to prod:
   stage: deploy
@@ -204,5 +204,5 @@ Deploy exporter to prod:
     # - .k8/production/mainnet/scripts/deploy-exporters.sh $DOCKER_REPO_INFRA_PROD $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_PROD blox-infra-prod kubernetes-admin@blox-infra-prod ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
 
   only:
-    - main
+    - fix-prysm-debug-check
 

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -288,17 +288,17 @@ func (gc *goClient) checkPrysmDebugEndpoints() error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v2/debug/beacon/heads", address), nil)
 	if err != nil {
-		return fmt.Errorf("failed to create fork choice request: %w", err)
+		return fmt.Errorf("failed to create beacon heads request: %w", err)
 	}
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to get fork choice: %w", err)
+		return fmt.Errorf("failed to get beacon heads: %w", err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("Prysm node doesn't have debug endpoints enabled, please enable them with --enable-debug-rpc-endpoints")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to get fork choice: %s", resp.Status)
+		return fmt.Errorf("failed to get beacon heads: %s", resp.Status)
 	}
 	var data struct {
 		Data []struct {
@@ -306,13 +306,13 @@ func (gc *goClient) checkPrysmDebugEndpoints() error {
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return fmt.Errorf("failed to decode fork choice response: %w", err)
+		return fmt.Errorf("failed to decode beacon heads response: %w", err)
 	}
 	if len(data.Data) == 0 {
-		return fmt.Errorf("no fork choice found")
+		return fmt.Errorf("no beacon heads found")
 	}
 	if data.Data[0].Root == (phase0.Root{}) {
-		return fmt.Errorf("no justified checkpoint found")
+		return fmt.Errorf("beacon head is empty")
 	}
 	gc.log.Debug("Prysm debug endpoints are enabled", zap.Duration("took", time.Since(start)))
 	return nil

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -286,7 +286,7 @@ func (gc *goClient) checkPrysmDebugEndpoints() error {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultCommonTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v2/beacon/heads", address), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v2/debug/beacon/heads", address), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create fork choice request: %w", err)
 	}


### PR DESCRIPTION
Prysm v4.2.1 fixed the incorrect endpoint which we depended on in `checkPrysmDebugEndpoints` (they reverted it back to the correct `v1` path).

For that reason, we're now querying a different debug endpoint which didn't change in order to support both Prysm v4.2.0 and v4.2.1