### PR TITLE
Exporter: adapt websocket /query endpoint to exporter v2

### DIFF
--- a/operator/node.go
+++ b/operator/node.go
@@ -2,9 +2,15 @@ package operator
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/exporter"
@@ -16,11 +22,13 @@ import (
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/operator/duties"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
+	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
 	"github.com/ssvlabs/ssv/operator/fee_recipient"
 	"github.com/ssvlabs/ssv/operator/slotticker"
 	"github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/operator/validator"
 	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	"github.com/ssvlabs/ssv/protocol/v2/message"
 	storage2 "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
@@ -44,6 +52,13 @@ type Options struct {
 	WsAPIPort           int
 }
 
+// dutyTraceDecidedsProvider is the minimal interface used from the duty trace collector
+// to serve websocket /query decided lookups.
+type dutyTraceDecidedsProvider interface {
+	GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error)
+	GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error)
+}
+
 type Node struct {
 	logger *zap.Logger
 
@@ -61,6 +76,8 @@ type Node struct {
 
 	ws        api.WebSocketServer
 	wsAPIPort int
+
+	traceCollector dutyTraceDecidedsProvider
 }
 
 // New is the constructor of Node
@@ -117,8 +134,9 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 		}),
 		feeRecipientCtrl: feeRecipientCtrl,
 
-		ws:        opts.WS,
-		wsAPIPort: opts.WsAPIPort,
+		ws:             opts.WS,
+		wsAPIPort:      opts.WsAPIPort,
+		traceCollector: opts.ValidatorOptions.DutyTraceCollector,
 	}
 
 	// Wire the beacon client to the fee recipient controller
@@ -243,12 +261,98 @@ func (n *Node) handleQueryRequests(nm *api.NetworkMessage) {
 
 	switch nm.Msg.Type {
 	case api.TypeDecided:
-		h.HandleParticipantsQuery(n.qbftStorage, nm, n.network.DomainType)
+		// In exporter v2 (archive) mode we collect decided data via the duty trace collector
+		// instead of the legacy qbft storage. When the collector is available, serve queries
+		// from it to avoid empty responses while no validators are running locally.
+		// The check for `nil` allows backward compatibility when running without exporter v2.
+		if n.traceCollector != nil {
+			n.handleDecidedFromTraceCollector(nm)
+		} else {
+			h.HandleParticipantsQuery(n.qbftStorage, nm, n.network.DomainType)
+		}
 	case api.TypeError:
 		h.HandleErrorQuery(nm)
 	default:
 		h.HandleUnknownQuery(nm)
 	}
+}
+
+// handleDecidedFromTraceCollector responds to /query requests using duty trace data when available.
+func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
+	res := api.Message{Type: nm.Msg.Type, Filter: nm.Msg.Filter}
+
+	pkBytes, err := hex.DecodeString(nm.Msg.Filter.PublicKey)
+	if err != nil {
+		n.logger.Warn("failed to decode validator public key", zap.Error(err))
+		res.Type = api.TypeError
+		res.Data = []string{"invalid publicKey"}
+		nm.Msg = res
+		return
+	}
+
+	var pk spectypes.ValidatorPK
+	copy(pk[:], pkBytes)
+
+	idx, ok := n.validatorOptions.ValidatorStore.ValidatorIndex(pk)
+	if !ok {
+		n.logger.Warn("validator not found for public key", zap.String("validator_pubkey", hex.EncodeToString(pk[:])))
+		res.Type = api.TypeError
+		res.Data = []string{"validator not found"}
+		nm.Msg = res
+		return
+	}
+
+	role, err := message.BeaconRoleFromString(nm.Msg.Filter.Role)
+	if err != nil {
+		n.logger.Warn("failed to parse role", zap.Error(err))
+		res.Type = api.TypeError
+		res.Data = []string{"role doesn't exist"}
+		nm.Msg = res
+		return
+	}
+
+	participations := make([]qbftstorage.Participation, 0)
+
+	for slot := phase0.Slot(nm.Msg.Filter.From); slot <= phase0.Slot(nm.Msg.Filter.To); slot++ {
+		var entries []dutytracer.ParticipantsRangeIndexEntry
+		if role == spectypes.BNRoleAttester || role == spectypes.BNRoleSyncCommittee {
+			entries, err = n.traceCollector.GetCommitteeDecideds(slot, idx, role)
+		} else {
+			entries, err = n.traceCollector.GetValidatorDecideds(role, slot, []phase0.ValidatorIndex{idx})
+		}
+
+		if err != nil {
+			// not-found is expected; only log unexpected errors
+			if !errors.Is(err, dutytracer.ErrNotFound) {
+				n.logger.Warn("failed to get decided entries from collector", zap.Error(err), fields.Slot(slot), fields.ValidatorIndex(idx))
+			}
+			continue
+		}
+
+		for _, e := range entries {
+			participations = append(participations, qbftstorage.Participation{
+				ParticipantsRangeEntry: qbftstorage.ParticipantsRangeEntry{
+					Slot:    e.Slot,
+					PubKey:  pk,
+					Signers: e.Signers,
+				},
+				Role:   role,
+				PubKey: pk,
+			})
+		}
+	}
+
+	data, err := api.ParticipantsAPIData(n.network.DomainType, participations...)
+	if err != nil {
+		n.logger.Warn("failed to build participants api data", zap.Error(err))
+		res.Type = api.TypeError
+		res.Data = []string{"internal error - could not build response"}
+		nm.Msg = res
+		return
+	}
+
+	res.Data = data
+	nm.Msg = res
 }
 
 func (n *Node) startWSServer() error {

--- a/operator/node.go
+++ b/operator/node.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -15,6 +16,7 @@ import (
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/api"
+	exporterstore "github.com/ssvlabs/ssv/exporter/store"
 	qbftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -312,6 +314,8 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 	}
 
 	participations := make([]qbftstorage.Participation, 0)
+	var hasUnexpectedError bool
+	var lastUnexpectedErr error
 
 	for slot := phase0.Slot(nm.Msg.Filter.From); slot <= phase0.Slot(nm.Msg.Filter.To); slot++ {
 		var entries []dutytracer.ParticipantsRangeIndexEntry
@@ -322,8 +326,17 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 		}
 
 		if err != nil {
-			// not-found is expected; only log unexpected errors
-			if !errors.Is(err, dutytracer.ErrNotFound) {
+			var merr *multierror.Error
+			if errors.As(err, &merr) {
+				merr = filterOutDutyNotFoundErrors(merr)
+				if merr != nil && merr.ErrorOrNil() != nil {
+					hasUnexpectedError = true
+					lastUnexpectedErr = merr
+					n.logger.Warn("failed to get decided entries from collector", zap.Error(merr), fields.Slot(slot), fields.ValidatorIndex(idx))
+				}
+			} else if !isNotFoundError(err) {
+				hasUnexpectedError = true
+				lastUnexpectedErr = err
 				n.logger.Warn("failed to get decided entries from collector", zap.Error(err), fields.Slot(slot), fields.ValidatorIndex(idx))
 			}
 			continue
@@ -342,6 +355,19 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 		}
 	}
 
+	if len(participations) == 0 {
+		if hasUnexpectedError {
+			n.logger.Warn("failed to build participants api data due to collector errors", zap.Error(lastUnexpectedErr), fields.ValidatorIndex(idx))
+			res.Type = api.TypeError
+			res.Data = []string{"internal error - could not build response"}
+		} else {
+			// Mirror legacy exporter behavior: empty range returns "no messages" as a decided response.
+			res.Data = []string{"no messages"}
+		}
+		nm.Msg = res
+		return
+	}
+
 	data, err := api.ParticipantsAPIData(n.network.DomainType, participations...)
 	if err != nil {
 		n.logger.Warn("failed to build participants api data", zap.Error(err))
@@ -353,6 +379,29 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 
 	res.Data = data
 	nm.Msg = res
+}
+
+// isNotFoundError returns true if the error represents an expected "no duty"
+// condition, either from the duty tracer or the underlying exporter store.
+// It mirrors the semantics in exporter2 helpers to ease future refactoring.
+func isNotFoundError(err error) bool {
+	return errors.Is(err, dutytracer.ErrNotFound) || errors.Is(err, exporterstore.ErrNotFound)
+}
+
+// filterOutDutyNotFoundErrors removes not-found duty errors from a multierror,
+// returning nil if nothing remains. It mirrors exporter2.filterOutDutyNotFoundErrors
+// to make future WS refactoring simpler.
+func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
+	if e == nil || e.ErrorOrNil() == nil {
+		return nil
+	}
+	var filtered *multierror.Error
+	for _, err := range e.Errors {
+		if !isNotFoundError(err) {
+			filtered = multierror.Append(filtered, err)
+		}
+	}
+	return filtered
 }
 
 func (n *Node) startWSServer() error {

--- a/operator/node.go
+++ b/operator/node.go
@@ -254,7 +254,10 @@ func (n *Node) HealthCheck() error {
 // handleQueryRequests waits for incoming messages and
 func (n *Node) handleQueryRequests(nm *api.NetworkMessage) {
 	if nm.Err != nil {
-		nm.Msg = api.Message{Type: api.TypeError, Data: []string{"could not parse network message"}}
+		nm.Msg = api.Message{
+			Type: api.TypeError,
+			Data: []string{fmt.Sprintf("could not parse network message: %v", nm.Err)},
+		}
 	}
 	n.logger.Debug("got incoming export request",
 		zap.String("type", string(nm.Msg.Type)))
@@ -287,7 +290,7 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 	if err != nil {
 		n.logger.Warn("failed to decode validator public key", zap.Error(err))
 		res.Type = api.TypeError
-		res.Data = []string{"invalid publicKey"}
+		res.Data = []string{fmt.Sprintf("invalid publicKey %q: %v", nm.Msg.Filter.PublicKey, err)}
 		nm.Msg = res
 		return
 	}
@@ -299,7 +302,7 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 	if !ok {
 		n.logger.Warn("validator not found for public key", zap.String("validator_pubkey", hex.EncodeToString(pk[:])))
 		res.Type = api.TypeError
-		res.Data = []string{"validator not found"}
+		res.Data = []string{fmt.Sprintf("validator not found for public key %s", nm.Msg.Filter.PublicKey)}
 		nm.Msg = res
 		return
 	}
@@ -308,7 +311,7 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 	if err != nil {
 		n.logger.Warn("failed to parse role", zap.Error(err))
 		res.Type = api.TypeError
-		res.Data = []string{"role doesn't exist"}
+		res.Data = []string{fmt.Sprintf("role doesn't exist: %q", nm.Msg.Filter.Role)}
 		nm.Msg = res
 		return
 	}
@@ -332,12 +335,12 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 				if merr != nil && merr.ErrorOrNil() != nil {
 					hasUnexpectedError = true
 					lastUnexpectedErr = merr
-					n.logger.Warn("failed to get decided entries from collector", zap.Error(merr), fields.Slot(slot), fields.ValidatorIndex(idx))
+					n.logger.Warn("failed to get decided entries from collector", zap.Error(merr), fields.Slot(slot), fields.ValidatorIndex(idx), fields.BeaconRole(role))
 				}
 			} else if !isNotFoundError(err) {
 				hasUnexpectedError = true
 				lastUnexpectedErr = err
-				n.logger.Warn("failed to get decided entries from collector", zap.Error(err), fields.Slot(slot), fields.ValidatorIndex(idx))
+				n.logger.Warn("failed to get decided entries from collector", zap.Error(err), fields.Slot(slot), fields.ValidatorIndex(idx), fields.BeaconRole(role))
 			}
 			continue
 		}
@@ -359,7 +362,7 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 		if hasUnexpectedError {
 			n.logger.Warn("failed to build participants api data due to collector errors", zap.Error(lastUnexpectedErr), fields.ValidatorIndex(idx))
 			res.Type = api.TypeError
-			res.Data = []string{"internal error - could not build response"}
+			res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", lastUnexpectedErr)}
 		} else {
 			// Mirror legacy exporter behavior: empty range returns "no messages" as a decided response.
 			res.Data = []string{"no messages"}
@@ -372,7 +375,7 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 	if err != nil {
 		n.logger.Warn("failed to build participants api data", zap.Error(err))
 		res.Type = api.TypeError
-		res.Data = []string{"internal error - could not build response"}
+		res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", err)}
 		nm.Msg = res
 		return
 	}

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -1,0 +1,161 @@
+package operator
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/exporter/api"
+	"github.com/ssvlabs/ssv/networkconfig"
+	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
+	"github.com/ssvlabs/ssv/operator/validator"
+	registrystoragemocks "github.com/ssvlabs/ssv/registry/storage/mocks"
+)
+
+type traceCollectorStub struct {
+	entries map[phase0.Slot][]dutytracer.ParticipantsRangeIndexEntry
+}
+
+func (t *traceCollectorStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return t.entries[slot], nil
+}
+
+func (t *traceCollectorStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, dutytracer.ErrNotFound
+}
+
+type traceCollectorErrStub struct {
+	err error
+}
+
+func (t *traceCollectorErrStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, t.err
+}
+
+func (t *traceCollectorErrStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, t.err
+}
+
+func newNodeWithCollector(t *testing.T, collector dutyTraceDecidedsProvider, setupStore func(*registrystoragemocks.MockValidatorStore)) *Node {
+	logger := zaptest.NewLogger(t)
+	ctrl := gomock.NewController(t)
+	store := registrystoragemocks.NewMockValidatorStore(ctrl)
+	if setupStore != nil {
+		setupStore(store)
+	}
+	return &Node{
+		logger:         logger,
+		network:        networkconfig.TestNetwork,
+		traceCollector: collector,
+		validatorOptions: validator.ControllerOptions{
+			ValidatorStore: store,
+		},
+	}
+}
+
+func decidedMessage(from, to uint64, pkHex, role string) *api.NetworkMessage {
+	return &api.NetworkMessage{Msg: api.Message{
+		Type: api.TypeDecided,
+		Filter: api.MessageFilter{
+			From:      from,
+			To:        to,
+			PublicKey: pkHex,
+			Role:      role,
+		},
+	}}
+}
+
+func makePK(bytes []byte) spectypes.ValidatorPK {
+	var pk spectypes.ValidatorPK
+	copy(pk[:], bytes)
+	return pk
+}
+
+func TestHandleQueryRequests_UsesTraceCollector(t *testing.T) {
+	pk := makePK([]byte{1, 2, 3, 4, 5})
+	idx := phase0.ValidatorIndex(7)
+
+	collector := &traceCollectorStub{
+		entries: map[phase0.Slot][]dutytracer.ParticipantsRangeIndexEntry{
+			phase0.Slot(10): {
+				{Slot: phase0.Slot(10), Index: idx, Signers: []spectypes.OperatorID{11, 12}},
+			},
+		},
+	}
+
+	node := newNodeWithCollector(t, collector, func(s *registrystoragemocks.MockValidatorStore) {
+		s.EXPECT().ValidatorIndex(pk).Return(idx, true).AnyTimes()
+	})
+
+	nm := decidedMessage(uint64(10), uint64(10), hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	node.handleQueryRequests(nm)
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 1)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Equal(t, []spectypes.OperatorID{11, 12}, data[0].Signers)
+}
+
+func TestHandleQueryRequests_ValidatorNotFound(t *testing.T) {
+	node := newNodeWithCollector(t, &traceCollectorStub{}, func(s *registrystoragemocks.MockValidatorStore) {
+		s.EXPECT().ValidatorIndex(gomock.Any()).Return(phase0.ValidatorIndex(0), false).AnyTimes()
+	})
+
+	nm := decidedMessage(1, 1, "abcd", spectypes.BNRoleProposer.String())
+
+	node.handleQueryRequests(nm)
+
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Contains(t, nm.Msg.Data.([]string)[0], "validator not found")
+}
+
+func TestHandleDecidedFromTraceCollector_InvalidPubKey(t *testing.T) {
+	node := newNodeWithCollector(t, &traceCollectorStub{}, nil)
+
+	nm := decidedMessage(1, 1, "zz-not-hex", spectypes.BNRoleProposer.String())
+
+	node.handleQueryRequests(nm)
+
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Contains(t, nm.Msg.Data.([]string)[0], "invalid publicKey")
+}
+
+func TestHandleDecidedFromTraceCollector_InvalidRole(t *testing.T) {
+	pk := makePK([]byte{1, 2, 3})
+	node := newNodeWithCollector(t, &traceCollectorStub{}, func(s *registrystoragemocks.MockValidatorStore) {
+		s.EXPECT().ValidatorIndex(pk).Return(phase0.ValidatorIndex(5), true).AnyTimes()
+	})
+
+	nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), "NOT_A_ROLE")
+
+	node.handleQueryRequests(nm)
+
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Contains(t, nm.Msg.Data.([]string)[0], "role doesn't exist")
+}
+
+func TestHandleDecidedFromTraceCollector_CollectorError(t *testing.T) {
+	pk := makePK([]byte{1, 2, 3})
+	collector := &traceCollectorErrStub{err: errors.New("boom")}
+
+	node := newNodeWithCollector(t, collector, func(s *registrystoragemocks.MockValidatorStore) {
+		s.EXPECT().ValidatorIndex(pk).Return(phase0.ValidatorIndex(5), true).AnyTimes()
+	})
+
+	nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	node.handleQueryRequests(nm)
+
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Contains(t, nm.Msg.Data.([]string)[0], "internal error - could not build response")
+}

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -13,6 +13,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/exporter/api"
+	exporterstore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/networkconfig"
 	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
 	"github.com/ssvlabs/ssv/operator/validator"
@@ -41,6 +42,26 @@ func (t *traceCollectorErrStub) GetValidatorDecideds(role spectypes.BeaconRole, 
 
 func (t *traceCollectorErrStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
 	return nil, t.err
+}
+
+type traceCollectorNotFoundStub struct{}
+
+func (t *traceCollectorNotFoundStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, dutytracer.ErrNotFound
+}
+
+func (t *traceCollectorNotFoundStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, dutytracer.ErrNotFound
+}
+
+type traceCollectorStoreNotFoundStub struct{}
+
+func (t *traceCollectorStoreNotFoundStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, exporterstore.ErrNotFound
+}
+
+func (t *traceCollectorStoreNotFoundStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+	return nil, exporterstore.ErrNotFound
 }
 
 func newNodeWithCollector(t *testing.T, collector dutyTraceDecidedsProvider, setupStore func(*registrystoragemocks.MockValidatorStore)) *Node {
@@ -158,4 +179,41 @@ func TestHandleDecidedFromTraceCollector_CollectorError(t *testing.T) {
 
 	require.Equal(t, api.TypeError, nm.Msg.Type)
 	require.Contains(t, nm.Msg.Data.([]string)[0], "internal error - could not build response")
+}
+
+func TestHandleDecidedFromTraceCollector_NoMessagesOnNotFound(t *testing.T) {
+	pk := makePK([]byte{1, 2, 3, 4})
+	idx := phase0.ValidatorIndex(10)
+
+	tests := []struct {
+		name      string
+		collector dutyTraceDecidedsProvider
+	}{
+		{
+			name:      "dutytracer not found",
+			collector: &traceCollectorNotFoundStub{},
+		},
+		{
+			name:      "store not found",
+			collector: &traceCollectorStoreNotFoundStub{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := newNodeWithCollector(t, tt.collector, func(s *registrystoragemocks.MockValidatorStore) {
+				s.EXPECT().ValidatorIndex(pk).Return(idx, true).AnyTimes()
+			})
+
+			nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+			node.handleQueryRequests(nm)
+
+			require.Equal(t, api.TypeDecided, nm.Msg.Type)
+			errs, ok := nm.Msg.Data.([]string)
+			require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+			require.Len(t, errs, 1)
+			require.Equal(t, "no messages", errs[0])
+		})
+	}
 }


### PR DESCRIPTION
**Goal**

The goal of this PR is to fix the websocket `/query` endpoint to use the exporter v2 and return valid data.
