### PR TITLE
fix(network/p2p/p2p_setup.go): data race in connection stats during network initialization

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -380,7 +380,16 @@ func (n *p2pNetwork) inboundLimit() int {
 	return int(float64(n.cfg.MaxPeers) * inboundLimitRatio)
 }
 
+// connectionStats returns the number of inbound and outbound connections.
+// It safely handles the case where the host is not yet initialized, which can
+// occur during network setup when the connection gater is active but libp2p.New()
+// hasn't completed yet. In this case, it returns (0, 0) since no connections
+// exist before the host is fully initialized.
 func (n *p2pNetwork) connectionStats() (inbound, outbound int) {
+	if n.host == nil {
+		return 0, 0
+	}
+
 	return connectionStats(n.host)
 }
 


### PR DESCRIPTION
This PR fixes a data race that occurs when the connection gater checks connection limits before the host is fully initialized.

Flow:
- libp2p.New() → cfg.NewNode() → creates swarm with the ConnectionGater
- In fx.Provide for swarm, it starts listening immediately:
```go
OnStart: func(context.Context) error {
    return sw.Listen(cfg.ListenAddrs...)
}
```
- Once listening starts, incoming connections trigger InterceptAccept on the gater. But libp2p.New() hasn't returned yet, so n.host is still `nil`