### PR TITLE
fix: get own sync committee duties after validators setup.

### DIFF
--- a/operator/duties/attester_test.go
+++ b/operator/duties/attester_test.go
@@ -43,7 +43,7 @@ func setupAttesterDutiesMock(s *Scheduler, dutiesMap *hashmap.Map[phase0.Epoch, 
 		return indices
 	}
 	s.validatorController.(*mocks.MockValidatorController).EXPECT().CommitteeActiveIndices(gomock.Any()).DoAndReturn(getIndices).AnyTimes()
-	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any()).DoAndReturn(getIndices).AnyTimes()
+	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any(), gomock.Any()).DoAndReturn(getIndices).AnyTimes()
 
 	s.beaconNode.(*mocks.MockBeaconNode).EXPECT().SubmitBeaconCommitteeSubscriptions(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 

--- a/operator/duties/mocks/scheduler.go
+++ b/operator/duties/mocks/scheduler.go
@@ -241,17 +241,17 @@ func (m *MockValidatorController) EXPECT() *MockValidatorControllerMockRecorder 
 }
 
 // AllActiveIndices mocks base method.
-func (m *MockValidatorController) AllActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex {
+func (m *MockValidatorController) AllActiveIndices(epoch phase0.Epoch, afterValidatorsSetup bool) []phase0.ValidatorIndex {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllActiveIndices", epoch)
+	ret := m.ctrl.Call(m, "AllActiveIndices", epoch, afterValidatorsSetup)
 	ret0, _ := ret[0].([]phase0.ValidatorIndex)
 	return ret0
 }
 
 // AllActiveIndices indicates an expected call of AllActiveIndices.
-func (mr *MockValidatorControllerMockRecorder) AllActiveIndices(epoch interface{}) *gomock.Call {
+func (mr *MockValidatorControllerMockRecorder) AllActiveIndices(epoch, afterValidatorsSetup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllActiveIndices", reflect.TypeOf((*MockValidatorController)(nil).AllActiveIndices), epoch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllActiveIndices", reflect.TypeOf((*MockValidatorController)(nil).AllActiveIndices), epoch, afterValidatorsSetup)
 }
 
 // CommitteeActiveIndices mocks base method.

--- a/operator/duties/mocks/scheduler.go
+++ b/operator/duties/mocks/scheduler.go
@@ -241,17 +241,17 @@ func (m *MockValidatorController) EXPECT() *MockValidatorControllerMockRecorder 
 }
 
 // AllActiveIndices mocks base method.
-func (m *MockValidatorController) AllActiveIndices(epoch phase0.Epoch, afterValidatorsSetup bool) []phase0.ValidatorIndex {
+func (m *MockValidatorController) AllActiveIndices(epoch phase0.Epoch, afterInit bool) []phase0.ValidatorIndex {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllActiveIndices", epoch, afterValidatorsSetup)
+	ret := m.ctrl.Call(m, "AllActiveIndices", epoch, afterInit)
 	ret0, _ := ret[0].([]phase0.ValidatorIndex)
 	return ret0
 }
 
 // AllActiveIndices indicates an expected call of AllActiveIndices.
-func (mr *MockValidatorControllerMockRecorder) AllActiveIndices(epoch, afterValidatorsSetup interface{}) *gomock.Call {
+func (mr *MockValidatorControllerMockRecorder) AllActiveIndices(epoch, afterInit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllActiveIndices", reflect.TypeOf((*MockValidatorController)(nil).AllActiveIndices), epoch, afterValidatorsSetup)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllActiveIndices", reflect.TypeOf((*MockValidatorController)(nil).AllActiveIndices), epoch, afterInit)
 }
 
 // CommitteeActiveIndices mocks base method.

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -146,7 +146,7 @@ func (h *ProposerHandler) processExecution(epoch phase0.Epoch, slot phase0.Slot)
 func (h *ProposerHandler) fetchAndProcessDuties(ctx context.Context, epoch phase0.Epoch) error {
 	start := time.Now()
 
-	allIndices := h.validatorController.AllActiveIndices(epoch)
+	allIndices := h.validatorController.AllActiveIndices(epoch, false)
 	if len(allIndices) == 0 {
 		return nil
 	}

--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -41,8 +41,13 @@ func setupProposerDutiesMock(s *Scheduler, dutiesMap *hashmap.Map[phase0.Epoch, 
 
 		return indices
 	}
+
+	getIndicesBool := func(epoch phase0.Epoch, wait bool) []phase0.ValidatorIndex {
+		return getIndices(epoch)
+	}
+
 	s.validatorController.(*mocks.MockValidatorController).EXPECT().CommitteeActiveIndices(gomock.Any()).DoAndReturn(getIndices).AnyTimes()
-	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any()).DoAndReturn(getIndices).AnyTimes()
+	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any(), gomock.Any()).DoAndReturn(getIndicesBool).AnyTimes()
 
 	return fetchDutiesCall, executeDutiesCall
 }

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -70,7 +70,7 @@ type ExecutionClient interface {
 // ValidatorController represents the component that controls validators via the scheduler
 type ValidatorController interface {
 	CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
-	AllActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
+	AllActiveIndices(epoch phase0.Epoch, afterMetadataFetch bool) []phase0.ValidatorIndex
 	GetOperatorShares() []*types.SSVShare
 }
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -70,7 +70,7 @@ type ExecutionClient interface {
 // ValidatorController represents the component that controls validators via the scheduler
 type ValidatorController interface {
 	CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
-	AllActiveIndices(epoch phase0.Epoch, afterValidatorsSetup bool) []phase0.ValidatorIndex
+	AllActiveIndices(epoch phase0.Epoch, afterInit bool) []phase0.ValidatorIndex
 	GetOperatorShares() []*types.SSVShare
 }
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -70,7 +70,7 @@ type ExecutionClient interface {
 // ValidatorController represents the component that controls validators via the scheduler
 type ValidatorController interface {
 	CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
-	AllActiveIndices(epoch phase0.Epoch, afterMetadataFetch bool) []phase0.ValidatorIndex
+	AllActiveIndices(epoch phase0.Epoch, afterValidatorsSetup bool) []phase0.ValidatorIndex
 	GetOperatorShares() []*types.SSVShare
 }
 

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -72,8 +72,13 @@ func setupSyncCommitteeDutiesMock(s *Scheduler, dutiesMap *hashmap.Map[uint64, [
 
 		return indices
 	}
+
+	getDutiesBool := func(epoch phase0.Epoch, wait bool) []phase0.ValidatorIndex {
+		return getDuties(epoch)
+	}
+
 	s.validatorController.(*mocks.MockValidatorController).EXPECT().CommitteeActiveIndices(gomock.Any()).DoAndReturn(getDuties).AnyTimes()
-	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any()).DoAndReturn(getDuties).AnyTimes()
+	s.validatorController.(*mocks.MockValidatorController).EXPECT().AllActiveIndices(gomock.Any(), gomock.Any()).DoAndReturn(getDutiesBool).AnyTimes()
 
 	s.beaconNode.(*mocks.MockBeaconNode).EXPECT().SubmitSyncCommitteeSubscriptions(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -761,40 +761,6 @@ func (c *controller) onShareStart(share *ssvtypes.SSVShare) (bool, error) {
 	return c.startValidator(v)
 }
 
-//
-//func (c *controller) onShareStartValidator() (bool, error) {
-//	if !share.HasBeaconMetadata() { // fetching index and status in case not exist
-//		c.logger.Warn("skipping validator until it becomes active", fields.PubKey(share.ValidatorPubKey))
-//		return false, nil
-//	}
-//	if err := c.setShareFeeRecipient(share, c.recipientsStorage.GetRecipientData); err != nil {
-//		return false, fmt.Errorf("could not set share fee recipient: %w", err)
-//	}
-//	// Start a committee validator.
-//	v, found := c.validatorsMap.GetValidator(hex.EncodeToString(share.ValidatorPubKey))
-//	if !found {
-//		if !share.HasBeaconMetadata() {
-//			return false, fmt.Errorf("beacon metadata is missing")
-//		}
-//		// Share context with both the validator and the runners,
-//		// so that when the validator is stopped, the runners are stopped as well.
-//		ctx, cancel := context.WithCancel(c.context)
-//
-//		opts := c.validatorOptions
-//		opts.SSVShare = share
-//		opts.DutyRunners = SetupRunners(ctx, c.logger, opts)
-//		v = validator.NewValidator(ctx, cancel, opts)
-//		c.validatorsMap.CreateValidator(hex.EncodeToString(share.ValidatorPubKey), v)
-//
-//		c.printShare(share, "setup validator done")
-//
-//	} else {
-//		c.printShare(v.Share, "get validator")
-//	}
-//
-//	return c.startValidator(v)
-//}
-
 func (c *controller) printShare(s *ssvtypes.SSVShare, msg string) {
 	committee := make([]string, len(s.Committee))
 	for i, c := range s.Committee {

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -96,7 +96,7 @@ type ControllerOptions struct {
 type Controller interface {
 	StartValidators()
 	CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
-	AllActiveIndices(epoch phase0.Epoch, afterValidatorSetup bool) []phase0.ValidatorIndex
+	AllActiveIndices(epoch phase0.Epoch, afterInit bool) []phase0.ValidatorIndex
 	GetValidator(pubKey string) (*validator.Validator, bool)
 	ExecuteDuty(logger *zap.Logger, duty *spectypes.Duty)
 	UpdateValidatorMetaDataLoop()
@@ -663,8 +663,8 @@ func (c *controller) CommitteeActiveIndices(epoch phase0.Epoch) []phase0.Validat
 	return indices
 }
 
-func (c *controller) AllActiveIndices(epoch phase0.Epoch, afterMetadata bool) []phase0.ValidatorIndex {
-	if afterMetadata {
+func (c *controller) AllActiveIndices(epoch phase0.Epoch, afterInit bool) []phase0.ValidatorIndex {
+	if afterInit {
 		<-c.initialValidatorSetup
 	}
 	shares := c.sharesStorage.List(nil, isShareActive(epoch))

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -445,6 +445,8 @@ func (c *controller) StartValidators() {
 		}
 	}
 
+	close(c.initialValidatorSetup)
+
 	c.startValidators(inited)
 
 	// Fetch metadata for all validators.

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -96,7 +96,7 @@ type ControllerOptions struct {
 type Controller interface {
 	StartValidators()
 	CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex
-	AllActiveIndices(epoch phase0.Epoch, afterMetadataFetch bool) []phase0.ValidatorIndex
+	AllActiveIndices(epoch phase0.Epoch, afterValidatorSetup bool) []phase0.ValidatorIndex
 	GetValidator(pubKey string) (*validator.Validator, bool)
 	ExecuteDuty(logger *zap.Logger, duty *spectypes.Duty)
 	UpdateValidatorMetaDataLoop()

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -474,6 +474,7 @@ func TestSetupValidators(t *testing.T) {
 		recipientMockTimes int
 		bcMockTimes        int
 		recipientFound     bool
+		inited             int
 		started            int
 		recipientErr       error
 		name               string
@@ -490,6 +491,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       nil,
 			recipientMockTimes: 1,
 			bcResponse:         bcResponse,
+			inited:             1,
 			started:            1,
 			bcMockTimes:        1,
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -504,6 +506,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       nil,
 			recipientMockTimes: 1,
 			bcResponse:         bcResponse,
+			inited:             1,
 			started:            1,
 			bcMockTimes:        1,
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -518,6 +521,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       errors.New("some error"),
 			recipientMockTimes: 1,
 			bcResponse:         bcResponse,
+			inited:             0,
 			started:            0,
 			bcMockTimes:        0,
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -532,6 +536,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       nil,
 			recipientMockTimes: 1,
 			bcResponse:         bcResponse,
+			inited:             1,
 			started:            1,
 			bcMockTimes:        0,
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -541,6 +546,7 @@ func TestSetupValidators(t *testing.T) {
 		{
 			name:               "start share without metadata",
 			bcMockTimes:        1,
+			inited:             0,
 			started:            0,
 			recipientMockTimes: 0,
 			recipientData:      nil,
@@ -560,6 +566,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       nil,
 			bcResponse:         nil,
 			recipientFound:     false,
+			inited:             0,
 			started:            0,
 			shares:             []*types.SSVShare{shareWithoutMetaData},
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -574,6 +581,7 @@ func TestSetupValidators(t *testing.T) {
 			recipientErr:       nil,
 			recipientMockTimes: 1,
 			bcResponse:         bcResponse,
+			inited:             1,
 			started:            0,
 			bcMockTimes:        0,
 			validatorStartFunc: func(validator *validator.Validator) (bool, error) {
@@ -625,8 +633,11 @@ func TestSetupValidators(t *testing.T) {
 			recipientStorage.EXPECT().GetRecipientData(gomock.Any(), gomock.Any()).Return(tc.recipientData, tc.recipientFound, tc.recipientErr).Times(tc.recipientMockTimes)
 			ctr := setupController(logger, controllerOptions)
 			ctr.validatorStartFunc = tc.validatorStartFunc
-			started := ctr.setupValidators(tc.shares)
-			require.Equal(t, tc.started, started)
+			inited := ctr.setupValidators(tc.shares)
+			require.Len(t, inited, tc.inited)
+			started := ctr.startValidators(inited)
+			require.Equal(t, started, tc.started)
+
 			//Add any assertions here to validate the behavior
 		})
 	}


### PR DESCRIPTION
#### Passed E2E

- [x] - [run log](https://github.com/bloxapp/ssv/actions/runs/7775676172)

## Description


This PR makes `AllActiveIndices` (optionally) wait for a channel that is closed only when an initial validators setup has already happened.

It aims to solve a situation where an operator that asked for sync-committee duties before validators setup will think it does not have any validators with sync-committee duties for a whole period, resulting in a lot of missing sync committee duties.

made with @moshe-blox 