### PR TITLE
goclient: fix flaky TestGetProposalParallel_MultiClient test

### DIFF
--- a/beacon/goclient/proposer_test.go
+++ b/beacon/goclient/proposer_test.go
@@ -407,7 +407,7 @@ func TestGetProposalParallel_MultiClient(t *testing.T) {
 		blockResponse3 := createProposalResponseSafe(testSlot, feeRecipient3, false)
 
 		server1, _ := createProposalBeaconServer(t, beaconProposalServerOptions{
-			ProposalResponseDuration: 100 * time.Millisecond,
+			ProposalResponseDuration: 500 * time.Millisecond,
 			ProposalResponse:         blockResponse1,
 		})
 		defer server1.Close()
@@ -419,7 +419,7 @@ func TestGetProposalParallel_MultiClient(t *testing.T) {
 		defer server2.Close()
 
 		server3, _ := createProposalBeaconServer(t, beaconProposalServerOptions{
-			ProposalResponseDuration: 200 * time.Millisecond,
+			ProposalResponseDuration: 1000 * time.Millisecond,
 			ProposalResponse:         blockResponse3,
 		})
 		defer server3.Close()


### PR DESCRIPTION
This PR should fix a flaky test (see [this failing pipeline](https://github.com/ssvlabs/ssv/actions/runs/17645921297/job/50143742769)):
```
--- FAIL: TestGetProposalParallel_MultiClient (0.47s)
    --- FAIL: TestGetProposalParallel_MultiClient/races_multiple_clients_for_fastest_response (0.46s)
        proposer_test.go:451: 
            	Error Trace:	/home/runner/work/ssv/ssv/beacon/goclient/proposer_test.go:451
            	Error:      	Not equal: 
            	            	expected: [34 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
            	            	actual  : [17 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,3 +1,3 @@
            	            	 (bellatrix.ExecutionAddress) (len=20) {
            	            	- 00000000  22 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |"...............|
            	            	+ 00000000  11 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
            	            	  00000010  00 00 00 00  
```
I believe the failure is due to execution env hanging for ~100ms (or more) - we probably should use > 100ms sleeps in tests that rely on `Sleep` (cc @oleg-ssvlabs @olegshmuelov @nkryuchkov @julienh-ssv @y0sher @kchojn)