### PR TITLE
re-enable duty scheduler for exporter

### DIFF
--- a/operator/node.go
+++ b/operator/node.go
@@ -3,9 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"go.uber.org/zap"
 
@@ -124,12 +121,10 @@ func (n *Node) Start() error {
 		}
 	}()
 
-	if !n.exporterOptions.Enabled {
-		// Start the duty scheduler, and a background goroutine to crash the node
-		// in case there were any errors.
-		if err := n.dutyScheduler.Start(ctx); err != nil {
-			return fmt.Errorf("failed to run duty scheduler: %w", err)
-		}
+	// Start the duty scheduler, and a background goroutine to crash the node
+	// in case there were any errors.
+	if err := n.dutyScheduler.Start(ctx); err != nil {
+		return fmt.Errorf("failed to run duty scheduler: %w", err)
 	}
 
 	n.validatorsCtrl.StartNetworkHandlers()
@@ -156,16 +151,8 @@ func (n *Node) Start() error {
 		}
 	}()
 
-	if n.exporterOptions.Enabled {
-		n.logger.Info("exporter is enabled, duty scheduler will not run")
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-		<-sigChan
-		n.logger.Info("received shutdown signal")
-	} else {
-		if err := n.dutyScheduler.Wait(); err != nil {
-			n.logger.Fatal("duty scheduler exited with error", zap.Error(err))
-		}
+	if err := n.dutyScheduler.Wait(); err != nil {
+		n.logger.Fatal("duty scheduler exited with error", zap.Error(err))
 	}
 
 	if err := n.net.Close(); err != nil {


### PR DESCRIPTION
This PR will replace https://github.com/ssvlabs/ssv/pull/2406 
We need to re-enable dutyscheduler that was disable - to make exporter more stable (many restarts on unavailable BNs), but we need dutyscheduler to fetch duties so we can pass msg validation