### PR TITLE
chore(ci) De-duplicate CI runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,8 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - stage
+    types: [opened, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/spec-alignment.yml
+++ b/.github/workflows/spec-alignment.yml
@@ -1,12 +1,8 @@
 name: Spec Alignment
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - stage
+    types: [opened, synchronize]
 
 jobs:
   align:

--- a/.github/workflows/spec-test-raceless.yml
+++ b/.github/workflows/spec-test-raceless.yml
@@ -1,12 +1,8 @@
 name: Spec tests (raceless)
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - stage
+    types: [opened, synchronize]
 
   workflow_dispatch:
 

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -1,12 +1,8 @@
 name: Spec tests
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - stage
+    types: [opened, synchronize]
 
   workflow_dispatch:
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,12 +1,9 @@
 name: Unit tests
 
+
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - stage
+    types: [opened, synchronize]
 
   workflow_dispatch:
 


### PR DESCRIPTION
sets the configuration of github actions to only run when:
* PR is opened (either from a fork or from the repository directly)
* a commit is pushed to a existing PR