### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/api/handlers/validators/model.go
+++ b/api/handlers/validators/model.go
@@ -18,9 +18,9 @@ func (c *requestClusters) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
-	for _, s := range strings.Split(value, " ") {
+	for s := range strings.SplitSeq(value, " ") {
 		var cluster []uint64
-		for _, s := range strings.Split(s, ",") {
+		for s := range strings.SplitSeq(s, ",") {
 			n, err := strconv.ParseUint(s, 10, 64)
 			if err != nil {
 				return err

--- a/api/types.go
+++ b/api/types.go
@@ -52,7 +52,7 @@ func (hs *HexSlice) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
-	for _, s := range strings.Split(value, ",") {
+	for s := range strings.SplitSeq(value, ",") {
 		var h Hex
 		err := h.Bind(s)
 		if err != nil {
@@ -69,7 +69,7 @@ func (us *Uint64Slice) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
-	for _, s := range strings.Split(value, ",") {
+	for s := range strings.SplitSeq(value, ",") {
 		n, err := strconv.ParseUint(s, 10, 64)
 		if err != nil {
 			return err
@@ -109,7 +109,7 @@ func (rs *RoleSlice) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
-	for _, s := range strings.Split(value, ",") {
+	for s := range strings.SplitSeq(value, ",") {
 		var r Role
 		err := r.Bind(s)
 		if err != nil {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -158,7 +158,7 @@ func (n *p2pNetwork) parseTrustedPeers() error {
 	// Group addresses by peer ID.
 	trustedPeers := map[peer.ID][]ma.Multiaddr{}
 	for _, mas := range n.cfg.TrustedPeers {
-		for _, ma := range strings.Split(mas, ",") {
+		for ma := range strings.SplitSeq(mas, ",") {
 			addrInfo, err := peer.AddrInfoFromString(ma)
 			if err != nil {
 				return fmt.Errorf("could not parse trusted peer: %w", err)


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901
