### PR TITLE
Update ca-certificates version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ FROM alpine:3.18.3 AS runner
 
 # Install ca-certificates, bash
 RUN apk -v --update add \
-  ca-certificates=20230506-r0 \
+  ca-certificates=20240226-r0 \
   bash=5.2.15-r5 \
   make=4.4.1-r1 \
   bind-tools=9.18.24-r0 && \


### PR DESCRIPTION
The version `20230506-r0` causes build failures. 

The new version `20240226-r0` is taken from https://pkgs.alpinelinux.org/packages?name=ca-certificates&branch=edge&repo=&arch=&maintainer=