### PR TITLE
storage: ListOperatorsAll method

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -1142,7 +1142,7 @@ func syncContractEvents(
 
 		// Print registry stats.
 		shares := nodeStorage.Shares().List(nil)
-		operators, err := nodeStorage.ListOperators(nil, 0, 0)
+		operators, err := nodeStorage.ListOperatorsAll(nil)
 		if err != nil {
 			logger.Error("failed to get operators", zap.Error(err))
 		}

--- a/operator/node.go
+++ b/operator/node.go
@@ -222,14 +222,14 @@ func (n *Node) startWSServer() error {
 }
 
 func (n *Node) reportOperators() {
-	operators, err := n.storage.ListOperators(nil, 0, 1000) // TODO more than 1000?
+	operators, err := n.storage.ListOperatorsAll(nil)
 	if err != nil {
-		n.logger.Warn("failed to get all operators for reporting", zap.Error(err))
+		n.logger.Warn("(reporting) couldn't fetch all operators from DB", zap.Error(err))
 		return
 	}
-	n.logger.Debug("reporting operators", zap.Int("count", len(operators)))
+	n.logger.Debug("(reporting) fetched all stored operators from DB", zap.Int("count", len(operators)))
 	for i := range operators {
-		n.logger.Debug("report operator public key",
+		n.logger.Debug("(reporting) operator fetched from DB",
 			fields.OperatorID(operators[i].ID),
 			fields.OperatorPubKey(operators[i].PublicKey))
 	}

--- a/operator/storage/storage.go
+++ b/operator/storage/storage.go
@@ -124,6 +124,10 @@ func (s *storage) DeleteOperatorData(rw basedb.ReadWriter, id spectypes.Operator
 	return s.operatorStore.DeleteOperatorData(rw, id)
 }
 
+func (s *storage) ListOperatorsAll(r basedb.Reader) ([]registrystorage.OperatorData, error) {
+	return s.operatorStore.ListOperatorsAll(r)
+}
+
 func (s *storage) ListOperators(r basedb.Reader, from uint64, to uint64) ([]registrystorage.OperatorData, error) {
 	return s.operatorStore.ListOperators(r, from, to)
 }

--- a/registry/storage/mocks/operators.go
+++ b/registry/storage/mocks/operators.go
@@ -131,6 +131,21 @@ func (mr *MockOperatorsMockRecorder) ListOperators(r, from, to any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOperators", reflect.TypeOf((*MockOperators)(nil).ListOperators), r, from, to)
 }
 
+// ListOperatorsAll mocks base method.
+func (m *MockOperators) ListOperatorsAll(r basedb.Reader) ([]storage.OperatorData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOperatorsAll", r)
+	ret0, _ := ret[0].([]storage.OperatorData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOperatorsAll indicates an expected call of ListOperatorsAll.
+func (mr *MockOperatorsMockRecorder) ListOperatorsAll(r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOperatorsAll", reflect.TypeOf((*MockOperators)(nil).ListOperatorsAll), r)
+}
+
 // OperatorsExist mocks base method.
 func (m *MockOperators) OperatorsExist(r basedb.Reader, ids []types.OperatorID) (bool, error) {
 	m.ctrl.T.Helper()

--- a/registry/storage/operators.go
+++ b/registry/storage/operators.go
@@ -69,6 +69,7 @@ type Operators interface {
 	OperatorsExist(r basedb.Reader, ids []spectypes.OperatorID) (bool, error)
 	SaveOperatorData(rw basedb.ReadWriter, operatorData *OperatorData) (bool, error)
 	DeleteOperatorData(rw basedb.ReadWriter, id spectypes.OperatorID) error
+	ListOperatorsAll(r basedb.Reader) ([]OperatorData, error)
 	ListOperators(r basedb.Reader, from uint64, to uint64) ([]OperatorData, error)
 	GetOperatorsPrefix() []byte
 	DropOperators() error
@@ -95,13 +96,17 @@ func (s *operatorsStorage) GetOperatorsPrefix() []byte {
 	return operatorsPrefix
 }
 
+// ListOperatorsAll returns data of the all known operators.
+func (s *operatorsStorage) ListOperatorsAll(r basedb.Reader) ([]OperatorData, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.listOperators(r, 0, 0)
+}
+
 // ListOperators returns data of the all known operators by index range (from, to)
 // when 'to' equals zero, all operators will be returned
-func (s *operatorsStorage) ListOperators(
-	r basedb.Reader,
-	from uint64,
-	to uint64,
-) ([]OperatorData, error) {
+func (s *operatorsStorage) ListOperators(r basedb.Reader, from uint64, to uint64) ([]OperatorData, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 


### PR DESCRIPTION
This PR is addressing a `TODO` comment I've spotted while doing something else.

BTW, I'm not 100% sure we need to print all operators (their pubkeys) on SSV node startup ... maybe it's useful but it's ~1k extra log-lines