### PR TITLE
operator/duties: fix missing duty fetch on an epoch boundary

### DIFF
--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -84,6 +84,11 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			slot := h.ticker.Slot()
 			next = h.ticker.Next()
 			currentEpoch := h.beaconConfig.EstimatedEpochAtSlot(slot)
+			// If we don't yet have duties recorded for the current epoch (e.g., restart right
+			// before/after an epoch boundary), force a fetch of current-epoch duties.
+			if !h.duties.IsEpochSet(currentEpoch) {
+				h.fetchCurrentEpoch = true
+			}
 			buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, slot, slot%32+1)
 			h.logger.Debug("🛠 ticker event", zap.String("epoch_slot_pos", buildStr))
 
@@ -162,6 +167,12 @@ func (h *AttesterHandler) HandleInitialDuties(ctx context.Context) {
 
 	slot := h.beaconConfig.EstimatedCurrentSlot()
 	epoch := h.beaconConfig.EstimatedEpochAtSlot(slot)
+	// If starting near an epoch boundary, prefetch next-epoch duties so they're
+	// available immediately after rollover.
+	slotsPerEpoch := h.beaconConfig.SlotsPerEpoch
+	if uint64(slot)%slotsPerEpoch >= slotsPerEpoch-2 {
+		h.fetchNextEpoch = true
+	}
 	h.processFetching(ctx, epoch, slot)
 }
 

--- a/operator/duties/attester_test.go
+++ b/operator/duties/attester_test.go
@@ -23,7 +23,9 @@ func setupAttesterDutiesMock(
 	dutiesMap *hashmap.Map[phase0.Epoch, []*eth2apiv1.AttesterDuty],
 	waitForDuties *SafeValue[bool],
 ) (chan struct{}, chan []*spectypes.ValidatorDuty) {
-	fetchDutiesCall := make(chan struct{})
+	// Buffered to avoid deadlocks during HandleInitialDuties (which runs synchronously
+	// inside Scheduler.Start) when the test hasn't started receiving yet.
+	fetchDutiesCall := make(chan struct{}, 8)
 	executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 
 	s.beaconNode.(*MockBeaconNode).EXPECT().AttesterDuties(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -104,6 +106,125 @@ func expectedExecutedAttesterDuties(handler *AttesterHandler, duties []*eth2apiv
 		expectedDuties = append(expectedDuties, handler.toSpecDuty(d, spectypes.BNRoleAggregator))
 	}
 	return expectedDuties
+}
+
+// waitForFetchCount waits for exactly n fetch calls to occur (signaled on fetchDutiesCall)
+// within the given timeout. It fails the test if fewer than n occur before timeout
+// or if any executeDutiesCall arrives unexpectedly.
+func waitForFetchCount(
+	t *testing.T,
+	fetchDutiesCall chan struct{},
+	executeDutiesCall chan []*spectypes.ValidatorDuty,
+	n int,
+	timeout time.Duration,
+) {
+	deadline := time.After(timeout)
+	got := 0
+	for got < n {
+		select {
+		case <-fetchDutiesCall:
+			got++
+		case <-executeDutiesCall:
+			require.FailNow(t, "unexpected execute duty call")
+		case <-deadline:
+			require.FailNowf(t, "timed out waiting for fetch calls", "wanted=%d got=%d", n, got)
+		}
+	}
+}
+
+// Regression: when starting near an epoch boundary, HandleInitialDuties should also
+// prefetch next-epoch duties so the new epoch does not start empty.
+func TestAttester_HandleInitialDuties_PrefetchNextEpoch_NearBoundary(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAttesterHandler(dutystore.NewDuties[eth2apiv1.AttesterDuty](), false)
+	dutiesMap := hashmap.New[phase0.Epoch, []*eth2apiv1.AttesterDuty]()
+	waitForDuties := &SafeValue[bool]{}
+
+	// Start at the last slot of epoch 0 so initial run is "near boundary".
+	startSlot := phase0.Slot(testSlotsPerEpoch - 1)
+
+	// Duty executor expects a deadline on the parent context.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	scheduler, _, schedulerPool := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+	// Ensure wall-clock aligns with the start slot time.
+	waitForSlotN(scheduler.beaconConfig, startSlot)
+
+	// Provide at least one eligible validator so fetches actually occur.
+	dutiesMap.Set(phase0.Epoch(0), []*eth2apiv1.AttesterDuty{{
+		PubKey:         phase0.BLSPubKey{0xaa},
+		Slot:           startSlot, // any slot in epoch 0
+		ValidatorIndex: phase0.ValidatorIndex(1),
+	}})
+	dutiesMap.Set(phase0.Epoch(1), []*eth2apiv1.AttesterDuty{{
+		PubKey:         phase0.BLSPubKey{0xbb},
+		Slot:           startSlot + 1, // any slot in epoch 1
+		ValidatorIndex: phase0.ValidatorIndex(2),
+	}})
+
+	fetchDutiesCall, executeDutiesCall := setupAttesterDutiesMock(scheduler, dutiesMap, waitForDuties)
+
+	// We want to observe both current-epoch and next-epoch fetches during HandleInitialDuties.
+	waitForDuties.Set(true)
+
+	// Start scheduler (synchronously calls HandleInitialDuties for handlers).
+	startScheduler(ctx, t, scheduler, schedulerPool)
+
+	// Expect 2 fetches: one for current epoch (0) and one prefetch for next epoch (1).
+	waitForFetchCount(t, fetchDutiesCall, executeDutiesCall, 2, timeout)
+
+	// No slot tick needed for this test; ensure no spurious executions happen immediately.
+	waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+	// Cleanup.
+	cancel()
+	require.NoError(t, schedulerPool.Wait())
+}
+
+// Regression: when entering a new epoch with an empty duty store (e.g., restart right
+// before epoch rollover), the first tick in the new epoch should force a fetch for
+// the current epoch.
+func TestAttester_Tick_ForceFetch_WhenEpochMissing(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAttesterHandler(dutystore.NewDuties[eth2apiv1.AttesterDuty](), false)
+	dutiesMap := hashmap.New[phase0.Epoch, []*eth2apiv1.AttesterDuty]()
+	waitForDuties := &SafeValue[bool]{}
+
+	// Start early in the epoch (not near boundary) to avoid the startup prefetch path.
+	// This ensures epoch 1 remains missing in the store until the first tick of epoch 1.
+	startSlot := phase0.Slot(1)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	scheduler, mockTicker, schedulerPool := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+	waitForSlotN(scheduler.beaconConfig, startSlot)
+
+	// Prepare shares that will be eligible in epoch 1 so the tick-forced fetch will occur.
+	dutiesMap.Set(phase0.Epoch(1), []*eth2apiv1.AttesterDuty{{
+		PubKey:         phase0.BLSPubKey{0xcc},
+		Slot:           phase0.Slot(testSlotsPerEpoch + 1),
+		ValidatorIndex: phase0.ValidatorIndex(7),
+	}})
+
+	fetchDutiesCall, executeDutiesCall := setupAttesterDutiesMock(scheduler, dutiesMap, waitForDuties)
+
+	// Do not listen to initial fetches.
+	waitForDuties.Set(false)
+	startScheduler(ctx, t, scheduler, schedulerPool)
+
+	// Advance into the first slot of the new epoch.
+	newEpochFirstSlot := phase0.Slot(testSlotsPerEpoch)
+	waitForSlotN(scheduler.beaconConfig, newEpochFirstSlot)
+
+	// Now we want to observe a fetch triggered by the tick due to missing epoch in store.
+	waitForDuties.Set(true)
+	mockTicker.Send(newEpochFirstSlot)
+
+	waitForDutiesFetch(t, fetchDutiesCall, executeDutiesCall, timeout)
+
+	// Cleanup.
+	cancel()
+	require.NoError(t, schedulerPool.Wait())
 }
 
 func TestScheduler_Attester_Same_Slot(t *testing.T) {

--- a/operator/duties/dutystore/sync_committee.go
+++ b/operator/duties/dutystore/sync_committee.go
@@ -78,3 +78,11 @@ func (d *SyncCommitteeDuties) Reset(period uint64) {
 
 	delete(d.m, period)
 }
+
+// IsPeriodSet returns true if there are stored duties for the given period.
+func (d *SyncCommitteeDuties) IsPeriodSet(period uint64) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.m[period]
+	return ok
+}

--- a/operator/duties/sync_committee.go
+++ b/operator/duties/sync_committee.go
@@ -98,6 +98,12 @@ func (h *SyncCommitteeHandler) HandleDuties(ctx context.Context) {
 				tickCtx, cancel := h.ctxWithDeadlineOnNextSlot(ctx, slot)
 				defer cancel()
 
+				// If we don't yet have duties recorded for the current period (e.g., restart right
+				// before/after a period boundary), force a fetch of current-period duties.
+				if !h.duties.IsPeriodSet(period) {
+					h.fetchCurrentPeriod = true
+				}
+
 				h.processExecution(tickCtx, period, slot)
 				h.processFetching(tickCtx, epoch, period, true)
 			}()
@@ -148,6 +154,13 @@ func (h *SyncCommitteeHandler) HandleInitialDuties(ctx context.Context) {
 
 	epoch := h.beaconConfig.EstimatedCurrentEpoch()
 	period := h.beaconConfig.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+	// If starting very close to a period boundary, prefetch next-period duties so they're
+	// available immediately after rollover.
+	slot := h.beaconConfig.EstimatedCurrentSlot()
+	lastSlot := h.beaconConfig.LastSlotOfSyncPeriod(period)
+	if slot >= lastSlot-1 {
+		h.fetchNextPeriod = true
+	}
 	h.processFetching(ctx, epoch, period, false)
 }
 

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -24,7 +24,9 @@ func setupSyncCommitteeDutiesMock(
 	dutiesMap *hashmap.Map[uint64, []*v1.SyncCommitteeDuty],
 	waitForDuties *SafeValue[bool],
 ) (chan struct{}, chan []*spectypes.ValidatorDuty) {
-	fetchDutiesCall := make(chan struct{})
+	// Buffered to avoid deadlocks during HandleInitialDuties (which runs synchronously
+	// inside Scheduler.Start) when the test hasn't started receiving yet.
+	fetchDutiesCall := make(chan struct{}, 8)
 	executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 
 	s.beaconNode.(*MockBeaconNode).EXPECT().SyncCommitteeDuties(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -91,6 +93,85 @@ func expectedExecutedSyncCommitteeDuties(handler *SyncCommitteeHandler, duties [
 		expectedDuties = append(expectedDuties, handler.toSpecDuty(d, slot, spectypes.BNRoleSyncCommitteeContribution))
 	}
 	return expectedDuties
+}
+
+// Prefetch next period during HandleInitialDuties when starting near the period boundary.
+func TestSyncCommittee_HandleInitialDuties_PrefetchNextPeriod_NearBoundary(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+	dutiesMap := hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+	waitForDuties := &SafeValue[bool]{}
+	activeShares := eligibleShares()
+
+	// Start at the last slot of period 0 to be "near boundary".
+	startSlot := phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 1)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	scheduler, _, schedulerPool := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+	waitForSlotN(scheduler.beaconConfig, startSlot)
+
+	// Seed one duty for current period (0) and one for next period (1).
+	dutiesMap.Set(0, []*v1.SyncCommitteeDuty{{
+		PubKey:         phase0.BLSPubKey{0xaa},
+		ValidatorIndex: 1,
+	}})
+	dutiesMap.Set(1, []*v1.SyncCommitteeDuty{{
+		PubKey:         phase0.BLSPubKey{0xbb},
+		ValidatorIndex: 2,
+	}})
+
+	fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMock(scheduler, activeShares, dutiesMap, waitForDuties)
+	waitForDuties.Set(true)
+
+	startScheduler(ctx, t, scheduler, schedulerPool)
+
+	// Expect two fetches during initial handling: current and next period.
+	waitForDutiesFetch(t, fetchDutiesCall, executeDutiesCall, timeout)
+	waitForDutiesFetch(t, fetchDutiesCall, executeDutiesCall, timeout)
+
+	cancel()
+	require.NoError(t, schedulerPool.Wait())
+}
+
+// Force fetch on tick if current period is missing in the store.
+func TestSyncCommittee_Tick_ForceFetch_WhenPeriodMissing(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+	dutiesMap := hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+	waitForDuties := &SafeValue[bool]{}
+	activeShares := eligibleShares()
+
+	// Start early in period 0; we'll remove stored duties then tick to force fetch.
+	startSlot := phase0.Slot(1)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	scheduler, ticker, schedulerPool := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+	waitForSlotN(scheduler.beaconConfig, startSlot)
+
+	// Seed duties for period 0 so a fetch would have content.
+	dutiesMap.Set(0, []*v1.SyncCommitteeDuty{{
+		PubKey:         phase0.BLSPubKey{0xcc},
+		ValidatorIndex: 7,
+	}})
+
+	fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMock(scheduler, activeShares, dutiesMap, waitForDuties)
+	// Let initial duties run (it will fetch current period), then clear the store to mimic "missing".
+	waitForDuties.Set(false)
+	startScheduler(ctx, t, scheduler, schedulerPool)
+
+	// Clear current period from handler store to simulate the gap.
+	period := scheduler.beaconConfig.EstimatedSyncCommitteePeriodAtEpoch(scheduler.beaconConfig.EstimatedCurrentEpoch())
+	handler.duties.Reset(period)
+
+	// Now observe fetch on tick due to missing period.
+	waitForDuties.Set(true)
+	ticker.Send(startSlot + 1)
+	waitForDutiesFetch(t, fetchDutiesCall, executeDutiesCall, timeout)
+
+	cancel()
+	require.NoError(t, schedulerPool.Wait())
 }
 
 func TestScheduler_SyncCommittee_Same_Period(t *testing.T) {


### PR DESCRIPTION
Eliminates missed attestations/sync messages after restarting near a boundary.

Changes:

  - Add startup prefetch when starting in the last 2 slots of an epoch/period.
  - Add tick‑time “fetch‑on‑miss” to immediately fetch duties if the new epoch/period store is empty.
  - Applies to attester and sync‑committee handlers.
