### PR TITLE
runners: remove retry-related log-lines

### DIFF
--- a/protocol/v2/ssv/validator/committee_queue.go
+++ b/protocol/v2/ssv/validator/committee_queue.go
@@ -227,12 +227,12 @@ func (c *Committee) ConsumeQueue(
 			case runner.IsRetryable(err) && msgState.attempts <= retryCount:
 				msgState.attempts++
 				msgStates.Set(msgKey, msgState, ttlcache.DefaultTTL)
-				var retryingMsgDueToErrorEvent = fmt.Sprintf(couldNotHandleMsgLogPrefix+"retrying message in ~%dms", retryDelay.Milliseconds())
-				msgLogger.Debug(retryingMsgDueToErrorEvent, zap.Error(err))
-				msgState.span.AddEvent(retryingMsgDueToErrorEvent, trace.WithAttributes(
-					attribute.String("retry_reason", err.Error()),
-					attribute.Int64("attempt", currentAttempt),
-				))
+				msgState.span.AddEvent(fmt.Sprintf(couldNotHandleMsgLogPrefix+"retrying in ~%dms", retryDelay.Milliseconds()),
+					trace.WithAttributes(
+						attribute.String("retry_reason", err.Error()),
+						attribute.Int64("attempt", currentAttempt),
+					),
+				)
 				go func(msg *queue.SSVMessage, msgState *messageProcessingState, attempt int64) {
 					select {
 					case <-time.After(retryDelay):

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -230,12 +230,12 @@ func (v *Validator) StartQueueConsumer(
 				case runner.IsRetryable(err) && msgState.attempts <= retryCount:
 					msgState.attempts++
 					msgStates.Set(msgKey, msgState, ttlcache.DefaultTTL)
-					var retryingMsgDueToErrorEvent = fmt.Sprintf(couldNotHandleMsgLogPrefix+"retrying message in ~%dms", retryDelay.Milliseconds())
-					msgLogger.Debug(retryingMsgDueToErrorEvent, zap.Error(err))
-					msgState.span.AddEvent(retryingMsgDueToErrorEvent, trace.WithAttributes(
-						attribute.String("retry_reason", err.Error()),
-						attribute.Int64("attempt", currentAttempt),
-					))
+					msgState.span.AddEvent(fmt.Sprintf(couldNotHandleMsgLogPrefix+"retrying in ~%dms", retryDelay.Milliseconds()),
+						trace.WithAttributes(
+							attribute.String("retry_reason", err.Error()),
+							attribute.Int64("attempt", currentAttempt),
+						),
+					)
 					go func(msg *queue.SSVMessage, msgState *messageProcessingState, attempt int64) {
 						select {
 						case <-time.After(retryDelay):


### PR DESCRIPTION
This reduces our log-volume removing retry-related logs that are mostly not necessary (were used for debugging previously).