### PR TITLE
fix: (ProposerRunner) missing block summary for Deneb

### DIFF
--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -467,6 +467,9 @@ func summarizeBlock(block any) (summary blockSummary, err error) {
 		summary.Hash = b.Body.ExecutionPayload.BlockHash
 		summary.Version = spec.DataVersionDeneb
 
+	case *apiv1deneb.BlockContents:
+		return summarizeBlock(b.Block)
+
 	case *apiv1capella.BlindedBeaconBlock:
 		if b == nil || b.Body == nil || b.Body.ExecutionPayloadHeader == nil {
 			return summary, fmt.Errorf("block, body or execution payload header is nil")


### PR DESCRIPTION
This PR covers the case of `BlockContents` in `summarizeBlock`, which was missing in the Deneb upgrades.