### PR TITLE
traces: droppable spans

### DIFF
--- a/observability/traces/provider.go
+++ b/observability/traces/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -13,7 +14,9 @@ import (
 
 func InitializeProvider(ctx context.Context, resources *resource.Resource, isEnabled bool) (trace.TracerProvider, func(context.Context) error, error) {
 	if !isEnabled {
-		noopShutdown := func(ctx context.Context) error { return nil }
+		noopShutdown := func(ctx context.Context) error {
+			return nil
+		}
 		return noop.NewTracerProvider(), noopShutdown, nil
 	}
 
@@ -24,8 +27,47 @@ func InitializeProvider(ctx context.Context, resources *resource.Resource, isEna
 
 	provider := sdktrace.NewTracerProvider(
 		sdktrace.WithResource(resources),
-		sdktrace.WithBatcher(autoExporter),
+		sdktrace.WithBatcher(newFilteringExporter(autoExporter)),
 	)
 
 	return provider, autoExporter.Shutdown, nil
+}
+
+type filteringExporter struct {
+	delegate sdktrace.SpanExporter
+}
+
+func newFilteringExporter(delegate sdktrace.SpanExporter) *filteringExporter {
+	return &filteringExporter{
+		delegate: delegate,
+	}
+}
+
+func (fe *filteringExporter) ExportSpans(ctx context.Context, rs []sdktrace.ReadOnlySpan) error {
+	hasBoolAttr := func(attrs []attribute.KeyValue, key string) bool {
+		for _, kv := range attrs {
+			if string(kv.Key) == key && kv.Value.Type() == attribute.BOOL && kv.Value.AsBool() {
+				return true
+			}
+		}
+		return false
+	}
+
+	result := make([]sdktrace.ReadOnlySpan, 0, len(rs))
+	for _, s := range rs {
+		if hasBoolAttr(s.Attributes(), droppableSpan) {
+			continue // drop this span
+		}
+		result = append(result, s)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return fe.delegate.ExportSpans(ctx, result)
+}
+
+func (fe *filteringExporter) Shutdown(ctx context.Context) error {
+	return fe.delegate.Shutdown(ctx)
 }

--- a/observability/traces/span.go
+++ b/observability/traces/span.go
@@ -1,0 +1,13 @@
+package traces
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	droppableSpan = "span.droppable"
+)
+
+func DroppableSpan() attribute.KeyValue {
+	return attribute.Bool(droppableSpan, true)
+}

--- a/observability/traces/trace.go
+++ b/observability/traces/trace.go
@@ -41,8 +41,7 @@ func Context(ctx context.Context, str string) context.Context {
 // Errorf sets the status of the span to error and returns an error with the formatted message.
 func Errorf(span trace.Span, f string, args ...any) error {
 	err := fmt.Errorf(f, args...)
-	span.SetStatus(codes.Error, err.Error())
-	return err
+	return Error(span, err)
 }
 
 func Error(span trace.Span, err error) error {

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
-	"github.com/ssvlabs/ssv/observability/traces"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
@@ -116,7 +115,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 
 	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, r, signedMsg)
 	if err != nil {
-		return traces.Errorf(span, "failed processing selection proof message: %w", err)
+		return tracedErrorf(span, "failed processing selection proof message: %w", err)
 	}
 	// quorum returns true only once (first time quorum achieved)
 	if !hasQuorum {
@@ -140,7 +139,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.BaseRunner.FallBackAndVerifyEachSignature(r.GetState().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return traces.Errorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
+		return tracedErrorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 
 	// signer must be same for all messages, at least 1 message must be present (this is validated prior)
@@ -174,13 +173,13 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 			observability.ValidatorIndexAttribute(duty.ValidatorIndex)))
 	res, ver, err := r.GetBeaconNode().SubmitAggregateSelectionProof(ctx, duty.Slot, duty.CommitteeIndex, duty.CommitteeLength, duty.ValidatorIndex, fullSig)
 	if err != nil {
-		return traces.Errorf(span, "failed to submit aggregate and proof: %w", err)
+		return tracedErrorf(span, "failed to submit aggregate and proof: %w", err)
 	}
 	r.measurements.ContinueDutyFlow()
 
 	byts, err := res.MarshalSSZ()
 	if err != nil {
-		return traces.Errorf(span, "could not marshal aggregate and proof: %w", err)
+		return tracedErrorf(span, "could not marshal aggregate and proof: %w", err)
 	}
 	input := &spectypes.ValidatorConsensusData{
 		Duty:    *duty,
@@ -189,7 +188,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	}
 
 	if err := r.BaseRunner.decide(ctx, logger, r, duty.Slot, input, r.ValCheck); err != nil {
-		return traces.Errorf(span, "can't start new duty runner instance for duty: %w", err)
+		return tracedErrorf(span, "can't start new duty runner instance for duty: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -209,7 +208,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	span.AddEvent("checking if instance is decided")
 	decided, encDecidedValue, err := r.BaseRunner.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
 	if err != nil {
-		return traces.Errorf(span, "failed processing consensus message: %w", err)
+		return tracedErrorf(span, "failed processing consensus message: %w", err)
 	}
 
 	// Decided returns true only once so if it is true it must be for the current running instance
@@ -233,7 +232,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 
 	_, aggregateAndProofHashRoot, err := decidedValue.GetAggregateAndProof()
 	if err != nil {
-		return traces.Errorf(span, "could not get aggregate and proof: %w", err)
+		return tracedErrorf(span, "could not get aggregate and proof: %w", err)
 	}
 
 	span.AddEvent("signing post consensus")
@@ -247,7 +246,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 		spectypes.DomainAggregateAndProof,
 	)
 	if err != nil {
-		return traces.Errorf(span, "failed signing aggregate and proof: %w", err)
+		return tracedErrorf(span, "failed signing aggregate and proof: %w", err)
 	}
 
 	postConsensusMsg := &spectypes.PartialSignatureMessages{
@@ -260,7 +259,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 
 	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
-		return traces.Errorf(span, "could not encode post consensus partial signature message: %w", err)
+		return tracedErrorf(span, "could not encode post consensus partial signature message: %w", err)
 	}
 
 	ssvMsg := &spectypes.SSVMessage{
@@ -272,7 +271,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	span.AddEvent("signing post consensus partial signature message")
 	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
 	if err != nil {
-		return traces.Errorf(span, "could not sign post-consensus partial signature message: %w", err)
+		return tracedErrorf(span, "could not sign post-consensus partial signature message: %w", err)
 	}
 
 	msgToBroadcast := &spectypes.SignedSSVMessage{
@@ -283,7 +282,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 
 	span.AddEvent("broadcasting post consensus partial signature message")
 	if err := r.GetNetwork().Broadcast(msgID, msgToBroadcast); err != nil {
-		return traces.Errorf(span, "can't broadcast partial post consensus sig: %w", err)
+		return tracedErrorf(span, "can't broadcast partial post consensus sig: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -301,7 +300,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 
 	hasQuorum, roots, err := r.BaseRunner.basePostConsensusMsgProcessing(ctx, r, signedMsg)
 	if err != nil {
-		return traces.Errorf(span, "failed processing post consensus message: %w", err)
+		return tracedErrorf(span, "failed processing post consensus message: %w", err)
 	}
 
 	span.SetAttributes(
@@ -326,7 +325,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.BaseRunner.FallBackAndVerifyEachSignature(r.GetState().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return traces.Errorf(span, "got post-consensus quorum but it has invalid signatures: %w", err)
+		return tracedErrorf(span, "got post-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], sig)
@@ -334,16 +333,16 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	cd := &spectypes.ValidatorConsensusData{}
 	err = cd.Decode(r.GetState().DecidedValue)
 	if err != nil {
-		return traces.Errorf(span, "could not decode consensus data: %w", err)
+		return tracedErrorf(span, "could not decode consensus data: %w", err)
 	}
 	aggregateAndProof, _, err := cd.GetAggregateAndProof()
 	if err != nil {
-		return traces.Errorf(span, "could not get aggregate and proof: %w", err)
+		return tracedErrorf(span, "could not get aggregate and proof: %w", err)
 	}
 
 	msg, err := constructVersionedSignedAggregateAndProof(*aggregateAndProof, specSig)
 	if err != nil {
-		return traces.Errorf(span, "could not construct versioned aggregate and proof: %w", err)
+		return tracedErrorf(span, "could not construct versioned aggregate and proof: %w", err)
 	}
 
 	start := time.Now()
@@ -351,7 +350,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 		recordFailedSubmission(ctx, spectypes.BNRoleAggregator)
 		const errMsg = "could not submit to Beacon chain reconstructed contribution and proof"
 		logger.Error(errMsg, fields.SubmissionTime(time.Since(start)), zap.Error(err))
-		return traces.Errorf(span, "%s: %w", errMsg, err)
+		return tracedErrorf(span, "%s: %w", errMsg, err)
 	}
 	const eventMsg = "✅ successful submitted aggregate"
 	span.AddEvent(eventMsg)
@@ -423,7 +422,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 		spectypes.DomainSelectionProof,
 	)
 	if err != nil {
-		return traces.Errorf(span, "could not sign randao: %w", err)
+		return tracedErrorf(span, "could not sign randao: %w", err)
 	}
 	msgs := &spectypes.PartialSignatureMessages{
 		Type:     spectypes.SelectionProofPartialSig,
@@ -434,7 +433,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return traces.Errorf(span, "could not encode selection proof partial signature message: %w", err)
+		return tracedErrorf(span, "could not encode selection proof partial signature message: %w", err)
 	}
 
 	r.measurements.StartConsensus()
@@ -448,7 +447,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 	span.AddEvent("signing SSV message")
 	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
 	if err != nil {
-		return traces.Errorf(span, "could not sign SSVMessage: %w", err)
+		return tracedErrorf(span, "could not sign SSVMessage: %w", err)
 	}
 
 	msgToBroadcast := &spectypes.SignedSSVMessage{
@@ -459,7 +458,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 
 	span.AddEvent("broadcasting signed SSV message")
 	if err := r.GetNetwork().Broadcast(msgID, msgToBroadcast); err != nil {
-		return traces.Errorf(span, "can't broadcast partial selection proof sig: %w", err)
+		return tracedErrorf(span, "can't broadcast partial selection proof sig: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/protocol/v2/ssv/runner/error.go
+++ b/protocol/v2/ssv/runner/error.go
@@ -3,6 +3,10 @@ package runner
 import (
 	"errors"
 	"fmt"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ssvlabs/ssv/observability/traces"
 )
 
 var (
@@ -46,4 +50,20 @@ func (e RetryableError) Unwrap() error {
 func IsRetryable(err error) bool {
 	var retryableErr *RetryableError
 	return errors.As(err, &retryableErr)
+}
+
+// Errorf sets the status of the span to error and returns an error with the formatted message.
+func tracedErrorf(span trace.Span, f string, args ...any) error {
+	err := fmt.Errorf(f, args...)
+	return tracedError(span, err)
+}
+
+func tracedError(span trace.Span, err error) error {
+	// In case of retryable error, mark this span as "droppable" since we don't necessarily want to
+	// keep track of those retried spans (these generate lots of useless data).
+	if IsRetryable(err) {
+		span.SetAttributes(traces.DroppableSpan())
+	}
+
+	return traces.Error(span, err)
 }

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
-	"github.com/ssvlabs/ssv/observability/traces"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/instance"
@@ -215,13 +214,13 @@ func (b *BaseRunner) baseStartNewDuty(ctx context.Context, logger *zap.Logger, r
 	defer span.End()
 
 	if err := b.ShouldProcessDuty(duty); err != nil {
-		return traces.Errorf(span, "can't start duty: %w", err)
+		return tracedErrorf(span, "can't start duty: %w", err)
 	}
 
 	b.baseSetupForNewDuty(duty, quorum)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
-		return traces.Errorf(span, "failed to execute duty: %w", err)
+		return tracedErrorf(span, "failed to execute duty: %w", err)
 	}
 	span.SetStatus(codes.Ok, "")
 	return nil
@@ -394,11 +393,11 @@ func (b *BaseRunner) decide(
 
 	byts, err := input.Encode()
 	if err != nil {
-		return traces.Errorf(span, "could not encode input data for consensus: %w", err)
+		return tracedErrorf(span, "could not encode input data for consensus: %w", err)
 	}
 
 	if err := valueChecker.CheckValue(byts); err != nil {
-		return traces.Errorf(span, "input data invalid: %w", err)
+		return tracedErrorf(span, "input data invalid: %w", err)
 	}
 
 	span.AddEvent("start new instance")
@@ -409,11 +408,11 @@ func (b *BaseRunner) decide(
 		byts,
 		valueChecker,
 	); err != nil {
-		return traces.Errorf(span, "could not start new QBFT instance: %w", err)
+		return tracedErrorf(span, "could not start new QBFT instance: %w", err)
 	}
 	newInstance := b.QBFTController.StoredInstances.FindInstance(b.QBFTController.Height)
 	if newInstance == nil {
-		return traces.Errorf(span, "could not find newly created QBFT instance")
+		return tracedErrorf(span, "could not find newly created QBFT instance")
 	}
 
 	b.State.RunningInstance = newInstance

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
-	"github.com/ssvlabs/ssv/observability/traces"
 	"github.com/ssvlabs/ssv/operator/slotticker"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
@@ -104,7 +103,7 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 
 	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, r, signedMsg)
 	if err != nil {
-		return traces.Errorf(span, "failed processing validator registration message: %w", err)
+		return tracedErrorf(span, "failed processing validator registration message: %w", err)
 	}
 
 	logger.Debug("got partial sig",
@@ -126,14 +125,14 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.BaseRunner.FallBackAndVerifyEachSignature(r.GetState().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return traces.Errorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
+		return tracedErrorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], fullSig)
 
 	registration, err := r.buildValidatorRegistration(r.BaseRunner.State.CurrentDuty.DutySlot())
 	if err != nil {
-		return traces.Errorf(span, "could not calculate validator registration: %w", err)
+		return tracedErrorf(span, "could not calculate validator registration: %w", err)
 	}
 
 	signedRegistration := &api.VersionedSignedValidatorRegistration{
@@ -146,7 +145,7 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 
 	span.AddEvent("submitting validator registration")
 	if err := r.validatorRegistrationSubmitter.Enqueue(signedRegistration); err != nil {
-		return traces.Errorf(span, "could not submit validator registration: %w", err)
+		return tracedErrorf(span, "could not submit validator registration: %w", err)
 	}
 
 	const eventMsg = "validator registration submitted successfully"
@@ -199,7 +198,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 
 	vr, err := r.buildValidatorRegistration(duty.DutySlot())
 	if err != nil {
-		return traces.Errorf(span, "could not calculate validator registration: %w", err)
+		return tracedErrorf(span, "could not calculate validator registration: %w", err)
 	}
 
 	// sign partial randao
@@ -213,7 +212,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 		spectypes.DomainApplicationBuilder,
 	)
 	if err != nil {
-		return traces.Errorf(span, "could not sign validator registration: %w", err)
+		return tracedErrorf(span, "could not sign validator registration: %w", err)
 	}
 
 	msgs := &spectypes.PartialSignatureMessages{
@@ -225,7 +224,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return traces.Errorf(span, "could not encode validator registration partial sig message: %w", err)
+		return tracedErrorf(span, "could not encode validator registration partial sig message: %w", err)
 	}
 
 	ssvMsg := &spectypes.SSVMessage{
@@ -237,7 +236,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 	span.AddEvent("signing SSV message")
 	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
 	if err != nil {
-		return traces.Errorf(span, "could not sign SSVMessage: %w", err)
+		return tracedErrorf(span, "could not sign SSVMessage: %w", err)
 	}
 
 	msgToBroadcast := &spectypes.SignedSSVMessage{
@@ -249,7 +248,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 	logger.Debug("broadcasting validator registration partial sig", zap.Any("validator_registration", vr))
 
 	if err := r.GetNetwork().Broadcast(msgID, msgToBroadcast); err != nil {
-		return traces.Errorf(span, "can't broadcast partial randao sig: %w", err)
+		return tracedErrorf(span, "can't broadcast partial randao sig: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
-	"github.com/ssvlabs/ssv/observability/traces"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -93,7 +92,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 
 	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, r, signedMsg)
 	if err != nil {
-		return traces.Errorf(span, "failed processing voluntary exit message: %w", err)
+		return tracedErrorf(span, "failed processing voluntary exit message: %w", err)
 	}
 
 	// quorum returns true only once (first time quorum achieved)
@@ -110,7 +109,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.BaseRunner.FallBackAndVerifyEachSignature(r.GetState().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return traces.Errorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
+		return tracedErrorf(span, "got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], fullSig)
@@ -123,7 +122,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 
 	span.AddEvent("submitting voluntary exit")
 	if err := r.beacon.SubmitVoluntaryExit(ctx, signedVoluntaryExit); err != nil {
-		return traces.Errorf(span, "could not submit voluntary exit: %w", err)
+		return tracedErrorf(span, "could not submit voluntary exit: %w", err)
 	}
 
 	const eventMsg = "✅ successfully submitted voluntary exit"
@@ -175,7 +174,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 
 	voluntaryExit, err := r.calculateVoluntaryExit()
 	if err != nil {
-		return traces.Errorf(span, "could not calculate voluntary exit: %w", err)
+		return tracedErrorf(span, "could not calculate voluntary exit: %w", err)
 	}
 
 	// get PartialSignatureMessage with voluntaryExit root and signature
@@ -189,7 +188,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 		spectypes.DomainVoluntaryExit,
 	)
 	if err != nil {
-		return traces.Errorf(span, "could not sign VoluntaryExit object: %w", err)
+		return tracedErrorf(span, "could not sign VoluntaryExit object: %w", err)
 	}
 
 	msgs := &spectypes.PartialSignatureMessages{
@@ -201,7 +200,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return traces.Errorf(span, "could not encode PartialSignatureMessages: %w", err)
+		return tracedErrorf(span, "could not encode PartialSignatureMessages: %w", err)
 	}
 
 	ssvMsg := &spectypes.SSVMessage{
@@ -213,7 +212,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 	span.AddEvent("signing SSV message")
 	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
 	if err != nil {
-		return traces.Errorf(span, "could not sign SSVMessage: %w", err)
+		return tracedErrorf(span, "could not sign SSVMessage: %w", err)
 	}
 
 	msgToBroadcast := &spectypes.SignedSSVMessage{
@@ -224,7 +223,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 
 	span.AddEvent("broadcasting signed SSV message")
 	if err := r.GetNetwork().Broadcast(msgID, msgToBroadcast); err != nil {
-		return traces.Errorf(span, "can't broadcast signedPartialMsg with VoluntaryExit: %w", err)
+		return tracedErrorf(span, "can't broadcast signedPartialMsg with VoluntaryExit: %w", err)
 	}
 
 	// stores value for later using in ProcessPreConsensus


### PR DESCRIPTION
This PR adds a tracing middleware that allows us to filter out certain spans (marked with `DroppableSpan` attribute) before sending the data to the server.

This is needed because tracing is typically done for the entire func (meaning for **every** func-call a span will be generated, recorded & sent to the server), while for some funcs we want to record & send only **certain** func-call outcomes (not each one of them); For example, we don't want to record & send every retry-call because this will generate a lot of useless data.

Implementation-wise, seems like there is no `span.Discard()` (or similar) we could use on a `span` object directly ... so we have to use an attribute to "mark a particular span".
