### PR TITLE
fix(exporter): prevent empty HTTP responses for undecided round changes

### DIFF
--- a/api/handlers/model.go
+++ b/api/handlers/model.go
@@ -106,6 +106,15 @@ func toProposalTrace(rt *model.ProposalTrace) *proposalTrace {
 	if rt == nil {
 		return nil
 	}
+
+	// Filter out zero-valued ProposalTrace objects created by SSZ encoding.
+	// These occur when rounds exist with only roundChanges (or possibly also prepares/commits) but no actual proposal.
+	// Without filtering, they appear as confusing proposals with round=0, leader=0, epoch timestamp.
+	// While 0-valued proposals are technically valid according to our data model, they show up as confusing API responses.
+	if rt.Round == 0 && rt.Signer == 0 && rt.ReceivedTime == 0 {
+		return nil
+	}
+
 	return &proposalTrace{
 		Round:                 rt.Round,
 		BeaconRoot:            rt.BeaconRoot,


### PR DESCRIPTION
When querying `/v1/exporter/traces/committee`, the API sometimes returns "proposal" objects with all fields set to zero (e.g., `round: 0, leader: 0, time: "1970-01-01T00:00:00Z"`), especially for rounds that only had roundChange, prepare, or commit messages but no actual proposal. This is confusing.

**TL;DR** During SSZ serialization, `nil` values are encoded as zero values. This PR introduces logic to convert them back to `nil` in API responses to improve user experience.

**What is actually happening**

The zero values are actually not a bug, but just an artifact of serialization.

- Our data model creates a `RoundTrace` for any round that receives a message (proposal, prepare, commit, or roundChange).
- If a round only receives roundChange (or prepare/commit) messages and no proposal, the ProposalTrace pointer is left as nil in memory.
- When traces are serialized to disk using fastSSZ, SSZ does not support serializing nil pointers for composite types. Instead, it encodes them as zero-valued structs.
- When deserialized, these fields are no longer nil but are pointers to zero-valued structs, which the API then renders as a proposal with all fields zeroed.

**Fix**
- In the API conversion layer, filter out zero-valued `ProposalTrace` objects (i.e., those with `round == 0`, `leader == 0`, and `receivedTime == 0`).
- This makes the API response clearer and more intuitive: rounds with no proposal now show "proposal": null instead of a confusing zero-valued object.