### PR TITLE
migrations: fix order

### DIFF
--- a/migrations/migration_7_derive_signer_key_with_hkdf.go
+++ b/migrations/migration_7_derive_signer_key_with_hkdf.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-var migration_8_derive_signer_key_with_hkdf = Migration{
-	Name: "migration_8_derive_signer_key_with_hkdf",
+var migration_7_derive_signer_key_with_hkdf = Migration{
+	Name: "migration_7_derive_signer_key_with_hkdf",
 	Run: func(ctx context.Context, logger *zap.Logger, opt Options, key []byte, completed CompletedFunc) (err error) {
 		return opt.Db.Update(func(txn basedb.Txn) error {
 			if opt.OperatorPrivKey == nil {

--- a/migrations/migration_7_derive_signer_key_with_hkdf_test.go
+++ b/migrations/migration_7_derive_signer_key_with_hkdf_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-func TestMigration8DeriveSignerKeyWithHKDF(t *testing.T) {
+func TestMigration7DeriveSignerKeyWithHKDF(t *testing.T) {
 	require.NoError(t, bls.Init(bls.BLS12_381))
 
 	t.Run("successfully migrates accounts with new key derivation", func(t *testing.T) {
@@ -47,8 +47,8 @@ func TestMigration8DeriveSignerKeyWithHKDF(t *testing.T) {
 			OperatorPrivKey: operatorPrivKey,
 		}
 
-		err = migration_8_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
-			[]byte(migration_8_derive_signer_key_with_hkdf.Name),
+		err = migration_7_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
+			[]byte(migration_7_derive_signer_key_with_hkdf.Name),
 			func(rw basedb.ReadWriter) error { return nil })
 		assert.NoError(t, err)
 
@@ -81,8 +81,8 @@ func TestMigration8DeriveSignerKeyWithHKDF(t *testing.T) {
 		}
 
 		completedExecuted := false
-		err = migration_8_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
-			[]byte(migration_8_derive_signer_key_with_hkdf.Name),
+		err = migration_7_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
+			[]byte(migration_7_derive_signer_key_with_hkdf.Name),
 			func(rw basedb.ReadWriter) error {
 				completedExecuted = true
 				return nil
@@ -113,8 +113,8 @@ func TestMigration8DeriveSignerKeyWithHKDF(t *testing.T) {
 		}
 
 		completedExecuted := false
-		err = migration_8_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
-			[]byte(migration_8_derive_signer_key_with_hkdf.Name),
+		err = migration_7_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
+			[]byte(migration_7_derive_signer_key_with_hkdf.Name),
 			func(rw basedb.ReadWriter) error {
 				completedExecuted = true
 				return nil
@@ -146,8 +146,8 @@ func TestMigration8DeriveSignerKeyWithHKDF(t *testing.T) {
 			OperatorPrivKey: operatorPrivKey,
 		}
 
-		err = migration_8_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
-			[]byte(migration_8_derive_signer_key_with_hkdf.Name),
+		err = migration_7_derive_signer_key_with_hkdf.Run(t.Context(), logger, options,
+			[]byte(migration_7_derive_signer_key_with_hkdf.Name),
 			func(rw basedb.ReadWriter) error {
 				return fmt.Errorf("completion error")
 			})

--- a/migrations/migration_8_populate_validator_index_mapping.go
+++ b/migrations/migration_8_populate_validator_index_mapping.go
@@ -14,8 +14,8 @@ import (
 
 // This migration populates the mapping between validator pubkey -> index
 // It reads all the shares to collect relevant data
-var migration_7_populate_validator_index_mapping = Migration{
-	Name: "migration_7_populate_validator_index_mapping",
+var migration_8_populate_validator_index_mapping = Migration{
+	Name: "migration_8_populate_validator_index_mapping",
 	Run: func(ctx context.Context, logger *zap.Logger, opt Options, key []byte, completed CompletedFunc) (err error) {
 		var validatorsMapped int
 

--- a/migrations/migration_8_populate_validator_index_mapping_test.go
+++ b/migrations/migration_8_populate_validator_index_mapping_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-func TestMigration7PopulateValidatorIndexMapping(t *testing.T) {
+func TestMigration8PopulateValidatorIndexMapping(t *testing.T) {
 	ctx := t.Context()
 	logger := zap.NewNop()
 	sharesPrefix := storage.SharesDBPrefix(opstorage.OperatorStoragePrefix)
@@ -24,10 +24,10 @@ func TestMigration7PopulateValidatorIndexMapping(t *testing.T) {
 		options, err := setupOptions(ctx, t)
 		require.NoError(t, err)
 
-		err = migration_7_populate_validator_index_mapping.Run(ctx,
+		err = migration_8_populate_validator_index_mapping.Run(ctx,
 			logger,
 			options,
-			[]byte(migration_7_populate_validator_index_mapping.Name),
+			[]byte(migration_8_populate_validator_index_mapping.Name),
 			func(rw basedb.ReadWriter) error { return nil },
 		)
 		assert.NoError(t, err)
@@ -47,10 +47,10 @@ func TestMigration7PopulateValidatorIndexMapping(t *testing.T) {
 		seededShares := seedDatabase7(t, 5, options.Db, storageSetSharesKey)
 
 		called := false
-		err = migration_7_populate_validator_index_mapping.Run(ctx,
+		err = migration_8_populate_validator_index_mapping.Run(ctx,
 			logger,
 			options,
-			[]byte(migration_7_populate_validator_index_mapping.Name),
+			[]byte(migration_8_populate_validator_index_mapping.Name),
 			func(rw basedb.ReadWriter) error {
 				called = true
 				return nil
@@ -66,20 +66,20 @@ func TestMigration7PopulateValidatorIndexMapping(t *testing.T) {
 		require.NoError(t, err)
 		seededShares := seedDatabase7(t, 7, options.Db, storageSetSharesKey)
 
-		err = migration_7_populate_validator_index_mapping.Run(ctx,
+		err = migration_8_populate_validator_index_mapping.Run(ctx,
 			logger,
 			options,
-			[]byte(migration_7_populate_validator_index_mapping.Name),
+			[]byte(migration_8_populate_validator_index_mapping.Name),
 			func(rw basedb.ReadWriter) error { return fmt.Errorf("fail complete") },
 		)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "fail complete")
 
 		// Should be able to re-run and succeed
-		err = migration_7_populate_validator_index_mapping.Run(ctx,
+		err = migration_8_populate_validator_index_mapping.Run(ctx,
 			logger,
 			options,
-			[]byte(migration_7_populate_validator_index_mapping.Name),
+			[]byte(migration_8_populate_validator_index_mapping.Name),
 			func(rw basedb.ReadWriter) error { return nil },
 		)
 		assert.NoError(t, err)
@@ -93,10 +93,10 @@ func TestMigration7PopulateValidatorIndexMapping(t *testing.T) {
 		err = options.Db.Set(sharesPrefix, []byte("corrupt"), []byte{0x01, 0x02, 0x03})
 		require.NoError(t, err)
 
-		err = migration_7_populate_validator_index_mapping.Run(ctx,
+		err = migration_8_populate_validator_index_mapping.Run(ctx,
 			logger,
 			options,
-			[]byte(migration_7_populate_validator_index_mapping.Name),
+			[]byte(migration_8_populate_validator_index_mapping.Name),
 			func(rw basedb.ReadWriter) error { return nil },
 		)
 		assert.Error(t, err)

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -29,8 +29,8 @@ var (
 		migration_4_configlock_add_alan_fork_to_network_name,
 		migration_5_change_share_format_from_gob_to_ssz,
 		migration_6_share_exit_epoch,
-		migration_7_populate_validator_index_mapping,
-		migration_8_derive_signer_key_with_hkdf,
+		migration_7_derive_signer_key_with_hkdf,
+		migration_8_populate_validator_index_mapping,
 	}
 )
 


### PR DESCRIPTION
The `main` branch already contains the HKDF migrations as 7th, so it must go 7th. The current state of `stage` has it as 8th, which may cause incompatibilities with the `main` branch.
