### PR TITLE
majority fork protection: remove target root check

### DIFF
--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -69,6 +69,7 @@ func (v *voteChecker) CheckValue(value []byte) error {
 	}
 
 	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69
+	// Not checking target root due to possible orphaned blocks.
 	if bv.Source.Epoch != v.expectedVote.Source.Epoch {
 		return fmt.Errorf("unexpected source epoch %v, expected %v", bv.Source.Epoch, v.expectedVote.Source.Epoch)
 	}

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -81,10 +81,6 @@ func (v *voteChecker) CheckValue(value []byte) error {
 		return fmt.Errorf("unexpected source root %x, expected %x", bv.Source.Root, v.expectedVote.Source.Root)
 	}
 
-	if bv.Target.Root != v.expectedVote.Target.Root {
-		return fmt.Errorf("unexpected target root %x, expected %x", bv.Target.Root, v.expectedVote.Target.Root)
-	}
-
 	return nil
 }
 

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -68,8 +68,8 @@ func (v *voteChecker) CheckValue(value []byte) error {
 		}
 	}
 
-	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69
-	// Not checking target root due to possible orphaned blocks.
+	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69, except the target root check is deleted
+	// because reorgs/orphaned blocks will trigger the protection and cause performance drops.
 	if bv.Source.Epoch != v.expectedVote.Source.Epoch {
 		return fmt.Errorf("unexpected source epoch %v, expected %v", bv.Source.Epoch, v.expectedVote.Source.Epoch)
 	}


### PR DESCRIPTION
While checking the target root is correct, it seems to cause some performance drops on reorgs.

This PR resolves the performance drops by removing the target root check until we come up with a better solution.