### PR TITLE
[SSV-7] ssvsigner: Integer Underflow in `computeMinimalAttestationSP()` Leads to Corrupted Slashing Data when Initializing at Epoch 0

### DIFF
--- a/ssvsigner/ekm/slashing_protector.go
+++ b/ssvsigner/ekm/slashing_protector.go
@@ -183,8 +183,14 @@ func (sp *SlashingProtector) updateHighestProposal(pubKey phase0.BLSPubKey, slot
 func (sp *SlashingProtector) computeMinimalAttestationSP(epoch phase0.Epoch) *phase0.AttestationData {
 	// Calculate the highest safe target epoch based on the current epoch and a predefined minimum distance.
 	highestTarget := epoch + minSPAttestationEpochGap
+
 	// The highest safe source epoch is one less than the highest target epoch.
-	highestSource := highestTarget - 1
+	var highestSource phase0.Epoch
+	if highestTarget > 0 {
+		highestSource = highestTarget - 1
+	} else {
+		highestSource = 0
+	}
 
 	// Return a new AttestationData object with the calculated source and target epochs.
 	return &phase0.AttestationData{


### PR DESCRIPTION
> The function `computeMinimalAttestationSP()` in `slashing_protector.go` is vulnerable to an integer
underflow if called with `epoch = 0`. Given `minSPAttestationEpochGap = 0`, `highestTarget` becomes `0`, and the
subsequent calculation `highestSource := highestTarget - 1` causes `highestSource` (`uint64`) to underflow to
`MaxUint64`. This results in corrupted `AttestationData` (`Source.Epoch = MaxUint64`, `Target.Epoch = 0`) being used for
slashing protection.

Backport of https://github.com/ssvlabs/ssv/pull/2273 to `main`