### PR TITLE
spec-alignment: trigger manually only

### DIFF
--- a/.github/workflows/spec-alignment.yml
+++ b/.github/workflows/spec-alignment.yml
@@ -1,12 +1,7 @@
 name: Spec Alignment
 
 on:
-  push:
-    branches:
-      - stage
-      - main
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   align:


### PR DESCRIPTION
Disables spec-alignment (limit it to manual runs only for now) because it doesn't make much sense to resolve ~75 conflicts on PRs like this one - https://github.com/ssvlabs/ssv/pull/2445