### PR TITLE
p2p: adjust connection settings

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -38,7 +38,7 @@ const (
 	defaultReqTimeout = 10 * time.Second
 	// backoffLow is the min value backoff strategy will use for its delay
 	backoffLow = 10 * time.Second
-	// backoffLow is the max value backoff strategy will use for its delay
+	// backoffHigh is the max value backoff strategy will use for its delay
 	backoffHigh = 5 * time.Minute
 	// backoffExponentBase is the base of the backoff exponent
 	backoffExponentBase = 2.0


### PR DESCRIPTION
While investigating some p2p connection issues (reported by some Operators) I've noticed we could "tighten" some p2p-connection-related settings:
- `backoffHigh` at 30m seems too high, I think there is no reason to wait that long for retrying to reconnect a peer (set it to 5m instead, but maybe we should go even lower because I don't see the `BackoffStrategy.Reset` being called - which probably means "the accumulated backoff penalty only resets upon SSV node restart")
- the rest of the values look good to me