### PR TITLE
fix(exporter): don't disable duty sched to not lose msgs in validation

### DIFF
--- a/operator/node.go
+++ b/operator/node.go
@@ -3,10 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
@@ -156,16 +152,9 @@ func (n *Node) Start() error {
 		}
 	}()
 
-	if n.exporterOptions.Enabled {
-		n.logger.Info("exporter is enabled, duty scheduler will not run")
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-		<-sigChan
-		n.logger.Info("received shutdown signal")
-	} else {
-		if err := n.dutyScheduler.Wait(); err != nil {
-			n.logger.Fatal("duty scheduler exited with error", zap.Error(err))
-		}
+	// TODO: consider not running this if exporter is enabled, ATM it's needed for msg validation
+	if err := n.dutyScheduler.Wait(); err != nil {
+		n.logger.Fatal("duty scheduler exited with error", zap.Error(err))
 	}
 
 	if err := n.net.Close(); err != nil {


### PR DESCRIPTION
### Description 

in #2008 we introduced new exporter version, but it disabled the duty scheduler functionality which is required to validate incoming messages in duty validation. 

This PR reverts only this part so messages are not filtered in msg validation if they are a valid duty (we get this from the beacon node)