### PR TITLE
Fix exporter-v2: publish decided quorums to websocket

### DIFF
--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ssvlabs/ssv/exporter/api"
 	"github.com/ssvlabs/ssv/logging/fields"
+	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	qbftstorage "github.com/ssvlabs/ssv/protocol/v2/qbft/storage"
 )
@@ -30,5 +31,40 @@ func NewStreamPublisher(logger *zap.Logger, domainType spectypes.DomainType, ws 
 
 		logger.Debug("broadcast decided stream", fields.PubKey(msg.PubKey[:]), fields.Slot(msg.Slot))
 		feed.Send(api.NewParticipantsAPIMsg(domainType, msg))
+	}
+}
+
+// NewDecidedListener handles incoming newly decided messages.
+// it forward messages to websocket stream, where messages are cached (1m TTL) to avoid flooding
+func NewDecidedListener(logger *zap.Logger, domainType spectypes.DomainType, ws api.WebSocketServer) func(dutytracer.DecidedInfo) {
+	feed := ws.BroadcastFeed()
+	logger = logger.Named("DecidedListener")
+	cache := cache.New(time.Minute, 90*time.Second) // 1m TTL, 1.5m eviction to avoid flooding ws stream
+
+	return func(msg dutytracer.DecidedInfo) {
+		participation := qbftstorage.Participation{
+			ParticipantsRangeEntry: qbftstorage.ParticipantsRangeEntry{
+				PubKey:  msg.PubKey,
+				Slot:    msg.Slot,
+				Signers: msg.Signers,
+			},
+			Role:   msg.Role,
+			PubKey: msg.PubKey,
+		}
+
+		key := fmt.Sprintf("%x:%d:%d", msg.PubKey[:], msg.Slot, len(msg.Signers))
+		_, ok := cache.Get(key)
+		if ok {
+			// already sent in the last minute, skipping to avoid flooding ws stream
+			return
+		}
+		logger.Info("sending to websocket feed",
+			zap.String("validator_pk", fmt.Sprintf("%x", msg.PubKey[:])),
+			zap.String("signers", fmt.Sprintf("%v", msg.Signers)),
+			zap.Uint64("slot", uint64(msg.Slot)),
+			zap.String("role", msg.Role.String()),
+		)
+		cache.SetDefault(key, true)
+		feed.Send(api.NewParticipantsAPIMsg(domainType, participation))
 	}
 }

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,6 +28,13 @@ import (
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
+
+type DecidedInfo struct {
+	PubKey  spectypes.ValidatorPK
+	Slot    phase0.Slot
+	Role    spectypes.BeaconRole
+	Signers []spectypes.OperatorID
+}
 
 type Collector struct {
 	logger *zap.Logger
@@ -53,6 +61,8 @@ type Collector struct {
 
 	inFlightCommittee hashmap.Map[spectypes.CommitteeID, struct{}]
 	inFlightValidator hashmap.Map[spectypes.ValidatorPK, struct{}]
+
+	decidedListenerFunc func(msg DecidedInfo)
 }
 
 type DomainDataProvider interface {
@@ -65,12 +75,13 @@ func New(
 	client DomainDataProvider,
 	store DutyTraceStore,
 	beaconNetwork *networkconfig.BeaconConfig,
+	decidedListenerFunc func(msg DecidedInfo),
 ) *Collector {
 
 	ttl := time.Duration(slotTTL) * beaconNetwork.SlotDuration
 
 	collector := &Collector{
-		logger:                         logger,
+		logger:                         logger.Named("dutytracer"),
 		store:                          store,
 		client:                         client,
 		beacon:                         beaconNetwork,
@@ -81,6 +92,7 @@ func New(
 		syncCommitteeRootsCache:        ttlcache.New(ttlcache.WithTTL[scRootKey, phase0.Root](ttl)),
 		inFlightCommittee:              hashmap.Map[spectypes.CommitteeID, struct{}]{},
 		inFlightValidator:              hashmap.Map[spectypes.ValidatorPK, struct{}]{},
+		decidedListenerFunc:            decidedListenerFunc,
 	}
 
 	return collector
@@ -628,6 +640,9 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 			return nil
 		}
 	case spectypes.SSVPartialSignatureMsgType:
+		logger := c.logger.With(zap.String("msg_id", msg.MsgID.String()))
+		logger.Debug("processing partial signature message")
+
 		pSigMessages := new(spectypes.PartialSignatureMessages)
 		err := pSigMessages.Decode(msg.SignedSSVMessage.SSVMessage.GetData())
 		if err != nil {
@@ -667,6 +682,7 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 			defer trace.Unlock()
 
 			c.processPartialSigCommittee(startTime, pSigMessages, committeeID, trace)
+			c.checkAndPublishQuorum(logger, pSigMessages, committeeID, trace)
 
 			if late {
 				_ = c.inFlightCommittee.Delete(committeeID)
@@ -783,6 +799,10 @@ type committeeDutyTrace struct {
 	sync.Mutex
 	syncCommitteeRoot phase0.Root
 	model.CommitteeDutyTrace
+
+	// Track published quorums to avoid duplicates (validator -> role -> signers hash)
+	// Not part of the model.CommitteeDutyTrace, because it's not persisted to disk
+	publishedQuorums map[phase0.ValidatorIndex]map[spectypes.BeaconRole]string
 }
 
 func (dt *committeeDutyTrace) trace() *model.CommitteeDutyTrace {
@@ -799,4 +819,157 @@ func getOrCreateRound(trace *model.ConsensusTrace, rnd uint64) *model.RoundTrace
 	}
 
 	return trace.Rounds[rnd-1]
+}
+
+// checkAndPublishQuorum detects when quorum is reached and publishes decisions to websocket.
+// IMPORTANT: trace must be locked by the caller before calling this function.
+func (c *Collector) checkAndPublishQuorum(logger *zap.Logger, msg *spectypes.PartialSignatureMessages, committeeID spectypes.CommitteeID, trace *committeeDutyTrace) {
+	if c.decidedListenerFunc == nil {
+		return
+	}
+
+	committee, found := c.validators.Committee(committeeID)
+	if !found || len(committee.Operators) == 0 {
+		return
+	}
+
+	threshold := uint64(len(committee.Operators))*2/3 + 1
+
+	if trace.publishedQuorums == nil {
+		trace.publishedQuorums = make(map[phase0.ValidatorIndex]map[spectypes.BeaconRole]string)
+	}
+
+	// Check each validator in the partial signature for quorum
+	for _, partialMsg := range msg.Messages {
+		validator, exists := c.validators.ValidatorByIndex(partialMsg.ValidatorIndex)
+		if !exists {
+			logger.Debug("validator not found by index",
+				zap.Uint64("validator_index", uint64(partialMsg.ValidatorIndex)))
+			continue
+		}
+
+		var validatorPK spectypes.ValidatorPK
+		copy(validatorPK[:], validator.ValidatorPubKey[:])
+
+		logger.Debug("processing validator for quorum check",
+			zap.Uint64("validator_index", uint64(partialMsg.ValidatorIndex)),
+			zap.String("validator_pk", fmt.Sprintf("%x", validatorPK[:])),
+			zap.Uint64("signer", partialMsg.Signer),
+			zap.Uint64("threshold", threshold))
+
+		// Initialize tracking for this validator if needed
+		if trace.publishedQuorums[partialMsg.ValidatorIndex] == nil {
+			trace.publishedQuorums[partialMsg.ValidatorIndex] = make(map[spectypes.BeaconRole]string)
+		}
+
+		// Check quorum for both attester and sync committee roles
+		c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleAttester, msg, partialMsg, validatorPK, threshold)
+		c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleSyncCommittee, msg, partialMsg, validatorPK, threshold)
+	}
+}
+
+// checkAndPublishQuorumForRole checks if quorum is reached for a specific role and publishes if it's the first time
+func (c *Collector) checkAndPublishQuorumForRole(
+	logger *zap.Logger,
+	trace *committeeDutyTrace,
+	role spectypes.BeaconRole,
+	msg *spectypes.PartialSignatureMessages,
+	partialMsg *spectypes.PartialSignatureMessage,
+	validatorPK spectypes.ValidatorPK,
+	threshold uint64,
+) {
+	var signerData []*model.SignerData
+	var roleLogName string
+
+	switch role {
+	case spectypes.BNRoleAttester:
+		signerData = trace.Attester
+		roleLogName = "attester"
+	case spectypes.BNRoleSyncCommittee:
+		signerData = trace.SyncCommittee
+		roleLogName = "sync committee"
+	default:
+		return
+	}
+
+	signers := c.countUniqueSignersForValidatorAndRoot(logger, signerData, partialMsg.ValidatorIndex, partialMsg.SigningRoot)
+	if uint64(len(signers)) < threshold {
+		return
+	}
+
+	signersKey := c.signersToKey(signers)
+	lastPublished := trace.publishedQuorums[partialMsg.ValidatorIndex][role]
+
+	logger.Debug("quorum check",
+		zap.String("role", roleLogName),
+		zap.Uint64("validator_index", uint64(partialMsg.ValidatorIndex)),
+		zap.String("signers_key", signersKey),
+		zap.String("last_published", lastPublished),
+		zap.Bool("will_publish", lastPublished == ""))
+
+	// Only publish the FIRST time quorum is reached, not for every signer set change
+	if lastPublished == "" {
+		trace.publishedQuorums[partialMsg.ValidatorIndex][role] = signersKey
+
+		decidedInfo := DecidedInfo{
+			PubKey:  validatorPK,
+			Slot:    msg.Slot,
+			Role:    role,
+			Signers: signers,
+		}
+		c.decidedListenerFunc(decidedInfo)
+
+		logger.Info("data sent to listener feed",
+			zap.String("role", roleLogName),
+			zap.Uint64("validator_index", uint64(partialMsg.ValidatorIndex)),
+			zap.String("validator_pk", fmt.Sprintf("%x", validatorPK[:])),
+			zap.Any("signers", signers))
+	}
+}
+
+// countUniqueSignersForValidatorAndRoot counts unique signers for a specific validator and signing root
+func (c *Collector) countUniqueSignersForValidatorAndRoot(logger *zap.Logger, signerData []*model.SignerData, validatorIndex phase0.ValidatorIndex, signingRoot phase0.Root) []spectypes.OperatorID {
+	signers := make(map[spectypes.OperatorID]struct{})
+
+	logger.Debug("counting signers for validator",
+		zap.Uint64("validator_index", uint64(validatorIndex)),
+		zap.String("signing_root", fmt.Sprintf("%x", signingRoot[:])),
+		zap.Int("total_signer_data_entries", len(signerData)))
+
+	for i, data := range signerData {
+		// Check if this validator index is in the signer data
+		for _, vIdx := range data.ValidatorIdx {
+			if vIdx == validatorIndex {
+				signers[data.Signer] = struct{}{}
+				logger.Debug("found signer for validator",
+					zap.Uint64("validator_index", uint64(validatorIndex)),
+					zap.Uint64("signer", data.Signer),
+					zap.Int("signer_data_entry", i))
+				break
+			}
+		}
+	}
+
+	// Convert map to sorted slice
+	var result []spectypes.OperatorID
+	for signer := range signers {
+		result = append(result, signer)
+	}
+	slices.Sort(result)
+
+	logger.Debug("final unique signers for validator",
+		zap.Uint64("validator_index", uint64(validatorIndex)),
+		zap.Any("signers", result),
+		zap.Int("count", len(result)))
+
+	return result
+}
+
+// signersToKey creates a string key from sorted signers for deduplication
+func (c *Collector) signersToKey(signers []spectypes.OperatorID) string {
+	var parts []string
+	for _, signer := range signers {
+		parts = append(parts, fmt.Sprintf("%d", signer))
+	}
+	return strings.Join(parts, ",")
 }

--- a/operator/dutytracer/collector_bench_test.go
+++ b/operator/dutytracer/collector_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkTracer(b *testing.B) {
 
 			b.ResetTimer()
 			for b.Loop() {
-				collector := New(zap.NewNop(), vstore, mockDomainDataProvider{}, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+				collector := New(zap.NewNop(), vstore, mockDomainDataProvider{}, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 				var wg sync.WaitGroup
 				for _, msg := range traces[:actualCount] {

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/registry/storage"
 	registrystoragemocks "github.com/ssvlabs/ssv/registry/storage/mocks"
 	kv "github.com/ssvlabs/ssv/storage/badger"
@@ -49,7 +51,7 @@ func TestValidatorDuty(t *testing.T) {
 
 	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
 
-	collector := New(logger, validators, nil, nil, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(logger, validators, nil, nil, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	var wantBeaconRoot phase0.Root
 	bnVal := [32]byte{1, 2, 3}
@@ -388,7 +390,7 @@ func TestCommitteeDuty(t *testing.T) {
 	validators.EXPECT().Committee(committeeID).Return(committee, true)
 
 	dutyStore := new(mockDutyTraceStore)
-	tracer := New(logger, validators, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	tracer := New(logger, validators, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	var wantBeaconRoot phase0.Root
 	bnVal := [32]byte{1, 2, 3}
@@ -697,7 +699,7 @@ func TestCollector_GetCommitteeDuty(t *testing.T) {
 		OperatorIDs: []uint64{1, 2, 3, 4},
 	}
 
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 	committeeID := spectypes.CommitteeID{1}
 	slot := phase0.Slot(10)
 
@@ -788,7 +790,7 @@ func justification(rcj [][]byte) []byte {
 }
 
 func TestDutyTracer_SyncCommitteeRoots(t *testing.T) {
-	collector := New(zap.NewNop(), nil, mockclient{}, nil, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), nil, mockclient{}, nil, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	bnVote := &spectypes.BeaconVote{BlockRoot: [32]byte{1, 2, 3}}
 
@@ -846,7 +848,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 	var committeeID = spectypes.CommitteeID{1}
 
 	t.Run("slot > last evicted", func(t *testing.T) {
-		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 		slot := phase0.Slot(10)
 		collector.lastEvictedSlot.Store(uint64(5))
 
@@ -886,7 +888,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		evictionSlot := phase0.Slot(5)
 
 		t.Run("committeeID is in flight", func(t *testing.T) {
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 			_, _ = collector.inFlightCommittee.GetOrSet(committeeID, struct{}{})
 
@@ -896,7 +898,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		})
 
 		t.Run("committeeID not found on disk", func(t *testing.T) {
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
 			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
@@ -908,7 +910,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		})
 
 		t.Run("committeeID found on disk", func(t *testing.T) {
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			// Setup: Create a collector, save a trace, and then evict it to disk.
 			trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
 			require.NoError(t, err)
@@ -929,7 +931,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 			innerErr := errors.New("error")
 			dutyTraceStore := &mockDutyTraceStore{err: innerErr}
 
-			collector := New(zap.NewNop(), vstore, nil, dutyTraceStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyTraceStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
 			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
@@ -952,7 +954,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 	var role = spectypes.BNRoleAggregator
 
 	t.Run("slot > last evicted", func(t *testing.T) {
-		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 		slot := phase0.Slot(10)
 		collector.lastEvictedSlot.Store(uint64(5))
 
@@ -994,7 +996,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 		evictionSlot := phase0.Slot(5)
 
 		t.Run("validator is in flight", func(t *testing.T) {
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 			_, _ = collector.inFlightValidator.GetOrSet(vPubKey, struct{}{})
 
@@ -1007,7 +1009,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
 
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
 			vstore.EXPECT().ValidatorIndex(vPubKey).Return(phase0.ValidatorIndex(1), true)
@@ -1028,7 +1030,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
 
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
 			vstore.EXPECT().ValidatorIndex(vPubKey).Return(phase0.ValidatorIndex(1), true)
@@ -1044,7 +1046,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
 
-			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 			vstore.EXPECT().ValidatorIndex(vPubKey).Return(phase0.ValidatorIndex(1), true).AnyTimes()
 
@@ -1114,7 +1116,7 @@ func TestCollector_saveLateValidatorToCommiteeLinks(t *testing.T) {
 	committeeID := spectypes.CommitteeID{1}
 
 	t.Run("save late validator to committee links", func(t *testing.T) {
-		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 		var called bool
 		dutyStore.saveCommitteeDutyLinkFn = func(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error {
@@ -1133,7 +1135,7 @@ func TestCollector_saveLateValidatorToCommiteeLinks(t *testing.T) {
 	t.Run("save late validator to committee links error", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(core)
-		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 		var called bool
 		dutyStore.saveCommitteeDutyLinkFn = func(phase0.Slot, phase0.ValidatorIndex, spectypes.CommitteeID) error {
@@ -1164,7 +1166,7 @@ func TestCollector_lateMessage(t *testing.T) {
 	t.Run("late message in flight", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(core)
-		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 		msgID := spectypes.NewMsgID(spectypes.DomainType{1}, []byte{1}, spectypes.RoleCommittee)
 
@@ -1203,7 +1205,7 @@ func TestCollector_lateMessage(t *testing.T) {
 	t.Run("late message in flight exhausted retries", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(core)
-		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 		msgID := spectypes.NewMsgID(spectypes.DomainType{1}, []byte{1}, spectypes.RoleCommittee)
 
@@ -1239,7 +1241,7 @@ func TestCollector_lateMessage(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(core)
-		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 		msg := &queue.SSVMessage{
 			SSVMessage: &spectypes.SSVMessage{
@@ -1262,7 +1264,7 @@ func TestEvict(t *testing.T) {
 
 		slot := phase0.Slot(10)
 
-		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+		collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 		collector.evict(slot)
 
 		threshold := slot - slotTTL
@@ -1278,7 +1280,7 @@ func TestCollector_GetCommitteeID(t *testing.T) {
 	vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
 	dutyStore := new(mockDutyTraceStore)
 
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	slotToCommittee := hashmap.New[phase0.Slot, spectypes.CommitteeID]()
 	slotToCommittee.Set(slot, spectypes.CommitteeID{1})
@@ -1290,6 +1292,193 @@ func TestCollector_GetCommitteeID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, committeeID, spectypes.CommitteeID{1})
 	require.Equal(t, index, phase0.ValidatorIndex(1))
+}
+
+func TestCollector_PublishDecidedsToListener(t *testing.T) {
+	logger := zap.NewNop()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	const (
+		slot      = phase0.Slot(100)
+		vIndex1   = phase0.ValidatorIndex(10)
+		vIndex2   = phase0.ValidatorIndex(20)
+		operator1 = spectypes.OperatorID(1)
+		operator2 = spectypes.OperatorID(2)
+		operator3 = spectypes.OperatorID(3)
+		operator4 = spectypes.OperatorID(4)
+	)
+
+	identifier := spectypes.NewMsgID([4]byte{}, []byte("committee_pk"), spectypes.RoleCommittee)
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], identifier.GetDutyExecutorID()[16:])
+
+	committee := &storage.Committee{
+		ID:        committeeID,
+		Operators: []spectypes.OperatorID{operator1, operator2, operator3, operator4}, // 4 operators = need 3 for quorum
+	}
+
+	var validatorPK1 spectypes.ValidatorPK
+	copy(validatorPK1[:], []byte("validator_pk_1_padded_to_48_bytes_exactly_here"))
+	var validatorPK2 spectypes.ValidatorPK
+	copy(validatorPK2[:], []byte("validator_pk_2_padded_to_48_bytes_exactly_here"))
+
+	share1 := &ssvtypes.SSVShare{}
+	share1.ValidatorPubKey = validatorPK1
+	share2 := &ssvtypes.SSVShare{}
+	share2.ValidatorPubKey = validatorPK2
+
+	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
+	validators.EXPECT().Committee(committeeID).Return(committee, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndex1).Return(share1, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndex2).Return(share2, true).AnyTimes()
+
+	listener := &mockDecidedListener{}
+	dutyStore := new(mockDutyTraceStore)
+	collector := New(logger, validators, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, listener.OnDecided)
+
+	signingRoot := [32]byte{1, 2, 3, 4, 5}
+	fakeSig := [96]byte{}
+
+	t.Run("first validator reaches quorum", func(t *testing.T) {
+		listener.Reset()
+
+		// Send partial signatures from 3 operators for validator1 (reaches quorum)
+		// Send each operator's signature separately
+		operators := []spectypes.OperatorID{operator1, operator2, operator3}
+		for _, op := range operators {
+			partSigMessages := &spectypes.PartialSignatureMessages{
+				Slot: slot,
+				Messages: []*spectypes.PartialSignatureMessage{
+					{ValidatorIndex: vIndex1, Signer: op, PartialSignature: fakeSig[:], SigningRoot: signingRoot},
+				},
+			}
+
+			partSigMessagesData, err := partSigMessages.Encode()
+			require.NoError(t, err)
+
+			partSigMsg := buildPartialSigMessage(identifier, partSigMessagesData)
+			err = collector.Collect(t.Context(), partSigMsg, dummyVerify)
+			require.NoError(t, err)
+		}
+
+		// Verify listener was called once (after reaching quorum)
+		calls := listener.GetCalls()
+		require.Len(t, calls, 1)
+
+		// Verify the call has correct data
+		call := calls[0]
+		assert.Equal(t, validatorPK1, call.PubKey)
+		assert.Equal(t, slot, call.Slot)
+		assert.Equal(t, spectypes.BNRoleAttester, call.Role)
+		assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, call.Signers)
+	})
+
+	t.Run("additional signers don't trigger duplicate publication", func(t *testing.T) {
+		listener.Reset()
+
+		// Send signature from 4th operator for same validator1 (should not trigger new publication)
+		partSigMessages := &spectypes.PartialSignatureMessages{
+			Slot: slot,
+			Messages: []*spectypes.PartialSignatureMessage{
+				{ValidatorIndex: vIndex1, Signer: operator4, PartialSignature: fakeSig[:], SigningRoot: signingRoot},
+			},
+		}
+
+		partSigMessagesData, err := partSigMessages.Encode()
+		require.NoError(t, err)
+
+		partSigMsg := buildPartialSigMessage(identifier, partSigMessagesData)
+		err = collector.Collect(t.Context(), partSigMsg, dummyVerify)
+		require.NoError(t, err)
+
+		// Verify listener was NOT called (deduplication working)
+		calls := listener.GetCalls()
+		require.Len(t, calls, 0)
+	})
+
+	t.Run("second validator reaches quorum", func(t *testing.T) {
+		listener.Reset()
+
+		// Send partial signatures from 3 operators for validator2 (reaches quorum)
+		operators := []spectypes.OperatorID{operator1, operator2, operator3}
+		for _, op := range operators {
+			partSigMessages := &spectypes.PartialSignatureMessages{
+				Slot: slot,
+				Messages: []*spectypes.PartialSignatureMessage{
+					{ValidatorIndex: vIndex2, Signer: op, PartialSignature: fakeSig[:], SigningRoot: signingRoot},
+				},
+			}
+
+			partSigMessagesData, err := partSigMessages.Encode()
+			require.NoError(t, err)
+
+			partSigMsg := buildPartialSigMessage(identifier, partSigMessagesData)
+			err = collector.Collect(t.Context(), partSigMsg, dummyVerify)
+			require.NoError(t, err)
+		}
+
+		// Verify listener was called once for the new validator
+		calls := listener.GetCalls()
+		require.Len(t, calls, 1)
+
+		// Verify the call has correct data for validator2
+		call := calls[0]
+		assert.Equal(t, validatorPK2, call.PubKey)
+		assert.Equal(t, slot, call.Slot)
+		assert.Equal(t, spectypes.BNRoleAttester, call.Role)
+		assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, call.Signers)
+	})
+
+	t.Run("insufficient signers don't trigger publication", func(t *testing.T) {
+		listener.Reset()
+
+		// Send partial signatures from only 2 operators for a new validator (below quorum)
+		operators := []spectypes.OperatorID{operator1, operator2}
+		for _, op := range operators {
+			partSigMessages := &spectypes.PartialSignatureMessages{
+				Slot: slot + 1, // Different slot to avoid conflicts
+				Messages: []*spectypes.PartialSignatureMessage{
+					{ValidatorIndex: vIndex1, Signer: op, PartialSignature: fakeSig[:], SigningRoot: signingRoot},
+				},
+			}
+
+			partSigMessagesData, err := partSigMessages.Encode()
+			require.NoError(t, err)
+
+			partSigMsg := buildPartialSigMessage(identifier, partSigMessagesData)
+			err = collector.Collect(t.Context(), partSigMsg, dummyVerify)
+			require.NoError(t, err)
+		}
+
+		// Verify listener was NOT called (insufficient quorum)
+		calls := listener.GetCalls()
+		require.Len(t, calls, 0)
+	})
+}
+
+// mockDecidedListener captures calls to OnDecided for testing
+type mockDecidedListener struct {
+	calls []DecidedInfo
+	mu    sync.Mutex
+}
+
+func (m *mockDecidedListener) OnDecided(msg DecidedInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, msg)
+}
+
+func (m *mockDecidedListener) GetCalls() []DecidedInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]DecidedInfo{}, m.calls...)
+}
+
+func (m *mockDecidedListener) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = nil
 }
 
 type mockDutyTraceStore struct {

--- a/operator/dutytracer/store_test.go
+++ b/operator/dutytracer/store_test.go
@@ -32,7 +32,7 @@ func TestValidatorCommitteeMapping(t *testing.T) {
 	dutyStore := store.New(db)
 	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.NetworkConfig{}, db, nil)
 
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	var committeeID1 spectypes.CommitteeID
 	committeeID1[0] = 1
@@ -139,7 +139,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 
 	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.NetworkConfig{}, db, nil)
 
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	var committeeID1 spectypes.CommitteeID
 	committeeID1[0] = 1
@@ -323,7 +323,7 @@ func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 			ValidatorPubKey: validatorPK7,
 		},
 	})
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	// Create a new trace
 	dutyTrace, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID1)
@@ -386,7 +386,7 @@ func TestValidatorDutyStore(t *testing.T) {
 
 	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.NetworkConfig{}, db, nil)
 
-	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig)
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.BeaconConfig, nil)
 
 	slot4 := phase0.Slot(4)
 


### PR DESCRIPTION
## What this PR does:

Exporter v2 did not send any messages to the websocket. This PR adds a `DecidedListener` to exporter v2 to listen to new decided quorums. When the node starts, the websocket publisher is passed as DecidedListener to the exporter.

## Implementation notes

After several attempts, the most robust was to store the quorums on the temporary in-memory trace directly. Quorum are not persisted on disk.

## How to run on local:

  **1. Edit you config to make sure to enable exporter v2 and websockets:**

```
global:
  LogLevel: debug # enable debug to see the websocket trace
  
exporter:
  Enabled: true
  Mode: archive
  RetainSlots: 5

SSVAPIPort: 31602
WebSocketAPIPort: 31603
WithPing: true
```

**2. Compile and run:**

```
make build
go run $(pwd)/cmd/ssvnode start-node --config="$CONFIG_PATH"  | grep DecidedListener
```

**3. Start a websocket connection**

```
wscat -c ws://localhost:31603/stream
```