### PR TITLE
fix: Resolve race condition in goclient tests

### DIFF
--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -179,9 +179,10 @@ func TestAssertSameGenesisVersionWhenSame(t *testing.T) {
 			return resp, nil
 		}
 
-		undialableServer := mockServer(t, callback)
+		server := mockServer(t, callback)
+		defer server.Close()
 		t.Run(fmt.Sprintf("When genesis versions are the same (%s)", string(network)), func(t *testing.T) {
-			c, err := mockClientWithNetwork(ctx, undialableServer.URL, 100*time.Millisecond, 500*time.Millisecond, network)
+			c, err := mockClientWithNetwork(ctx, server.URL, 100*time.Millisecond, 500*time.Millisecond, network)
 			require.NoError(t, err, "failed to create client")
 			client := c.(*GoClient)
 
@@ -198,8 +199,9 @@ func TestAssertSameGenesisVersionWhenDifferent(t *testing.T) {
 
 	t.Run("When genesis versions are different", func(t *testing.T) {
 		ctx := context.Background()
-		undialableServer := mockServer(t, nil)
-		c, err := mockClientWithNetwork(ctx, undialableServer.URL, 100*time.Millisecond, 500*time.Millisecond, network)
+		server := mockServer(t, nil)
+		defer server.Close()
+		c, err := mockClientWithNetwork(ctx, server.URL, 100*time.Millisecond, 500*time.Millisecond, network)
 		require.NoError(t, err, "failed to create client")
 		client := c.(*GoClient)
 		forkVersion := phase0.Version{0x01, 0x02, 0x03, 0x04}


### PR DESCRIPTION
There are failing tests on `stage` after my previous pull requests due to this error:

```
2025/02/25 10:27:31 http: panic serving 127.0.0.1:34412: Log in goroutine after TestAssertSameGenesisVersionWhenDifferent/When_genesis_versions_are_different has completed: mock server handling request: /eth/v1/beacon/genesis
```

This PR hopes to fix the issues by waiting for the server to finish before ending the test.