### PR TITLE
ssvsigner: fix parsing arguments

### DIFF
--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -36,12 +36,7 @@ type CLI struct {
 func main() {
 	var cli CLI
 
-	kong.Must(&cli,
-		kong.Name("purge-keys"),
-		kong.UsageOnError(),
-	)
-
-	_ = kong.Parse(&cli)
+	_ = kong.Parse(&cli, kong.Name("purge-keys"), kong.UsageOnError())
 
 	log, err := logger.SetupProductionLogger()
 	if err != nil {

--- a/ssvsigner/cmd/ssv-signer/ssv-signer.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer.go
@@ -46,12 +46,7 @@ type CLI struct {
 func main() {
 	var cli CLI
 
-	kong.Must(&cli,
-		kong.Name("ssv-signer"),
-		kong.UsageOnError(),
-	)
-
-	_ = kong.Parse(&cli)
+	_ = kong.Parse(&cli, kong.Name("ssv-signer"), kong.UsageOnError())
 
 	log, err := logger.SetupLogger(cli.LogLevel, cli.LogFormat)
 	if err != nil {


### PR DESCRIPTION
`kong.Parse` was deleted in https://github.com/ssvlabs/ssv/pull/2279, so the config is currently not parsed