### PR TITLE
flaky-test: TestScheduler_Attester_Early_Block

### DIFF
--- a/operator/duties/attester_test.go
+++ b/operator/duties/attester_test.go
@@ -904,7 +904,7 @@ func TestScheduler_Attester_Early_Block(t *testing.T) {
 	duties, _ := dutiesMap.Get(phase0.Epoch(0))
 	expected := expectedExecutedAttesterDuties(handler, duties)
 	setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
-	startTime := time.Now()
+	slotStartTime := time.Now()
 	mockTicker.Send(phase0.Slot(2))
 
 	// STEP 4: trigger head event (block arrival)
@@ -915,7 +915,7 @@ func TestScheduler_Attester_Early_Block(t *testing.T) {
 	}
 	scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 	waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
-	require.Less(t, time.Since(startTime), scheduler.beaconConfig.SlotDuration/3)
+	require.Less(t, time.Since(slotStartTime), scheduler.beaconConfig.SlotDuration/3)
 
 	// Stop scheduler & wait for graceful exit.
 	cancel()

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	baseDuration            = 1 * time.Millisecond
+	baseDuration            = 100 * time.Millisecond
 	slotDuration            = 15 * baseDuration
 	timeout                 = 20 * baseDuration
 	noActionTimeout         = 7 * baseDuration


### PR DESCRIPTION
This should resolve the following flaky-test failure I observed when running unit-tests locally:
```
--- FAIL: TestScheduler_Attester_Early_Block (0.04s)
    attester_test.go:918:
        	Error Trace:	/go/src/github.com/ssvlabs/ssv/operator/duties/attester_test.go:918
        	Error:      	"6.010667ms" is not less than "5ms"
        	Test:       	TestScheduler_Attester_Early_Block
```

In general, I think we should use at least `100ms` sleeps in tests at a minimum if we want to rely on go-scheduler timings (execution can easily hang for tens of milliseconds, I'm afraid `100ms` might still not be enough in some cases ... but I think it strikes a good balance between flaky-ness & test run time).