### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/api/bind.go
+++ b/api/bind.go
@@ -17,7 +17,7 @@ type Binder interface {
 
 var errInvalidType = errors.New("invalid type")
 
-func Bind(r *http.Request, dest interface{}) error {
+func Bind(r *http.Request, dest any) error {
 	if err := r.ParseForm(); err != nil {
 		return err
 	}

--- a/api/bind_test.go
+++ b/api/bind_test.go
@@ -38,7 +38,7 @@ type TestStructPointer struct {
 }
 
 // runTestBindForm is a helper that binds form data to dest and then runs the provided validation.
-func runTestBindForm(t *testing.T, dest interface{}, validate func(*testing.T, interface{})) {
+func runTestBindForm(t *testing.T, dest any, validate func(*testing.T, any)) {
 	form := url.Values{
 		"name":  []string{"John Doe"},
 		"age":   []string{"30"},
@@ -61,7 +61,7 @@ func TestBindFormNonPointer(t *testing.T) {
 	t.Parallel()
 
 	dest := &TestStructNonPointer{}
-	validate := func(t *testing.T, dest interface{}) {
+	validate := func(t *testing.T, dest any) {
 		s, ok := dest.(*TestStructNonPointer)
 
 		require.True(t, ok)
@@ -80,7 +80,7 @@ func TestBindFormPointer(t *testing.T) {
 	t.Parallel()
 
 	dest := &TestStructPointer{}
-	validate := func(t *testing.T, dest interface{}) {
+	validate := func(t *testing.T, dest any) {
 		s, ok := dest.(*TestStructPointer)
 
 		require.True(t, ok)
@@ -296,7 +296,7 @@ func TestInvalidDestinationType(t *testing.T) {
 
 	testCases := []struct {
 		name string
-		dest interface{}
+		dest any
 	}{
 		{"non-pointer", TestStructNonPointer{}},
 		{"pointer to non-struct", new(string)},

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -149,14 +149,14 @@ func TestTransformToParticipantResponse(t *testing.T) {
 func TestExporterDecideds(t *testing.T) {
 	tests := []struct {
 		name           string
-		request        map[string]interface{}
+		request        map[string]any
 		setupMock      func(*mockParticipantStore)
 		expectedStatus int
 		validateResp   func(*testing.T, *httptest.ResponseRecorder)
 	}{
 		{
 			name: "valid request - roles & slot range",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from":  100,
 				"to":    200,
 				"roles": []string{"ATTESTER"},
@@ -197,7 +197,7 @@ func TestExporterDecideds(t *testing.T) {
 		},
 		{
 			name: "valid request - pubkeys filter",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from":    100,
 				"to":      200,
 				"roles":   []string{"ATTESTER"},
@@ -232,7 +232,7 @@ func TestExporterDecideds(t *testing.T) {
 		},
 		{
 			name: "invalid request - from > to",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from":  200,
 				"to":    100,
 				"roles": []string{"ATTESTER"},
@@ -253,7 +253,7 @@ func TestExporterDecideds(t *testing.T) {
 		},
 		{
 			name: "invalid request - no roles",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from": 100,
 				"to":   200,
 			},
@@ -273,7 +273,7 @@ func TestExporterDecideds(t *testing.T) {
 		},
 		{
 			name: "multiple roles",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from":  100,
 				"to":    200,
 				"roles": []string{"ATTESTER", "PROPOSER"},
@@ -303,7 +303,7 @@ func TestExporterDecideds(t *testing.T) {
 		},
 		{
 			name: "invalid request - invalid pubkey length",
-			request: map[string]interface{}{
+			request: map[string]any{
 				"from":    100,
 				"to":      200,
 				"roles":   []string{"ATTESTER"},
@@ -403,7 +403,7 @@ func TestExporterDecideds_ErrorGetAllParticipantsInRange(t *testing.T) {
 	stores.Add(spectypes.BNRoleAttester, store)
 
 	exporter := NewExporter(zap.NewNop(), stores, nil, nil)
-	reqData := map[string]interface{}{
+	reqData := map[string]any{
 		"from":  100,
 		"to":    200,
 		"roles": []string{"ATTESTER"},
@@ -447,7 +447,7 @@ func TestExporterDecideds_ErrorGetParticipantsInRange(t *testing.T) {
 
 	exporter := NewExporter(zap.NewNop(), stores, nil, nil)
 
-	reqData := map[string]interface{}{
+	reqData := map[string]any{
 		"from":    100,
 		"to":      200,
 		"roles":   []string{"ATTESTER"},

--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -253,7 +253,7 @@ func TestHealthCheckJSONString(t *testing.T) {
 	hc.Advanced.ListenAddresses = []string{"127.0.0.1:8000"}
 
 	s := hc.String()
-	var result map[string]interface{}
+	var result map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(s), &result))
 	require.Equal(t, "bad: not enough connected peers", result["p2p"])
@@ -261,11 +261,11 @@ func TestHealthCheckJSONString(t *testing.T) {
 	require.Equal(t, "good", result["execution_node"])
 	require.Equal(t, "good", result["event_syncer"])
 
-	advanced, ok := result["advanced"].(map[string]interface{})
+	advanced, ok := result["advanced"].(map[string]any)
 
 	require.True(t, ok)
 	require.Equal(t, float64(3), advanced["peers"])
 	require.Equal(t, float64(3), advanced["inbound_conns"])
 	require.Equal(t, float64(0), advanced["outbound_conns"])
-	require.Equal(t, []interface{}{"127.0.0.1:8000"}, advanced["p2p_listen_addresses"])
+	require.Equal(t, []any{"127.0.0.1:8000"}, advanced["p2p_listen_addresses"])
 }

--- a/api/handling_test.go
+++ b/api/handling_test.go
@@ -56,7 +56,7 @@ func TestRender(t *testing.T) {
 		{
 			name:              "fallthrough json when no fmt.stringer with text/plain",
 			acceptHeader:      "text/plain",
-			response:          map[string]interface{}{"key": "value"},
+			response:          map[string]any{"key": "value"},
 			wantContentType:   "application/json",
 			wantBodySubstring: `"key":"value"`,
 		},
@@ -70,14 +70,14 @@ func TestRender(t *testing.T) {
 		{
 			name:              "explicit json rendering",
 			acceptHeader:      "application/json",
-			response:          map[string]interface{}{"foo": "bar", "baz": 123},
+			response:          map[string]any{"foo": "bar", "baz": 123},
 			wantContentType:   "application/json",
 			wantBodySubstring: `"foo":"bar"`,
 		},
 		{
 			name:              "default json when no accept header",
 			acceptHeader:      "",
-			response:          map[string]interface{}{"key": "value"},
+			response:          map[string]any{"key": "value"},
 			wantContentType:   "application/json",
 			wantBodySubstring: `"key":"value"`,
 		},

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -36,7 +36,7 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	router.Use(middlewareNodeVersion)
 
 	nodeIdentityHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, map[string]interface{}{
+		err := api.Render(w, r, map[string]any{
 			"peer_id":   "test-node-id",
 			"addresses": []string{"test-address"},
 			"subnets":   "test-subnets",
@@ -48,7 +48,7 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	}
 
 	nodePeersHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, []map[string]interface{}{
+		err := api.Render(w, r, []map[string]any{
 			{"id": "peer1", "addresses": []string{"addr1"}},
 		})
 		if err != nil {
@@ -57,9 +57,9 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	}
 
 	nodeTopicsHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, map[string]interface{}{
+		err := api.Render(w, r, map[string]any{
 			"all_peers": []string{"peer1", "peer2"},
-			"peers_by_topic": []map[string]interface{}{
+			"peers_by_topic": []map[string]any{
 				{
 					"topic": "topic1",
 					"peers": []string{"peer1"},
@@ -72,12 +72,12 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	}
 
 	nodeHealthHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, map[string]interface{}{
+		err := api.Render(w, r, map[string]any{
 			"p2p":            "good",
 			"beacon_node":    "good",
 			"execution_node": "good",
 			"event_syncer":   "good",
-			"advanced": map[string]interface{}{
+			"advanced": map[string]any{
 				"peers":                2,
 				"inbound_conns":        1,
 				"outbound_conns":       1,
@@ -90,8 +90,8 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	}
 
 	validatorsListHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, map[string]interface{}{
-			"data": []map[string]interface{}{
+		err := api.Render(w, r, map[string]any{
+			"data": []map[string]any{
 				{"validator": "1", "pubkey": "0x123"},
 			},
 		})
@@ -101,8 +101,8 @@ func setupTestServer(t *testing.T) *httptest.Server {
 	}
 
 	exporterDecidedsHandler := func(w http.ResponseWriter, r *http.Request) {
-		err := api.Render(w, r, map[string]interface{}{
-			"data": []map[string]interface{}{
+		err := api.Render(w, r, map[string]any{
+			"data": []map[string]any{
 				{"slot": 1, "role": "attester"},
 			},
 		})

--- a/beacon/goclient/proposer_test.go
+++ b/beacon/goclient/proposer_test.go
@@ -140,7 +140,7 @@ func createProposalResponseSafe(slot phase0.Slot, feeRecipient bellatrix.Executi
 		block.Body.ExecutionPayloadHeader.FeeRecipient = feeRecipient
 
 		// Wrap in response structure
-		response := map[string]interface{}{
+		response := map[string]any{
 			"data": block,
 		}
 		data, _ := json.Marshal(response)
@@ -156,7 +156,7 @@ func createProposalResponseSafe(slot phase0.Slot, feeRecipient bellatrix.Executi
 	blockContents.Block.Body.ExecutionPayload.FeeRecipient = feeRecipient
 
 	// Wrap in response structure
-	response := map[string]interface{}{
+	response := map[string]any{
 		"data": blockContents,
 	}
 	data, _ := json.Marshal(response)

--- a/beacon/goclient/signing.go
+++ b/beacon/goclient/signing.go
@@ -95,7 +95,7 @@ func (gc *GoClient) DomainData(
 //	       object_root=hash_tree_root(ssz_object),
 //	       domain=domain,
 //	   ))
-func (gc *GoClient) ComputeSigningRoot(object interface{}, domain phase0.Domain) ([32]byte, error) {
+func (gc *GoClient) ComputeSigningRoot(object any, domain phase0.Domain) ([32]byte, error) {
 	if object == nil {
 		return [32]byte{}, errors.New("cannot compute signing root of nil")
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -27,7 +27,7 @@ type Global struct {
 }
 
 // ProcessArgs processes and handles CLI arguments
-func ProcessArgs(cfg interface{}, a *Args, cmd *cobra.Command) {
+func ProcessArgs(cfg any, a *Args, cmd *cobra.Command) {
 	configFlag := "config"
 	cmd.PersistentFlags().StringVarP(&a.ConfigPath, configFlag, "c", "./config/config.yaml", "Path to configuration file")
 	_ = cmd.MarkFlagRequired(configFlag)
@@ -40,7 +40,7 @@ func ProcessArgs(cfg interface{}, a *Args, cmd *cobra.Command) {
 	cmd.SetUsageTemplate(envHelp + "\n" + cmd.UsageTemplate())
 }
 
-func Prepare(cfg interface{}, a *Args) error {
+func Prepare(cfg any, a *Args) error {
 	if a.ConfigPath != "" {
 		err := cleanenv.ReadConfig(a.ConfigPath, cfg)
 		if err != nil {

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -346,7 +346,7 @@ func TestFetchHistoricalLogs_Subdivide(t *testing.T) {
 
 			wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				raw, _ := io.ReadAll(r.Body)
-				var req map[string]interface{}
+				var req map[string]any
 				_ = json.Unmarshal(raw, &req)
 
 				if req["method"] == "eth_getLogs" {
@@ -357,15 +357,15 @@ func TestFetchHistoricalLogs_Subdivide(t *testing.T) {
 						return
 					}
 
-					flt := req["params"].([]interface{})[0].(map[string]interface{})
+					flt := req["params"].([]any)[0].(map[string]any)
 					from, _ := strconv.ParseInt(strings.TrimPrefix(flt["fromBlock"].(string), "0x"), 16, 64)
 					to, _ := strconv.ParseInt(strings.TrimPrefix(flt["toBlock"].(string), "0x"), 16, 64)
 					if uint64(to-from) > tc.threshold {
 						w.Header().Set("Content-Type", "application/json")
-						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						_ = json.NewEncoder(w).Encode(map[string]any{
 							"jsonrpc": "2.0",
 							"id":      req["id"],
-							"error": map[string]interface{}{
+							"error": map[string]any{
 								"code":    -32005,
 								"message": "query limit exceeded",
 							},

--- a/eth/localevents/local_events.go
+++ b/eth/localevents/local_events.go
@@ -19,7 +19,7 @@ type Event struct {
 	// Name is the event name used for internal representation.
 	Name string
 	// Data is the parsed event
-	Data interface{}
+	Data any
 }
 
 func Load(path string) ([]Event, error) {
@@ -37,7 +37,7 @@ func Load(path string) ([]Event, error) {
 }
 
 type eventData interface {
-	toEventData() (interface{}, error)
+	toEventData() (any, error)
 }
 
 type eventDataUnmarshaler struct {
@@ -88,7 +88,7 @@ type ValidatorExitedEventYAML struct {
 	OperatorIds []uint64 `yaml:"OperatorIds"`
 }
 
-func (e *OperatorAddedEventYAML) toEventData() (interface{}, error) {
+func (e *OperatorAddedEventYAML) toEventData() (any, error) {
 	return contract.ContractOperatorAdded{
 		OperatorId: e.ID,
 		Owner:      ethcommon.HexToAddress(e.Owner),
@@ -96,13 +96,13 @@ func (e *OperatorAddedEventYAML) toEventData() (interface{}, error) {
 	}, nil
 }
 
-func (e *OperatorRemovedEventYAML) toEventData() (interface{}, error) {
+func (e *OperatorRemovedEventYAML) toEventData() (any, error) {
 	return contract.ContractOperatorRemoved{
 		OperatorId: e.ID,
 	}, nil
 }
 
-func (e *ValidatorAddedEventYAML) toEventData() (interface{}, error) {
+func (e *ValidatorAddedEventYAML) toEventData() (any, error) {
 	pubKey, err := hex.DecodeString(strings.TrimPrefix(e.PublicKey, "0x"))
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (e *ValidatorAddedEventYAML) toEventData() (interface{}, error) {
 	}, nil
 }
 
-func (e *ValidatorRemovedEventYAML) toEventData() (interface{}, error) {
+func (e *ValidatorRemovedEventYAML) toEventData() (any, error) {
 	return contract.ContractValidatorRemoved{
 		Owner:       ethcommon.HexToAddress(e.Owner),
 		OperatorIds: e.OperatorIds,
@@ -129,28 +129,28 @@ func (e *ValidatorRemovedEventYAML) toEventData() (interface{}, error) {
 	}, nil
 }
 
-func (e *ClusterLiquidatedEventYAML) toEventData() (interface{}, error) {
+func (e *ClusterLiquidatedEventYAML) toEventData() (any, error) {
 	return contract.ContractClusterLiquidated{
 		Owner:       ethcommon.HexToAddress(e.Owner),
 		OperatorIds: e.OperatorIds,
 	}, nil
 }
 
-func (e *ClusterReactivatedEventYAML) toEventData() (interface{}, error) {
+func (e *ClusterReactivatedEventYAML) toEventData() (any, error) {
 	return contract.ContractClusterReactivated{
 		Owner:       ethcommon.HexToAddress(e.Owner),
 		OperatorIds: e.OperatorIds,
 	}, nil
 }
 
-func (e *FeeRecipientAddressUpdatedEventYAML) toEventData() (interface{}, error) {
+func (e *FeeRecipientAddressUpdatedEventYAML) toEventData() (any, error) {
 	return contract.ContractFeeRecipientAddressUpdated{
 		Owner:            ethcommon.HexToAddress(e.Owner),
 		RecipientAddress: ethcommon.HexToAddress(e.RecipientAddress),
 	}, nil
 }
 
-func (e *ValidatorExitedEventYAML) toEventData() (interface{}, error) {
+func (e *ValidatorExitedEventYAML) toEventData() (any, error) {
 	return contract.ContractValidatorExited{
 		PublicKey:   []byte(strings.TrimPrefix(e.PublicKey, "0x")),
 		OperatorIds: e.OperatorIds,

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -19,7 +19,7 @@ type Message struct {
 	// Filter
 	Filter MessageFilter `json:"filter"`
 	// Values holds the results, optional as it's relevant for response
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 type ParticipantsAPI struct {
@@ -55,7 +55,7 @@ func NewParticipantsAPIMsg(domainType spectypes.DomainType, msg qbftstorage.Part
 }
 
 // ParticipantsAPIData creates a new message from the given message in a new format.
-func ParticipantsAPIData(domainType spectypes.DomainType, msgs ...qbftstorage.Participation) (interface{}, error) {
+func ParticipantsAPIData(domainType spectypes.DomainType, msgs ...qbftstorage.Participation) (any, error) {
 	if len(msgs) == 0 {
 		return nil, errors.New("no messages")
 	}

--- a/network/peers/connections/mock/mock_peerstore.go
+++ b/network/peers/connections/mock/mock_peerstore.go
@@ -94,7 +94,7 @@ func (p Peerstore) PeersWithKeys() peer.IDSlice {
 	panic("implement me")
 }
 
-func (p Peerstore) Get(pid peer.ID, key string) (interface{}, error) {
+func (p Peerstore) Get(pid peer.ID, key string) (any, error) {
 	for _, epid := range p.ExistingPIDs {
 		if epid == pid {
 			return epid, nil
@@ -103,7 +103,7 @@ func (p Peerstore) Get(pid peer.ID, key string) (interface{}, error) {
 	return nil, errors.New("error")
 }
 
-func (p Peerstore) Put(pid peer.ID, key string, val interface{}) error {
+func (p Peerstore) Put(pid peer.ID, key string, val any) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/networkconfig/ssv.go
+++ b/networkconfig/ssv.go
@@ -91,7 +91,7 @@ func (s *SSV) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.marshal())
 }
 
-func (s *SSV) MarshalYAML() (interface{}, error) {
+func (s *SSV) MarshalYAML() (any, error) {
 	return s.marshal(), nil
 }
 
@@ -119,7 +119,7 @@ func (s *SSV) unmarshalFromConfig(aux marshaledConfig) error {
 	return nil
 }
 
-func (s *SSV) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *SSV) UnmarshalYAML(unmarshal func(any) error) error {
 	var aux marshaledConfig
 	if err := unmarshal(&aux); err != nil {
 		return err

--- a/networkconfig/ssv_test.go
+++ b/networkconfig/ssv_test.go
@@ -100,8 +100,8 @@ func TestSSVConfig_MarshalUnmarshalYAML(t *testing.T) {
 
 	// Compare the original and remarshaled YAML bytes
 	// YAML doesn't preserve order by default, so we need to compare the unmarshaled content
-	var originalYAMLMap map[string]interface{}
-	var remarshaledYAMLMap map[string]interface{}
+	var originalYAMLMap map[string]any
+	var remarshaledYAMLMap map[string]any
 
 	err = yaml.Unmarshal(yamlBytes, &originalYAMLMap)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestSSVConfig_MarshalUnmarshalYAML(t *testing.T) {
 }
 
 // hashStructJSON creates a deterministic hash of a struct by marshaling to sorted JSON
-func hashStructJSON(v interface{}) (string, error) {
+func hashStructJSON(v any) (string, error) {
 	// Create a JSON encoder that sorts map keys
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -107,7 +107,7 @@ type proposalPreparations interface {
 
 // TODO need to handle differently (by spec)
 type signer interface {
-	ComputeSigningRoot(object interface{}, domain phase0.Domain) ([32]byte, error)
+	ComputeSigningRoot(object any, domain phase0.Domain) ([32]byte, error)
 }
 
 // TODO: remove temp spec intefaces once spec is settled

--- a/protocol/v2/qbft/instance/instance.go
+++ b/protocol/v2/qbft/instance/instance.go
@@ -161,7 +161,7 @@ func (i *Instance) ProcessMsg(ctx context.Context, logger *zap.Logger, msg *spec
 		return false, nil, nil, errors.Wrap(err, "invalid signed message")
 	}
 
-	res := i.processMsgF.Run(func() interface{} {
+	res := i.processMsgF.Run(func() any {
 		switch msg.QBFTMessage.MsgType {
 		case specqbft.ProposalMsgType:
 			return i.uponProposal(ctx, logger, msg)

--- a/protocol/v2/qbft/spectest/qbft_mapping_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_test.go
@@ -23,7 +23,7 @@ func TestQBFTMapping(t *testing.T) {
 	jsonTests, err := storage.GenerateSpecTestJSON(path, "qbft")
 	require.NoError(t, err)
 
-	untypedTests := map[string]interface{}{}
+	untypedTests := map[string]any{}
 	if err := json.Unmarshal(jsonTests, &untypedTests); err != nil {
 		panic(err.Error())
 	}

--- a/protocol/v2/ssv/queue/message_prioritizer_test.go
+++ b/protocol/v2/ssv/queue/message_prioritizer_test.go
@@ -355,8 +355,8 @@ func (m messageSlice) dump(s *State) string {
 	for i, msg := range m {
 		var (
 			kind         string
-			typ          interface{}
-			heightOrSlot interface{}
+			typ          any
+			heightOrSlot any
 			relation     string
 		)
 

--- a/protocol/v2/ssv/queue/messages.go
+++ b/protocol/v2/ssv/queue/messages.go
@@ -22,7 +22,7 @@ type SSVMessage struct {
 	*spectypes.SSVMessage
 
 	// Body is the decoded Data.
-	Body interface{} // *specqbft.Message | *spectypes.PartialSignatureMessages | *EventMsg
+	Body any // *specqbft.Message | *spectypes.PartialSignatureMessages | *EventMsg
 }
 
 func (d *SSVMessage) DecodedSSVMessage() {}
@@ -78,8 +78,8 @@ func DecodeSSVMessage(m *spectypes.SSVMessage) (*SSVMessage, error) {
 	}, nil
 }
 
-func ExtractMsgBody(m *spectypes.SSVMessage) (interface{}, error) {
-	var body interface{}
+func ExtractMsgBody(m *spectypes.SSVMessage) (any, error) {
+	var body any
 	switch m.MsgType {
 	case spectypes.SSVConsensusMsgType:
 		sm := &specqbft.Message{}

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -614,7 +614,7 @@ type hasher struct {
 func newHasher() *hasher {
 	return &hasher{
 		sha256Pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return sha256.New()
 			},
 		},

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -936,11 +936,11 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndDomain(context.Context) (
 func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context.Context, logger *zap.Logger) (
 	attestationMap map[phase0.ValidatorIndex][32]byte,
 	syncCommitteeMap map[phase0.ValidatorIndex][32]byte,
-	beaconObjects map[phase0.ValidatorIndex]map[[32]byte]interface{}, err error,
+	beaconObjects map[phase0.ValidatorIndex]map[[32]byte]any, err error,
 ) {
 	attestationMap = make(map[phase0.ValidatorIndex][32]byte)
 	syncCommitteeMap = make(map[phase0.ValidatorIndex][32]byte)
-	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]interface{})
+	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]any)
 	duty := r.BaseRunner.State.CurrentDuty
 	beaconVoteData := r.BaseRunner.State.DecidedValue
 	beaconVote := &spectypes.BeaconVote{}
@@ -989,7 +989,7 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context
 			// Add to map
 			attestationMap[validatorDuty.ValidatorIndex] = root
 			if _, ok := beaconObjects[validatorDuty.ValidatorIndex]; !ok {
-				beaconObjects[validatorDuty.ValidatorIndex] = make(map[[32]byte]interface{})
+				beaconObjects[validatorDuty.ValidatorIndex] = make(map[[32]byte]any)
 			}
 			beaconObjects[validatorDuty.ValidatorIndex][root] = attestationResponse
 		case spectypes.BNRoleSyncCommittee:
@@ -1017,7 +1017,7 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context
 			// Set root and beacon object
 			syncCommitteeMap[validatorDuty.ValidatorIndex] = root
 			if _, ok := beaconObjects[validatorDuty.ValidatorIndex]; !ok {
-				beaconObjects[validatorDuty.ValidatorIndex] = make(map[[32]byte]interface{})
+				beaconObjects[validatorDuty.ValidatorIndex] = make(map[[32]byte]any)
 			}
 			beaconObjects[validatorDuty.ValidatorIndex][root] = syncMsg
 		default:

--- a/protocol/v2/ssv/spectest/committee_msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/committee_msg_processing_type.go
@@ -32,7 +32,7 @@ type CommitteeSpecTest struct {
 	Name                   string
 	ParentName             string
 	Committee              *validator.Committee
-	Input                  []interface{} // Can be a types.Duty or a *types.SignedSSVMessage
+	Input                  []any // Can be a types.Duty or a *types.SignedSSVMessage
 	PostDutyCommitteeRoot  string
 	PostDutyCommittee      spectypes.Root `json:"-"` // Field is ignored by encoding/json
 	OutputMessages         []*spectypes.PartialSignatureMessages
@@ -119,7 +119,7 @@ func (test *CommitteeSpecTest) overrideStateComparison(t *testing.T) {
 	overrideStateComparisonCommitteeSpecTest(t, test, test.Name, strType)
 }
 
-func (test *CommitteeSpecTest) GetPostState(logger *zap.Logger) (interface{}, error) {
+func (test *CommitteeSpecTest) GetPostState(logger *zap.Logger) (any, error) {
 	lastErr := test.runPreTesting(logger)
 	if lastErr != nil && test.ExpectedErrorCode == 0 {
 		return nil, lastErr
@@ -159,7 +159,7 @@ func (tests *MultiCommitteeSpecTest) overrideStateComparison(t *testing.T) {
 	}
 }
 
-func (tests *MultiCommitteeSpecTest) GetPostState(logger *zap.Logger) (interface{}, error) {
+func (tests *MultiCommitteeSpecTest) GetPostState(logger *zap.Logger) (any, error) {
 	ret := make(map[string]spectypes.Root, len(tests.Tests))
 	for _, test := range tests.Tests {
 		err := test.runPreTesting(logger)

--- a/protocol/v2/ssv/spectest/debug_states.go
+++ b/protocol/v2/ssv/spectest/debug_states.go
@@ -30,7 +30,7 @@ func dumpState(t *testing.T,
 	diff := cmp.Diff(a, b,
 		cmp.FilterValues(func(x, y []byte) bool {
 			return json.Valid(x) && json.Valid(y)
-		}, cmp.Transformer("ParseJSON", func(in []byte) (out interface{}) {
+		}, cmp.Transformer("ParseJSON", func(in []byte) (out any) {
 			if err := json.Unmarshal(in, &out); err != nil {
 				panic(err) // should never occur given previous filter to ensure valid JSON
 			}
@@ -46,7 +46,7 @@ func dumpState(t *testing.T,
 	return diff
 }
 
-func logJSON(t *testing.T, name string, value interface{}) {
+func logJSON(t *testing.T, name string, value any) {
 	bytes, err := json.Marshal(value)
 	require.NoError(t, err)
 	err = os.WriteFile(fmt.Sprintf("%s/%s_test_serialized.json", dumpDir, name), bytes, 0600)

--- a/protocol/v2/ssv/spectest/runner_construction_type.go
+++ b/protocol/v2/ssv/spectest/runner_construction_type.go
@@ -41,6 +41,6 @@ func (test *RunnerConstructionSpecTest) Run(t *testing.T) {
 	}
 }
 
-func (test *RunnerConstructionSpecTest) GetPostState() (interface{}, error) {
+func (test *RunnerConstructionSpecTest) GetPostState() (any, error) {
 	return nil, nil
 }

--- a/protocol/v2/ssv/validator/committee_queue_test.go
+++ b/protocol/v2/ssv/validator/committee_queue_test.go
@@ -35,7 +35,7 @@ import (
 // - A unique message ID
 // - Custom message body (QBFT message or partial signature message)
 // The function handles encoding the message body appropriately based on its type.
-func makeTestSSVMessage(t *testing.T, msgType spectypes.MsgType, msgID spectypes.MessageID, body interface{}) *queue.SSVMessage {
+func makeTestSSVMessage(t *testing.T, msgType spectypes.MsgType, msgID spectypes.MessageID, body any) *queue.SSVMessage {
 	t.Helper()
 
 	sig, err := base64.StdEncoding.DecodeString("sVV0fsvqQlqliKv/ussGIatxpe8LDWhc9uoaM5WpjbiYvvxUr1eCpz0ja7UT1PGNDdmoGi6xbMC1g/ozhAt4uCdpy0Xdfqbv2hMf2iRL5ZPKOSmMifHbd8yg4PeeceyN")

--- a/storage/badger/logger.go
+++ b/storage/badger/logger.go
@@ -20,21 +20,21 @@ func newLogger(l *zap.Logger) badger.Logger {
 }
 
 // Errorf implements badger.Logger
-func (bl *badgerLogger) Errorf(s string, i ...interface{}) {
+func (bl *badgerLogger) Errorf(s string, i ...any) {
 	bl.logger.Error(fmt.Sprintf(s, i...))
 }
 
 // Warningf implements badger.Logger
-func (bl *badgerLogger) Warningf(s string, i ...interface{}) {
+func (bl *badgerLogger) Warningf(s string, i ...any) {
 	bl.logger.Warn(fmt.Sprintf(s, i...))
 }
 
 // Infof implements badger.Logger
-func (bl *badgerLogger) Infof(s string, i ...interface{}) {
+func (bl *badgerLogger) Infof(s string, i ...any) {
 	bl.logger.Info(fmt.Sprintf(s, i...))
 }
 
 // Debugf implements badger.Logger
-func (bl *badgerLogger) Debugf(s string, i ...interface{}) {
+func (bl *badgerLogger) Debugf(s string, i ...any) {
 	bl.logger.Debug(fmt.Sprintf(s, i...))
 }

--- a/utils/format/regexp_pool.go
+++ b/utils/format/regexp_pool.go
@@ -14,7 +14,7 @@ type RegexpPool struct {
 // NewRegexpPool creates a new instance of RegexpPool
 func NewRegexpPool(pattern string) *RegexpPool {
 	return &RegexpPool{
-		pool: sync.Pool{New: func() interface{} {
+		pool: sync.Pool{New: func() any {
 			return regexp.MustCompile(pattern)
 		}},
 		pattern: pattern,


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.