### PR TITLE
Fix: Always Update Metrics on Peer Inspection, Even When Logging is Skipped

### DIFF
--- a/network/topics/scoring.go
+++ b/network/topics/scoring.go
@@ -55,13 +55,6 @@ func scoreInspector(logger *zap.Logger,
 		}
 		gossipScoreIndex.SetScores(peerScores)
 
-		// Skip if it's not time to log yet.
-		if inspections%logFrequency != 0 {
-			inspections++
-			return
-		}
-		inspections++
-
 		// Reset metrics before updating them.
 		metrics.ResetPeerScores()
 
@@ -154,6 +147,11 @@ func scoreInspector(logger *zap.Logger,
 			// Short logs per topic https://github.com/ssvlabs/ssv/issues/1666
 			invalidMessagesStats := formatInvalidMessageStats(filtered)
 
+			if inspections%logFrequency != 0 {
+				// Don't log yet.
+				continue
+			}
+
 			// Log.
 			fields := []zap.Field{
 				fields.PeerID(pid),
@@ -185,6 +183,8 @@ func scoreInspector(logger *zap.Logger,
 			//		zap.Any("scores", scores), zap.Any("topicScores", peerScores.Topics))
 			//}
 		}
+
+		inspections++
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue where both metrics updates and logging were skipped when not at the logging frequency. Metrics should always be updated on every peer inspection, but logging should occur based on logFrequency.

Changes:

	•	Ensured metrics updates happen on every inspection.
	•	Separated the logging logic so it only skips logging when needed, without affecting metrics updates.