### PR TITLE
Fix Message Validation and Validator Registration for Newly Active Validators

### DIFF
--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -427,7 +427,7 @@ func (mv *messageValidator) validateSSVMessage(ssvMessage *spectypes.SSVMessage,
 			return nil, descriptor, ErrNoShareMetadata
 		}
 
-		if !share.BeaconMetadata.IsAttesting() {
+		if !share.IsActive(mv.netCfg.Beacon.EstimatedCurrentEpoch()) {
 			err := ErrValidatorNotAttesting
 			err.got = share.BeaconMetadata.Status.String()
 			return nil, descriptor, err

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -660,13 +659,12 @@ func CreateDutyExecuteMsg(duty *spectypes.Duty, pubKey phase0.BLSPubKey, domain 
 	}, nil
 }
 
-// CommitteeActiveIndices fetches indices of in-committee validators who are either attesting or queued and
-// whose activation epoch is not greater than the passed epoch. It logs a warning if an error occurs.
+// CommitteeActiveIndices fetches indices of in-committee validators who are attest eligible at the given epoch.
 func (c *controller) CommitteeActiveIndices(epoch phase0.Epoch) []phase0.ValidatorIndex {
 	validators := c.validatorsMap.GetAll()
 	indices := make([]phase0.ValidatorIndex, 0, len(validators))
 	for _, v := range validators {
-		if isShareActive(epoch)(v.Share) {
+		if v.Share.IsActive(epoch) {
 			indices = append(indices, v.Share.BeaconMetadata.Index)
 		}
 	}
@@ -677,20 +675,12 @@ func (c *controller) AllActiveIndices(epoch phase0.Epoch, afterInit bool) []phas
 	if afterInit {
 		<-c.committeeValidatorSetup
 	}
-	shares := c.sharesStorage.List(nil, isShareActive(epoch))
+	shares := c.sharesStorage.List(nil, registrystorage.ByAttesting(epoch))
 	indices := make([]phase0.ValidatorIndex, len(shares))
 	for i, share := range shares {
 		indices[i] = share.BeaconMetadata.Index
 	}
 	return indices
-}
-
-func isShareActive(epoch phase0.Epoch) func(share *ssvtypes.SSVShare) bool {
-	return func(share *ssvtypes.SSVShare) bool {
-		return share != nil && share.BeaconMetadata != nil &&
-			(share.BeaconMetadata.IsAttesting() || share.BeaconMetadata.Status == v1.ValidatorStatePendingQueued) &&
-			share.BeaconMetadata.ActivationEpoch <= epoch
-	}
 }
 
 // onMetadataUpdated is called when validator's metadata was updated

--- a/protocol/v2/types/ssvshare.go
+++ b/protocol/v2/types/ssvshare.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"sort"
 
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -59,6 +61,11 @@ func (s *SSVShare) BelongsToOperator(operatorID spectypes.OperatorID) bool {
 // HasBeaconMetadata checks whether the BeaconMetadata field is not nil.
 func (s *SSVShare) HasBeaconMetadata() bool {
 	return s != nil && s.BeaconMetadata != nil
+}
+
+func (s *SSVShare) IsActive(epoch phase0.Epoch) bool {
+	return s.HasBeaconMetadata() &&
+		(s.BeaconMetadata.IsAttesting() || (s.BeaconMetadata.Status == eth2apiv1.ValidatorStatePendingQueued && s.BeaconMetadata.ActivationEpoch <= epoch))
 }
 
 func (s *SSVShare) SetFeeRecipient(feeRecipient bellatrix.ExecutionAddress) {

--- a/protocol/v2/types/ssvshare_test.go
+++ b/protocol/v2/types/ssvshare_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/bloxapp/ssv-spec/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	beaconprotocol "github.com/bloxapp/ssv/protocol/v2/blockchain/beacon"
@@ -102,6 +103,85 @@ func TestValidCommitteeSize(t *testing.T) {
 			for _, size := range tc.sizes {
 				require.Equal(t, tc.valid, ValidCommitteeSize(size))
 			}
+		})
+	}
+}
+
+func TestSSVShare_IsActive(t *testing.T) {
+	currentEpoch := phase0.Epoch(100) // Example current epoch for testing
+	tt := []struct {
+		Name     string
+		Share    *SSVShare
+		Epoch    phase0.Epoch
+		Expected bool
+	}{
+		{
+			Name: "No BeaconMetadata",
+			Share: &SSVShare{
+				Metadata: Metadata{
+					BeaconMetadata: nil,
+				},
+			},
+			Epoch:    currentEpoch,
+			Expected: false,
+		},
+		{
+			Name: "Is Attesting",
+			Share: &SSVShare{
+				Metadata: Metadata{
+					BeaconMetadata: &beaconprotocol.ValidatorMetadata{
+						Status: eth2apiv1.ValidatorStateActiveOngoing,
+					},
+				},
+			},
+			Epoch:    currentEpoch,
+			Expected: true,
+		},
+		{
+			Name: "Pending Queued with Future Activation Epoch",
+			Share: &SSVShare{
+				Metadata: Metadata{
+					BeaconMetadata: &beaconprotocol.ValidatorMetadata{
+						Status:          eth2apiv1.ValidatorStatePendingQueued,
+						ActivationEpoch: currentEpoch + 1,
+					},
+				},
+			},
+			Epoch:    currentEpoch,
+			Expected: false,
+		},
+		{
+			Name: "Pending Queued with Current Epoch as Activation Epoch",
+			Share: &SSVShare{
+				Metadata: Metadata{
+					BeaconMetadata: &beaconprotocol.ValidatorMetadata{
+						Status:          eth2apiv1.ValidatorStatePendingQueued,
+						ActivationEpoch: currentEpoch,
+					},
+				},
+			},
+			Epoch:    currentEpoch,
+			Expected: true,
+		},
+		{
+			Name: "Pending Queued with Past Activation Epoch",
+			Share: &SSVShare{
+				Metadata: Metadata{
+					BeaconMetadata: &beaconprotocol.ValidatorMetadata{
+						Status:          eth2apiv1.ValidatorStatePendingQueued,
+						ActivationEpoch: currentEpoch - 1,
+					},
+				},
+			},
+			Epoch:    currentEpoch,
+			Expected: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Share.IsActive(tc.Epoch)
+			require.Equal(t, tc.Expected, result)
 		})
 	}
 }

--- a/registry/storage/shares.go
+++ b/registry/storage/shares.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
@@ -206,9 +207,9 @@ func ByActiveValidator() SharesFilter {
 }
 
 // ByAttesting filters for attesting validators.
-func ByAttesting() SharesFilter {
+func ByAttesting(epoch phase0.Epoch) SharesFilter {
 	return func(share *types.SSVShare) bool {
-		return share.HasBeaconMetadata() && share.BeaconMetadata.IsAttesting()
+		return share.IsActive(epoch)
 	}
 }
 


### PR DESCRIPTION
This PR introduces fixes to two critical areas affecting newly active validators: message validation and validator registration processes. These changes ensure that validators becoming active are not unfairly penalized due to metadata update delays and are correctly registered for duties in a timely manner.

**Changes**
1. **Message Validation Fix:**
	- **Issue**: Validators that had recently become active were having their messages ignored because their metadata had not yet been updated to reflect their new status.

	- **Resolution**: Updated the message validation logic to allow for validators in the process of becoming active (i.e., their status is pending queued but the activation epoch is current or past) to have their messages processed. This was achieved by adjusting the validation checks to consider the estimated current epoch and the validator's activation epoch.

2. **Validator Registration Fix:**
	- **Issue**: In the process of validator registration, validators whose status was pending in the queue but eligible for activation based on the epoch were not being registered to relays.

	- **Resolution**: Modified the HandleDuties function within the ValidatorRegistrationHandler to ensure that validators pending activation but within the eligible epoch window are now correctly registered. This adjustment ensures that all validators due for activation are considered for registration, aligning their duties with their activation status.
