### PR TITLE
logs: trim the clutter (on SSV node startup)

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -20,6 +20,8 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap"
 
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
+
 	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
@@ -33,7 +35,6 @@ import (
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
-	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	"github.com/ssvlabs/ssv/utils/async"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 	"github.com/ssvlabs/ssv/utils/tasks"
@@ -93,7 +94,8 @@ type p2pNetwork struct {
 
 	state int32
 
-	activeCommittees *hashmap.Map[string, validatorStatus]
+	// subscribedCommittees tracks committee subscription statuses for committees we've subscribed to.
+	subscribedCommittees *hashmap.Map[string, committeeSubscriptionStatus]
 
 	backoffConnector *libp2pdiscbackoff.BackoffConnector
 
@@ -135,7 +137,7 @@ func New(
 		msgRouter:               cfg.Router,
 		msgValidator:            cfg.MessageValidator,
 		state:                   stateClosed,
-		activeCommittees:        hashmap.New[string, validatorStatus](),
+		subscribedCommittees:    hashmap.New[string, committeeSubscriptionStatus](),
 		nodeStorage:             cfg.NodeStorage,
 		operatorPKHashToPKCache: hashmap.New[string, []byte](),
 		operatorSigner:          cfg.OperatorSigner,


### PR DESCRIPTION
This PR aims to trim down some "excessive/unnecessary logging" we **have a lot of** right after SSV node start (the reason to do it is because it takes time to identify and filter these out when we are trying to debug issues that occur around the time of SSV node restart, see the spike on screenshot below):
- `subscribing to committee` log-line is now only printed once per committee (as opposed to once per share - of which we have thousands)
- everything else we log on startup in bulk is actually quite relevant (eg. we log a lot of `queue consumer is running` - but it's  being logged for each separate **pubkey** which seems fine, I guess)
- these changes additionally: clarify certain variable names, add explanation comments, remove duplicate logging for certain errors around committee-subscription logic

<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/4ed1dddb-792f-4213-a85c-639a67fac06a" />
