### PR TITLE
majority fork protection: add the strict mode with a flag

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -171,7 +171,8 @@ type Controller struct {
 
 // NewController creates a new validator controller instance.
 func NewController(logger *zap.Logger, options ControllerOptions, exporterOptions exporter.Options) *Controller {
-	logger.Debug("setting up validator controller")
+	logger.Debug("setting up validator controller",
+		zap.Bool("mfp_strict", options.MajorityForkProtectionStrict))
 
 	// lookup in a map that holds all relevant operators
 	operatorsIDs := &sync.Map{}

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -89,9 +89,10 @@ type ControllerOptions struct {
 	ProposerDelay                  time.Duration
 
 	// worker flags
-	WorkersCount    int    `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of message processing workers"`
-	QueueBufferSize int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
-	GasLimit        uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
+	WorkersCount                 int    `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of message processing workers"`
+	QueueBufferSize              int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
+	GasLimit                     uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
+	MajorityForkProtectionStrict bool   `yaml:"MajorityForkProtectionStrict" env:"MAJORITY_FORK_PROTECTION_STRICT" env-description:"Check if the attestation target root matches the proposed one. It should improve Ethereum network split detection in case of global network incidents. However, it can worsen the performance on reorgs."`
 }
 
 type Nonce uint16
@@ -197,6 +198,7 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 		options.MessageValidator,
 		options.Graffiti,
 		options.ProposerDelay,
+		options.MajorityForkProtectionStrict,
 	)
 
 	cacheTTL := 2 * options.NetworkConfig.EpochDuration() // #nosec G115
@@ -1050,6 +1052,7 @@ func SetupCommitteeRunners(
 			options.OperatorSigner,
 			dutyGuard,
 			options.DoppelgangerHandler,
+			options.MajorityForkProtectionStrict,
 		)
 		if err != nil {
 			return nil, err

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -92,7 +92,7 @@ type ControllerOptions struct {
 	WorkersCount                 int    `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of message processing workers"`
 	QueueBufferSize              int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
 	GasLimit                     uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
-	MajorityForkProtectionStrict bool   `yaml:"MajorityForkProtectionStrict" env:"MAJORITY_FORK_PROTECTION_STRICT" env-description:"Check if the attestation target root matches the proposed one. It should improve Ethereum network split detection in case of global network incidents. However, it can worsen the performance on reorgs."`
+	MajorityForkProtectionStrict bool   `yaml:"MajorityForkProtectionStrict" env:"MAJORITY_FORK_PROTECTION_STRICT" env-description:"Refuse to sign attestations with different target roots than your own. This does not increase validator safety. Instead, this is potentially more beneficial for Ethereum (area of active research), at the cost of potentially decrease validator performance during transitory disagreements between operators (e.g., when some of the operators' Beacon nodes are behind, and during re-orgs)."`
 }
 
 type Nonce uint16

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -54,6 +54,7 @@ type CommitteeRunner struct {
 	DutyGuard           CommitteeDutyGuard
 	doppelgangerHandler DoppelgangerProvider
 	measurements        *dutyMeasurements
+	mfpStrict           bool
 
 	// ValCheck is used to validate the qbft-value(s) proposed by other Operators.
 	ValCheck ssv.ValueChecker
@@ -72,6 +73,7 @@ func NewCommitteeRunner(
 	operatorSigner ssvtypes.OperatorSigner,
 	dutyGuard CommitteeDutyGuard,
 	doppelgangerHandler DoppelgangerProvider,
+	mfpStrict bool,
 ) (Runner, error) {
 	if len(share) == 0 {
 		return nil, errors.New("no shares")
@@ -94,6 +96,7 @@ func NewCommitteeRunner(
 		DutyGuard:           dutyGuard,
 		doppelgangerHandler: doppelgangerHandler,
 		measurements:        newMeasurementsStore(),
+		mfpStrict:           mfpStrict,
 	}, nil
 }
 
@@ -1062,6 +1065,7 @@ func (r *CommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, d
 		r.attestingValidators,
 		r.GetNetworkConfig().EstimatedCurrentEpoch(),
 		vote,
+		r.mfpStrict,
 	)
 	if err := r.BaseRunner.decide(ctx, logger, duty.DutySlot(), vote, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -280,6 +280,7 @@ var baseCommitteeWithRunnerSample = func(
 			runnerSample.GetOperatorSigner(),
 			committeeDutyGuard,
 			runnerSample.GetDoppelgangerHandler(),
+			false,
 		)
 		return r.(*runner.CommitteeRunner), err
 	}

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -89,7 +89,7 @@ var ConstructBaseRunner = func(
 	switch role {
 	case spectypes.RoleCommittee:
 		valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
-			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)}, spectestingutils.TestingDutyEpoch, vote)
+			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)}, spectestingutils.TestingDutyEpoch, vote, false)
 	case spectypes.RoleProposer:
 		valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 			(spectypes.ValidatorPK)(spectestingutils.TestingValidatorPubKey), spectestingutils.TestingValidatorIndex,
@@ -138,6 +138,7 @@ var ConstructBaseRunner = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
+			false,
 		)
 	case spectypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(
@@ -221,6 +222,7 @@ var ConstructBaseRunner = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
+			false,
 		)
 		r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType
 	default:
@@ -356,7 +358,7 @@ var ConstructBaseRunnerWithShareMap = func(
 		switch role {
 		case spectypes.RoleCommittee:
 			valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
-				sharePubKeys, spectestingutils.TestingDutyEpoch, vote)
+				sharePubKeys, spectestingutils.TestingDutyEpoch, vote, false)
 		case spectypes.RoleProposer:
 			valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 				shareInstance.ValidatorPubKey, shareInstance.ValidatorIndex, phase0.BLSPubKey(shareInstance.SharePubKey))
@@ -400,6 +402,7 @@ var ConstructBaseRunnerWithShareMap = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
+			false,
 		)
 	case spectypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(
@@ -483,6 +486,7 @@ var ConstructBaseRunnerWithShareMap = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
+			false,
 		)
 		if r != nil {
 			r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -29,21 +29,22 @@ type Options struct {
 
 // CommonOptions represents options that all validators share.
 type CommonOptions struct {
-	NetworkConfig       *networkconfig.Network
-	Network             specqbft.Network
-	Beacon              beacon.BeaconNode
-	Storage             *storage.ParticipantStores
-	Signer              ekm.BeaconSigner
-	OperatorSigner      ssvtypes.OperatorSigner
-	DoppelgangerHandler runner.DoppelgangerProvider
-	NewDecidedHandler   qbftctrl.NewDecidedHandler
-	FullNode            bool
-	ExporterOptions     exporter.Options
-	QueueSize           int
-	GasLimit            uint64
-	MessageValidator    validation.MessageValidator
-	Graffiti            []byte
-	ProposerDelay       time.Duration
+	NetworkConfig                *networkconfig.Network
+	Network                      specqbft.Network
+	Beacon                       beacon.BeaconNode
+	Storage                      *storage.ParticipantStores
+	Signer                       ekm.BeaconSigner
+	OperatorSigner               ssvtypes.OperatorSigner
+	DoppelgangerHandler          runner.DoppelgangerProvider
+	NewDecidedHandler            qbftctrl.NewDecidedHandler
+	FullNode                     bool
+	ExporterOptions              exporter.Options
+	QueueSize                    int
+	GasLimit                     uint64
+	MessageValidator             validation.MessageValidator
+	Graffiti                     []byte
+	ProposerDelay                time.Duration
+	MajorityForkProtectionStrict bool
 }
 
 func NewCommonOptions(
@@ -62,23 +63,25 @@ func NewCommonOptions(
 	messageValidator validation.MessageValidator,
 	graffiti []byte,
 	proposerDelay time.Duration,
+	mfpStrict bool,
 ) *CommonOptions {
 	result := &CommonOptions{
-		NetworkConfig:       networkConfig,
-		Network:             network,
-		Beacon:              beacon,
-		Storage:             storage,
-		Signer:              signer,
-		OperatorSigner:      operatorSigner,
-		DoppelgangerHandler: doppelgangerHandler,
-		NewDecidedHandler:   newDecidedHandler,
-		FullNode:            fullNode,
-		ExporterOptions:     exporterOptions,
-		QueueSize:           1000,
-		GasLimit:            gasLimit,
-		MessageValidator:    messageValidator,
-		Graffiti:            graffiti,
-		ProposerDelay:       proposerDelay,
+		NetworkConfig:                networkConfig,
+		Network:                      network,
+		Beacon:                       beacon,
+		Storage:                      storage,
+		Signer:                       signer,
+		OperatorSigner:               operatorSigner,
+		DoppelgangerHandler:          doppelgangerHandler,
+		NewDecidedHandler:            newDecidedHandler,
+		FullNode:                     fullNode,
+		ExporterOptions:              exporterOptions,
+		QueueSize:                    1000,
+		GasLimit:                     gasLimit,
+		MessageValidator:             messageValidator,
+		Graffiti:                     graffiti,
+		ProposerDelay:                proposerDelay,
+		MajorityForkProtectionStrict: mfpStrict,
 	}
 
 	// If full node, increase the queue size to make enough room for history sync batches to be pushed whole.

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -72,7 +72,7 @@ func (v *voteChecker) CheckValue(value []byte) error {
 	}
 
 	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69, except the target root check is optional,
-	// because reorgs/orphaned blocks will trigger the target root mismatch and cause performance drops.
+	// because reorgs/orphaned blocks will trigger the target root mismatch and cause attestation misses.
 	if bv.Source.Epoch != v.expectedVote.Source.Epoch {
 		return fmt.Errorf("unexpected source epoch %v, expected %v", bv.Source.Epoch, v.expectedVote.Source.Epoch)
 	}

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -23,6 +23,7 @@ type voteChecker struct {
 	sharePublicKeys       []phase0.BLSPubKey
 	estimatedCurrentEpoch phase0.Epoch
 	expectedVote          *spectypes.BeaconVote
+	mfpStrict             bool
 }
 
 func NewVoteChecker(
@@ -31,6 +32,7 @@ func NewVoteChecker(
 	sharePublicKeys []phase0.BLSPubKey,
 	estimatedCurrentEpoch phase0.Epoch,
 	expectedVote *spectypes.BeaconVote,
+	mfpStrict bool,
 ) ValueChecker {
 	return &voteChecker{
 		signer:                signer,
@@ -38,6 +40,7 @@ func NewVoteChecker(
 		sharePublicKeys:       sharePublicKeys,
 		estimatedCurrentEpoch: estimatedCurrentEpoch,
 		expectedVote:          expectedVote,
+		mfpStrict:             mfpStrict,
 	}
 }
 
@@ -80,6 +83,12 @@ func (v *voteChecker) CheckValue(value []byte) error {
 
 	if bv.Source.Root != v.expectedVote.Source.Root {
 		return fmt.Errorf("unexpected source root %x, expected %x", bv.Source.Root, v.expectedVote.Source.Root)
+	}
+
+	if v.mfpStrict {
+		if bv.Target.Root != v.expectedVote.Target.Root {
+			return fmt.Errorf("unexpected target root %x, expected %x", bv.Target.Root, v.expectedVote.Target.Root)
+		}
 	}
 
 	return nil

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -71,8 +71,8 @@ func (v *voteChecker) CheckValue(value []byte) error {
 		}
 	}
 
-	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69, except the target root check is deleted
-	// because reorgs/orphaned blocks will trigger the protection and cause performance drops.
+	// Implemented according to https://github.com/ssvlabs/SIPs/pull/69, except the target root check is optional,
+	// because reorgs/orphaned blocks will trigger the target root mismatch and cause performance drops.
 	if bv.Source.Epoch != v.expectedVote.Source.Epoch {
 		return fmt.Errorf("unexpected source epoch %v, expected %v", bv.Source.Epoch, v.expectedVote.Source.Epoch)
 	}


### PR DESCRIPTION
Add a flag for the target root check.

**How to Enable**

  ```yaml
  ssv:
    ValidatorOptions:
      MajorityForkProtectionStrict: true
  ```

  *Environment variable:*

  ```bash
  MAJORITY_FORK_PROTECTION_STRICT=true
  ```