### PR TITLE
feat(exporter): Create LogAnalyzer

### DIFF
--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -137,6 +137,7 @@ func TestNew(t *testing.T) {
 		node,
 		validators,
 		exporter,
+		nil, // logAnalyzer
 		false,
 	)
 
@@ -172,6 +173,7 @@ func TestRun_ActualExecution(t *testing.T) {
 		&hnode.Node{},
 		&hvalidators.Validators{},
 		&hexporter.Exporter{},
+		nil, // logAnalyzer
 		false,
 	)
 
@@ -237,6 +239,7 @@ func TestRun_ActualExecutionFullMode(t *testing.T) {
 		&hnode.Node{},
 		&hvalidators.Validators{},
 		&hexporter.Exporter{},
+		nil, // logAnalyzer
 		true,
 	)
 

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -9,10 +9,11 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/eth/loganalyzer"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	nodestorage "github.com/ssvlabs/ssv/operator/storage"
 )
@@ -23,7 +24,7 @@ import (
 // https://github.com/ssvlabs/ssv/pull/1053
 
 const (
-	defaultStalenessThreshold = 300 * time.Second
+	defaultStalenessThreshold = 1296 * time.Second
 )
 
 var (
@@ -34,7 +35,9 @@ var (
 type ExecutionClient interface {
 	FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (logs <-chan executionclient.BlockLogs, errors <-chan error, err error)
 	StreamLogs(ctx context.Context, fromBlock uint64) <-chan executionclient.BlockLogs
-	HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error)
+	StreamFilterLogs(ctx context.Context, fromBlock uint64) <-chan ethtypes.Log
+	StreamFinalizedLogs(ctx context.Context, fromBlock uint64) <-chan executionclient.BlockLogs
+	HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*ethtypes.Header, error)
 }
 
 type EventHandler interface {
@@ -50,6 +53,9 @@ type EventSyncer struct {
 
 	logger             *zap.Logger
 	stalenessThreshold time.Duration
+
+	// Optional log analyzer for debugging missing events
+	logAnalyzer *loganalyzer.LogAnalyzer
 
 	lastProcessedBlock       uint64
 	lastProcessedBlockChange time.Time
@@ -121,6 +127,9 @@ func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64) (lastP
 			return 0, fmt.Errorf("failed to fetch historical events: %w", err)
 		}
 
+		// Intercept fetchLogs and forward a copy to the log analyzer.
+		fetchLogs = es.analyzeLogStream(fetchLogs)
+
 		lastProcessedBlock, err = es.eventHandler.HandleBlockEventsStream(ctx, fetchLogs, false)
 		if err != nil {
 			return 0, fmt.Errorf("handle historical block events: %w", err)
@@ -160,11 +169,74 @@ func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64) (lastP
 	return 0, fmt.Errorf("highest block is too old (%d)", lastProcessedBlock)
 }
 
+// Intercept StreamLogs and forward a copy to the log analyzer.
+func (es *EventSyncer) analyzeLogStream(logStream <-chan executionclient.BlockLogs) <-chan executionclient.BlockLogs {
+	if es.logAnalyzer == nil {
+		return logStream
+	}
+
+	analyzedLogStream := make(chan executionclient.BlockLogs)
+	go func() {
+		defer close(analyzedLogStream)
+		es.logger.Debug("started batch logs stream interceptor")
+		for blockLogs := range logStream {
+			es.logger.Debug("batch logs stream received block",
+				zap.Uint64("block", blockLogs.BlockNumber),
+				zap.Int("log_count", len(blockLogs.Logs)))
+			// Analyze the logs
+			es.logAnalyzer.RecordBlockLogs(blockLogs)
+			// Pass through to the event handler
+			analyzedLogStream <- blockLogs
+		}
+		es.logger.Debug("batch logs stream interceptor closed")
+	}()
+	return analyzedLogStream
+}
+
 // SyncOngoing streams and processes ongoing events as they come since the given fromBlock.
 func (es *EventSyncer) SyncOngoing(ctx context.Context, fromBlock uint64) error {
 	es.logger.Info("subscribing to ongoing registry events", fields.FromBlock(fromBlock))
 
 	logStream := es.executionClient.StreamLogs(ctx, fromBlock)
+
+	// Set up log analysis if enabled
+	if es.logAnalyzer != nil {
+		es.logger.Info("setting up log analyzer with three streams", fields.FromBlock(fromBlock))
+
+		// Intercept StreamLogs and forward a copy to the log analyzer.
+		logStream = es.analyzeLogStream(logStream)
+
+		// Also start a second subscription to the filter logs
+		// to compare them with the logs from the block stream.
+		filterLogStream := es.executionClient.StreamFilterLogs(ctx, fromBlock)
+		go func() {
+			es.logger.Debug("started filter logs stream")
+			for log := range filterLogStream {
+				es.logger.Debug("filter logs stream received log",
+					zap.Uint64("block", log.BlockNumber),
+					zap.Uint("log_index", log.Index))
+				es.logAnalyzer.RecordFilterLogs(log)
+			}
+			es.logger.Debug("filter logs stream closed")
+		}()
+
+		// Start a third subscription to finalized logs for ground truth comparison
+		finalizedLogStream := es.executionClient.StreamFinalizedLogs(ctx, fromBlock)
+		go func() {
+			es.logger.Debug("started finalized logs stream")
+			for blockLogs := range finalizedLogStream {
+				es.logger.Debug("finalized logs stream received block",
+					zap.Uint64("block", blockLogs.BlockNumber),
+					zap.Int("log_count", len(blockLogs.Logs)))
+				es.logAnalyzer.RecordFinalizedLogs(blockLogs)
+			}
+			es.logger.Debug("finalized logs stream closed")
+		}()
+
+		// Log analyzer now uses event-driven reporting (after finalized blocks)
+		es.logger.Info("log analyzer streams started")
+	}
+
 	_, err := es.eventHandler.HandleBlockEventsStream(ctx, logStream, true)
 	return err
 }

--- a/eth/eventsyncer/event_syncer_mock.go
+++ b/eth/eventsyncer/event_syncer_mock.go
@@ -74,6 +74,34 @@ func (mr *MockExecutionClientMockRecorder) HeaderByNumber(ctx, blockNumber any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockExecutionClient)(nil).HeaderByNumber), ctx, blockNumber)
 }
 
+// StreamFilterLogs mocks base method.
+func (m *MockExecutionClient) StreamFilterLogs(ctx context.Context, fromBlock uint64) <-chan types.Log {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFilterLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan types.Log)
+	return ret0
+}
+
+// StreamFilterLogs indicates an expected call of StreamFilterLogs.
+func (mr *MockExecutionClientMockRecorder) StreamFilterLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFilterLogs", reflect.TypeOf((*MockExecutionClient)(nil).StreamFilterLogs), ctx, fromBlock)
+}
+
+// StreamFinalizedLogs mocks base method.
+func (m *MockExecutionClient) StreamFinalizedLogs(ctx context.Context, fromBlock uint64) <-chan executionclient.BlockLogs {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFinalizedLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan executionclient.BlockLogs)
+	return ret0
+}
+
+// StreamFinalizedLogs indicates an expected call of StreamFinalizedLogs.
+func (mr *MockExecutionClientMockRecorder) StreamFinalizedLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFinalizedLogs", reflect.TypeOf((*MockExecutionClient)(nil).StreamFinalizedLogs), ctx, fromBlock)
+}
+
 // StreamLogs mocks base method.
 func (m *MockExecutionClient) StreamLogs(ctx context.Context, fromBlock uint64) <-chan executionclient.BlockLogs {
 	m.ctrl.T.Helper()

--- a/eth/eventsyncer/options.go
+++ b/eth/eventsyncer/options.go
@@ -3,6 +3,7 @@ package eventsyncer
 import (
 	"go.uber.org/zap"
 
+	"github.com/ssvlabs/ssv/eth/loganalyzer"
 	"github.com/ssvlabs/ssv/observability/log"
 )
 
@@ -13,5 +14,12 @@ type Option func(*EventSyncer)
 func WithLogger(logger *zap.Logger) Option {
 	return func(es *EventSyncer) {
 		es.logger = logger.Named(log.NameEventSyncer)
+	}
+}
+
+// WithLogAnalyzer enables log analysis for debugging missing events.
+func WithLogAnalyzer(analyzer *loganalyzer.LogAnalyzer) Option {
+	return func(es *EventSyncer) {
+		es.logAnalyzer = analyzer
 	}
 }

--- a/eth/executionclient/mocks.go
+++ b/eth/executionclient/mocks.go
@@ -148,6 +148,34 @@ func (mr *MockProviderMockRecorder) Healthy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthy", reflect.TypeOf((*MockProvider)(nil).Healthy), ctx)
 }
 
+// StreamFilterLogs mocks base method.
+func (m *MockProvider) StreamFilterLogs(ctx context.Context, fromBlock uint64) <-chan types.Log {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFilterLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan types.Log)
+	return ret0
+}
+
+// StreamFilterLogs indicates an expected call of StreamFilterLogs.
+func (mr *MockProviderMockRecorder) StreamFilterLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFilterLogs", reflect.TypeOf((*MockProvider)(nil).StreamFilterLogs), ctx, fromBlock)
+}
+
+// StreamFinalizedLogs mocks base method.
+func (m *MockProvider) StreamFinalizedLogs(ctx context.Context, fromBlock uint64) <-chan BlockLogs {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFinalizedLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan BlockLogs)
+	return ret0
+}
+
+// StreamFinalizedLogs indicates an expected call of StreamFinalizedLogs.
+func (mr *MockProviderMockRecorder) StreamFinalizedLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFinalizedLogs", reflect.TypeOf((*MockProvider)(nil).StreamFinalizedLogs), ctx, fromBlock)
+}
+
 // StreamLogs mocks base method.
 func (m *MockProvider) StreamLogs(ctx context.Context, fromBlock uint64) <-chan BlockLogs {
 	m.ctrl.T.Helper()
@@ -303,6 +331,34 @@ func (m *MockSingleClientProvider) Healthy(ctx context.Context) error {
 func (mr *MockSingleClientProviderMockRecorder) Healthy(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthy", reflect.TypeOf((*MockSingleClientProvider)(nil).Healthy), ctx)
+}
+
+// StreamFilterLogs mocks base method.
+func (m *MockSingleClientProvider) StreamFilterLogs(ctx context.Context, fromBlock uint64) <-chan types.Log {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFilterLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan types.Log)
+	return ret0
+}
+
+// StreamFilterLogs indicates an expected call of StreamFilterLogs.
+func (mr *MockSingleClientProviderMockRecorder) StreamFilterLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFilterLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).StreamFilterLogs), ctx, fromBlock)
+}
+
+// StreamFinalizedLogs mocks base method.
+func (m *MockSingleClientProvider) StreamFinalizedLogs(ctx context.Context, fromBlock uint64) <-chan BlockLogs {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamFinalizedLogs", ctx, fromBlock)
+	ret0, _ := ret[0].(<-chan BlockLogs)
+	return ret0
+}
+
+// StreamFinalizedLogs indicates an expected call of StreamFinalizedLogs.
+func (mr *MockSingleClientProviderMockRecorder) StreamFinalizedLogs(ctx, fromBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFinalizedLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).StreamFinalizedLogs), ctx, fromBlock)
 }
 
 // StreamLogs mocks base method.

--- a/eth/loganalyzer/api_handlers.go
+++ b/eth/loganalyzer/api_handlers.go
@@ -1,0 +1,328 @@
+package loganalyzer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/api"
+)
+
+const (
+	MaxAPIRange   = 1000 // Maximum allowed block range for API queries
+	healthyStatus = "healthy"
+)
+
+// ParameterError represents a parameter validation error.
+type ParameterError struct {
+	Parameter string
+	Value     string
+	Reason    string
+}
+
+func (e ParameterError) Error() string {
+	return fmt.Sprintf("invalid parameter '%s' with value '%s': %s", e.Parameter, e.Value, e.Reason)
+}
+
+func (h *APIHandler) parseBlockNumber(value string) (uint64, error) {
+	if value == "latest" {
+		blockNumber, err := h.store.GetLastReceivedBlock(context.Background(), FinalizedLogType)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return 0, ParameterError{Parameter: "block", Value: value, Reason: "no finalized blocks available yet"}
+			}
+			return 0, fmt.Errorf("failed to get last finalized block: %w", err)
+		}
+		return blockNumber, nil
+	}
+
+	blockNumber, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, ParameterError{Parameter: "block", Value: value, Reason: err.Error()}
+	}
+	return blockNumber, nil
+}
+
+func parseUint64Parameter(paramName, value string) (uint64, error) {
+	result, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, ParameterError{Parameter: paramName, Value: value, Reason: err.Error()}
+	}
+	return result, nil
+}
+
+func parseUint32Parameter(paramName, value string) (uint32, error) {
+	result, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, ParameterError{Parameter: paramName, Value: value, Reason: err.Error()}
+	}
+	return uint32(result), nil
+}
+
+func validateBlockRange(fromBlock, toBlock uint64) error {
+	if fromBlock > toBlock {
+		return ParameterError{Parameter: "range", Value: fmt.Sprintf("%d-%d", fromBlock, toBlock), Reason: "from block cannot be greater than to block"}
+	}
+
+	if toBlock-fromBlock > MaxAPIRange {
+		return ParameterError{Parameter: "range", Value: fmt.Sprintf("%d-%d", fromBlock, toBlock), Reason: fmt.Sprintf("range too large, maximum allowed range is %d blocks", MaxAPIRange)}
+	}
+
+	return nil
+}
+
+// LogAnalyzerProvider interface for accessing LogAnalyzer health status.
+type LogAnalyzerProvider interface {
+	GetHealthStatus() HealthStatus
+}
+
+// APIHandler provides HTTP endpoints for log analysis queries.
+type APIHandler struct {
+	logger   *zap.Logger
+	store    LogAnalyzerStore
+	analyzer LogAnalyzerProvider
+}
+
+// NewAPIHandler creates a new API handler for log analysis.
+func NewAPIHandler(logger *zap.Logger, store LogAnalyzerStore, analyzer LogAnalyzerProvider) *APIHandler {
+	if logger == nil {
+		panic("logger cannot be nil")
+	}
+	if store == nil {
+		panic("store cannot be nil")
+	}
+	if analyzer == nil {
+		panic("analyzer cannot be nil - use the enhanced LogAnalyzer for comprehensive health monitoring")
+	}
+
+	return &APIHandler{
+		logger:   logger.Named("logAnalyzerAPI"),
+		store:    store,
+		analyzer: analyzer,
+	}
+}
+
+// Stats handles requests for block analysis statistics.
+// Supports both single blocks (?block=123) and ranges (?from=100&to=200).
+func (h *APIHandler) Stats(w http.ResponseWriter, r *http.Request) error {
+	blockParam := r.URL.Query().Get("block")
+	fromParam := r.URL.Query().Get("from")
+	toParam := r.URL.Query().Get("to")
+
+	if blockParam != "" {
+		return h.handleSingleBlock(w, r, blockParam)
+	} else if fromParam != "" && toParam != "" {
+		return h.handleBlockRange(w, r, fromParam, toParam)
+	}
+	return api.BadRequestError(errors.New("must specify either 'block' or 'from'+'to' parameters"))
+}
+
+func (h *APIHandler) handleSingleBlock(w http.ResponseWriter, r *http.Request, blockParam string) error {
+	blockNumber, err := h.parseBlockNumber(blockParam)
+	if err != nil {
+		var paramErr ParameterError
+		if errors.As(err, &paramErr) {
+			return api.BadRequestError(paramErr)
+		}
+		h.logger.Error("failed to parse block number", zap.Error(err))
+		return api.Error(err)
+	}
+
+	stats, err := h.store.GetBlockStats(r.Context(), blockNumber)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return api.ErrNotFound
+		}
+		h.logger.Error("failed to get block stats", zap.Uint64("block", blockNumber), zap.Error(err))
+		return api.Error(fmt.Errorf("failed to get block stats for block %d: %w", blockNumber, err))
+	}
+
+	allLogs, err := h.store.GetAllLogs(r.Context(), blockNumber)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		h.logger.Error("failed to get all logs for transaction stats", zap.Uint64("block", blockNumber), zap.Error(err))
+	}
+
+	var txStats []*TxLogStats
+	if err == nil {
+		txStats = ComputeTransactionStats(allLogs.BatchLogs, allLogs.FilterLogs, allLogs.FinalizedLogs)
+	} else {
+		txStats = []*TxLogStats{}
+	}
+
+	return api.Render(w, r, &BlockStatsResponse{
+		BlockStats:       []*BlockAnalysisStats{stats},
+		TransactionStats: txStats,
+		HasMore:          false,
+	})
+}
+
+func (h *APIHandler) handleBlockRange(w http.ResponseWriter, r *http.Request, fromParam, toParam string) error {
+	fromBlock, err := parseUint64Parameter("from", fromParam)
+	if err != nil {
+		return api.BadRequestError(err)
+	}
+
+	toBlock, err := parseUint64Parameter("to", toParam)
+	if err != nil {
+		return api.BadRequestError(err)
+	}
+
+	if err := validateBlockRange(fromBlock, toBlock); err != nil {
+		return api.BadRequestError(err)
+	}
+
+	stats, err := h.store.GetBlockRange(r.Context(), fromBlock, toBlock)
+	if err != nil {
+		h.logger.Error("failed to get block range stats",
+			zap.Uint64("from", fromBlock),
+			zap.Uint64("to", toBlock),
+			zap.Error(err))
+		return api.Error(fmt.Errorf("failed to get block range stats from %d to %d: %w", fromBlock, toBlock, err))
+	}
+
+	// Compute transaction stats for blocks with discrepancies
+	var allTxStats []*TxLogStats
+	for _, blockStats := range stats {
+		if blockStats.HasDiscrepancies {
+			allLogs, err := h.store.GetAllLogs(r.Context(), blockStats.BlockNumber)
+			if err != nil {
+				h.logger.Debug("could not get logs for transaction stats",
+					zap.Uint64("block", blockStats.BlockNumber),
+					zap.Error(err))
+				continue
+			}
+			txStats := ComputeTransactionStats(allLogs.BatchLogs, allLogs.FilterLogs, allLogs.FinalizedLogs)
+			allTxStats = append(allTxStats, txStats...)
+		}
+	}
+
+	if allTxStats == nil {
+		allTxStats = []*TxLogStats{}
+	}
+
+	return api.Render(w, r, &BlockStatsResponse{
+		BlockStats:       stats,
+		TransactionStats: allTxStats,
+		HasMore:          false,
+	})
+}
+
+// ProblematicBlocks handles requests for blocks with log discrepancies.
+func (h *APIHandler) ProblematicBlocks(w http.ResponseWriter, r *http.Request) error {
+	lastFinalized, err := h.store.GetLastReceivedBlock(r.Context(), FinalizedLogType)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			lastFinalized = 0
+		} else {
+			h.logger.Error("failed to get last finalized block", zap.Error(err))
+			return api.Error(err)
+		}
+	}
+
+	startBlockParam := r.URL.Query().Get("start_block")
+	endBlockParam := r.URL.Query().Get("end_block")
+	limitParam := r.URL.Query().Get("limit")
+
+	var startBlock uint64
+	var endBlock *uint64
+	var limit uint32 = 100
+	var description string
+
+	// Handle case where no start_block is provided
+	if startBlockParam == "" {
+		limit = 10
+		if limitParam != "" {
+			limitVal, err := parseUint32Parameter("limit", limitParam)
+			if err != nil {
+				return api.BadRequestError(err)
+			}
+			limit = limitVal
+		}
+
+		startBlock = 0
+		description = fmt.Sprintf("last %d problematic blocks", limit)
+	} else {
+		var err error
+		startBlock, err = parseUint64Parameter("start_block", startBlockParam)
+		if err != nil {
+			return api.BadRequestError(err)
+		}
+
+		if endBlockParam != "" {
+			endBlockVal, err := parseUint64Parameter("end_block", endBlockParam)
+			if err != nil {
+				return api.BadRequestError(err)
+			}
+			endBlock = &endBlockVal
+
+			if *endBlock < startBlock {
+				return api.BadRequestError(ParameterError{Parameter: "end_block", Value: endBlockParam, Reason: "end_block cannot be less than start_block"})
+			}
+		}
+
+		if limitParam != "" {
+			limitVal, err := parseUint32Parameter("limit", limitParam)
+			if err != nil {
+				return api.BadRequestError(err)
+			}
+			limit = limitVal
+		}
+
+		if endBlock != nil {
+			description = fmt.Sprintf("problematic blocks between block %d and %d", startBlock, *endBlock)
+		} else {
+			description = fmt.Sprintf("problematic blocks after block %d", startBlock)
+		}
+	}
+
+	blocks, hasMore, err := h.store.GetProblematicBlocks(r.Context(), startBlock, endBlock, limit)
+	if err != nil {
+		h.logger.Error("failed to get problematic blocks",
+			zap.Uint64("start_block", startBlock),
+			zap.Any("end_block", endBlock),
+			zap.Uint32("limit", limit),
+			zap.Error(err))
+		return api.Error(fmt.Errorf("failed to get problematic blocks (start=%d end=%v limit=%d): %w", startBlock, endBlock, limit, err))
+	}
+
+	return api.Render(w, r, &ProblematicBlocksResponse{
+		ProblematicBlocks:  blocks,
+		HasMore:            hasMore,
+		LastFinalizedBlock: lastFinalized,
+		Description:        description,
+	})
+}
+
+// Health provides comprehensive health check and status summary.
+func (h *APIHandler) Health(w http.ResponseWriter, r *http.Request) error {
+	// TODO fix possible data race since we access analyzer stats
+	health := h.analyzer.GetHealthStatus()
+
+	// Additional storage verification
+	_, err := h.store.GetLastReceivedBlock(r.Context(), FinalizedLogType)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		health.Status = "unhealthy"
+		h.logger.Error("storage health check failed", zap.Error(err))
+	} else if errors.Is(err, ErrNotFound) && health.Status == healthyStatus {
+		health.Status = "no_data"
+	}
+
+	// Add queue health warnings
+	if health.Status == healthyStatus {
+		for queueType, depth := range health.QueueDepths {
+			maxQueueSize := 5000 // Default from constants
+			if float64(depth)/float64(maxQueueSize) > 0.8 {
+				health.Status = "degraded"
+				h.logger.Warn("queue depth high",
+					zap.String("queue_type", queueType),
+					zap.Int("depth", depth))
+			}
+		}
+	}
+
+	return api.Render(w, r, health)
+}

--- a/eth/loganalyzer/api_handlers_test.go
+++ b/eth/loganalyzer/api_handlers_test.go
@@ -1,0 +1,387 @@
+package loganalyzer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+)
+
+func TestAPIHandler_Health(t *testing.T) {
+	handler, _, analyzer := testAPIHandler(t)
+
+	finalizedLogs := executionclient.BlockLogs{
+		BlockNumber: 100,
+		Logs:        []ethtypes.Log{},
+	}
+	errCh := analyzer.RecordFinalizedLogs(finalizedLogs)
+	require.NoError(t, <-errCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	err := handler.Health(rec, req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	require.Equal(t, healthyStatus, response["status"])
+	require.Equal(t, float64(100), response["lastFinalizedBlock"])
+
+	require.Contains(t, response, "queueDepths")
+	require.Contains(t, response, "processedLogCounts")
+	require.Contains(t, response, "features")
+}
+
+// TestAPIHandler_ParameterValidation consolidates all parameter validation tests
+func TestAPIHandler_ParameterValidation(t *testing.T) {
+	handler, _, _ := testAPIHandler(t)
+
+	invalidParamTests := []struct {
+		name     string
+		endpoint string
+		query    string
+	}{
+		// Stats endpoint validation
+		{"Stats_NoParams", "/stats", ""},
+		{"Stats_InvalidBlock", "/stats", "?block=invalid"},
+		{"Stats_InvalidFrom", "/stats", "?from=invalid&to=200"},
+		{"Stats_InvalidTo", "/stats", "?from=100&to=invalid"},
+		{"Stats_FromGreaterThanTo", "/stats", "?from=200&to=100"},
+		{"Stats_RangeTooLarge", "/stats", "?from=100&to=1200"}, // >1000 range
+
+		// ProblematicBlocks endpoint validation
+		{"ProblematicBlocks_InvalidStartBlock", "/problematic-blocks", "?start_block=invalid"},
+		{"ProblematicBlocks_InvalidEndBlock", "/problematic-blocks", "?start_block=100&end_block=invalid"},
+		{"ProblematicBlocks_EndBeforeStart", "/problematic-blocks", "?start_block=100&end_block=50"},
+		{"ProblematicBlocks_InvalidLimit", "/problematic-blocks", "?start_block=100&limit=invalid"},
+	}
+
+	for _, tt := range invalidParamTests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.endpoint + tt.query)
+			req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+			rec := httptest.NewRecorder()
+
+			var err error
+			switch tt.endpoint {
+			case "/stats":
+				err = handler.Stats(rec, req)
+			case "/problematic-blocks":
+				err = handler.ProblematicBlocks(rec, req)
+			}
+
+			require.Error(t, err, "Expected error for %s", tt.name)
+		})
+	}
+}
+
+// TestAPIHandler_Stats consolidates all stats endpoint tests
+func TestAPIHandler_Stats(t *testing.T) {
+	handler, store, _ := testAPIHandler(t)
+	ctx := context.Background()
+
+	// Setup test data
+	blockNumber := uint64(100)
+	err := store.SaveLastReceivedBlock(ctx, FinalizedLogType, blockNumber)
+	require.NoError(t, err)
+
+	stats := &BlockAnalysisStats{
+		BlockNumber:       blockNumber,
+		BatchLogCount:     5,
+		FilterLogCount:    4,
+		FinalizedLogCount: 5,
+		HasDiscrepancies:  true,
+		MissingInBatch:    0,
+		MissingInFilter:   1,
+		ExtraInBatch:      0,
+		ExtraInFilter:     0,
+		AnalyzedAt:        time.Now().Unix(),
+		IsFinal:           true,
+	}
+	err = store.SaveBlockStats(ctx, stats)
+	require.NoError(t, err)
+
+	// Setup range data for range tests
+	for i := uint64(200); i <= 202; i++ {
+		rangeStats := &BlockAnalysisStats{
+			BlockNumber:       i,
+			BatchLogCount:     i,
+			FilterLogCount:    i,
+			FinalizedLogCount: i,
+			HasDiscrepancies:  i%2 == 0,
+			AnalyzedAt:        time.Now().Unix(),
+			IsFinal:           true,
+		}
+		err = store.SaveBlockStats(ctx, rangeStats)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name           string
+		query          string
+		expectedStatus int
+		validator      func(*testing.T, []byte)
+	}{
+		{
+			name:           "SingleBlock",
+			query:          "?block=100",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response BlockStatsResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Len(t, response.BlockStats, 1)
+				require.Equal(t, blockNumber, response.BlockStats[0].BlockNumber)
+				require.True(t, response.BlockStats[0].HasDiscrepancies)
+				require.NotNil(t, response.TransactionStats)
+			},
+		},
+		{
+			name:           "Latest",
+			query:          "?block=latest",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response BlockStatsResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Len(t, response.BlockStats, 1)
+				require.Equal(t, blockNumber, response.BlockStats[0].BlockNumber)
+			},
+		},
+		{
+			name:           "BlockRange",
+			query:          "?from=200&to=202",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response BlockStatsResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Len(t, response.BlockStats, 3)
+				require.Equal(t, uint64(200), response.BlockStats[0].BlockNumber)
+				require.Equal(t, uint64(202), response.BlockStats[2].BlockNumber)
+				require.NotNil(t, response.TransactionStats)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse("/stats" + tt.query)
+			req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+			rec := httptest.NewRecorder()
+
+			err := handler.Stats(rec, req)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, rec.Code)
+
+			if tt.validator != nil {
+				tt.validator(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestAPIHandler_Stats_ErrorCases(t *testing.T) {
+	handler, _, _ := testAPIHandler(t)
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"LatestBlock_NoData", "?block=latest"},
+		{"BlockNotFound", "?block=999999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse("/stats" + tt.query)
+			req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+			rec := httptest.NewRecorder()
+
+			err := handler.Stats(rec, req)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestAPIHandler_ProblematicBlocks consolidates all problematic blocks endpoint tests
+func TestAPIHandler_ProblematicBlocks(t *testing.T) {
+	handler, store, _ := testAPIHandler(t)
+	ctx := context.Background()
+
+	// Setup test data
+	blockNumber := uint64(100)
+	err := store.SaveLastReceivedBlock(ctx, FinalizedLogType, blockNumber)
+	require.NoError(t, err)
+
+	problematicBlock := &ProblematicBlock{
+		BlockNumber:        blockNumber,
+		DetectedAt:         time.Now().Unix(),
+		TotalDiscrepancies: 2,
+	}
+	err = store.SaveProblematicBlock(ctx, problematicBlock)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		query          string
+		expectedStatus int
+		validator      func(*testing.T, []byte)
+	}{
+		{
+			name:           "Success",
+			query:          "?start_block=100",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response ProblematicBlocksResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Len(t, response.ProblematicBlocks, 1)
+				require.Equal(t, blockNumber, response.ProblematicBlocks[0].BlockNumber)
+				require.False(t, response.HasMore)
+				require.Equal(t, blockNumber, response.LastFinalizedBlock)
+				require.Equal(t, "problematic blocks after block 100", response.Description)
+			},
+		},
+		{
+			name:           "WithEndBlock",
+			query:          "?start_block=100&end_block=200",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response ProblematicBlocksResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Equal(t, blockNumber, response.LastFinalizedBlock)
+				require.Equal(t, "problematic blocks between block 100 and 200", response.Description)
+			},
+		},
+		{
+			name:           "WithLimit",
+			query:          "?start_block=100&limit=5",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response ProblematicBlocksResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.NotNil(t, response.ProblematicBlocks)
+				require.Equal(t, blockNumber, response.LastFinalizedBlock)
+				require.Equal(t, "problematic blocks after block 100", response.Description)
+			},
+		},
+		{
+			name:           "NoArguments_Default",
+			query:          "",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response ProblematicBlocksResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.NotNil(t, response.ProblematicBlocks)
+				require.Equal(t, blockNumber, response.LastFinalizedBlock)
+				require.Equal(t, "last 10 problematic blocks", response.Description)
+			},
+		},
+		{
+			name:           "NoArguments_WithCustomLimit",
+			query:          "?limit=20",
+			expectedStatus: http.StatusOK,
+			validator: func(t *testing.T, body []byte) {
+				var response ProblematicBlocksResponse
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.NotNil(t, response.ProblematicBlocks)
+				require.Equal(t, blockNumber, response.LastFinalizedBlock)
+				require.Equal(t, "last 20 problematic blocks", response.Description)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse("/problematic-blocks" + tt.query)
+			req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+			rec := httptest.NewRecorder()
+
+			err := handler.ProblematicBlocks(rec, req)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, rec.Code)
+
+			if tt.validator != nil {
+				tt.validator(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestComputeTransactionStats(t *testing.T) {
+	blockNumber := uint64(100)
+
+	// Create test logs with different transaction hashes
+	batchLogs := []InternalLog{
+		testInternalLog(blockNumber, 0, "0x1111", "0x1111111111111111111111111111111111111111111111111111111111111111"),
+		testInternalLog(blockNumber, 1, "0x2222", "0x1111111111111111111111111111111111111111111111111111111111111111"), // tx1 has 2 logs in batch
+		testInternalLog(blockNumber, 2, "0x3333", "0x2222222222222222222222222222222222222222222222222222222222222222"), // tx2 has 1 log in batch
+	}
+
+	filterLogs := []InternalLog{
+		testInternalLog(blockNumber, 0, "0x1111", "0x1111111111111111111111111111111111111111111111111111111111111111"), // tx1 has 1 log in filter (missing 1)
+		testInternalLog(blockNumber, 2, "0x3333", "0x2222222222222222222222222222222222222222222222222222222222222222"), // tx2 has 1 log in filter
+		testInternalLog(blockNumber, 3, "0x4444", "0x3333333333333333333333333333333333333333333333333333333333333333"), // tx3 only in filter
+	}
+
+	finalizedLogs := []InternalLog{
+		testInternalLog(blockNumber, 0, "0x1111", "0x1111111111111111111111111111111111111111111111111111111111111111"),
+		testInternalLog(blockNumber, 1, "0x2222", "0x1111111111111111111111111111111111111111111111111111111111111111"), // tx1 should have 2 logs
+		testInternalLog(blockNumber, 2, "0x3333", "0x2222222222222222222222222222222222222222222222222222222222222222"), // tx2 should have 1 log
+		testInternalLog(blockNumber, 3, "0x4444", "0x3333333333333333333333333333333333333333333333333333333333333333"), // tx3 should have 1 log
+	}
+
+	txStats := ComputeTransactionStats(batchLogs, filterLogs, finalizedLogs)
+	require.Len(t, txStats, 3) // Should have stats for tx1, tx2, tx3
+
+	// Convert to map for easier testing
+	statsMap := make(map[string]*TxLogStats)
+	for _, stat := range txStats {
+		statsMap[stat.TxHash] = stat
+	}
+
+	// Test tx1 (should have all logs in batch, missing 1 in filter)
+	tx1Stats := statsMap["0x1111111111111111111111111111111111111111111111111111111111111111"]
+	require.NotNil(t, tx1Stats)
+	require.Equal(t, uint64(2), tx1Stats.ExpectedLogs)
+	require.Equal(t, uint64(2), tx1Stats.BatchLogs)
+	require.Equal(t, uint64(1), tx1Stats.FilterLogs)
+	require.Equal(t, uint64(0), tx1Stats.MissingFromBatch)
+	require.Equal(t, uint64(1), tx1Stats.MissingFromFilter)
+
+	// Test tx2 (should have all logs in both)
+	tx2Stats := statsMap["0x2222222222222222222222222222222222222222222222222222222222222222"]
+	require.NotNil(t, tx2Stats)
+	require.Equal(t, uint64(1), tx2Stats.ExpectedLogs)
+	require.Equal(t, uint64(1), tx2Stats.BatchLogs)
+	require.Equal(t, uint64(1), tx2Stats.FilterLogs)
+	require.Equal(t, uint64(0), tx2Stats.MissingFromBatch)
+	require.Equal(t, uint64(0), tx2Stats.MissingFromFilter)
+
+	// Test tx3 (missing from batch, present in filter)
+	tx3Stats := statsMap["0x3333333333333333333333333333333333333333333333333333333333333333"]
+	require.NotNil(t, tx3Stats)
+	require.Equal(t, uint64(1), tx3Stats.ExpectedLogs)
+	require.Equal(t, uint64(0), tx3Stats.BatchLogs)
+	require.Equal(t, uint64(1), tx3Stats.FilterLogs)
+	require.Equal(t, uint64(1), tx3Stats.MissingFromBatch)
+	require.Equal(t, uint64(0), tx3Stats.MissingFromFilter)
+}

--- a/eth/loganalyzer/integration_test.go
+++ b/eth/loganalyzer/integration_test.go
@@ -1,0 +1,318 @@
+package loganalyzer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+)
+
+func TestLogAnalyzer_IntegrationScenario(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Create logAnalyzer with in-memory storage
+	config := Config{
+		MaxQueueSize: 1000,
+		Storage: StorageConfig{
+			RetainBlocks: 100,
+		},
+	}
+	analyzer := New(context.Background(), logger, nil, config)
+	require.NotNil(t, analyzer)
+	defer analyzer.Close()
+
+	// Create API handler
+	apiHandler := NewAPIHandler(logger, analyzer.GetStore(), analyzer)
+
+	// Test scenario blocks
+	emptyBlock1 := uint64(1000)      // Empty block (no logs)
+	normalBlock := uint64(1001)      // Normal block (matching logs)
+	emptyBlock2 := uint64(1002)      // Another empty block
+	problematicBlock := uint64(1003) // Problematic block (missing logs)
+	emptyBlock3 := uint64(1004)      // Final empty block
+
+	// Create test logs for normal block (all sources match)
+	normalLog1 := ethtypes.Log{
+		Address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		Topics:      []common.Hash{common.HexToHash("0xabcd")},
+		Data:        []byte("normal data 1"),
+		BlockNumber: normalBlock,
+		TxHash:      common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+		Index:       0,
+		Removed:     false,
+	}
+
+	normalLog2 := ethtypes.Log{
+		Address:     common.HexToAddress("0x9876543210987654321098765432109876543210"),
+		Topics:      []common.Hash{common.HexToHash("0xefgh")},
+		Data:        []byte("normal data 2"),
+		BlockNumber: normalBlock,
+		TxHash:      common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+		Index:       1,
+		Removed:     false,
+	}
+
+	// Create test logs for problematic block
+	// Batch and finalized will have both logs, but filter will miss one
+	problematicLog1 := ethtypes.Log{
+		Address:     common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		Topics:      []common.Hash{common.HexToHash("0x1234")},
+		Data:        []byte("problematic data 1"),
+		BlockNumber: problematicBlock,
+		TxHash:      common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+		Index:       0,
+		Removed:     false,
+	}
+
+	problematicLog2 := ethtypes.Log{
+		Address:     common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		Topics:      []common.Hash{common.HexToHash("0x5678")},
+		Data:        []byte("problematic data 2"),
+		BlockNumber: problematicBlock,
+		TxHash:      common.HexToHash("0x4444444444444444444444444444444444444444444444444444444444444444"),
+		Index:       1,
+		Removed:     false,
+	}
+
+	// Simulate processing empty blocks
+	for _, blockNum := range []uint64{emptyBlock1, emptyBlock2, emptyBlock3} {
+		emptyBlockLogs := executionclient.BlockLogs{
+			BlockNumber: blockNum,
+			Logs:        []ethtypes.Log{}, // No logs
+		}
+
+		// Process through all sources
+		<-analyzer.RecordBlockLogs(emptyBlockLogs)
+		<-analyzer.RecordFinalizedLogs(emptyBlockLogs)
+	}
+
+	// Simulate processing normal block (all sources have same logs)
+	normalBlockLogs := executionclient.BlockLogs{
+		BlockNumber: normalBlock,
+		Logs:        []ethtypes.Log{normalLog1, normalLog2},
+	}
+
+	// Process batch logs
+	<-analyzer.RecordBlockLogs(normalBlockLogs)
+
+	// Process filter logs
+	<-analyzer.RecordFilterLogs(normalLog1)
+	<-analyzer.RecordFilterLogs(normalLog2)
+
+	// Process finalized logs (this triggers comparison)
+	<-analyzer.RecordFinalizedLogs(normalBlockLogs)
+
+	// Simulate processing problematic block (filter source missing one log)
+	problematicBlockLogs := executionclient.BlockLogs{
+		BlockNumber: problematicBlock,
+		Logs:        []ethtypes.Log{problematicLog1, problematicLog2},
+	}
+
+	// Process batch logs
+	<-analyzer.RecordBlockLogs(problematicBlockLogs)
+
+	// Filter source only has first log (missing second log to create discrepancy)
+	<-analyzer.RecordFilterLogs(problematicLog1)
+	// Note: We deliberately don't send problematicLog2 to filter source
+
+	// Process finalized logs (this triggers comparison and detects discrepancy)
+	<-analyzer.RecordFinalizedLogs(problematicBlockLogs)
+
+	// Test 1: Check stats for empty block - should return success with zero counts
+	t.Run("EmptyBlock_ReturnsZeroStats", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/stats?block=%d", emptyBlock1), nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.Stats(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response BlockStatsResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Len(t, response.BlockStats, 1)
+		stats := response.BlockStats[0]
+		require.Equal(t, emptyBlock1, stats.BlockNumber)
+		require.Equal(t, uint64(0), stats.BatchLogCount)
+		require.Equal(t, uint64(0), stats.FilterLogCount)
+		require.Equal(t, uint64(0), stats.FinalizedLogCount)
+		require.False(t, stats.HasDiscrepancies)
+		require.True(t, stats.IsFinal)
+	})
+
+	// Test 2: Check stats for normal block - should return success with no discrepancies
+	t.Run("NormalBlock_ReturnsStats", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/stats?block=%d", normalBlock), nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.Stats(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response BlockStatsResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Len(t, response.BlockStats, 1)
+		stats := response.BlockStats[0]
+		require.Equal(t, normalBlock, stats.BlockNumber)
+		require.Equal(t, uint64(2), stats.BatchLogCount)
+		require.Equal(t, uint64(2), stats.FilterLogCount)
+		require.Equal(t, uint64(2), stats.FinalizedLogCount)
+		require.False(t, stats.HasDiscrepancies)
+		require.Equal(t, uint64(0), stats.MissingInBatch)
+		require.Equal(t, uint64(0), stats.MissingInFilter)
+		require.True(t, stats.IsFinal)
+	})
+
+	// Test 3: Check stats for problematic block - should show discrepancies
+	t.Run("ProblematicBlock_ShowsDiscrepancies", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/stats?block=%d", problematicBlock), nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.Stats(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response BlockStatsResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Len(t, response.BlockStats, 1)
+		stats := response.BlockStats[0]
+		require.Equal(t, problematicBlock, stats.BlockNumber)
+		require.Equal(t, uint64(2), stats.BatchLogCount)
+		require.Equal(t, uint64(1), stats.FilterLogCount) // Only first log sent to filter
+		require.Equal(t, uint64(2), stats.FinalizedLogCount)
+		require.True(t, stats.HasDiscrepancies)
+		require.Equal(t, uint64(0), stats.MissingInBatch)
+		require.Equal(t, uint64(1), stats.MissingInFilter) // One log missing in filter
+		require.True(t, stats.IsFinal)
+
+		// Transaction stats should be initialized (can be empty if no logs found)
+		require.NotNil(t, response.TransactionStats)
+	})
+
+	// Test 4: Check stats for block range - should include both normal and problematic blocks
+	t.Run("BlockRange_ReturnsMultipleStats", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/stats?from=%d&to=%d", emptyBlock1, problematicBlock), nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.Stats(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response BlockStatsResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, len(response.BlockStats), 2) // Should have at least our test blocks
+		require.False(t, response.HasMore)
+
+		// Find each block in results
+		var normalStats, problematicStats *BlockAnalysisStats
+		for _, stats := range response.BlockStats {
+			switch stats.BlockNumber {
+			case normalBlock:
+				normalStats = stats
+			default:
+				problematicStats = stats
+			}
+		}
+
+		require.NotNil(t, normalStats, "Should find normal block stats")
+		require.NotNil(t, problematicStats, "Should find problematic block stats")
+		require.False(t, normalStats.HasDiscrepancies, "Normal block should have no discrepancies")
+		require.True(t, problematicStats.HasDiscrepancies, "Problematic block should have discrepancies")
+	})
+
+	// Test 5: Check problematic blocks endpoint - should return problematic blocks
+	t.Run("ProblematicBlocks_ReturnsProblematicBlocks", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/problematic-blocks?start_block=%d&end_block=%d", emptyBlock1, emptyBlock3), nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.ProblematicBlocks(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response ProblematicBlocksResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, len(response.ProblematicBlocks), 1) // At least one problematic block
+		require.False(t, response.HasMore)
+
+		// Find our specific problematic block
+		var found bool
+		for _, block := range response.ProblematicBlocks {
+			if block.BlockNumber == problematicBlock {
+				found = true
+				require.Greater(t, block.TotalDiscrepancies, uint64(0))
+				require.Greater(t, block.DetectedAt, int64(0))
+				break
+			}
+		}
+		require.True(t, found, "Should find our problematic block in results")
+	})
+
+	// Test 6: Check problematic blocks with no results - should return empty array
+	t.Run("ProblematicBlocks_EmptyRange_ReturnsEmptyArray", func(t *testing.T) {
+		// Query a range before our test blocks
+		req := httptest.NewRequest(http.MethodGet, "/problematic-blocks?start_block=500&end_block=600", nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.ProblematicBlocks(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response ProblematicBlocksResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.NotNil(t, response.ProblematicBlocks) // Should be empty array, not nil
+		require.Len(t, response.ProblematicBlocks, 0)
+		require.False(t, response.HasMore)
+
+		// Verify JSON structure
+		jsonStr := rec.Body.String()
+		require.Contains(t, jsonStr, `"problematic_blocks":[]`) // Empty array, not null
+	})
+
+	// Test 7: Check health endpoint
+	t.Run("Health_ReturnsHealthyStatus", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+
+		err := apiHandler.Health(rec, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Equal(t, "healthy", response["status"])
+		require.Contains(t, response, "lastFinalizedBlock")
+
+		// Verify comprehensive health data
+		require.Contains(t, response, "queueDepths")
+		require.Contains(t, response, "processedLogCounts")
+		require.Contains(t, response, "headToFinalizedLag")
+
+		features := response["features"].(map[string]interface{})
+		require.True(t, features["storage"].(bool))
+		require.True(t, features["problematic_blocks"].(bool))
+		require.True(t, features["block_analysis"].(bool))
+		require.True(t, features["queue_monitoring"].(bool))
+	})
+}

--- a/eth/loganalyzer/log_analyzer.go
+++ b/eth/loganalyzer/log_analyzer.go
@@ -1,0 +1,661 @@
+package loganalyzer
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+const (
+	DefaultMaxQueueSize       = 5000
+	DefaultRetentionBlocks    = 1000
+	QueueFullWarningThreshold = 0.8
+	DefaultEvictionThreshold  = 100
+)
+
+// LogAnalyzerStats holds internal statistics for the LogAnalyzer.
+type LogAnalyzerStats struct {
+	LogCount              map[LogType]uint64
+	LastReceivedBlock     map[LogType]uint64
+	LastEvictedBlock      uint64
+	StorageErrors         uint64
+	ProblematicBlockCount uint64
+}
+
+// HealthStatus provides comprehensive health information for the LogAnalyzer.
+type HealthStatus struct {
+	Status             string            `json:"status"`
+	LastFinalizedBlock uint64            `json:"lastFinalizedBlock"`
+	LastReceivedBlocks map[string]uint64 `json:"lastReceivedBlocks"`
+	QueueDepths        map[string]int    `json:"queueDepths"`
+	QueueDroppedCounts map[string]uint64 `json:"queueDroppedCounts"`
+	ProcessedLogCounts map[string]uint64 `json:"processedLogCounts"`
+	StorageErrors      uint64            `json:"storageErrors"`
+	ProblematicBlocks  uint64            `json:"problematicBlocks"`
+	LastEvictedBlock   uint64            `json:"lastEvictedBlock"`
+	HeadToFinalizedLag uint64            `json:"headToFinalizedLag"`
+	IsEnabled          bool              `json:"isEnabled"`
+	Features           map[string]bool   `json:"features"`
+}
+
+func (s *LogAnalyzerStats) increaseCounter(logType LogType, logCount uint64) {
+	s.LogCount[logType] += logCount
+}
+
+func (s *LogAnalyzerStats) updateLastReceivedBlock(logType LogType, blockNumber uint64) {
+	if blockNumber > s.LastReceivedBlock[logType] {
+		s.LastReceivedBlock[logType] = blockNumber
+	}
+}
+
+// LogRequest represents a unified request for all log types.
+type LogRequest struct {
+	logs       any
+	Type       LogType
+	ResponseCh chan error
+}
+
+type CloseRequest struct {
+	ResponseCh chan error
+}
+
+type Queue struct {
+	channel        chan LogRequest
+	droppedCounter *atomic.Uint64
+	logDescription string
+}
+
+func newQueue(maxSize int, description string) Queue {
+	return Queue{
+		channel:        make(chan LogRequest, maxSize),
+		droppedCounter: &atomic.Uint64{},
+		logDescription: description,
+	}
+}
+
+func (q *Queue) tryEnqueue(request LogRequest, logger *zap.Logger) error {
+	select {
+	case q.channel <- request:
+		return nil
+	default:
+		// Channel is full, drop the oldest log
+		select {
+		case toDrop := <-q.channel:
+			q.droppedCounter.Add(1)
+			logger.Warn(q.logDescription+" queue full, dropping oldest log",
+				zap.String("log_type", q.logDescription),
+				zap.Uint64("total_dropped", q.droppedCounter.Load()))
+
+			select {
+			case toDrop.ResponseCh <- errors.New("queue full"):
+			default:
+			}
+			close(toDrop.ResponseCh)
+		default:
+			// Should not happen, but just in case
+		}
+		// Now there is space, enqueue the new request
+		select {
+		case q.channel <- request:
+			return nil
+		default:
+			q.droppedCounter.Add(1)
+			logger.Warn(q.logDescription+" queue full, dropping newest log",
+				zap.String("log_type", q.logDescription),
+				zap.Uint64("total_dropped", q.droppedCounter.Load()))
+			return errors.New("queue full")
+		}
+	}
+}
+
+func (q *Queue) depth() int {
+	return len(q.channel)
+}
+
+func (q *Queue) dropped() uint64 {
+	return q.droppedCounter.Load()
+}
+
+// LogAnalyzer provides thread-safe analysis of blockchain logs from multiple sources.
+// Designed for high-throughput log processing with minimal back pressure.
+type LogAnalyzer struct {
+	logger        *zap.Logger
+	ctx           context.Context
+	cancel        context.CancelFunc
+	enabled       bool
+	store         LogAnalyzerStore
+	ownedDB       basedb.Database
+	storageConfig StorageConfig
+	maxQueueSize  int
+	closed        atomic.Bool
+
+	// Statistics - accessed only by processor goroutine
+	stats LogAnalyzerStats
+
+	// Request queues
+	logsQueues   map[LogType]Queue
+	closeRequest chan CloseRequest
+}
+
+// Config holds configuration for the LogAnalyzer.
+type Config struct {
+	MaxQueueSize int           `yaml:"maxQueueSize" env:"LOG_ANALYZER_MAX_QUEUE_SIZE" env-default:"5000"`
+	Storage      StorageConfig `yaml:"storage"`
+}
+
+// New creates a new LogAnalyzer instance.
+func New(ctx context.Context, logger *zap.Logger, db basedb.Database, config Config) *LogAnalyzer {
+	if ctx == nil {
+		ctx = context.Background()
+		logger.Debug("context is nil, using background context")
+	}
+	if logger == nil {
+		return nil
+	}
+
+	// Set defaults
+	if config.MaxQueueSize <= 0 {
+		config.MaxQueueSize = DefaultMaxQueueSize
+	}
+	if config.Storage.RetainBlocks == 0 {
+		config.Storage.RetainBlocks = DefaultRetentionBlocks
+	}
+
+	var store LogAnalyzerStore
+	var ownedDB basedb.Database
+
+	if db == nil {
+		inMemoryDB, err := badger.NewInMemory(logger.Named("logAnalyzer.db"), basedb.Options{})
+		if err != nil {
+			logger.Error("failed to create in-memory badger database for log analyzer", zap.Error(err))
+			return nil
+		}
+		store = NewLogAnalyzerStore(inMemoryDB)
+		ownedDB = inMemoryDB
+		logger.Debug("created in-memory store for log analyzer")
+	} else {
+		store = NewLogAnalyzerStore(db)
+		logger.Debug("using provided database for log analyzer")
+	}
+
+	analyzerCtx, cancel := context.WithCancel(ctx)
+	analyzer := &LogAnalyzer{
+		logger:        logger.Named("logAnalyzer"),
+		maxQueueSize:  config.MaxQueueSize,
+		logsQueues:    make(map[LogType]Queue),
+		ctx:           analyzerCtx,
+		cancel:        cancel,
+		enabled:       true,
+		store:         store,
+		ownedDB:       ownedDB,
+		storageConfig: config.Storage,
+		closeRequest:  make(chan CloseRequest, 1),
+		stats: LogAnalyzerStats{
+			LogCount:          make(map[LogType]uint64),
+			LastReceivedBlock: make(map[LogType]uint64),
+		},
+	}
+
+	// Initialize queues for each log type
+	for _, logType := range []LogType{BatchLogType, FilterLogType, FinalizedLogType} {
+		analyzer.logsQueues[logType] = newQueue(config.MaxQueueSize, logType.String())
+	}
+
+	go analyzer.processor()
+
+	return analyzer
+}
+
+// GetStore returns the LogAnalyzer's store for API access.
+func (l *LogAnalyzer) GetStore() LogAnalyzerStore {
+	return l.store
+}
+
+// GetHealthStatus returns comprehensive health information about the LogAnalyzer.
+func (l *LogAnalyzer) GetHealthStatus() HealthStatus {
+	status := "healthy"
+	if l.closed.Load() {
+		status = "closed"
+	} else if !l.enabled {
+		status = "disabled"
+	} else if l.stats.StorageErrors > 0 {
+		status = "degraded"
+	}
+
+	// Calculate head to finalized lag
+	var lastReceived uint64
+	for _, blockNum := range l.stats.LastReceivedBlock {
+		if blockNum > lastReceived {
+			lastReceived = blockNum
+		}
+	}
+	lastFinalized := l.stats.LastReceivedBlock[FinalizedLogType]
+	var headToFinalizedLag uint64
+	if lastReceived >= lastFinalized {
+		headToFinalizedLag = lastReceived - lastFinalized
+	}
+
+	// Build maps with string keys for JSON
+	lastReceivedBlocks := make(map[string]uint64)
+	for logType, blockNum := range l.stats.LastReceivedBlock {
+		lastReceivedBlocks[logType.String()] = blockNum
+	}
+
+	queueDepths := make(map[string]int)
+	queueDroppedCounts := make(map[string]uint64)
+	for logType, queue := range l.logsQueues {
+		queueDepths[logType.String()] = queue.depth()
+		queueDroppedCounts[logType.String()] = queue.dropped()
+	}
+
+	processedLogCounts := make(map[string]uint64)
+	for logType, count := range l.stats.LogCount {
+		processedLogCounts[logType.String()] = count
+	}
+
+	return HealthStatus{
+		Status:             status,
+		LastFinalizedBlock: lastFinalized,
+		LastReceivedBlocks: lastReceivedBlocks,
+		QueueDepths:        queueDepths,
+		QueueDroppedCounts: queueDroppedCounts,
+		ProcessedLogCounts: processedLogCounts,
+		StorageErrors:      l.stats.StorageErrors,
+		ProblematicBlocks:  l.stats.ProblematicBlockCount,
+		LastEvictedBlock:   l.stats.LastEvictedBlock,
+		HeadToFinalizedLag: headToFinalizedLag,
+		IsEnabled:          l.enabled,
+		Features: map[string]bool{
+			"storage":            true,
+			"problematic_blocks": true,
+			"block_analysis":     true,
+			"queue_monitoring":   true,
+		},
+	}
+}
+
+// Close gracefully shuts down the LogAnalyzer.
+func (l *LogAnalyzer) Close() <-chan error {
+	errCh := make(chan error, 1)
+
+	if !l.closed.CompareAndSwap(false, true) {
+		close(errCh)
+		return errCh
+	}
+
+	request := CloseRequest{
+		ResponseCh: errCh,
+	}
+
+	select {
+	case l.closeRequest <- request:
+	default:
+		l.cancel()
+		close(errCh)
+	}
+
+	return errCh
+}
+
+// RecordBlockLogs processes logs received from batch operations.
+func (l *LogAnalyzer) RecordBlockLogs(blockLogs executionclient.BlockLogs) <-chan error {
+	l.logger.Debug("recordBlockLogs called",
+		zap.Uint64("block", blockLogs.BlockNumber),
+		zap.Int("log_count", len(blockLogs.Logs)))
+
+	internalBlockLogs := ToInternalBlockLogs(blockLogs)
+	return l.recordLogs(BatchLogType, &internalBlockLogs)
+}
+
+// RecordFilterLogs processes logs received from filter subscriptions.
+func (l *LogAnalyzer) RecordFilterLogs(log ethtypes.Log) <-chan error {
+	l.logger.Debug("recordFilterLogs called",
+		zap.Uint64("block", log.BlockNumber),
+		zap.Uint("log_index", log.Index))
+
+	internalLog := ToInternalLog(log)
+	internalBlockLogs := InternalBlockLogs{
+		BlockNumber: log.BlockNumber,
+		Logs:        []InternalLog{internalLog},
+	}
+	return l.recordLogs(FilterLogType, &internalBlockLogs)
+}
+
+// RecordFinalizedLogs processes logs received from finalized blocks.
+func (l *LogAnalyzer) RecordFinalizedLogs(blockLogs executionclient.BlockLogs) <-chan error {
+	l.logger.Debug("recordFinalizedLogs called",
+		zap.Uint64("block", blockLogs.BlockNumber),
+		zap.Int("log_count", len(blockLogs.Logs)))
+
+	internalBlockLogs := ToInternalBlockLogs(blockLogs)
+	return l.recordLogs(FinalizedLogType, &internalBlockLogs)
+}
+
+func (l *LogAnalyzer) recordLogs(logType LogType, logs any) <-chan error {
+	errCh := make(chan error, 1)
+
+	if !l.enabled {
+		close(errCh)
+		return errCh
+	}
+
+	request := LogRequest{
+		Type:       logType,
+		logs:       logs,
+		ResponseCh: errCh,
+	}
+
+	queue := l.logsQueues[logType]
+	if err := queue.tryEnqueue(request, l.logger); err != nil {
+		select {
+		case errCh <- err:
+		default:
+		}
+		close(errCh)
+	}
+
+	return errCh
+}
+
+// processor is the single goroutine that processes all log messages.
+func (l *LogAnalyzer) processor() {
+	for {
+		select {
+		case <-l.ctx.Done():
+			return
+
+		case request := <-l.closeRequest:
+			l.handleCloseWithResponse(request)
+			return
+
+		case request := <-l.logsQueues[BatchLogType].channel:
+			l.processLogRequest(request)
+
+		case request := <-l.logsQueues[FilterLogType].channel:
+			l.processLogRequest(request)
+
+		case request := <-l.logsQueues[FinalizedLogType].channel:
+			l.processLogRequest(request)
+		}
+	}
+}
+
+func (l *LogAnalyzer) handleCloseWithResponse(request CloseRequest) {
+	defer func() {
+		if r := recover(); r != nil {
+			select {
+			case request.ResponseCh <- errors.New("close panic"):
+			default:
+			}
+			return
+		}
+		close(request.ResponseCh)
+	}()
+
+	l.cancel()
+
+	for _, queue := range l.logsQueues {
+		close(queue.channel)
+	}
+	close(l.closeRequest)
+
+	if l.ownedDB != nil {
+		if err := l.ownedDB.Close(); err != nil {
+			l.logger.Warn("failed to close database", zap.Error(err))
+		}
+	}
+}
+
+func (l *LogAnalyzer) processLogRequest(request LogRequest) {
+	defer func() {
+		if r := recover(); r != nil {
+			select {
+			case request.ResponseCh <- errors.New("processing panic"):
+			default:
+			}
+			return
+		}
+		close(request.ResponseCh)
+	}()
+
+	select {
+	case <-l.ctx.Done():
+		select {
+		case request.ResponseCh <- l.ctx.Err():
+		default:
+		}
+		return
+	default:
+	}
+
+	start := time.Now()
+
+	internalBlockLogs := request.logs.(*InternalBlockLogs)
+	blockNumber := internalBlockLogs.BlockNumber
+	logs := internalBlockLogs.Logs
+
+	if err := l.store.SaveLastReceivedBlock(l.ctx, request.Type, blockNumber); err != nil {
+		l.logger.Error("failed to save last received block for "+request.Type.String(),
+			zap.Uint64("block", blockNumber),
+			zap.Error(err))
+	}
+
+	select {
+	case <-l.ctx.Done():
+		select {
+		case request.ResponseCh <- l.ctx.Err():
+		default:
+		}
+		return
+	default:
+	}
+
+	logCount := uint64(len(logs))
+	if logCount > 0 {
+		if err := l.store.SaveLogs(l.ctx, request.Type, blockNumber, logs); err != nil {
+			l.stats.StorageErrors++
+			l.logger.Error("failed to process logs for "+request.Type.String(),
+				zap.Uint64("block", blockNumber),
+				zap.Error(err))
+			return
+		}
+	}
+
+	l.stats.updateLastReceivedBlock(request.Type, blockNumber)
+	l.stats.increaseCounter(request.Type, logCount)
+
+	select {
+	case <-l.ctx.Done():
+		select {
+		case request.ResponseCh <- l.ctx.Err():
+		default:
+		}
+		return
+	default:
+	}
+
+	l.postProcess(request.Type, blockNumber)
+
+	l.logger.Debug("processed "+request.Type.String(),
+		zap.Uint64("block", blockNumber),
+		zap.Uint64("log_count", logCount),
+		zap.Duration("took", time.Since(start)))
+}
+
+func (l *LogAnalyzer) postProcess(logType LogType, blockNumber uint64) {
+	if logType != FinalizedLogType {
+		// Prevent memory leaks in case we stopped receiving finalized blocks
+		if blockNumber > DefaultEvictionThreshold {
+			blockToDelete := blockNumber - DefaultEvictionThreshold
+			l.logger.Info("deleting old logs without comparison to prevent memory leaks",
+				zap.Uint64("block", blockToDelete))
+			if err := l.store.DeleteLogs(l.ctx, blockToDelete); err != nil {
+				l.stats.StorageErrors++
+				l.logger.Error("failed to delete temporary logs",
+					zap.Uint64("block", blockToDelete),
+					zap.Error(err))
+			}
+			l.removeOldBlocks(blockToDelete)
+		}
+		return
+	}
+	l.compareLogsForBlock(blockNumber)
+
+	if err := l.store.DeleteLogs(l.ctx, blockNumber); err != nil {
+		l.stats.StorageErrors++
+		l.logger.Error("failed to delete temporary logs",
+			zap.Uint64("block", blockNumber),
+			zap.Error(err))
+	}
+	l.removeOldBlocks(blockNumber)
+	l.generateReport()
+}
+
+func (l *LogAnalyzer) compareLogsForBlock(blockNumber uint64) {
+	allLogs, err := l.store.GetAllLogs(l.ctx, blockNumber)
+	if err != nil {
+		l.stats.StorageErrors++
+		l.logger.Error("failed to get logs for comparison",
+			zap.Uint64("block", blockNumber),
+			zap.Error(err))
+		return
+	}
+
+	batchInternalLogs := allLogs.BatchLogs
+	filterInternalLogs := allLogs.FilterLogs
+	finalizedInternalLogs := allLogs.FinalizedLogs
+
+	batchHashes := ExtractLogHashes(batchInternalLogs)
+	filterHashes := ExtractLogHashes(filterInternalLogs)
+	finalizedHashes := ExtractLogHashes(finalizedInternalLogs)
+
+	missingInBatchCount, missingInFilterCount, extraInBatchCount, extraInFilterCount := CountDiscrepanciesByHash(
+		batchHashes, filterHashes, finalizedHashes)
+
+	stats := &BlockAnalysisStats{
+		BlockNumber:       blockNumber,
+		BatchLogCount:     uint64(len(allLogs.BatchLogs)),
+		FilterLogCount:    uint64(len(allLogs.FilterLogs)),
+		FinalizedLogCount: uint64(len(allLogs.FinalizedLogs)),
+		AnalyzedAt:        time.Now().Unix(),
+		IsFinal:           true,
+		HasDiscrepancies:  missingInBatchCount > 0 || missingInFilterCount > 0 || extraInBatchCount > 0 || extraInFilterCount > 0,
+		MissingInBatch:    missingInBatchCount,
+		MissingInFilter:   missingInFilterCount,
+		ExtraInBatch:      extraInBatchCount,
+		ExtraInFilter:     extraInFilterCount,
+	}
+
+	if stats.HasDiscrepancies {
+		l.logger.Warn("log discrepancies detected",
+			zap.Uint64("block", blockNumber),
+			zap.Uint64("missing_in_batch", missingInBatchCount),
+			zap.Uint64("missing_in_filter", missingInFilterCount),
+			zap.Uint64("extra_in_batch", extraInBatchCount),
+			zap.Uint64("extra_in_filter", extraInFilterCount))
+	}
+
+	if err := l.store.SaveBlockStats(l.ctx, stats); err != nil {
+		l.stats.StorageErrors++
+		l.logger.Error("failed to save block stats",
+			zap.Uint64("block", blockNumber),
+			zap.Error(err))
+	}
+
+	if stats.HasDiscrepancies {
+		problematicBlock := &ProblematicBlock{
+			BlockNumber:        blockNumber,
+			DetectedAt:         stats.AnalyzedAt,
+			TotalDiscrepancies: missingInBatchCount + missingInFilterCount + extraInBatchCount + extraInFilterCount,
+		}
+
+		if err := l.store.SaveProblematicBlock(l.ctx, problematicBlock); err != nil {
+			l.stats.StorageErrors++
+			l.logger.Error("failed to save problematic block",
+				zap.Uint64("block", blockNumber),
+				zap.Error(err))
+		} else {
+			l.stats.ProblematicBlockCount++
+			l.logger.Info("saved problematic block",
+				zap.Uint64("block", blockNumber),
+				zap.Uint64("total_discrepancies", problematicBlock.TotalDiscrepancies))
+		}
+	}
+}
+
+func (l *LogAnalyzer) removeOldBlocks(blockNumber uint64) {
+	if l.storageConfig.RetainBlocks > 0 && blockNumber > l.storageConfig.RetainBlocks {
+		oldBlock := blockNumber - l.storageConfig.RetainBlocks
+		lastEvicted := l.stats.LastEvictedBlock
+		if oldBlock > lastEvicted {
+			if err := l.store.DeleteBlockData(l.ctx, oldBlock); err != nil {
+				l.stats.StorageErrors++
+				l.logger.Error("failed to delete old block data",
+					zap.Uint64("block", oldBlock),
+					zap.Error(err))
+			} else {
+				l.stats.LastEvictedBlock = oldBlock
+				l.logger.Debug("evicted old block data", zap.Uint64("block", oldBlock))
+			}
+		}
+	}
+}
+
+func (l *LogAnalyzer) generateReport() {
+	// Calculate lag between head and finalized
+	var lastReceived uint64
+	for _, blockNum := range l.stats.LastReceivedBlock {
+		if blockNum > lastReceived {
+			lastReceived = blockNum
+		}
+	}
+	lastFinalized := l.stats.LastReceivedBlock[FinalizedLogType]
+	var headToFinalizedLag uint64
+	if lastReceived >= lastFinalized {
+		headToFinalizedLag = lastReceived - lastFinalized
+	}
+
+	batchQueue := l.logsQueues[BatchLogType]
+	filterQueue := l.logsQueues[FilterLogType]
+	finalizedQueue := l.logsQueues[FinalizedLogType]
+
+	storageErrors := l.stats.StorageErrors
+	problematicBlockCount := l.stats.ProblematicBlockCount
+
+	// Warn if queue depths are getting high
+	warningThreshold := int(QueueFullWarningThreshold * float64(l.maxQueueSize))
+	for _, queue := range l.logsQueues {
+		if depth := queue.depth(); depth > warningThreshold {
+			l.logger.Warn(queue.logDescription+" queue depth is high",
+				zap.Int("queue_depth", depth),
+				zap.Uint64("dropped_total", queue.dropped()))
+		}
+	}
+
+	l.logger.Debug("log analyzer stats",
+		zap.Uint64("batch_log_count", l.stats.LogCount[BatchLogType]),
+		zap.Uint64("filter_log_count", l.stats.LogCount[FilterLogType]),
+		zap.Uint64("finalized_log_count", l.stats.LogCount[FinalizedLogType]),
+		zap.Uint64("last_received_block", lastReceived),
+		zap.Uint64("last_finalized_block", lastFinalized),
+		zap.Uint64("last_evicted_block", l.stats.LastEvictedBlock),
+		zap.Uint64("head_to_finalized_lag", headToFinalizedLag),
+		zap.Int("batch_queue_depth", batchQueue.depth()),
+		zap.Uint64("batch_queue_dropped", batchQueue.dropped()),
+		zap.Int("filter_queue_depth", filterQueue.depth()),
+		zap.Uint64("filter_queue_dropped", filterQueue.dropped()),
+		zap.Int("finalized_queue_depth", finalizedQueue.depth()),
+		zap.Uint64("finalized_queue_dropped", finalizedQueue.dropped()),
+		zap.Uint64("storage_errors", storageErrors),
+		zap.Uint64("problematic_block_count", problematicBlockCount),
+		zap.Bool("storage_enabled", true),
+		zap.Uint64("retention_blocks", l.storageConfig.RetainBlocks))
+}

--- a/eth/loganalyzer/log_analyzer_test.go
+++ b/eth/loganalyzer/log_analyzer_test.go
@@ -1,0 +1,257 @@
+package loganalyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestLogAnalyzer_New(t *testing.T) {
+	analyzer := testLogAnalyzer(t)
+
+	require.NotNil(t, analyzer)
+	require.NotNil(t, analyzer.logger)
+	require.NotNil(t, analyzer.logsQueues)
+	require.NotNil(t, analyzer.logsQueues[BatchLogType].channel)
+	require.NotNil(t, analyzer.logsQueues[FilterLogType].channel)
+	require.NotNil(t, analyzer.logsQueues[FinalizedLogType].channel)
+	require.NotNil(t, analyzer.store)
+	require.NotNil(t, analyzer.GetStore())
+}
+
+// TestLogAnalyzer_CoreFunctionality tests the essential LogAnalyzer operations
+func TestLogAnalyzer_CoreFunctionality(t *testing.T) {
+	analyzer := testLogAnalyzer(t)
+
+	t.Run("InitializationAndCleanup", func(t *testing.T) {
+		// Verify proper initialization
+		require.NotNil(t, analyzer.logger)
+		require.NotNil(t, analyzer.logsQueues[BatchLogType].channel)
+		require.NotNil(t, analyzer.logsQueues[FilterLogType].channel)
+		require.NotNil(t, analyzer.logsQueues[FinalizedLogType].channel)
+		require.NotNil(t, analyzer.store)
+		require.NotNil(t, analyzer.GetStore())
+
+		// Test idempotent close
+		errCh1 := analyzer.Close()
+		errCh2 := analyzer.Close()
+
+		<-errCh1 // Wait for first close
+		<-errCh2 // Second close should complete immediately
+
+		// Context should be canceled
+		select {
+		case <-analyzer.ctx.Done():
+			// Expected
+		default:
+			t.Fatal("Context not canceled after Close()")
+		}
+	})
+
+	// Create fresh analyzer for remaining tests since previous one was closed
+	analyzer = testLogAnalyzer(t)
+
+	t.Run("QueueProcessing", func(t *testing.T) {
+		blockLogs := simpleTestBlockLogs(100)
+		log := simpleTestLog(100)
+
+		// Test that all queue operations complete without blocking
+		errCh1 := analyzer.RecordBlockLogs(blockLogs)
+		errCh2 := analyzer.RecordFilterLogs(log)
+		errCh3 := analyzer.RecordFinalizedLogs(blockLogs)
+
+		// Wait for all processing to complete
+		<-errCh1
+		<-errCh2
+		<-errCh3
+
+		// Verify queues are processed (empty)
+		require.Equal(t, 0, len(analyzer.logsQueues[BatchLogType].channel))
+		require.Equal(t, 0, len(analyzer.logsQueues[FilterLogType].channel))
+		require.Equal(t, 0, len(analyzer.logsQueues[FinalizedLogType].channel))
+	})
+
+	t.Run("FilterLogBatching", func(t *testing.T) {
+		blockNumber := uint64(500)
+
+		// Add multiple filter logs
+		var errChannels []<-chan error
+		for i := 0; i < 10; i++ {
+			log := testLog(blockNumber, uint(i), "0x1234", "0xabcd")
+			errCh := analyzer.RecordFilterLogs(log)
+			errChannels = append(errChannels, errCh)
+		}
+
+		// Wait for all logs to be processed
+		for _, errCh := range errChannels {
+			<-errCh
+		}
+
+		// Verify storage (no flush needed since we save immediately)
+
+		savedLogs, err := analyzer.store.GetLogs(context.Background(), FilterLogType, blockNumber)
+		require.NoError(t, err)
+		require.Len(t, savedLogs, 10)
+	})
+}
+
+func TestLogAnalyzer_FilterLogBatchingLarge(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	config := Config{
+		Storage:      StorageConfig{RetainBlocks: 1000},
+		MaxQueueSize: 5000,
+	}
+	analyzer := New(context.Background(), logger, nil, config)
+	require.NotNil(t, analyzer)
+	defer analyzer.Close()
+
+	// Add multiple filter logs for the same block
+	blockNumber := uint64(500)
+	var errChannels []<-chan error
+	for i := 0; i < 50; i++ {
+		log := testLog(blockNumber, uint(i), "0x1234", "0xabcd")
+		errCh := analyzer.RecordFilterLogs(log)
+		errChannels = append(errChannels, errCh)
+	}
+
+	// Wait for all logs to be processed
+	for _, errCh := range errChannels {
+		<-errCh
+	}
+
+	// No flush needed since we save logs immediately
+
+	// Verify logs were saved to storage
+	savedLogs, err := analyzer.store.GetLogs(context.Background(), FilterLogType, blockNumber)
+	require.NoError(t, err)
+	require.Equal(t, 50, len(savedLogs), "All filter logs should be saved to storage")
+}
+
+// TestLogAnalyzer_HashComparison tests the hash-based log comparison logic
+func TestLogAnalyzer_HashComparison(t *testing.T) {
+	blockNumber := uint64(600)
+
+	// Create logs with same content but different indices
+	log1 := ethtypes.Log{
+		Address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		Topics:      []common.Hash{common.HexToHash("0xabcd")},
+		Data:        []byte("test data"),
+		BlockNumber: blockNumber,
+		TxHash:      common.HexToHash("0x1111"),
+		Index:       10, // Different index
+	}
+
+	log2 := ethtypes.Log{
+		Address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		Topics:      []common.Hash{common.HexToHash("0xabcd")},
+		Data:        []byte("test data"),
+		BlockNumber: blockNumber,
+		TxHash:      common.HexToHash("0x1111"),
+		Index:       99, // Different index, same content
+	}
+
+	// Convert to internal representation
+	internal1 := ToInternalLog(log1)
+	internal2 := ToInternalLog(log2)
+
+	t.Run("SameContentSameHash", func(t *testing.T) {
+		// Logs with same content should have same hash despite different indices
+		require.Equal(t, internal1.Hash, internal2.Hash)
+		require.NotEqual(t, internal1.Index, internal2.Index)
+	})
+
+	t.Run("HashBasedComparison", func(t *testing.T) {
+		hashes1 := ExtractLogHashes([]InternalLog{internal1})
+		hashes2 := ExtractLogHashes([]InternalLog{internal2})
+
+		// Should be considered the same log
+		missing, _, extra, _ := CountDiscrepanciesByHash(hashes1, hashes1, hashes2)
+		require.Equal(t, uint64(0), missing)
+		require.Equal(t, uint64(0), extra)
+	})
+
+	t.Run("DifferentContentDifferentHash", func(t *testing.T) {
+		differentLog := ethtypes.Log{
+			Address:     common.HexToAddress("0x9999999999999999999999999999999999999999"),
+			Topics:      []common.Hash{common.HexToHash("0xefgh")},
+			Data:        []byte("different data"),
+			BlockNumber: blockNumber,
+			TxHash:      common.HexToHash("0x2222"),
+			Index:       10,
+		}
+
+		internal3 := ToInternalLog(differentLog)
+		require.NotEqual(t, internal1.Hash, internal3.Hash)
+
+		hashes1 := ExtractLogHashes([]InternalLog{internal1})
+		hashes3 := ExtractLogHashes([]InternalLog{internal3})
+
+		missing, _, extra, _ := CountDiscrepanciesByHash(hashes1, hashes1, hashes3)
+		require.Equal(t, uint64(1), missing)
+		require.Equal(t, uint64(1), extra)
+	})
+}
+
+func TestLogAnalyzer_HashBasedComparisonDetailed(t *testing.T) {
+	blockNumber := uint64(600)
+
+	// Create test logs with same content but different indices
+	testLogs := []ethtypes.Log{
+		{
+			Address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			Topics:      []common.Hash{common.HexToHash("0xabcd")},
+			Data:        []byte("test data 1"),
+			BlockNumber: blockNumber,
+			TxHash:      common.HexToHash("0x1111"),
+			Index:       10, // Different index
+		},
+		{
+			Address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			Topics:      []common.Hash{common.HexToHash("0xabcd")},
+			Data:        []byte("test data 1"),
+			BlockNumber: blockNumber,
+			TxHash:      common.HexToHash("0x1111"),
+			Index:       99, // Different index, same content
+		},
+	}
+
+	// Convert to internal representation
+	internal1 := ToInternalLog(testLogs[0])
+	internal2 := ToInternalLog(testLogs[1])
+
+	// Verify that logs with same content have same hash despite different indices
+	require.Equal(t, internal1.Hash, internal2.Hash, "Logs with same content should have same hash")
+	require.NotEqual(t, internal1.Index, internal2.Index, "Test logs should have different indices")
+
+	// Test hash-based comparison
+	hashes1 := ExtractLogHashes([]InternalLog{internal1})
+	hashes2 := ExtractLogHashes([]InternalLog{internal2})
+
+	// Should be considered the same log for discrepancy analysis
+	missing, _, extra, _ := CountDiscrepanciesByHash(hashes1, hashes1, hashes2)
+	require.Equal(t, uint64(0), missing, "No logs should be missing when comparing same content")
+	require.Equal(t, uint64(0), extra, "No extra logs when comparing same content")
+
+	// Test with different content
+	differentLog := ethtypes.Log{
+		Address:     common.HexToAddress("0x9999999999999999999999999999999999999999"),
+		Topics:      []common.Hash{common.HexToHash("0xefgh")},
+		Data:        []byte("different data"),
+		BlockNumber: blockNumber,
+		TxHash:      common.HexToHash("0x2222"),
+		Index:       10, // Same index as first log
+	}
+
+	internal3 := ToInternalLog(differentLog)
+	require.NotEqual(t, internal1.Hash, internal3.Hash, "Logs with different content should have different hashes")
+
+	hashes3 := ExtractLogHashes([]InternalLog{internal3})
+	missing, _, extra, _ = CountDiscrepanciesByHash(hashes1, hashes1, hashes3)
+	require.Equal(t, uint64(1), missing, "Should detect missing log when content differs")
+	require.Equal(t, uint64(1), extra, "Should detect extra log when content differs")
+}

--- a/eth/loganalyzer/model.go
+++ b/eth/loganalyzer/model.go
@@ -1,0 +1,242 @@
+// Package loganalyzer provides analysis and comparison of blockchain logs from multiple sources.
+// It tracks discrepancies between batch logs, filter logs, and finalized logs to detect
+// potential issues in log processing pipelines.
+package loganalyzer
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+	"hash/fnv"
+	"sync"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+)
+
+// LogType represents the different sources of logs being processed.
+type LogType int
+
+const (
+	BatchLogType LogType = iota
+	FilterLogType
+	FinalizedLogType
+)
+
+func (lt LogType) String() string {
+	switch lt {
+	case BatchLogType:
+		return "batch logs"
+	case FilterLogType:
+		return "filter logs"
+	case FinalizedLogType:
+		return "finalized logs"
+	default:
+		return "unknown"
+	}
+}
+
+// hasherPool reuses hash instances for better performance in concurrent processing.
+var hasherPool = sync.Pool{
+	New: func() interface{} {
+		return fnv.New64()
+	},
+}
+
+// InternalLog represents an optimized log structure for analysis and comparison.
+type InternalLog struct {
+	BlockNumber uint64 `json:"block_number"`
+	Index       uint   `json:"index"`   // Log index within block
+	Hash        string `json:"hash"`    // Content-based hash for reliable comparison
+	TxHash      string `json:"tx_hash"` // Transaction hash for tracking
+	Removed     bool   `json:"removed"` // Whether this log was removed
+}
+
+// computeLogHash creates a content-based hash for reliable log comparison.
+// Uses FNV64 for performance while maintaining good distribution properties.
+func computeLogHash(log ethtypes.Log) string {
+	hasher := hasherPool.Get().(hash.Hash64)
+	defer hasherPool.Put(hasher)
+	hasher.Reset()
+
+	// Hash address, topics, data, and transaction hash
+	_, _ = hasher.Write(log.Address.Bytes())
+	for _, topic := range log.Topics {
+		_, _ = hasher.Write(topic.Bytes())
+	}
+	_, _ = hasher.Write(log.Data)
+	_, _ = hasher.Write(log.TxHash.Bytes())
+
+	hashBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hashBytes, hasher.Sum64())
+	return hex.EncodeToString(hashBytes)
+}
+
+// InternalBlockLogs represents a block of internal logs.
+type InternalBlockLogs struct {
+	BlockNumber uint64        `json:"block_number"`
+	Logs        []InternalLog `json:"logs"`
+}
+
+// ToInternalLog converts an ethereum log to our internal representation.
+func ToInternalLog(log ethtypes.Log) InternalLog {
+	return InternalLog{
+		BlockNumber: log.BlockNumber,
+		Index:       log.Index,
+		Hash:        computeLogHash(log),
+		TxHash:      log.TxHash.Hex(),
+		Removed:     log.Removed,
+	}
+}
+
+// ToInternalBlockLogs converts executionclient.BlockLogs to our internal representation.
+func ToInternalBlockLogs(blockLogs executionclient.BlockLogs) InternalBlockLogs {
+	internalLogs := make([]InternalLog, len(blockLogs.Logs))
+	for i, log := range blockLogs.Logs {
+		internalLogs[i] = ToInternalLog(log)
+	}
+	return InternalBlockLogs{
+		BlockNumber: blockLogs.BlockNumber,
+		Logs:        internalLogs,
+	}
+}
+
+// ExtractLogHashes returns a set of log hashes for comparison.
+func ExtractLogHashes(logs []InternalLog) map[string]struct{} {
+	hashes := make(map[string]struct{}, len(logs))
+	for _, log := range logs {
+		hashes[log.Hash] = struct{}{}
+	}
+	return hashes
+}
+
+// CountDiscrepanciesByHash compares log hashes and returns discrepancy counts.
+func CountDiscrepanciesByHash(batchHashes, filterHashes, finalizedHashes map[string]struct{}) (missingInBatch, missingInFilter, extraInBatch, extraInFilter uint64) {
+	// Count logs missing in batch (present in finalized but not in batch)
+	for hash := range finalizedHashes {
+		if _, found := batchHashes[hash]; !found {
+			missingInBatch++
+		}
+	}
+
+	// Count logs missing in filter (present in finalized but not in filter)
+	for hash := range finalizedHashes {
+		if _, found := filterHashes[hash]; !found {
+			missingInFilter++
+		}
+	}
+
+	// Count extra logs in batch (present in batch but not in finalized)
+	for hash := range batchHashes {
+		if _, found := finalizedHashes[hash]; !found {
+			extraInBatch++
+		}
+	}
+
+	// Count extra logs in filter (present in filter but not in finalized)
+	for hash := range filterHashes {
+		if _, found := finalizedHashes[hash]; !found {
+			extraInFilter++
+		}
+	}
+
+	return missingInBatch, missingInFilter, extraInBatch, extraInFilter
+}
+
+// ComputeTransactionStats aggregates logs by transaction hash and computes per-transaction statistics.
+func ComputeTransactionStats(batchLogs, filterLogs, finalizedLogs []InternalLog) []*TxLogStats {
+	// Group logs by transaction hash
+	txMap := make(map[string]*TxLogStats)
+
+	// Process finalized logs (ground truth)
+	for _, log := range finalizedLogs {
+		if _, exists := txMap[log.TxHash]; !exists {
+			txMap[log.TxHash] = &TxLogStats{
+				TxHash: log.TxHash,
+			}
+		}
+		txMap[log.TxHash].ExpectedLogs++
+	}
+
+	// Process batch logs
+	for _, log := range batchLogs {
+		if _, exists := txMap[log.TxHash]; !exists {
+			txMap[log.TxHash] = &TxLogStats{
+				TxHash: log.TxHash,
+			}
+		}
+		txMap[log.TxHash].BatchLogs++
+	}
+
+	// Process filter logs
+	for _, log := range filterLogs {
+		if _, exists := txMap[log.TxHash]; !exists {
+			txMap[log.TxHash] = &TxLogStats{
+				TxHash: log.TxHash,
+			}
+		}
+		txMap[log.TxHash].FilterLogs++
+	}
+
+	// Compute missing counts
+	for _, stats := range txMap {
+		if stats.BatchLogs < stats.ExpectedLogs {
+			stats.MissingFromBatch = stats.ExpectedLogs - stats.BatchLogs
+		}
+		if stats.FilterLogs < stats.ExpectedLogs {
+			stats.MissingFromFilter = stats.ExpectedLogs - stats.FilterLogs
+		}
+	}
+
+	// Convert to slice
+	result := make([]*TxLogStats, 0, len(txMap))
+	for _, stats := range txMap {
+		result = append(result, stats)
+	}
+
+	return result
+}
+
+// StorageConfig defines the storage configuration.
+type StorageConfig struct {
+	RetainBlocks uint64 `yaml:"retain_blocks"`
+}
+
+// BlockStatsResponse represents the API response for block statistics.
+type BlockStatsResponse struct {
+	BlockStats       []*BlockAnalysisStats `json:"block_stats"`
+	TransactionStats []*TxLogStats         `json:"transaction_stats"`
+	HasMore          bool                  `json:"has_more"`
+}
+
+// ProblematicBlock represents a block with log discrepancies.
+type ProblematicBlock struct {
+	BlockNumber        uint64 `json:"block_number"`
+	DetectedAt         int64  `json:"detected_at"`
+	TotalDiscrepancies uint64 `json:"total_discrepancies"`
+}
+
+// ProblematicBlocksResponse represents the API response for problematic blocks.
+type ProblematicBlocksResponse struct {
+	ProblematicBlocks  []*ProblematicBlock `json:"problematic_blocks"`
+	HasMore            bool                `json:"has_more"`
+	LastFinalizedBlock uint64              `json:"last_finalized_block"`
+	Description        string              `json:"description"`
+}
+
+// TxLogStats represents log statistics per transaction hash.
+type TxLogStats struct {
+	TxHash            string `json:"tx_hash"`
+	ExpectedLogs      uint64 `json:"expected_logs"`
+	BatchLogs         uint64 `json:"batch_logs"`
+	FilterLogs        uint64 `json:"filter_logs"`
+	MissingFromBatch  uint64 `json:"missing_from_batch"`
+	MissingFromFilter uint64 `json:"missing_from_filter"`
+}
+
+// ProcessorRequest represents a request that can be processed by the analyzer.
+type ProcessorRequest interface {
+	Process(analyzer *LogAnalyzer) error
+	GetResponseChannel() chan error
+}

--- a/eth/loganalyzer/storage.go
+++ b/eth/loganalyzer/storage.go
@@ -1,0 +1,529 @@
+package loganalyzer
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+var ErrNotFound = errors.New("block logs not found")
+
+// AllBlockLogs holds all three types of logs for a single block.
+type AllBlockLogs struct {
+	BatchLogs     []InternalLog
+	FilterLogs    []InternalLog
+	FinalizedLogs []InternalLog
+}
+
+const (
+	storePrefix = "loganalyzer"
+
+	// Block-specific data prefixes
+	blockStatsKey       = "bs"
+	problematicBlockKey = "pb"
+	batchLogsKey        = "bl"
+	filterLogsKey       = "fl"
+	finalizedLogsKey    = "fnl"
+
+	// Global state keys
+	lastBatchBlockKey     = "lbb"
+	lastFilterBlockKey    = "lfb"
+	lastFinalizedBlockKey = "lf"
+	lastProcessedKey      = "lpb"
+)
+
+// getKeyPrefix returns the storage key prefix for the given log type.
+func (lt LogType) getKeyPrefix() string {
+	switch lt {
+	case BatchLogType:
+		return batchLogsKey
+	case FilterLogType:
+		return filterLogsKey
+	case FinalizedLogType:
+		return finalizedLogsKey
+	default:
+		return ""
+	}
+}
+
+// getLastBlockKey returns the storage key for tracking last received block by log type.
+func (lt LogType) getLastBlockKey() string {
+	switch lt {
+	case BatchLogType:
+		return lastBatchBlockKey
+	case FilterLogType:
+		return lastFilterBlockKey
+	case FinalizedLogType:
+		return lastFinalizedBlockKey
+	default:
+		return ""
+	}
+}
+
+// LogAnalyzerStore interface for persisting log analysis data.
+type LogAnalyzerStore interface {
+	// Block analysis results
+	SaveBlockStats(ctx context.Context, stats *BlockAnalysisStats) error
+	GetBlockStats(ctx context.Context, blockNumber uint64) (*BlockAnalysisStats, error)
+	GetBlockRange(ctx context.Context, fromBlock, toBlock uint64) ([]*BlockAnalysisStats, error)
+
+	// Problematic blocks tracking
+	SaveProblematicBlock(ctx context.Context, block *ProblematicBlock) error
+	GetProblematicBlock(ctx context.Context, blockNumber uint64) (*ProblematicBlock, error)
+	GetProblematicBlocks(ctx context.Context, startBlock uint64, endBlock *uint64, limit uint32) ([]*ProblematicBlock, bool, error)
+	DeleteProblematicBlock(ctx context.Context, blockNumber uint64) error
+
+	// Block data management
+	DeleteBlockData(ctx context.Context, blockNumber uint64) error
+
+	// Internal log storage
+	SaveLogs(ctx context.Context, logType LogType, blockNumber uint64, logs []InternalLog) error
+	SaveLastReceivedBlock(ctx context.Context, logType LogType, blockNumber uint64) error
+	GetLastReceivedBlock(ctx context.Context, logType LogType) (uint64, error)
+	GetLogs(ctx context.Context, logType LogType, blockNumber uint64) ([]InternalLog, error)
+	GetAllLogs(ctx context.Context, blockNumber uint64) (*AllBlockLogs, error)
+	DeleteLogs(ctx context.Context, blockNumber uint64) error
+
+	// Processing state tracking
+	SaveLastProcessedBlock(ctx context.Context, blockNumber uint64) error
+	GetLastProcessedBlock(ctx context.Context) (uint64, error)
+}
+
+// BlockAnalysisStats represents the analysis results for a single block.
+type BlockAnalysisStats struct {
+	BlockNumber uint64 `json:"block_number"`
+
+	// Counts from each source
+	BatchLogCount     uint64 `json:"batch_log_count"`
+	FilterLogCount    uint64 `json:"filter_log_count"`
+	FinalizedLogCount uint64 `json:"finalized_log_count"`
+
+	// Analysis results
+	HasDiscrepancies bool   `json:"has_discrepancies"`
+	MissingInBatch   uint64 `json:"missing_in_batch"`
+	MissingInFilter  uint64 `json:"missing_in_filter"`
+	ExtraInBatch     uint64 `json:"extra_in_batch"`
+	ExtraInFilter    uint64 `json:"extra_in_filter"`
+
+	// Metadata
+	AnalyzedAt int64 `json:"analyzed_at"`
+	IsFinal    bool  `json:"is_final"`
+}
+
+// LogReference identifies a specific log without storing full data.
+type LogReference struct {
+	LogIndex    uint     `json:"log_index"`
+	TxHash      string   `json:"tx_hash"`
+	Address     string   `json:"address"`
+	TopicHashes []string `json:"topic_hashes,omitempty"`
+}
+
+// logAnalyzerStore implements LogAnalyzerStore using basedb.
+type logAnalyzerStore struct {
+	db basedb.Database
+}
+
+// NewLogAnalyzerStore creates a new log analyzer store.
+func NewLogAnalyzerStore(db basedb.Database) LogAnalyzerStore {
+	return &logAnalyzerStore{
+		db: db,
+	}
+}
+
+func (s *logAnalyzerStore) marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}
+
+func (s *logAnalyzerStore) unmarshal(data []byte, v interface{}) error {
+	return msgpack.Unmarshal(data, v)
+}
+
+func (s *logAnalyzerStore) SaveBlockStats(ctx context.Context, stats *BlockAnalysisStats) error {
+	key := s.makeKeyForBlock(blockStatsKey, stats.BlockNumber)
+
+	value, err := s.marshal(stats)
+	if err != nil {
+		return fmt.Errorf("marshal block stats: %w", err)
+	}
+
+	return s.db.Set([]byte(storePrefix), key, value)
+}
+
+func (s *logAnalyzerStore) GetBlockStats(ctx context.Context, blockNumber uint64) (*BlockAnalysisStats, error) {
+	key := s.makeKeyForBlock(blockStatsKey, blockNumber)
+
+	obj, found, err := s.db.Get([]byte(storePrefix), key)
+	if err != nil {
+		return nil, fmt.Errorf("get block stats: %w", err)
+	}
+	if !found {
+		return nil, ErrNotFound
+	}
+
+	var stats BlockAnalysisStats
+
+	if err := s.unmarshal(obj.Value, &stats); err != nil {
+		return nil, fmt.Errorf("unmarshal block stats failed: %w", err)
+	}
+
+	return &stats, nil
+}
+
+func (s *logAnalyzerStore) DeleteBlockData(ctx context.Context, blockNumber uint64) error {
+	keys := [][]byte{
+		s.makeKeyForBlock(batchLogsKey, blockNumber),
+		s.makeKeyForBlock(filterLogsKey, blockNumber),
+		s.makeKeyForBlock(finalizedLogsKey, blockNumber),
+		s.makeKeyForBlock(blockStatsKey, blockNumber),
+		s.makeKeyForBlock(problematicBlockKey, blockNumber),
+	}
+
+	for _, key := range keys {
+		if err := s.db.Delete([]byte(storePrefix), key); err != nil {
+			return fmt.Errorf("delete block data for block %d: %w", blockNumber, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *logAnalyzerStore) GetBlockRange(ctx context.Context, fromBlock, toBlock uint64) ([]*BlockAnalysisStats, error) {
+	results := make([]*BlockAnalysisStats, 0, toBlock-fromBlock+1)
+
+	fromKey := s.makeKeyForBlock(blockStatsKey, fromBlock)
+	toKey := s.makeKeyForBlock(blockStatsKey, toBlock)
+	keyPrefixBytes := []byte(blockStatsKey)
+
+	err := s.db.GetAll([]byte(storePrefix), func(i int, obj basedb.Obj) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Quick prefix check
+		if len(obj.Key) < len(keyPrefixBytes) || !bytes.HasPrefix(obj.Key, keyPrefixBytes) {
+			return nil
+		}
+
+		// Validate key length
+		if len(obj.Key) != len(keyPrefixBytes)+8 {
+			return nil
+		}
+
+		// Range check using binary comparison
+		if bytes.Compare(obj.Key, fromKey) < 0 || bytes.Compare(obj.Key, toKey) > 0 {
+			return nil
+		}
+
+		blockBytes := obj.Key[len(keyPrefixBytes):]
+		blockNum := binary.LittleEndian.Uint64(blockBytes)
+
+		if blockNum < fromBlock || blockNum > toBlock {
+			return nil
+		}
+
+		var stats BlockAnalysisStats
+		if err := s.unmarshal(obj.Value, &stats); err != nil {
+			return fmt.Errorf("unmarshal block stats for block %d: %w", blockNum, err)
+		}
+
+		results = append(results, &stats)
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("block range query canceled (from=%d to=%d): %w", fromBlock, toBlock, err)
+		}
+		return nil, fmt.Errorf("iterate block range from=%d to=%d: %w", fromBlock, toBlock, err)
+	}
+
+	return results, nil
+}
+
+func (s *logAnalyzerStore) SaveProblematicBlock(ctx context.Context, block *ProblematicBlock) error {
+	key := s.makeKeyForBlock(problematicBlockKey, block.BlockNumber)
+
+	value, err := s.marshal(block)
+	if err != nil {
+		return fmt.Errorf("marshal problematic block: %w", err)
+	}
+
+	return s.db.Set([]byte(storePrefix), key, value)
+}
+
+func (s *logAnalyzerStore) GetProblematicBlocks(ctx context.Context, startBlock uint64, endBlock *uint64, limit uint32) ([]*ProblematicBlock, bool, error) {
+	upperBound := endBlock
+	if upperBound == nil {
+		lastFinalized, err := s.GetLastReceivedBlock(ctx, FinalizedLogType)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return []*ProblematicBlock{}, false, nil
+			}
+			return nil, false, fmt.Errorf("get last finalized block: %w", err)
+		}
+		upperBound = &lastFinalized
+	}
+
+	results := make([]*ProblematicBlock, 0)
+	hasMore := false
+
+	fromKey := s.makeKeyForBlock(problematicBlockKey, startBlock)
+	toKey := s.makeKeyForBlock(problematicBlockKey, *upperBound)
+	keyPrefixBytes := []byte(problematicBlockKey)
+
+	err := s.db.GetAll([]byte(storePrefix), func(i int, obj basedb.Obj) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if (limit > 0) && (len(results) >= int(limit)) {
+			hasMore = true
+			return nil
+		}
+
+		// Quick prefix check
+		if len(obj.Key) < len(keyPrefixBytes) || !bytes.HasPrefix(obj.Key, keyPrefixBytes) {
+			return nil
+		}
+
+		// Validate key length
+		if len(obj.Key) != len(keyPrefixBytes)+8 {
+			return nil
+		}
+
+		// Range check using binary comparison
+		if bytes.Compare(obj.Key, fromKey) < 0 || bytes.Compare(obj.Key, toKey) > 0 {
+			return nil
+		}
+
+		blockBytes := obj.Key[len(keyPrefixBytes):]
+		blockNum := binary.LittleEndian.Uint64(blockBytes)
+
+		if blockNum < startBlock || blockNum > *upperBound {
+			return nil
+		}
+
+		var block ProblematicBlock
+		if err := s.unmarshal(obj.Value, &block); err != nil {
+			return fmt.Errorf("unmarshal problematic block for block %d: %w", blockNum, err)
+		}
+
+		results = append(results, &block)
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, false, fmt.Errorf("problematic blocks query canceled (start=%d end=%v limit=%d): %w", startBlock, endBlock, limit, err)
+		}
+		return nil, false, fmt.Errorf("iterate problematic blocks start=%d end=%v limit=%d: %w", startBlock, endBlock, limit, err)
+	}
+
+	return results, hasMore, nil
+}
+
+func (s *logAnalyzerStore) DeleteProblematicBlock(ctx context.Context, blockNumber uint64) error {
+	key := s.makeKeyForBlock(problematicBlockKey, blockNumber)
+	return s.db.Delete([]byte(storePrefix), key)
+}
+
+// GetProblematicBlock retrieves a specific problematic block.
+func (s *logAnalyzerStore) GetProblematicBlock(ctx context.Context, blockNumber uint64) (*ProblematicBlock, error) {
+	key := s.makeKeyForBlock(problematicBlockKey, blockNumber)
+
+	obj, found, err := s.db.Get([]byte(storePrefix), key)
+	if err != nil {
+		return nil, fmt.Errorf("get problematic block: %w", err)
+	}
+	if !found {
+		return nil, ErrNotFound
+	}
+
+	var block ProblematicBlock
+
+	if err := s.unmarshal(obj.Value, &block); err != nil {
+		return nil, fmt.Errorf("unmarshal problematic block failed: %w", err)
+	}
+
+	return &block, nil
+}
+
+// SaveLogs saves logs for the specified type and block.
+// For filter logs, appends to existing logs; for others, overwrites.
+func (s *logAnalyzerStore) SaveLogs(ctx context.Context, logType LogType, blockNumber uint64, logs []InternalLog) error {
+	if logType == FilterLogType {
+		// For filter logs, append to existing logs
+		existingLogs, err := s.GetLogs(ctx, FilterLogType, blockNumber)
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return err
+		}
+
+		allLogs := append(existingLogs, logs...)
+		return s.saveLogs(logType, blockNumber, allLogs)
+	}
+	// For batch and finalized logs, save directly
+	return s.saveLogs(logType, blockNumber, logs)
+}
+
+// GetLastReceivedBlock retrieves the last received block number for the specified log type.
+func (s *logAnalyzerStore) GetLastReceivedBlock(ctx context.Context, logType LogType) (uint64, error) {
+	key := []byte(logType.getLastBlockKey())
+	obj, found, err := s.db.Get([]byte(storePrefix), key)
+	if err != nil {
+		return 0, fmt.Errorf("get last received block for %s: %w", logType.String(), err)
+	}
+	if !found {
+		return 0, ErrNotFound
+	}
+
+	var blockNumber uint64
+	if err := s.unmarshal(obj.Value, &blockNumber); err != nil {
+		return 0, fmt.Errorf("unmarshal last received block for %s: %w", logType.String(), err)
+	}
+
+	return blockNumber, nil
+}
+
+// SaveLastReceivedBlock saves the last received block number for the specified log type.
+func (s *logAnalyzerStore) SaveLastReceivedBlock(ctx context.Context, logType LogType, blockNumber uint64) error {
+	currentLast, err := s.GetLastReceivedBlock(ctx, logType)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("get current last received block for %s: %w", logType.String(), err)
+	}
+
+	// Only save if the new block number is higher
+	if blockNumber > currentLast {
+		key := []byte(logType.getLastBlockKey())
+		value, err := s.marshal(blockNumber)
+		if err != nil {
+			return fmt.Errorf("marshal last received block for %s: %w", logType.String(), err)
+		}
+		return s.db.Set([]byte(storePrefix), key, value)
+	}
+	return nil
+}
+
+func (s *logAnalyzerStore) GetAllLogs(ctx context.Context, blockNumber uint64) (*AllBlockLogs, error) {
+	result := &AllBlockLogs{}
+
+	batchLogs, err := s.GetLogs(ctx, BatchLogType, blockNumber)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("get batch logs: %w", err)
+	}
+	if batchLogs == nil {
+		batchLogs = []InternalLog{}
+	}
+	result.BatchLogs = batchLogs
+
+	filterLogs, err := s.GetLogs(ctx, FilterLogType, blockNumber)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("get filter logs: %w", err)
+	}
+	if filterLogs == nil {
+		filterLogs = []InternalLog{}
+	}
+	result.FilterLogs = filterLogs
+
+	finalizedLogs, err := s.GetLogs(ctx, FinalizedLogType, blockNumber)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("get finalized logs: %w", err)
+	}
+	if finalizedLogs == nil {
+		finalizedLogs = []InternalLog{}
+	}
+	result.FinalizedLogs = finalizedLogs
+
+	return result, nil
+}
+
+func (s *logAnalyzerStore) DeleteLogs(ctx context.Context, blockNumber uint64) error {
+	prefixes := []string{batchLogsKey, filterLogsKey, finalizedLogsKey}
+
+	for _, prefix := range prefixes {
+		key := s.makeKeyForBlock(prefix, blockNumber)
+		if err := s.db.Delete([]byte(storePrefix), key); err != nil {
+			return fmt.Errorf("failed to delete %s logs for block %d: %w", prefix, blockNumber, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *logAnalyzerStore) SaveLastProcessedBlock(ctx context.Context, blockNumber uint64) error {
+	key := []byte(lastProcessedKey)
+
+	value, err := s.marshal(blockNumber)
+	if err != nil {
+		return fmt.Errorf("marshal last processed block: %w", err)
+	}
+
+	return s.db.Set([]byte(storePrefix), key, value)
+}
+
+func (s *logAnalyzerStore) GetLastProcessedBlock(ctx context.Context) (uint64, error) {
+	key := []byte(lastProcessedKey)
+
+	obj, found, err := s.db.Get([]byte(storePrefix), key)
+	if err != nil {
+		return 0, fmt.Errorf("get last processed block: %w", err)
+	}
+	if !found {
+		return 0, ErrNotFound
+	}
+
+	var blockNumber uint64
+
+	if err := s.unmarshal(obj.Value, &blockNumber); err != nil {
+		return 0, fmt.Errorf("unmarshal last processed block failed: %w", err)
+	}
+
+	return blockNumber, nil
+}
+
+func (s *logAnalyzerStore) saveLogs(logType LogType, blockNumber uint64, logs []InternalLog) error {
+	key := s.makeKeyForBlock(logType.getKeyPrefix(), blockNumber)
+
+	value, err := s.marshal(logs)
+	if err != nil {
+		return fmt.Errorf("marshal %s logs: %w", logType.getKeyPrefix(), err)
+	}
+
+	return s.db.Set([]byte(storePrefix), key, value)
+}
+
+func (s *logAnalyzerStore) GetLogs(ctx context.Context, logType LogType, blockNumber uint64) ([]InternalLog, error) {
+	key := s.makeKeyForBlock(logType.getKeyPrefix(), blockNumber)
+
+	obj, found, err := s.db.Get([]byte(storePrefix), key)
+	if err != nil {
+		return nil, fmt.Errorf("get %s logs: %w", logType.getKeyPrefix(), err)
+	}
+	if !found {
+		return nil, ErrNotFound
+	}
+
+	var logs []InternalLog
+
+	if err := s.unmarshal(obj.Value, &logs); err != nil {
+		return nil, fmt.Errorf("unmarshal %s logs failed: %w", logType.getKeyPrefix(), err)
+	}
+
+	return logs, nil
+}
+
+func (s *logAnalyzerStore) makeKeyForBlock(prefix string, blockNumber uint64) []byte {
+	key := make([]byte, len(prefix)+8)
+	copy(key, prefix)
+	binary.LittleEndian.PutUint64(key[len(prefix):], blockNumber)
+	return key
+}

--- a/eth/loganalyzer/storage_test.go
+++ b/eth/loganalyzer/storage_test.go
@@ -1,0 +1,377 @@
+package loganalyzer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogStorage_CRUD consolidates all log storage CRUD operations
+func TestLogStorage_CRUD(t *testing.T) {
+	store := testStore(t)
+	blockNumber := uint64(100)
+
+	// Test data
+	logs := []InternalLog{
+		testInternalLog(blockNumber, 0, "0x1111", "0xaaa1"),
+		testInternalLog(blockNumber, 1, "0x2222", "0xaaa2"),
+	}
+
+	// Table-driven test for all log types
+	tests := []struct {
+		name    string
+		logType LogType
+	}{
+		{
+			name:    "BatchLogs",
+			logType: BatchLogType,
+		},
+		{
+			name:    "FilterLogs",
+			logType: FilterLogType,
+		},
+		{
+			name:    "FinalizedLogs",
+			logType: FinalizedLogType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Test save and retrieve
+			err := store.SaveLogs(ctx, tt.logType, blockNumber, logs)
+			require.NoError(t, err)
+
+			retrieved, err := store.GetLogs(ctx, tt.logType, blockNumber)
+			require.NoError(t, err)
+			require.Len(t, retrieved, 2)
+
+			// Verify internal log details are preserved
+			for i, log := range logs {
+				require.Equal(t, log.BlockNumber, retrieved[i].BlockNumber)
+				require.Equal(t, log.Index, retrieved[i].Index)
+				require.Equal(t, log.Hash, retrieved[i].Hash)
+				require.Equal(t, log.TxHash, retrieved[i].TxHash)
+				require.Equal(t, log.Removed, retrieved[i].Removed)
+			}
+
+			// Test not found
+			_, err = store.GetLogs(ctx, tt.logType, 999)
+			require.ErrorIs(t, err, ErrNotFound)
+
+			// Test overwrite (FilterLogType appends, others overwrite)
+			newLogs := []InternalLog{testInternalLog(blockNumber, 10, "0x3333", "0xbbb1")}
+			err = store.SaveLogs(ctx, tt.logType, blockNumber, newLogs)
+			require.NoError(t, err)
+
+			retrieved, err = store.GetLogs(ctx, tt.logType, blockNumber)
+			require.NoError(t, err)
+
+			if tt.logType == FilterLogType {
+				// FilterLogType appends to existing logs
+				require.Len(t, retrieved, 3)                         // original 2 + new 1
+				require.Equal(t, newLogs[0].Hash, retrieved[2].Hash) // new log is last
+			} else {
+				// BatchLogType and FinalizedLogType overwrite
+				require.Len(t, retrieved, 1)
+				require.Equal(t, newLogs[0].Hash, retrieved[0].Hash)
+			}
+		})
+	}
+}
+
+func TestLogAnalyzerStore_GetAllLogs(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	blockNumber := uint64(123)
+
+	t.Run("EmptyData", func(t *testing.T) {
+		// Test with no data
+		allLogs, err := store.GetAllLogs(ctx, blockNumber)
+		require.NoError(t, err)
+		require.Empty(t, allLogs.BatchLogs)
+		require.Empty(t, allLogs.FilterLogs)
+		require.Empty(t, allLogs.FinalizedLogs)
+	})
+
+	t.Run("WithData", func(t *testing.T) {
+		// Save some data and test again
+		logs := []InternalLog{testInternalLog(blockNumber, 0, "0x1111", "0x2222")}
+
+		err := store.SaveLogs(ctx, BatchLogType, blockNumber, logs)
+		require.NoError(t, err)
+		err = store.SaveLogs(ctx, FilterLogType, blockNumber, logs)
+		require.NoError(t, err)
+		err = store.SaveLogs(ctx, FinalizedLogType, blockNumber, logs)
+		require.NoError(t, err)
+
+		allLogs, err := store.GetAllLogs(ctx, blockNumber)
+		require.NoError(t, err)
+		require.Equal(t, logs, allLogs.BatchLogs)
+		require.Equal(t, logs, allLogs.FilterLogs)
+		require.Equal(t, logs, allLogs.FinalizedLogs)
+	})
+}
+
+// TestStorage_CRUD consolidates all storage CRUD operations
+func TestStorage_CRUD(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	t.Run("BlockStats", func(t *testing.T) {
+		stats := &BlockAnalysisStats{
+			BlockNumber:      500,
+			BatchLogCount:    10,
+			FilterLogCount:   8,
+			HasDiscrepancies: true,
+			AnalyzedAt:       time.Now().Unix(),
+			IsFinal:          true,
+		}
+
+		// Save and retrieve
+		err := store.SaveBlockStats(ctx, stats)
+		require.NoError(t, err)
+
+		retrieved, err := store.GetBlockStats(ctx, 500)
+		require.NoError(t, err)
+		require.Equal(t, stats.BlockNumber, retrieved.BlockNumber)
+		require.Equal(t, stats.HasDiscrepancies, retrieved.HasDiscrepancies)
+
+		// Test not found
+		_, err = store.GetBlockStats(ctx, 999)
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("ProblematicBlocks", func(t *testing.T) {
+		block := &ProblematicBlock{
+			BlockNumber:        700,
+			DetectedAt:         time.Now().Unix(),
+			TotalDiscrepancies: 6,
+		}
+
+		// Save and retrieve
+		err := store.SaveProblematicBlock(ctx, block)
+		require.NoError(t, err)
+
+		retrieved, err := store.GetProblematicBlock(ctx, 700)
+		require.NoError(t, err)
+		require.Equal(t, block.BlockNumber, retrieved.BlockNumber)
+		require.Equal(t, block.TotalDiscrepancies, retrieved.TotalDiscrepancies)
+
+		// Test not found
+		_, err = store.GetProblematicBlock(ctx, 999)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		// Test delete
+		err = store.DeleteProblematicBlock(ctx, 700)
+		require.NoError(t, err)
+
+		_, err = store.GetProblematicBlock(ctx, 700)
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("LastBlocks", func(t *testing.T) {
+		// Test LastFinalizedBlock
+		_, err := store.GetLastReceivedBlock(ctx, FinalizedLogType)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		err = store.SaveLastReceivedBlock(ctx, FinalizedLogType, 12345)
+		require.NoError(t, err)
+
+		lastFinalized, err := store.GetLastReceivedBlock(ctx, FinalizedLogType)
+		require.NoError(t, err)
+		require.Equal(t, uint64(12345), lastFinalized)
+
+		// Test LastProcessedBlock
+		_, err = store.GetLastProcessedBlock(ctx)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		err = store.SaveLastProcessedBlock(ctx, 67890)
+		require.NoError(t, err)
+
+		lastProcessed, err := store.GetLastProcessedBlock(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(67890), lastProcessed)
+	})
+}
+
+func TestLogAnalyzerStore_BlockRange(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Create test data
+	for i := uint64(600); i <= 605; i++ {
+		stats := &BlockAnalysisStats{
+			BlockNumber:      i,
+			BatchLogCount:    i * 2,
+			HasDiscrepancies: i%2 == 0,
+		}
+		err := store.SaveBlockStats(ctx, stats)
+		require.NoError(t, err)
+	}
+
+	// Test range
+	retrieved, err := store.GetBlockRange(ctx, 602, 604)
+	require.NoError(t, err)
+	require.Len(t, retrieved, 3) // 602, 603, 604
+	require.Equal(t, uint64(602), retrieved[0].BlockNumber)
+	require.Equal(t, uint64(604), retrieved[2].BlockNumber)
+
+	// Test empty range
+	retrieved, err = store.GetBlockRange(ctx, 700, 702)
+	require.NoError(t, err)
+	require.Len(t, retrieved, 0)
+}
+
+func TestLogAnalyzerStore_ProblematicBlocks_List(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Set last finalized block (required for GetProblematicBlocks)
+	err := store.SaveLastReceivedBlock(ctx, FinalizedLogType, 110)
+	require.NoError(t, err)
+
+	// Prepare test data
+	for i := uint64(100); i <= 105; i++ {
+		block := &ProblematicBlock{
+			BlockNumber:        i,
+			DetectedAt:         time.Now().Unix(),
+			TotalDiscrepancies: i,
+		}
+		err := store.SaveProblematicBlock(ctx, block)
+		require.NoError(t, err)
+	}
+
+	// Test GetProblematicBlocks with various parameters
+	blocks, hasMore, err := store.GetProblematicBlocks(ctx, 100, nil, 10)
+	require.NoError(t, err)
+	require.Len(t, blocks, 6) // All blocks from 100-105
+	require.False(t, hasMore)
+
+	// Test with limit
+	blocks, hasMore, err = store.GetProblematicBlocks(ctx, 100, nil, 3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+	require.True(t, hasMore)
+
+	// Test with end block
+	endBlock := uint64(103)
+	blocks, hasMore, err = store.GetProblematicBlocks(ctx, 100, &endBlock, 10)
+	require.NoError(t, err)
+	require.Len(t, blocks, 4) // 100, 101, 102, 103
+	require.False(t, hasMore)
+}
+
+// TestStorage_EdgeCases consolidates edge case testing
+func TestStorage_EdgeCases(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	blockNumber := uint64(1000)
+
+	t.Run("EmptyData", func(t *testing.T) {
+		// Empty logs should work
+		err := store.SaveLogs(ctx, BatchLogType, blockNumber, []InternalLog{})
+		require.NoError(t, err)
+
+		logs, err := store.GetLogs(ctx, BatchLogType, blockNumber)
+		require.NoError(t, err)
+		require.Len(t, logs, 0)
+
+		// Nil logs should work
+		err = store.SaveLogs(ctx, FilterLogType, blockNumber, nil)
+		require.NoError(t, err)
+
+		logs, err = store.GetLogs(ctx, FilterLogType, blockNumber)
+		require.NoError(t, err)
+		require.Len(t, logs, 0)
+	})
+
+	t.Run("DeleteOperations", func(t *testing.T) {
+		logs := []InternalLog{testInternalLog(blockNumber, 0, "0x1111", "0x2222")}
+		stats := &BlockAnalysisStats{
+			BlockNumber:       blockNumber,
+			BatchLogCount:     1,
+			FilterLogCount:    1,
+			FinalizedLogCount: 1,
+			AnalyzedAt:        time.Now().Unix(),
+			IsFinal:           true,
+		}
+		problemBlock := &ProblematicBlock{
+			BlockNumber:        blockNumber,
+			DetectedAt:         time.Now().Unix(),
+			TotalDiscrepancies: 1,
+		}
+
+		// Save all types of data
+		err := store.SaveLogs(ctx, BatchLogType, blockNumber, logs)
+		require.NoError(t, err)
+		err = store.SaveLogs(ctx, FilterLogType, blockNumber, logs)
+		require.NoError(t, err)
+		err = store.SaveLogs(ctx, FinalizedLogType, blockNumber, logs)
+		require.NoError(t, err)
+		err = store.SaveBlockStats(ctx, stats)
+		require.NoError(t, err)
+		err = store.SaveProblematicBlock(ctx, problemBlock)
+		require.NoError(t, err)
+
+		// Delete logs only
+		err = store.DeleteLogs(ctx, blockNumber)
+		require.NoError(t, err)
+
+		// Verify log deletion
+		_, err = store.GetLogs(ctx, BatchLogType, blockNumber)
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = store.GetLogs(ctx, FilterLogType, blockNumber)
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = store.GetLogs(ctx, FinalizedLogType, blockNumber)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		// Other data should still exist
+		_, err = store.GetBlockStats(ctx, blockNumber)
+		require.NoError(t, err)
+		_, err = store.GetProblematicBlock(ctx, blockNumber)
+		require.NoError(t, err)
+
+		// Delete all block data
+		err = store.DeleteBlockData(ctx, blockNumber)
+		require.NoError(t, err)
+
+		// Verify all data is gone
+		_, err = store.GetBlockStats(ctx, blockNumber)
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = store.GetProblematicBlock(ctx, blockNumber)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		// Test deleting non-existent data (should not error)
+		err = store.DeleteLogs(ctx, 9999)
+		require.NoError(t, err)
+		err = store.DeleteBlockData(ctx, 9999)
+		require.NoError(t, err)
+	})
+
+	t.Run("LargeData", func(t *testing.T) {
+		largeBlockNumber := uint64(1200)
+
+		// Create large internal log array
+		logs := make([]InternalLog, 1000)
+		for i := 0; i < 1000; i++ {
+			logs[i] = testInternalLog(largeBlockNumber, uint(i), "0x1234", "0xabcd")
+		}
+
+		// Test saving and retrieving large data
+		err := store.SaveLogs(ctx, BatchLogType, largeBlockNumber, logs)
+		require.NoError(t, err)
+
+		retrieved, err := store.GetLogs(ctx, BatchLogType, largeBlockNumber)
+		require.NoError(t, err)
+		require.Len(t, retrieved, 1000)
+
+		// Verify first and last logs
+		require.Equal(t, uint(0), retrieved[0].Index)
+		require.Equal(t, uint(999), retrieved[999].Index)
+	})
+}

--- a/eth/loganalyzer/test_helpers.go
+++ b/eth/loganalyzer/test_helpers.go
@@ -1,0 +1,121 @@
+package loganalyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+// TestLogOptions allows customization of test log creation.
+type TestLogOptions struct {
+	BlockNumber uint64
+	Index       uint
+	Address     string
+	TxHash      string
+	Topics      []string
+	Data        []byte
+	Removed     bool
+}
+
+func testLogAnalyzer(t *testing.T) *LogAnalyzer {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	config := Config{Storage: StorageConfig{RetainBlocks: 1000}}
+	analyzer := New(context.Background(), logger, nil, config)
+	require.NotNil(t, analyzer)
+
+	t.Cleanup(func() {
+		<-analyzer.Close()
+	})
+
+	return analyzer
+}
+
+func testStore(t *testing.T) LogAnalyzerStore {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	db, err := badger.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	return NewLogAnalyzerStore(db)
+}
+
+func testAPIHandler(t *testing.T) (*APIHandler, LogAnalyzerStore, *LogAnalyzer) {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	analyzer := testLogAnalyzer(t)
+	store := analyzer.GetStore()
+	handler := NewAPIHandler(logger, store, analyzer)
+	return handler, store, analyzer
+}
+
+func createTestLog(opts TestLogOptions) ethtypes.Log {
+	// Set defaults
+	if opts.Address == "" {
+		opts.Address = "0x1234567890123456789012345678901234567890"
+	}
+	if opts.TxHash == "" {
+		opts.TxHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	}
+	if opts.Topics == nil {
+		opts.Topics = []string{
+			"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+		}
+	}
+	if opts.Data == nil {
+		opts.Data = []byte("test data")
+	}
+
+	topics := make([]common.Hash, len(opts.Topics))
+	for i, topic := range opts.Topics {
+		topics[i] = common.HexToHash(topic)
+	}
+
+	return ethtypes.Log{
+		Address:     common.HexToAddress(opts.Address),
+		BlockNumber: opts.BlockNumber,
+		TxHash:      common.HexToHash(opts.TxHash),
+		Index:       opts.Index,
+		Topics:      topics,
+		Data:        opts.Data,
+		Removed:     opts.Removed,
+	}
+}
+
+func testLog(blockNumber uint64, index uint, address, txHash string) ethtypes.Log {
+	return createTestLog(TestLogOptions{
+		BlockNumber: blockNumber,
+		Index:       index,
+		Address:     address,
+		TxHash:      txHash,
+	})
+}
+
+func testInternalLog(blockNumber uint64, index uint, address, txHash string) InternalLog {
+	ethLog := testLog(blockNumber, index, address, txHash)
+	return ToInternalLog(ethLog)
+}
+
+func simpleTestLog(blockNumber uint64) ethtypes.Log {
+	return createTestLog(TestLogOptions{BlockNumber: blockNumber})
+}
+
+func simpleTestBlockLogs(blockNumber uint64) executionclient.BlockLogs {
+	return executionclient.BlockLogs{
+		BlockNumber: blockNumber,
+		Logs:        []ethtypes.Log{simpleTestLog(blockNumber)},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825140236-3dcbd8c693f7
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.10.0
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1
 	github.com/wealdtech/go-eth2-util v1.8.1
 	go.opentelemetry.io/contrib/exporters/autoexport v0.61.0
@@ -68,6 +69,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/pion/stun/v2 v2.0.0 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -816,6 +816,10 @@ github.com/valyala/fasthttp v1.58.0 h1:GGB2dWxSbEprU9j0iMJHgdKYJVDyjrOwF9RE59PbR
 github.com/valyala/fasthttp v1.58.0/go.mod h1:SYXvHHaFp7QZHGKSHmoMipInhrI5StHrhDTYVEjK/Kw=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSDJfjId/PEGEShv6ugrt4kYsC5UIDaQ=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/wealdtech/go-bytesutil v1.2.1 h1:TjuRzcG5KaPwaR5JB7L/OgJqMQWvlrblA1n0GfcXFSY=


### PR DESCRIPTION
Implement `LogAnalyzer` to compare events received from three sources:

- `eth_getLogs` on `head-8`
- `eth_getLogs` on finalized blocks
- `subscribeFilterLogs` directly

Provides HTTP endpoint to query collected results:

- `http://{{url}}/v1/loganalyzer/stats`
- `http://{{url}}/v1/loganalyzer/health`
- `http://{{url}}/v1/loganalyzer/problematic-blocks`