### PR TITLE
chore(Makefile): Remove default HostAddress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,6 @@ ifdef DEBUG_PORT
 	@dlv  --continue --accept-multiclient --headless --listen=:${DEBUG_PORT} --api-version=2 exec \
 	 ${BUILD_PATH} start-node -- ${NODE_COMMAND}
 else
-	@echo "Running node on address: ${HOST_ADDRESS})"
 	@${BUILD_PATH} start-node ${NODE_COMMAND}
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,6 @@ ifndef GOPATH
     export GOPATH
 endif
 
-ifndef HOST_ADDRESS
-    HOST_ADDRESS=$(shell dig @resolver4.opendns.com myip.opendns.com +short)
-    export HOST_ADDRESS
-endif
-
 ifndef BUILD_PATH
     BUILD_PATH="/go/bin/ssvnode"
     export BUILD_PATH

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -49,7 +49,11 @@ type Options struct {
 }
 
 // Validate checks if the options are valid.
-func (o *Options) Validate() error {
+func (o *Options) Validate(logger *zap.Logger) error {
+	logger.Debug("validating discovery options",
+		zap.String("host_address", o.HostAddress),
+		zap.String("host_dns", o.HostDNS),
+	)
 	if len(o.HostDNS) > 0 && len(o.HostAddress) > 0 {
 		return fmt.Errorf("only one of HostDNS or HostAddress may be set")
 	}
@@ -68,7 +72,7 @@ type Service interface {
 
 // NewService creates new discovery.Service
 func NewService(ctx context.Context, logger *zap.Logger, opts Options) (Service, error) {
-	if err := opts.Validate(); err != nil {
+	if err := opts.Validate(logger); err != nil {
 		return nil, err
 	}
 

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -49,13 +49,11 @@ type Options struct {
 }
 
 // Validate checks if the options are valid.
-func (o *Options) Validate(logger *zap.Logger) error {
-	logger.Debug("validating discovery options",
-		zap.String("host_address", o.HostAddress),
-		zap.String("host_dns", o.HostDNS),
-	)
+func (o *Options) Validate() error {
 	if len(o.HostDNS) > 0 && len(o.HostAddress) > 0 {
-		return fmt.Errorf("only one of HostDNS or HostAddress may be set")
+		return fmt.Errorf("conflicting host configuration: both HostDNS (%q) and HostAddress (%q) are set,"+
+			" specify only one",
+			o.HostDNS, o.HostAddress)
 	}
 	return nil
 }
@@ -72,7 +70,7 @@ type Service interface {
 
 // NewService creates new discovery.Service
 func NewService(ctx context.Context, logger *zap.Logger, opts Options) (Service, error) {
-	if err := opts.Validate(logger); err != nil {
+	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
> [!NOTE]
> I think we should mention in the release notes that we are now enforcing this behavior and that `HostAddress` default disappears from the build

Related pr: [feat(network/discovery/enode.go): make HostDNS and HostAddress mutually exclusive](https://github.com/ssvlabs/ssv/pull/2274)

Removed the default `HOST_ADDRESS` assignment from the `Makefile`.

Previously, the `Makefile` would automatically assign a public IP to `HOST_ADDRESS` if it wasn't already set. This behavior is being removed because the application requires that either `HostAddress` or `HostDNS` is explicitly provided by the user. The automatic setting in the `Makefile` could override a user's intention to use `HostDNS` or a different IP address.

By removing this default, the configuration becomes more explicit. Users are now required to set either `HOST_ADDRESS` or `HOST_DNS` via their configuration file or environment variables, ensuring the node's network configuration is always intentional.