### PR TITLE
 optimization: use miscrosoft/openssl for RSA sign/verify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,6 @@ RUN apt-get update                                                        && \
   make=4.3-4.1 \
   && rm -rf /var/lib/apt/lists/*
 
-# install jemalloc
-WORKDIR /tmp/jemalloc-temp
-RUN curl -s -L "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2" -o jemalloc.tar.bz2 \
-  && tar xjf ./jemalloc.tar.bz2
-RUN cd jemalloc-5.2.1 \
-  && ./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto' \
-  && make && make install
-
 RUN go version
 
 WORKDIR /go/src/github.com/bloxapp/ssv/
@@ -46,7 +38,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   COMMIT=$(git rev-parse HEAD) && \
   VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
   CGO_ENABLED=1 GOOS=linux go install \
-  -tags="blst_enabled,jemalloc,allocator" \
+  -tags="blst_enabled" \
   -ldflags "-X main.Commit=$COMMIT -X main.Version=$VERSION -linkmode external -extldflags \"-static -lm\"" \
   ./cmd/ssvnode
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 #
 # STEP 3: Prepare image to run the binary
 #
-FROM alpine:3.18.3 AS runner
+FROM golang:1.20.7 AS runner
 
-# Install ca-certificates, bash
-RUN apk -v --update add \
-  ca-certificates=20240226-r0 \
-  bash=5.2.15-r5 \
-  make=4.4.1-r1 \
-  bind-tools=9.18.24-r0 && \
-  rm /var/cache/apk/*
+WORKDIR /
 
 COPY --from=builder /go/bin/ssvnode /go/bin/ssvnode
 COPY ./Makefile .env* ./

--- a/operator/keys/jemalloc_check.go
+++ b/operator/keys/jemalloc_check.go
@@ -1,0 +1,8 @@
+//go:build jemalloc
+
+package keys
+
+func init() {
+	msg := "jemalloc is not supported because it clashes with openssl, please disable jemalloc by removing the build tags 'jemalloc, allocator' from the build command, e.g. 'go build -tags=\"allocator,jemalloc\"'"
+	panic(msg)
+}

--- a/operator/keys/rsa.go
+++ b/operator/keys/rsa.go
@@ -1,0 +1,31 @@
+//go:build !linux
+
+package keys
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+)
+
+type privateKey struct {
+	privKey *rsa.PrivateKey
+}
+
+type publicKey struct {
+	pubKey *rsa.PublicKey
+}
+
+func SignRSA(priv *privateKey, data []byte) ([]byte, error) {
+	return rsa.SignPKCS1v15(rand.Reader, priv.privKey, crypto.SHA256, data)
+}
+
+func EncryptRSA(pub *publicKey, data []byte) ([]byte, error) {
+	return rsa.EncryptPKCS1v15(rand.Reader, pub.pubKey, data)
+}
+
+func VerifyRSA(pub *publicKey, data, signature []byte) error {
+	hash := sha256.Sum256(data)
+	return rsa.VerifyPKCS1v15(pub.pubKey, crypto.SHA256, hash[:], signature)
+}

--- a/operator/keys/rsa_linux.go
+++ b/operator/keys/rsa_linux.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+package keys
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"math/big"
+
+	"github.com/microsoft/go-crypto-openssl/openssl"
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig/bridge"
+)
+
+type privateKey struct {
+	privKey       *rsa.PrivateKey
+	cachedPrivKey *openssl.PrivateKeyRSA
+}
+
+type publicKey struct {
+	pubKey       *rsa.PublicKey
+	cachedPubkey *openssl.PublicKeyRSA
+}
+
+func init() {
+	// TODO: check multiple versions of openssl
+	// TODO: fallback to stdlib when openssl is not available
+	if err := openssl.Init(); err != nil {
+		panic(err)
+	}
+}
+
+func rsaPrivateKeyToOpenSSL(priv *rsa.PrivateKey) (*openssl.PrivateKeyRSA, error) {
+	return bridge.NewPrivateKeyRSA(
+		priv.N,
+		big.NewInt(int64(priv.E)),
+		priv.D,
+		priv.Primes[0],
+		priv.Primes[1],
+		priv.Precomputed.Dp,
+		priv.Precomputed.Dq,
+		priv.Precomputed.Qinv,
+	)
+}
+
+func rsaPublicKeyToOpenSSL(pub *rsa.PublicKey) (*openssl.PublicKeyRSA, error) {
+	return bridge.NewPublicKeyRSA(
+		pub.N,
+		big.NewInt(int64(pub.E)),
+	)
+}
+
+func checkCachePrivkey(priv *privateKey) (*openssl.PrivateKeyRSA, error) {
+	if priv.cachedPrivKey != nil {
+		return priv.cachedPrivKey, nil
+	}
+	opriv, err := rsaPrivateKeyToOpenSSL(priv.privKey)
+	if err != nil {
+		return nil, err
+	}
+	priv.cachedPrivKey = opriv
+
+	return opriv, nil
+}
+
+func SignRSA(priv *privateKey, data []byte) ([]byte, error) {
+	opriv, err := checkCachePrivkey(priv)
+	if err != nil {
+		return nil, err
+	}
+	return openssl.SignRSAPKCS1v15(opriv, crypto.SHA256, data)
+}
+
+func checkCachePubkey(pub *publicKey) (*openssl.PublicKeyRSA, error) {
+	if pub.cachedPubkey != nil {
+		return pub.cachedPubkey, nil
+	}
+
+	opub, err := rsaPublicKeyToOpenSSL(pub.pubKey)
+	if err != nil {
+		return nil, err
+	}
+	pub.cachedPubkey = opub
+
+	return opub, nil
+}
+
+func EncryptRSA(pub *publicKey, data []byte) ([]byte, error) {
+	opub, err := checkCachePubkey(pub)
+	if err != nil {
+		return nil, err
+	}
+	return openssl.EncryptRSAPKCS1(opub, data)
+}
+
+func VerifyRSA(pub *publicKey, data, signature []byte) error {
+	opub, err := checkCachePubkey(pub)
+	if err != nil {
+		return err
+	}
+	hashed := sha256.Sum256(data)
+	return openssl.VerifyRSAPKCS1v15(opub, crypto.SHA256, hashed[:], signature)
+}

--- a/operator/keys/rsa_linux_test.go
+++ b/operator/keys/rsa_linux_test.go
@@ -55,6 +55,28 @@ func Test_VerifyOpenSSLWithOpenSSL(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_ConversionError(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	key.D = nil
+	msg := []byte("hello")
+	priv := &privateKey{key, nil}
+	_, err = priv.Sign(msg)
+	require.Error(t, err)
+
+	key2, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	priv2 := &privateKey{key2, nil}
+	sig, err := priv2.Sign(msg)
+	require.NoError(t, err)
+	pub := priv2.Public().(*publicKey)
+
+	pub.pubKey.N = nil
+	require.Error(t, VerifyRSA(pub, msg, sig))
+}
+
 func Test_Caches(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)

--- a/operator/keys/rsa_linux_test.go
+++ b/operator/keys/rsa_linux_test.go
@@ -1,0 +1,40 @@
+// go:build linux
+package keys
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+
+	"github.com/stretchr/testify/require"
+
+	"testing"
+)
+
+func Test_VerifyRegularSigWithOpenSSL(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	msg := []byte("hello")
+	hashed := sha256.Sum256(msg)
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed[:])
+	require.NoError(t, err)
+
+	pk := &privateKey{key, nil}
+	pub := pk.Public().(*publicKey)
+
+	require.NoError(t, VerifyRSA(pub, msg, sig))
+}
+
+func Test_VerifyOpenSSLWithOpenSSL(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	msg := []byte("hello")
+	priv := &privateKey{key, nil}
+	sig, err := priv.Sign(msg)
+	require.NoError(t, err)
+
+	pub := priv.Public().(*publicKey)
+
+	require.NoError(t, VerifyRSA(pub, msg, sig))
+}

--- a/operator/keys/rsa_linux_test.go
+++ b/operator/keys/rsa_linux_test.go
@@ -38,3 +38,26 @@ func Test_VerifyOpenSSLWithOpenSSL(t *testing.T) {
 
 	require.NoError(t, VerifyRSA(pub, msg, sig))
 }
+
+func Test_Caches(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	msg := []byte("hello")
+	priv := &privateKey{key, nil}
+	sig, err := priv.Sign(msg)
+	require.NoError(t, err)
+
+	pub := priv.Public().(*publicKey)
+
+	require.NoError(t, VerifyRSA(pub, msg, sig))
+
+	// should sign using cache
+	require.NotNil(t, priv.cachedPrivKey)
+
+	sig2, err := priv.Sign(msg)
+	require.NoError(t, err)
+
+	require.NotNil(t, pub.cachedPubkey)
+
+	require.NoError(t, VerifyRSA(pub, msg, sig2))
+}


### PR DESCRIPTION
### Description 
This uses  is based on #1274 and uses parts from #1348.

### Changes 

- When running linux use https://github.com/microsoft/go-crypto-openssl/ which is orders of magnitude faster than golang std lib.
- docker to run from ubuntu golang to have openssl by default
- disable jemalloc because it clashes with openssl and causes panic (check the build and panic if jemalloc is present)