### PR TITLE
node: should start up with 0 active validators (part 2)

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -472,7 +472,7 @@ func (c *Controller) InitValidators() ([]*validator.Validator, error) {
 		registrystorage.ByOperatorID(c.operatorDataStore.GetOperatorID()),
 	)
 	if len(ownShares) == 0 {
-		c.logger.Info("no validators to start: no own non-liquidated validator shares found in DB")
+		c.logger.Info("no validators to initialize: no own non-liquidated validator shares found in DB")
 		return nil, nil
 	}
 


### PR DESCRIPTION
A follow-up to https://github.com/ssvlabs/ssv/pull/2540 to fix a typo/bug with exiting on `if len(validatorsInitialized) == 0`