### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/operator/dutytracer/eviction.go
+++ b/operator/dutytracer/eviction.go
@@ -2,7 +2,7 @@ package validator
 
 import (
 	"encoding/hex"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -140,7 +140,7 @@ func pendingDetails(data map[phase0.Root]map[spectypes.OperatorID]map[uint64][]p
 			for ts := range byTs {
 				tsKeys = append(tsKeys, ts)
 			}
-			sort.Slice(tsKeys, func(i, j int) bool { return tsKeys[i] < tsKeys[j] })
+			slices.Sort(tsKeys)
 
 			buckets := make([]map[string]any, 0, len(tsKeys))
 			for _, ts := range tsKeys {
@@ -159,7 +159,7 @@ func pendingDetails(data map[phase0.Root]map[spectypes.OperatorID]map[uint64][]p
 				for v := range ded {
 					arr = append(arr, v)
 				}
-				sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+				slices.Sort(arr)
 				buckets = append(buckets, map[string]any{"t": ts, "indices": arr})
 			}
 			// union indices sorted
@@ -167,7 +167,7 @@ func pendingDetails(data map[phase0.Root]map[spectypes.OperatorID]map[uint64][]p
 			for v := range union {
 				unionArr = append(unionArr, v)
 			}
-			sort.Slice(unionArr, func(i, j int) bool { return unionArr[i] < unionArr[j] })
+			slices.Sort(unionArr)
 
 			inner[strconv.FormatUint(signer, 10)] = map[string]any{
 				"by_timestamp":  buckets,

--- a/protocol/v2/types/ssvshare.go
+++ b/protocol/v2/types/ssvshare.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"slices"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -210,9 +209,7 @@ func (s *SSVShare) Quorum() uint64 {
 
 // ComputeClusterIDHash will compute cluster ID hash with given owner address and operator ids
 func ComputeClusterIDHash(address common.Address, operatorIds []uint64) []byte {
-	sort.Slice(operatorIds, func(i, j int) bool {
-		return operatorIds[i] < operatorIds[j]
-	})
+	slices.Sort(operatorIds)
 
 	// Encode the address and operator IDs in the same way as Solidity's abi.encodePacked
 	var data []byte
@@ -245,9 +242,7 @@ func ValidCommitteeSize(committeeSize uint64) bool {
 // Return a 32 bytes ID for the committee of operators
 func ComputeCommitteeID(committee []spectypes.OperatorID) spectypes.CommitteeID {
 	// sort
-	sort.Slice(committee, func(i, j int) bool {
-		return committee[i] < committee[j]
-	})
+	slices.Sort(committee)
 	// Convert to bytes
 	bytes := make([]byte, len(committee)*4)
 	for i, v := range committee {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.