### PR TITLE
linter: enable shadow check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,7 +103,6 @@ linters:
     govet:
       enable:
         - atomicalign
-      disable:
         - shadow
       enable-all: false
       disable-all: false

--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -99,11 +99,11 @@ func (h *CommitteeHandler) buildCommitteeDuties(
 
 	validatorCommittees := map[phase0.ValidatorIndex]committeeDuty{}
 	for _, validatorShare := range selfValidators {
-		committeeDuty := committeeDuty{
+		cd := committeeDuty{
 			id:          validatorShare.CommitteeID(),
 			operatorIDs: validatorShare.OperatorIDs(),
 		}
-		validatorCommittees[validatorShare.ValidatorIndex] = committeeDuty
+		validatorCommittees[validatorShare.ValidatorIndex] = cd
 	}
 
 	resultCommitteeMap := make(committeeDutiesMap)


### PR DESCRIPTION
To avoid typos like [this one](https://github.com/ssvlabs/ssv/pull/2217) we can just lint for it, 

in the past "shadow" linter was a pain to deal with due to it complaining about `err` re-declarations all the time (from what I remember) - but now it doesn't seem to be an issue anymore (I assume they treat `err` as a special case to ignore `err` re-declarations at all times).