### PR TITLE
logs: standardize default log level

### DIFF
--- a/cli/GENERATE_CONFIG.md
+++ b/cli/GENERATE_CONFIG.md
@@ -24,7 +24,7 @@ The `generate-config` command allows you to generate a YAML configuration file b
 | Flag                                 | Type   | Default                           | Description                                                                |
 |--------------------------------------|--------|-----------------------------------|----------------------------------------------------------------------------|
 | `--output-path`                      | string | `./config/config.local.yaml`      | Output path for the generated configuration file.                          |
-| `--log-level`                        | string | `info`                            | Sets the logging level (e.g., `debug`, `info`, `warn`, `error`).           |
+| `--log-level`                        | string | `debug`                           | Sets the logging level (e.g., `debug`, `info`, `warn`, `error`).           |
 | `--db-path`                          | string | `./data/db`                       | Path to the database directory.                                            |
 | `--discovery`                        | string | `mdns`                            | Discovery method.                                                          |
 | `--consensus-client`                 | string | _Mandatory_                       | Address of the consensus client (e.g., `http://localhost:9000`).           |

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -18,7 +18,7 @@ type Args struct {
 
 // Global expose available global config for cli command
 type Global struct {
-	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Defines logger's log level"`
+	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"debug" env-description:"Defines logger's log level"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Defines logger's encoding, valid values are 'json' and 'console' (default)"`
 	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Defines logger's level format, valid values are 'capitalColor' (default), 'capital' or 'lowercase'"`
 	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./data/debug.log" env-description:"File path to write logs to"`

--- a/cli/generate_config.go
+++ b/cli/generate_config.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultOutputPath     = "./config/config.local.yaml"
-	defaultLogLevel       = "info"
+	defaultLogLevel       = "debug"
 	defaultDBPath         = "./data/db"
 	defaultDiscovery      = "mdns"
 	sliceSeparator        = ","

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,6 @@
 global:
   # Console log level (debug, info, warn, error, fatal, panic)
-  LogLevel: info
+  LogLevel: debug
   
   # Debug logs file path
   LogFilePath: ./data/debug.log

--- a/ssvsigner/cmd/ssv-signer/ssv-signer.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer.go
@@ -25,7 +25,7 @@ type CLI struct {
 	PrivateKey         string        `env:"PRIVATE_KEY" xor:"keys" required:"" help:"Base64‑encoded PEM blob (RSA PRIVATE KEY) for operator; exclusive with PRIVATE_KEY_FILE"`
 	PrivateKeyFile     string        `env:"PRIVATE_KEY_FILE" xor:"keys" and:"files" help:"Path to an encrypted keystore JSON file (v4 format) containing an RSA private key; exclusive with PRIVATE_KEY"`
 	PasswordFile       string        `env:"PASSWORD_FILE" and:"files" help:"Path to file containing the password used to decrypt the keystore JSON file"`
-	LogLevel           string        `env:"LOG_LEVEL" default:"info" enum:"debug,info,warn,error" help:"Set log level (debug, info, warn, error)"`
+	LogLevel           string        `env:"LOG_LEVEL" default:"debug" enum:"debug,info,warn,error" help:"Set log level (debug, info, warn, error)"`
 	LogFormat          string        `env:"LOG_FORMAT" default:"console" enum:"console,json" help:"Set log format (console, json)"`
 	RequestTimeout     time.Duration `env:"REQUEST_TIMEOUT" default:"10s" help:"Timeout for outgoing HTTP requests (e.g. 500ms, 10s)"`
 


### PR DESCRIPTION
We are using `DEBUG` as default log level almost everywhere (for our own deployments, as well as 3rd party Operators are also running with that level), and `INFO` produces way too little information for troubleshooting anyway,

so it's better to be explicit and consistent about it - this PR ensures we always default to `DEBUG` log level every time (unless it's explicitly overridden with a corresponding configuration setting).