### PR TITLE
metrics: (msg-validation) minor cleanup

### DIFF
--- a/message/validation/observability.go
+++ b/message/validation/observability.go
@@ -20,12 +20,6 @@ const (
 var (
 	meter = otel.Meter(observabilityName)
 
-	messageValidationsCounter = metrics.New(
-		meter.Int64Counter(
-			observabilityNamespace,
-			metric.WithUnit("{message_validation}"),
-			metric.WithDescription("total number of messages validated")))
-
 	messageValidationsAcceptedCounter = metrics.New(
 		meter.Int64Counter(
 			observability.InstrumentName(observabilityNamespace, "accepted"),
@@ -54,10 +48,6 @@ var (
 
 func reasonAttribute(reason string) attribute.KeyValue {
 	return attribute.String("ssv.p2p.message.validation.discard_reason", reason)
-}
-
-func recordMessage(ctx context.Context) {
-	messageValidationsCounter.Add(ctx, 1)
 }
 
 func recordAcceptedMessage(ctx context.Context, role types.RunnerRole) {

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -134,8 +134,6 @@ func (mv *messageValidator) Validate(ctx context.Context, peerID peer.ID, pmsg *
 		messageValidationDurationHistogram.Record(ctx, time.Since(validationStart).Seconds())
 	}()
 
-	recordMessage(ctx)
-
 	decodedMessage, err := mv.handlePubsubMessage(pmsg, time.Now())
 	if err != nil {
 		return mv.handleValidationError(ctx, peerID, decodedMessage, err)


### PR DESCRIPTION
Removing `messageValidationsCounter` in favor of `messageValidationDurationHistogram` that can be used as follows to get the same results:
```
sum by (pod) (
  increase(ssv_p2p_message_validations_duration_seconds_count{pod=~"ssv-node-65-0"}[2m])
) / (2 * 60) * 12
```
^ this is equivalent to the following query (that counts message-validations-per-slot):
```
sum by (pod) (
  increase(ssv_p2p_message_validations_total{pod=~"ssv-node-65-0"}[2m])
) / (2 * 60) * 12
```