### PR TITLE
Update Partial Signature Message Size Constants and Naming for Expanded Validator Support

### DIFF
--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -36,12 +36,12 @@ const (
 )
 
 const (
-	partialSignatureSize           = 96
-	partialSignatureMsgSize        = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
-	maxPartialSignatureMessages    = 1000
-	partialSigMsgTypeSize          = 8 // uint64
-	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
-	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor + 4
+	partialSignatureSize            = 96
+	maxSizePartialSignatureMessage  = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	maxSizePartialSignatureMessages = 1512
+	partialSigMsgTypeSize           = 8 // uint64
+	maxPartialSignatureMsgsSize     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessages*maxSizePartialSignatureMessage + 4
+	maxEncodedPartialSignatureSize  = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor
 )
 
 const (


### PR DESCRIPTION
**Description:**
This pull request updates the constants and naming conventions related to partial signature message sizes. Specifically, it aligns the configuration with an increased validator count (up to 1000), ensuring that the message validation rules are properly scaled and compliant with the latest specifications.

**Key Changes:**
- **Increased Size Limits:**
  - Adjusted `partialSignatureMsgSize` and related constants to accommodate up to 1000 validators.
  - Revised `maxPartialSignatureMsgsSize` and `maxEncodedPartialSignatureSize` to handle the larger data footprint associated with the expanded validator set.

- **Naming Improvements:**
  - Renamed constants to more clearly reflect their purpose and ensure consistency with the latest specification.
  - Simplified variable names to enhance readability and maintainability.

**IMPORTANT:**
This is first change out of 2, that should go in separate versions