### PR TITLE
Fix duplicate API calls in GetAttestationData due to race between cache check and singleflight registration

### DIFF
--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -48,18 +48,18 @@ func (gc *GoClient) GetAttestationData(slot phase0.Slot, committeeIndex phase0.C
 	spec.DataVersion,
 	error,
 ) {
-	// Check cache.
-	cachedResult := gc.attestationDataCache.Get(slot)
-	if cachedResult != nil {
-		data, err := withCommitteeIndex(cachedResult.Value(), committeeIndex)
-		if err != nil {
-			return nil, DataVersionNil, fmt.Errorf("failed to set committee index: %w", err)
-		}
-		return data, spec.DataVersionPhase0, nil
-	}
-
 	// Have to make beacon node request and cache the result.
 	result, err, _ := gc.attestationReqInflight.Do(slot, func() (*phase0.AttestationData, error) {
+		// Check cache.
+		cachedResult := gc.attestationDataCache.Get(slot)
+		if cachedResult != nil {
+			data, err := withCommitteeIndex(cachedResult.Value(), committeeIndex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set committee index: %w", err)
+			}
+			return data, nil
+		}
+
 		attDataReqStart := time.Now()
 		resp, err := gc.multiClient.AttestationData(gc.ctx, &api.AttestationDataOpts{
 			Slot: slot,


### PR DESCRIPTION
Description:
I discovered a race condition in the GetAttestationData method. The current implementation performs an early cache check outside of the singleflight mechanism. In a high-concurrency scenario, this can lead to the following issue:

1. Request R1 enters the singleflight closure and starts the API call.
2. Request R2 performs the cache check before R1 has stored the result and therefore sees no cached value.
3. R2 then enters the singleflight mechanism (or, in some cases, misses the already in-flight registration) and triggers its own API call.
4. Meanwhile, R1 finishes, caches its result, and returns.
5. R2’s separate API call then runs, causing two API calls for the same slot even though the cache should have prevented duplicates.

To address this, the fix moves the cache check inside the singleflight closure so that all calls go through the singleflight mechanism. This way, when multiple goroutines call GetAttestationData concurrently, they all participate in the same singleflight call. Inside the closure, we perform a “double-check” of the cache before actually calling the API. If a concurrent request has already fetched and cached the result, the closure returns the cached value immediately, and no duplicate API call is made.

resolves https://github.com/ssvlabs/ssv/issues/1925