### PR TITLE
deps: update go-eth2-client

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -421,11 +421,23 @@ func (gc *GoClient) applyBeaconConfig(nodeAddress string, beaconConfig *networkc
 	return gc.beaconConfig, nil
 }
 
-var errSyncing = errors.New("syncing")
+var (
+	errUndefinedResponse = fmt.Errorf("undefined response")
+	errSyncing           = fmt.Errorf("syncing")
+	errOptimistic        = fmt.Errorf("optimistic")
+)
 
-// Healthy returns if the consensus client (for single client) or at least one of consensus clients (for multi client)
-// is currently healthy. It's healthy if it: responds to requests, is not in the syncing state, is not optimistic
-// (for optimistic see https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#block-production).
+// Healthy returns if the consensus client (for single-client) or at least one of consensus clients (for multi-client)
+// is currently healthy.
+// It's healthy if it:
+// - responds to API requests
+// - is already synced (including sync-distance check)
+// - is not optimistic (see https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#block-production)
+// Note, for multi-client case this function is checking every client separately instead of simply relying on the
+// corresponding multi-client `NodeSyncing` endpoint - this is because multi-client implementation does not allow
+// for sync-distance to be > 1 while we do want to allow for that (in case we have multiple clients and none of them
+// has sync-distance of <= 1 we still want Healthy to report success so that SSV node can survive such occasional CL
+// hiccups without having to restart).
 func (gc *GoClient) Healthy(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -446,7 +458,7 @@ func (gc *GoClient) Healthy(ctx context.Context) error {
 		}()
 	}
 
-	// Wait only for the result: either one success, or all errors
+	// Wait only for the result: either one success or all errors
 	var errs error
 	for i := 0; i < len(gc.clients); i++ {
 		select {
@@ -487,12 +499,12 @@ func (gc *GoClient) checkNodeHealth(ctx context.Context, client Client) error {
 	if nodeSyncingResp == nil {
 		logger.Error(clNilResponseErrMsg)
 		recordBeaconClientStatus(ctx, statusUnknown, client.Address())
-		return fmt.Errorf("node syncing response is nil")
+		return fmt.Errorf("%w: node syncing response is nil", errUndefinedResponse)
 	}
 	if nodeSyncingResp.Data == nil {
 		logger.Error(clNilResponseDataErrMsg)
 		recordBeaconClientStatus(ctx, statusUnknown, client.Address())
-		return fmt.Errorf("node syncing data is nil")
+		return fmt.Errorf("%w: node syncing data is nil", errUndefinedResponse)
 	}
 	syncState := nodeSyncingResp.Data
 	recordBeaconClientStatus(ctx, statusSyncing, client.Address())
@@ -504,7 +516,7 @@ func (gc *GoClient) checkNodeHealth(ctx context.Context, client Client) error {
 	}
 	if syncState.IsOptimistic {
 		logger.Error("Consensus client is in optimistic mode")
-		return fmt.Errorf("optimistic")
+		return errOptimistic
 	}
 
 	recordBeaconClientStatus(ctx, statusSynced, client.Address())

--- a/go.mod
+++ b/go.mod
@@ -284,4 +284,4 @@ replace github.com/google/flatbuffers => github.com/google/flatbuffers v1.11.0
 
 replace github.com/dgraph-io/ristretto => github.com/dgraph-io/ristretto v0.1.1-0.20211108053508-297c39e6640f
 
-replace github.com/attestantio/go-eth2-client => github.com/ssvlabs/go-eth2-client v0.6.31-0.20250610091445-4c697a8c1568
+replace github.com/attestantio/go-eth2-client => github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,8 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/ssvlabs/eth2-key-manager v1.5.5 h1:AzwNowGvcmVpRCVHq10FVnpkVIUpoDo5YbJWNMnYA8Q=
 github.com/ssvlabs/eth2-key-manager v1.5.5/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
-github.com/ssvlabs/go-eth2-client v0.6.31-0.20250610091445-4c697a8c1568 h1:aOL0gvDaa9GyAbQIgptzYndUs2+a4fmv1vlpWImx9Ck=
-github.com/ssvlabs/go-eth2-client v0.6.31-0.20250610091445-4c697a8c1568/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
+github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4 h1:/Sq9pcFbr4GJlNIdfMCUHpsCSbYL49TXL/BH0AwD7GU=
+github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d h1:oMznS0mfgfEob1B0nSLZpGaAq0r1dhHFLOZ7PF/JbcA=


### PR DESCRIPTION
This PR updates `go-eth2-client` library (our own fork we use) to the latest version with the main intent to adopt the change implemented in https://github.com/ssvlabs/go-eth2-client/pull/11 

I've also went over the changes in https://github.com/ssvlabs/ssv/pull/2339 to check if https://github.com/ssvlabs/go-eth2-client/pull/11 completely removes the need for these ... unfortunately it doesn't due to the following (as is now documented in the comment for `Healthy` func):
```go
// ... multi-client implementation does not allow
// for sync-distance to be > 1 while we do want to allow for that (in case we have multiple clients and none of them
// has sync-distance of <= 1 we still want Healthy to report success so that SSV node can survive such occasional CL
// hiccups without having to restart).
```

_Before merging:_
- [x] test on **stage**
