### PR TITLE
git: stabilize tag versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,mode=0755,target=/go/pkg \
     COMMIT=$(git rev-parse HEAD) && \
-    VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
+    VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged") && \
     CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH \
     go install \
       -tags="blst_enabled" \

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -70,7 +70,7 @@ RUN set -eux; \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,mode=0755,target=/go/pkg \
     COMMIT=$(git rev-parse HEAD) && \
-    VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
+    VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged") && \
     CC=$(case "$TARGETARCH" in \
       amd64) echo x86_64-linux-gnu-gcc ;; \
       arm64) echo aarch64-linux-gnu-gcc ;; \

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ docker-benchmark:
 .PHONY: build
 .DEFAULT_GOAL := build # this makes `make` default to `make build`
 build:
-	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/
+	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged"`" ./cmd/ssvnode/
 
 .PHONY: spec-alignment-diff
 spec-alignment-diff:

--- a/hooks/build
+++ b/hooks/build
@@ -6,17 +6,17 @@ set -eo pipefail
 export DOCKER_BUILDKIT=1
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+# Use HEAD commit if none was specified (eg. when running locally)
+COMMIT="HEAD"
 if [ -n "${SOURCE_COMMIT}" ]; then
-  APP_VERSION=$(git describe --tags --exact-match "${SOURCE_COMMIT}" 2>/dev/null || echo "untagged")
+  COMMIT="${SOURCE_COMMIT}"
   echo "Using SOURCE_COMMIT=${SOURCE_COMMIT}"
-else
-  # We are running locally, use HEAD commit
-  APP_VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged")
 fi
+APP_VERSION=$(git describe --tags --exact-match "${COMMIT}" 2>/dev/null || echo "untagged")
 
 echo "Build Configuration:"
 echo "  Image: ${IMAGE_NAME}"
-echo "  Commit: ${SOURCE_COMMIT}"
+echo "  Commit: ${COMMIT}"
 echo "  Version: ${APP_VERSION}"
 
 docker buildx rm ssv-multiplatform-builder 2>/dev/null || true

--- a/hooks/build
+++ b/hooks/build
@@ -7,11 +7,11 @@ export DOCKER_BUILDKIT=1
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 if [ -n "${SOURCE_COMMIT}" ]; then
-  APP_VERSION=$(git describe --tags "${SOURCE_COMMIT}")
+  APP_VERSION=$(git describe --tags --exact-match "${SOURCE_COMMIT}" 2>/dev/null || echo "untagged")
   echo "Using SOURCE_COMMIT=${SOURCE_COMMIT}"
 else
-  # Extract Git tag when running locally
-  APP_VERSION=$(git describe --tags 2>/dev/null || echo "latest")
+  # We are running locally, use HEAD commit
+  APP_VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged")
 fi
 
 echo "Build Configuration:"

--- a/ssvsigner/Dockerfile
+++ b/ssvsigner/Dockerfile
@@ -37,7 +37,7 @@ COPY .. .
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,mode=0755,target=/go/pkg \
   COMMIT=$(git rev-parse HEAD) && \
-  VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
+  VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "untagged") && \
   CGO_ENABLED=1 GOOS=linux go install -C ./ssvsigner/cmd/ssv-signer \
   -tags="blst_enabled" \
   -ldflags "-X main.Commit=$COMMIT -X main.Version=$VERSION -linkmode external -extldflags \"-static -lm\"" 


### PR DESCRIPTION
This PR corrects `VERSION` attribute initialization such that it will always be:
- either initialized with the corresponding tag via `git describe --tags` lookup (if such tag exists)
- or explicitly mention that there is no tag associated with that commit (**untagged**), while previously it would assign the latest tag available (which is confusing in some situations since that tag would correspond to a different commit, not the commit we are actually running ... which is what `COMMIT` attribute is assigned to)

Example output (for untagged commit):
- before
```
{"level":"\u001b[34mINFO\u001b[0m","time":"2025-12-10T09:35:12.507697Z","msg":"starting SSV-Node:v2.3.9-unstable.2-4be3b68507921713e0fcc3c6de7e84864ec60076"}
```
- after
```
{"level":"\u001b[34mINFO\u001b[0m","time":"2025-12-10T12:05:13.977855Z","msg":"starting SSV-Node:untagged-5b117a30027d1b14388c1d10bab903bbf87edf66"}
```

Note, for `git describe --tags` to work properly we need to create "annotated" tags (otherwise the tag list corresponding to the same commit cannot be sorted correctly by git, potentially resulting in `VERSION` set to something like `v2.3.9-unstable.2` instead of `v2.3.9` ... which is technically correct, but a bit confusing still). I don't know of a simple way to improve that part.

Resolves https://github.com/ssvlabs/ssv/issues/2516