### PR TITLE
stop duties on validator removal

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -849,12 +849,14 @@ func (c *controller) onShareStop(pubKey spectypes.ValidatorPK) {
 	// remove from ValidatorsMap
 	v := c.validatorsMap.RemoveValidator(pubKey)
 
-	// stop instance
-	if v != nil {
-		v.Stop()
-		c.logger.Debug("validator was stopped", fields.PubKey(pubKey[:]))
+	if v == nil {
+		c.logger.Warn("could not find validator to stop", fields.PubKey(pubKey[:]))
+		return
 	}
 
+	// stop instance
+	v.Stop()
+	c.logger.Debug("validator was stopped", fields.PubKey(pubKey[:]))
 	vc, ok := c.validatorsMap.GetCommittee(v.Share.CommitteeID())
 	if ok {
 		vc.RemoveShare(v.Share.Share.ValidatorIndex)

--- a/protocol/v2/ssv/runner/runner_signatures.go
+++ b/protocol/v2/ssv/runner/runner_signatures.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"fmt"
+
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/herumi/bls-eth-go-binary/bls"
@@ -22,6 +24,9 @@ func (b *BaseRunner) signBeaconObject(
 	domain, err := runner.GetBeaconNode().DomainData(epoch, domainType)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get beacon domain")
+	}
+	if _, ok := runner.GetBaseRunner().Share[duty.ValidatorIndex]; !ok {
+		return nil, fmt.Errorf("unknown validator index %d", duty.ValidatorIndex)
 	}
 	sig, r, err := runner.GetSigner().SignBeaconObject(obj, domain, runner.GetBaseRunner().Share[duty.ValidatorIndex].SharePubKey, domainType)
 	if err != nil {


### PR DESCRIPTION
This PR fixes crash on `onShareStop` in case validator is already removed and also it stops duties for removed validator 