### PR TITLE
validator-registrations: broadcast to all CLs

### DIFF
--- a/beacon/goclient/validator.go
+++ b/beacon/goclient/validator.go
@@ -43,7 +43,9 @@ func (gc *GoClient) GetValidatorData(
 func (gc *GoClient) SubmitValidatorRegistrations(ctx context.Context, registrations []*api.VersionedSignedValidatorRegistration) error {
 	for chunk := range slices.Chunk(registrations, 500) {
 		reqStart := time.Now()
-		err := gc.multiClient.SubmitValidatorRegistrations(ctx, chunk)
+		err := gc.multiClientSubmit(ctx, "SubmitValidatorRegistrations", func(ctx context.Context, client Client) error {
+			return client.SubmitValidatorRegistrations(ctx, chunk)
+		})
 		recordRequest(ctx, gc.log, "SubmitValidatorRegistrations", gc.multiClient, http.MethodPost, true, time.Since(reqStart), err)
 		if err != nil {
 			return errMultiClient(fmt.Errorf("submit validator registrations (chunk size = %d): %w", len(chunk), err), "SubmitValidatorRegistrations")

--- a/beacon/goclient/validator.go
+++ b/beacon/goclient/validator.go
@@ -41,17 +41,18 @@ func (gc *GoClient) GetValidatorData(
 
 // SubmitValidatorRegistrations submits validator registrations, chunking it if necessary.
 func (gc *GoClient) SubmitValidatorRegistrations(ctx context.Context, registrations []*api.VersionedSignedValidatorRegistration) error {
+	start := time.Now()
+
 	for chunk := range slices.Chunk(registrations, 500) {
-		reqStart := time.Now()
 		err := gc.multiClientSubmit(ctx, "SubmitValidatorRegistrations", func(ctx context.Context, client Client) error {
 			return client.SubmitValidatorRegistrations(ctx, chunk)
 		})
-		recordRequest(ctx, gc.log, "SubmitValidatorRegistrations", gc.multiClient, http.MethodPost, true, time.Since(reqStart), err)
 		if err != nil {
 			return errMultiClient(fmt.Errorf("submit validator registrations (chunk size = %d): %w", len(chunk), err), "SubmitValidatorRegistrations")
 		}
-		gc.log.Info("submitted validator registrations", fields.Count(len(chunk)), fields.Took(time.Since(reqStart)))
 	}
+
+	gc.log.Info("submitted validator registrations", fields.Count(len(registrations)), fields.Took(time.Since(start)))
 
 	return nil
 }


### PR DESCRIPTION
This PR updates validator-registrations submission logic such that we'll now send validator-registrations to every CL available to us (instead of sending to just the currently active one, as `multiClient` was doing it previously).