### PR TITLE
CL/EL: clean handling for context cancel

### DIFF
--- a/beacon/goclient/observability.go
+++ b/beacon/goclient/observability.go
@@ -72,24 +72,32 @@ func recordRequest(
 	// to it (there are too many requests being made to log them every time, some requests don't even result
 	// into a network-based call due to caching implemented for some routes).
 	if err != nil || duration > 1*time.Millisecond {
+		success := "true"
+		if err != nil {
+			success = "false"
+			if errors.Is(err, context.Canceled) {
+				success = "unknown" // we don't know the outcome of this request
+			}
+		}
 		logger.Debug("CL request done",
 			zap.String("route_name", routeName),
 			zap.String("client_addr", client.Address()),
 			zap.String("http_method", httpMethod),
 			zap.Bool("maybe_fallback", maybeFallback),
 			fields.Took(duration),
-			zap.Bool("success", err == nil),
+			zap.String("success", success),
 			zap.Error(err),
 		)
 	}
 
-	// Build metric attributes, add error-code attribute in case there is an error.
+	// Build metric attributes, add error-code attribute in case there is an error (treat context.Canceled
+	// as non-error since it means we've canceled the request ourselves).
 	attr := []attribute.KeyValue{
 		semconv.ServerAddress(client.Address()),
 		semconv.HTTPRequestMethodKey.String(httpMethod),
 		attribute.String("http.route_name", routeName),
 	}
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Error code of 0 signifies the presence of some error, see if we can clarify if further by using
 		// api error codes.
 		errCode := 0


### PR DESCRIPTION
The `context canceled` error means we've canceled request on our own, so we shouldn't be treating/recording it as an error (to keep error-list clean and legible).