### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"slices"
+
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
@@ -76,12 +78,7 @@ func (dvs *DiscV5Service) subnetFilter(subnets ...uint64) func(node *enode.Node)
 		if err != nil {
 			return false
 		}
-		for _, subnet := range subnets {
-			if fromEntry.IsSet(subnet) {
-				return true
-			}
-		}
-		return false
+		return slices.ContainsFunc(subnets, fromEntry.IsSet)
 	}
 }
 

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -1085,11 +1086,8 @@ func TestCollector_processPartialSigCommittee_UnknownRootBuffers(t *testing.T) {
 	require.True(t, ok)
 	found := false
 	for _, idxs := range byTs {
-		for _, idx := range idxs {
-			if idx == 55 {
-				found = true
-				break
-			}
+		if slices.Contains(idxs, 55) {
+			found = true
 		}
 	}
 	require.True(t, found, "expected buffered index for unknown root")
@@ -1160,11 +1158,8 @@ func TestCollector_FlushPending_Timestamps(t *testing.T) {
 	var times []uint64
 	for _, sd := range duty.SyncCommittee {
 		if sd.Signer == 99 {
-			for _, idx := range sd.ValidatorIdx {
-				if idx == 77 {
-					times = append(times, sd.ReceivedTime)
-					break
-				}
+			if slices.Contains(sd.ValidatorIdx, 77) {
+				times = append(times, sd.ReceivedTime)
 			}
 		}
 	}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.