### PR TITLE
Rework Scored Proposal logic

### DIFF
--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -498,7 +498,7 @@ func createClient(
 			CommonTimeout:               defaultHardTimeout,
 			LongTimeout:                 time.Second,
 			WithWeightedAttestationData: withWeightedAttestationData,
-		}, 0)
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/beacon/goclient/events_test.go
+++ b/beacon/goclient/events_test.go
@@ -78,7 +78,7 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 }
 
 func eventsTestClient(t *testing.T, serverURL string) *GoClient {
-	opt, err := NewOptions(Options{BeaconNodeAddr: serverURL}, 0)
+	opt, err := NewOptions(Options{BeaconNodeAddr: serverURL})
 	require.NoError(t, err)
 
 	server, err := New(t.Context(), zap.NewNop(), opt)

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -130,13 +130,10 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
-	// proposalSoftTimeout is the maximum time to wait for multiple block proposals in
+	// proposalTimeout is the maximum time to wait for multiple block proposals in
 	// order to select the best one from multiple clients.
-	// If no proposal has been received after this time elapses, the first valid proposal
-	// seen is returned
-	// proposalHardTimeout is the hard timeout for retrieving any proposals.
-	proposalSoftTimeout time.Duration
-	proposalHardTimeout time.Duration
+	// When selecting from a single client, it is the timeout of the call.
+	proposalTimeout time.Duration
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
@@ -186,8 +183,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(opt.CommonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: opt.CommonTimeout,
-		proposalSoftTimeout:                opt.ProposalSoftTimeout,
-		proposalHardTimeout:                opt.ProposalHardTimeout,
+		proposalTimeout:                    opt.ProposalTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -1,7 +1,6 @@
 package goclient
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -13,8 +12,7 @@ const (
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
 	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Millisecond * 1600
-	DefaultProposalHardTimeout = time.Millisecond * 2600
+	DefaultProposalTimeout = time.Millisecond * 1600
 )
 
 // Options defines beacon client options
@@ -28,11 +26,10 @@ type Options struct {
 	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
 	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
-	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD_TIMEOUT" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
+	ProposalTimeout time.Duration `yaml:"ProposalTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection timeout, after proposer delay has ellapsed"`
 }
 
-func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
+func NewOptions(base Options) (Options, error) {
 	options := base
 
 	if options.CommonTimeout == 0 {
@@ -43,26 +40,8 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 		options.LongTimeout = DefaultLongTimeout
 	}
 
-	if options.ProposalSoftTimeout == 0 {
-		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
-	}
-
-	if options.ProposalHardTimeout == 0 {
-		options.ProposalHardTimeout = DefaultProposalHardTimeout
-	}
-
-	if proposerDelay > 0 {
-		options.ProposalSoftTimeout -= proposerDelay
-		options.ProposalHardTimeout -= proposerDelay
-	}
-
-	if options.ProposalSoftTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal soft timeout: %s", options.ProposalSoftTimeout)
-	}
-
-	if options.ProposalHardTimeout < options.ProposalSoftTimeout ||
-		options.ProposalHardTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal hard timeout: %s", options.ProposalHardTimeout)
+	if options.ProposalTimeout == 0 {
+		options.ProposalTimeout = DefaultProposalTimeout
 	}
 
 	return options, nil

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/observability/traces"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 )
 
 // ProposerDuties returns proposer duties for the given epoch.
@@ -68,9 +69,9 @@ func (gc *GoClient) GetBeaconBlock(
 	graffiti := [32]byte{}
 	copy(graffiti[:], graffitiBytes[:])
 
-	proposeTime, ok := ctx.Value("ProposeTime").(time.Time)
+	proposeTime, ok := ctx.Value(beacon.ProposeTimeContextKey{}).(time.Time)
 	if !ok {
-		// short circut the prefetch
+		// short circuit the prefetch
 		proposeTime = time.Now()
 	}
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -49,34 +49,6 @@ func (gc *GoClient) ProposerDuties(ctx context.Context, epoch phase0.Epoch, vali
 	return resp.Data, nil
 }
 
-// fetchProposal fetches a proposal from a single client and records metrics
-func (gc *GoClient) fetchProposal(
-	ctx context.Context,
-	client Client,
-	slot phase0.Slot,
-	sig phase0.BLSSignature,
-	graffiti [32]byte,
-) (*api.VersionedProposal, error) {
-	reqStart := time.Now()
-	resp, err := client.Proposal(ctx, &api.ProposalOpts{
-		Slot:         slot,
-		RandaoReveal: sig,
-		Graffiti:     graffiti,
-	})
-	recordRequest(ctx, gc.log, "Proposal", client, http.MethodGet, false, time.Since(reqStart), err)
-	if err != nil {
-		return nil, errSingleClient(fmt.Errorf("fetch proposal: %w", err), client.Address(), "Proposal")
-	}
-	if resp == nil {
-		return nil, errSingleClient(fmt.Errorf("proposal response is nil"), client.Address(), "Proposal")
-	}
-	if resp.Data == nil {
-		return nil, errSingleClient(fmt.Errorf("proposal response data is nil"), client.Address(), "Proposal")
-	}
-
-	return resp.Data, nil
-}
-
 // GetBeaconBlock implements ProposerCalls.GetBeaconBlock
 func (gc *GoClient) GetBeaconBlock(
 	ctx context.Context,
@@ -96,22 +68,77 @@ func (gc *GoClient) GetBeaconBlock(
 	graffiti := [32]byte{}
 	copy(graffiti[:], graffitiBytes[:])
 
+	proposeTime, ok := ctx.Value("ProposeTime").(time.Time)
+	if !ok {
+		// short circut the prefetch
+		proposeTime = time.Now()
+	}
+
 	var beaconBlock *api.VersionedProposal
+	var beaconClient string
 	var err error
 
-	// For single client, use direct call to avoid multi-client overhead
-	if len(gc.clients) == 1 {
-		beaconBlock, err = gc.fetchProposal(ctx, gc.clients[0], slot, sig, graffiti)
+	start := time.Now()
+
+	// if there is time before the proposal is due (factoring in proposer delay)
+	// we prefetch the current best block so that we are always ready to return
+	// a block.
+	if time.Now().Before(proposeTime) {
+		prefetchCtx, prefetchCancel := context.WithDeadline(ctx, proposeTime)
+		defer prefetchCancel()
+
+		startPrefetch := time.Now()
+
+		beaconBlock, beaconClient, err = gc.getProposal(prefetchCtx, logger, slot, sig, graffiti)
 		if err != nil {
-			return nil, nil, err
+			logger.Warn("failed to prefetch block proposal", zap.Error(err))
+		} else {
+			proposalScore := gc.scoreProposal(beaconBlock)
+			logger.Debug("prefetched proposal",
+				zap.String("client", beaconClient),
+				zap.Float64("score", proposalScore),
+				zap.Duration("latency", time.Since(startPrefetch)),
+				zap.Bool("blinded", beaconBlock.Blinded),
+				fields.Slot(slot),
+			)
 		}
-	} else {
-		// For multiple clients, race them in parallel for the fastest response
-		beaconBlock, err = gc.getProposalParallel(ctx, logger, slot, sig, graffiti)
-		if err != nil {
+
+		// wait out the prposer delay
+		if timeLeft := time.Until(proposeTime); timeLeft > 0 {
+			select {
+			case <-prefetchCtx.Done():
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
+		}
+	}
+
+	// now fetch again the best available block
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, gc.proposalTimeout)
+	defer fetchCancel()
+
+	latestBeaconBlock, latestBeaconClient, err := gc.getProposal(fetchCtx, logger, slot, sig, graffiti)
+	if err != nil {
+		logger.Warn("failed to fetch final block proposal", zap.Error(err))
+
+		if beaconBlock == nil {
 			return nil, nil, err
 		}
 	}
+
+	beaconBlock = gc.selectProposal(beaconBlock, latestBeaconBlock)
+	if beaconBlock == latestBeaconBlock {
+		beaconClient = latestBeaconClient
+	}
+
+	proposalScore := gc.scoreProposal(beaconBlock)
+	logger.Debug("selected proposal",
+		zap.String("client", beaconClient),
+		zap.Float64("score", proposalScore),
+		zap.Duration("latency", time.Since(start)),
+		zap.Bool("blinded", beaconBlock.Blinded),
+		fields.Slot(slot),
+	)
 
 	// Check and log if fee recipient is missing (for both single and multi-client paths)
 	feeRecipient, err := beaconBlock.FeeRecipient()
@@ -152,37 +179,68 @@ func (gc *GoClient) GetBeaconBlock(
 	}
 }
 
-// getProposalParallel races all beacon nodes and collects proposals for a short time
-// and returns the best one according to our score function.
-// If no valid proposals are collected in this time it returns the first valid one
-// it sees.
-//
-// This minimizes latency for time-critical block proposals, while still affording
-// some time for selecting maximally profitable proposals. Remaining requests are
-// canceled immediately to reduce load.
+func (gc *GoClient) getProposal(
+	ctx context.Context,
+	logger *zap.Logger,
+	slot phase0.Slot,
+	sig phase0.BLSSignature,
+	graffiti [32]byte,
+) (*api.VersionedProposal, string, error) {
+	if len(gc.clients) == 1 {
+		client := gc.clients[0]
+		block, err := gc.fetchProposal(ctx, logger, client, slot, sig, graffiti)
+		return block, client.Address(), err
+	}
+
+	return gc.fetchProposalParallel(ctx, logger, slot, sig, graffiti)
+}
+
+// fetchProposal fetches a proposal from a single client and records metrics
+func (gc *GoClient) fetchProposal(
+	ctx context.Context,
+	logger *zap.Logger,
+	client Client,
+	slot phase0.Slot,
+	sig phase0.BLSSignature,
+	graffiti [32]byte,
+) (*api.VersionedProposal, error) {
+	reqStart := time.Now()
+	resp, err := client.Proposal(ctx, &api.ProposalOpts{
+		Slot:         slot,
+		RandaoReveal: sig,
+		Graffiti:     graffiti,
+	})
+	recordRequest(ctx, gc.log, "Proposal", client, http.MethodGet, false, time.Since(reqStart), err)
+	if err != nil {
+		return nil, errSingleClient(fmt.Errorf("fetch proposal: %w", err), client.Address(), "Proposal")
+	}
+	if resp == nil {
+		return nil, errSingleClient(fmt.Errorf("proposal response is nil"), client.Address(), "Proposal")
+	}
+	if resp.Data == nil {
+		return nil, errSingleClient(fmt.Errorf("proposal response data is nil"), client.Address(), "Proposal")
+	}
+
+	return resp.Data, nil
+}
+
+// fetchProposalParallel races all beacon nodes to select the best block according
+// to our score function.
+// The race ends early if a blinded (MEV) block is encountered, at which point
+// we short circuit and select the current best block.
 //
 // Note: We used to prioritize speed over fee recipient validation - returning
 // the first response rather than waiting to compare fee recipients, as missing
 // a proposal slot is worse than a nil fee recipient.
 // However, it has been observed that the first proposal is usually not the most
 // profitable, so we added a little slack time to collect proposals.
-func (gc *GoClient) getProposalParallel(
+func (gc *GoClient) fetchProposalParallel(
 	ctx context.Context,
 	logger *zap.Logger,
 	slot phase0.Slot,
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
-) (*api.VersionedProposal, error) {
-	// Create a context that we'll use to collect and evaluate proposals for a short time
-	// after this context expires, we will return the current best proposal or the first
-	// on we see if we have none
-	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalSoftTimeout)
-	defer cancelSoft()
-
-	// Create a context for hard proposal timeout; we fail if this timeout expires
-	hardCtx, cancelHard := context.WithTimeout(ctx, gc.proposalHardTimeout)
-	defer cancelHard()
-
+) (*api.VersionedProposal, string, error) {
 	type result struct {
 		proposal *api.VersionedProposal
 		err      error
@@ -193,23 +251,22 @@ func (gc *GoClient) getProposalParallel(
 
 	for _, client := range gc.clients {
 		go func(c Client) {
-			proposal, err := gc.fetchProposal(hardCtx, c, slot, sig, graffiti)
+			proposal, err := gc.fetchProposal(ctx, logger, c, slot, sig, graffiti)
 			select {
 			case resultCh <- result{proposal: proposal, err: err, client: c.Address()}:
-			case <-hardCtx.Done():
-				// Context canceled, exit without blocking
+			case <-ctx.Done():
 			}
 		}(client)
 	}
 
 	var errs error
 	var bestProposal *api.VersionedProposal
-	var bestScore float64
 	var bestClient string
+	var bestScore float64
 
 	startCollect := time.Now()
 	pendingClients := len(gc.clients)
-collect:
+loop:
 	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
@@ -230,14 +287,11 @@ collect:
 				fields.Slot(slot),
 			)
 
-			if bestProposal == nil ||
-				proposalScore > bestScore ||
-				// this condition prefers the blinded proposal even if same score
-				// as the best we have observed so far
-				(res.proposal.Blinded && proposalScore == bestScore) {
-				bestProposal = res.proposal
-				bestScore = proposalScore
+			bestProposal = gc.selectProposal(bestProposal, res.proposal)
+
+			if bestProposal == res.proposal {
 				bestClient = res.client
+				bestScore = proposalScore
 			}
 
 			if res.proposal.Blinded {
@@ -248,12 +302,12 @@ collect:
 				// see https://github.com/ssvlabs/ssv/pull/2631#issuecomment-3678879204
 				// Note: We may want to add an operator option to disable this behavior
 				// in the future.
-				break collect
+				break loop
 			}
 
-		case <-softCtx.Done():
+		case <-ctx.Done():
 			// we are done collecting;
-			break collect
+			break loop
 		}
 	}
 
@@ -267,44 +321,10 @@ collect:
 			fields.Slot(slot),
 		)
 
-		return bestProposal, nil
+		return bestProposal, bestClient, nil
 	}
 
-	logger.Debug("did not receive any valid proposals during the collection period",
-		zap.Int("clients", len(gc.clients)),
-		zap.Int("pending", pendingClients),
-		fields.Slot(slot),
-	)
-
-	// there are potentially still some collectors running, just return the first valid one
-	for pendingClients > 0 {
-		select {
-		case res := <-resultCh:
-			pendingClients--
-
-			if res.err != nil {
-				errs = errors.Join(errs, res.err)
-				continue
-			}
-
-			// Got a successful response, cancel other requests and return.
-			proposalScore := gc.scoreProposal(res.proposal)
-			logger.Debug("received proposal; selected first proposal",
-				zap.String("client", res.client),
-				zap.Float64("score", proposalScore),
-				zap.Duration("latency", time.Since(startCollect)),
-				zap.Int("pending", pendingClients),
-				zap.Bool("blinded", res.proposal.Blinded),
-				fields.Slot(slot),
-			)
-			return res.proposal, nil
-
-		case <-hardCtx.Done():
-			return nil, hardCtx.Err()
-		}
-	}
-
-	return nil, fmt.Errorf("all %d clients failed to get proposal for slot %d, encountered errors: %w", len(gc.clients), slot, errs)
+	return nil, "", fmt.Errorf("all %d clients failed to get proposal for slot %d, encountered errors: %w", len(gc.clients), slot, errs)
 }
 
 // scoreProposal computes a score for a beacon proposal.
@@ -314,6 +334,41 @@ func (gc *GoClient) scoreProposal(
 ) float64 {
 	score, _ := new(big.Int).Add(proposal.ConsensusValue, proposal.ExecutionValue).Float64()
 	return score
+}
+
+// selectProposal selects between two, possibly nil, proposals based on score and blind
+func (gc *GoClient) selectProposal(
+	left *api.VersionedProposal,
+	right *api.VersionedProposal,
+) *api.VersionedProposal {
+	if left == nil {
+		return right
+	}
+
+	if right == nil {
+		return left
+	}
+
+	leftScore := gc.scoreProposal(left)
+	rightScore := gc.scoreProposal(right)
+
+	switch {
+	case leftScore < rightScore:
+		return right
+	case rightScore < leftScore:
+		return left
+	default:
+		// tie, select the blinded one
+		if left.Blinded {
+			return left
+		}
+
+		if right.Blinded {
+			return right
+		}
+
+		return left
+	}
 }
 
 // SubmitBeaconBlock submit the block to the node

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -127,8 +127,8 @@ func (gc *GoClient) GetBeaconBlock(
 		}
 	}
 
-	beaconBlock = gc.selectProposal(beaconBlock, latestBeaconBlock)
-	if beaconBlock == latestBeaconBlock {
+	if latestBeaconBlock != nil {
+		beaconBlock = latestBeaconBlock
 		beaconClient = latestBeaconClient
 	}
 

--- a/beacon/goclient/proposer_test.go
+++ b/beacon/goclient/proposer_test.go
@@ -684,7 +684,7 @@ func createClientForProposerTest(t *testing.T, serverURL string) (*GoClient, err
 			BeaconNodeAddr: serverURL,
 			CommonTimeout:  time.Second * 2,
 			LongTimeout:    time.Second * 5,
-		}, 0)
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -189,7 +189,7 @@ var StartNodeCmd = &cobra.Command{
 			zap.Bool("with_parallel_submissions", cfg.ConsensusClient.WithParallelSubmissions),
 		)
 
-		cliopt, err := goclient.NewOptions(cfg.ConsensusClient, cfg.ProposerDelay)
+		cliopt, err := goclient.NewOptions(cfg.ConsensusClient)
 		if err != nil {
 			logger.Fatal("failed to create beacon client options",
 				zap.Error(err),

--- a/protocol/v2/blockchain/beacon/context.go
+++ b/protocol/v2/blockchain/beacon/context.go
@@ -1,0 +1,3 @@
+package beacon
+
+type ProposeTimeContextKey struct{}

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -153,31 +153,20 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 		fields.PreConsensusTime(r.measurements.PreConsensusTime()),
 	)
 
-	// Sleep the remaining proposerDelay since slot start, ensuring on-time proposals even if duty began late.
+	// compute the remaining proposerDelay since slot start, ensuring on-time proposals even if duty began late.
 	slotTime := r.BaseRunner.NetworkConfig.SlotStartTime(duty.Slot)
 	proposeTime := slotTime.Add(r.proposerDelay)
-	if timeLeft := time.Until(proposeTime); timeLeft > 0 {
-		select {
-		case <-time.After(timeLeft):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-
-	waitedOutProposerDelayEvent := fmt.Sprintf("waited out proposer delay of %dms", r.proposerDelay.Milliseconds())
-	logger.Debug(waitedOutProposerDelayEvent)
-	span.AddEvent(waitedOutProposerDelayEvent)
-
-	duty = r.state().CurrentDuty.(*spectypes.ValidatorDuty)
+	fetchCtx := context.WithValue(ctx, "ProposeTime", proposeTime)
+	start := time.Now()
 
 	// Fetch the block our operator will propose if it is a Leader (note, even if our operator
 	// isn't leading the 1st QBFT round it might become a Leader in case of round change - hence
 	// we are always fetching Ethereum block here just in case we need to propose it).
-	start := time.Now()
-	vBlk, _, err := r.GetBeaconNode().GetBeaconBlock(ctx, duty.Slot, r.graffiti, fullSig)
+	vBlk, _, err := r.GetBeaconNode().GetBeaconBlock(fetchCtx, duty.Slot, r.graffiti, fullSig)
 	if err != nil {
 		return fmt.Errorf("get beacon block: %w", err)
 	}
+
 	// Log essentials about the retrieved block.
 	logFields := []zap.Field{
 		zap.String("version", vBlk.Version.String()),

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -156,7 +156,7 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	// compute the remaining proposerDelay since slot start, ensuring on-time proposals even if duty began late.
 	slotTime := r.BaseRunner.NetworkConfig.SlotStartTime(duty.Slot)
 	proposeTime := slotTime.Add(r.proposerDelay)
-	fetchCtx := context.WithValue(ctx, "ProposeTime", proposeTime)
+	fetchCtx := context.WithValue(ctx, beacon.ProposeTimeContextKey{}, proposeTime)
 	start := time.Now()
 
 	// Fetch the block our operator will propose if it is a Leader (note, even if our operator


### PR DESCRIPTION
Given our observations from QA testing, it seems our original logic is not robust. This reworks the logic so to properly account for the proposal delay.

The new logic is as follows:
1. If there is a proposer delay, prefetch the best block before waiting.
2. Wait for the proposer delay
3. Fetch the best block.

The soft/hard timeout distinction is also gone, no longer sensible.