### PR TITLE
metrics: (p2p messages) topic attribute

### DIFF
--- a/message/validation/observability.go
+++ b/message/validation/observability.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"time"
 
 	"github.com/ssvlabs/ssv-spec/types"
 	"go.opentelemetry.io/otel"
@@ -60,4 +61,8 @@ func recordRejectedMessage(ctx context.Context, role types.RunnerRole, reason st
 
 func recordIgnoredMessage(ctx context.Context, role types.RunnerRole, reason string) {
 	messageValidationsIgnoredCounter.Add(ctx, 1, metric.WithAttributes(reasonAttribute(reason), observability.RunnerRoleAttribute(role)))
+}
+
+func recordMessageDuration(ctx context.Context, role types.RunnerRole, dur time.Duration) {
+	messageValidationDurationHistogram.Record(ctx, dur.Seconds(), metric.WithAttributes(observability.RunnerRoleAttribute(role)))
 }

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -206,7 +206,7 @@ func (ctrl *topicsCtrl) Broadcast(topicName string, data []byte, timeout time.Du
 			return
 		}
 
-		outboundMessageCounter.Add(ctrl.ctx, 1, metric.WithAttributes(messageTopicAttribute(topicName)))
+		outboundMessageCounter.Add(ctrl.ctx, 1, metric.WithAttributes(messageTopicAttribute(topicNameFull)))
 	}()
 
 	return nil
@@ -258,9 +258,9 @@ func (ctrl *topicsCtrl) listen(sub *pubsub.Subscription) error {
 	ctx, cancel := context.WithCancel(ctrl.ctx)
 	defer cancel()
 
-	topicName := sub.Topic()
+	topicNameFull := sub.Topic()
 
-	logger := ctrl.logger.With(zap.String("topic", topicName))
+	logger := ctrl.logger.With(zap.String("topic", topicNameFull))
 	logger.Debug("start listening to topic")
 	for ctx.Err() == nil {
 		msg, err := sub.Next(ctx)
@@ -283,14 +283,14 @@ func (ctrl *topicsCtrl) listen(sub *pubsub.Subscription) error {
 		switch m := msg.ValidatorData.(type) {
 		case *queue.SSVMessage:
 			inboundMessageCounter.Add(ctrl.ctx, 1, metric.WithAttributes(
-				messageTopicAttribute(topicName),
+				messageTopicAttribute(topicNameFull),
 				messageTypeAttribute(uint64(m.MsgType)),
 			))
 		default:
 			logger.Warn("unknown message type", zap.Any("message", m))
 		}
 
-		if err := ctrl.msgHandler(ctx, topicName, msg); err != nil {
+		if err := ctrl.msgHandler(ctx, topicNameFull, msg); err != nil {
 			logger.Debug("could not handle msg", zap.Error(err))
 		}
 	}

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -188,26 +188,28 @@ func (ctrl *topicsCtrl) Subscribe(name string) error {
 	return nil
 }
 
-// Broadcast publishes the message on the given topic
-func (ctrl *topicsCtrl) Broadcast(name string, data []byte, timeout time.Duration) error {
-	name = commons.GetTopicFullName(name)
-
-	topic, err := ctrl.container.Join(name)
+// Broadcast publishes the message on the given topic in a non-blocking manner.
+func (ctrl *topicsCtrl) Broadcast(topicName string, data []byte, timeout time.Duration) error {
+	topicNameFull := commons.GetTopicFullName(topicName)
+	topic, err := ctrl.container.Join(topicNameFull)
 	if err != nil {
 		return err
 	}
 
 	go func() {
-		ctx, done := context.WithTimeout(ctrl.ctx, timeout)
-		defer done()
+		ctx, cancel := context.WithTimeout(ctrl.ctx, timeout)
+		defer cancel()
 
 		err := topic.Publish(ctx, data)
-		if err == nil {
-			outboundMessageCounter.Add(ctrl.ctx, 1)
+		if err != nil {
+			ctrl.logger.Error("could not publish p2p message", zap.String("topic", topicName), zap.Error(err))
+			return
 		}
+
+		outboundMessageCounter.Add(ctrl.ctx, 1, metric.WithAttributes(messageTopicAttribute(topicName)))
 	}()
 
-	return err
+	return nil
 }
 
 // Unsubscribe unsubscribes from the given topic, only if there are no other subscribers of the given topic
@@ -280,8 +282,10 @@ func (ctrl *topicsCtrl) listen(sub *pubsub.Subscription) error {
 
 		switch m := msg.ValidatorData.(type) {
 		case *queue.SSVMessage:
-			inboundMessageCounter.Add(ctrl.ctx, 1,
-				metric.WithAttributes(messageTypeAttribute(uint64(m.MsgType))))
+			inboundMessageCounter.Add(ctrl.ctx, 1, metric.WithAttributes(
+				messageTopicAttribute(topicName),
+				messageTypeAttribute(uint64(m.MsgType)),
+			))
 		default:
 			logger.Warn("unknown message type", zap.Any("message", m))
 		}

--- a/network/topics/observability.go
+++ b/network/topics/observability.go
@@ -30,6 +30,10 @@ var (
 			metric.WithDescription("total number of outbound(broadcasted) messages")))
 )
 
+func messageTopicAttribute(value string) attribute.KeyValue {
+	return attribute.String("ssv.p2p.message.topic", value)
+}
+
 func messageTypeAttribute(value uint64) attribute.KeyValue {
 	return attribute.KeyValue{
 		Key:   "ssv.p2p.message.type",


### PR DESCRIPTION
This allows us to see/measure the by-topic breakdown of p2p messages so we can compare topic volumes, for example, to identify "overloaded" ones and such.

<img width="700" height="300" alt="image" src="https://github.com/user-attachments/assets/d541da4d-91e9-4c7b-9020-e438c52d1145" />
