### PR TITLE
Proposal: only soft timeout and wait. use 1.8s default and allow flag to change.

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -130,13 +130,11 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
-	// proposalSoftTimeout is the maximum time to wait for multiple block proposals in
-	// order to select the best one from multiple clients.
-	// If no proposal has been received after this time elapses, the first valid proposal
-	// seen is returned
-	// proposalHardTimeout is the hard timeout for retrieving any proposals.
+	// proposalSoftTimeout is the collection period during which we gather proposals
+	// from multiple beacon nodes to select the best one. After this timeout, we return
+	// the best proposal seen so far, or wait for the first valid proposal if none
+	// received yet. The parent context (duty deadline) serves as the hard timeout.
 	proposalSoftTimeout time.Duration
-	proposalHardTimeout time.Duration
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
@@ -187,7 +185,6 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		weightedAttestationDataSoftTimeout: time.Duration(float64(opt.CommonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: opt.CommonTimeout,
 		proposalSoftTimeout:                opt.ProposalSoftTimeout,
-		proposalHardTimeout:                opt.ProposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -1,7 +1,6 @@
 package goclient
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -12,9 +11,23 @@ const (
 	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
-	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Millisecond * 1600
-	DefaultProposalHardTimeout = time.Millisecond * 2600
+	// DefaultProposalSoftTimeout is the base collection period during which we
+	// gather proposals from multiple beacon nodes to select the best one.
+	// This value is reduced by the proposer delay to maintain consistent timing.
+	// After the soft timeout, we return the best proposal seen so far, or wait
+	// for the first valid proposal if none received yet.
+	// The parent context (duty deadline) serves as the hard timeout.
+	//
+	// Note: MEV (blinded) blocks return immediately, so this timeout mainly
+	// affects how long we wait for MEV when we first receive a vanilla block.
+	//
+	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
+	// set, the value is used as-is without proposer delay reduction (power user mode).
+	DefaultProposalSoftTimeout = time.Millisecond * 3000
+
+	// MinProposalSoftTimeout is the minimum collection period, even with maximum
+	// proposer delay. This ensures we always have some time to compare proposals.
+	MinProposalSoftTimeout = time.Millisecond * 500
 )
 
 // Options defines beacon client options
@@ -28,8 +41,7 @@ type Options struct {
 	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
 	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
-	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD_TIMEOUT" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes)"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
@@ -43,27 +55,32 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 		options.LongTimeout = DefaultLongTimeout
 	}
 
+	// If user explicitly set ProposalSoftTimeout, use it as-is (power user mode).
+	// Otherwise, use default and reduce by proposer delay.
 	if options.ProposalSoftTimeout == 0 {
 		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
+
+		// Reduce soft timeout by proposer delay to maintain consistent timing.
+		// Users with proposer delay start fetching later, so they get a shorter
+		// collection period. This ensures consensus starts at roughly the same
+		// time regardless of proposer delay configuration.
+		//
+		// Examples (with default 3000ms soft timeout):
+		//   - 0ms delay    → 3000ms collection
+		//   - 500ms delay  → 2500ms collection
+		//   - 1500ms delay → 1500ms collection
+		//   - 2500ms delay → 500ms collection (capped at minimum)
+		if proposerDelay > 0 {
+			options.ProposalSoftTimeout -= proposerDelay
+			if options.ProposalSoftTimeout < MinProposalSoftTimeout {
+				options.ProposalSoftTimeout = MinProposalSoftTimeout
+			}
+		}
 	}
 
-	if options.ProposalHardTimeout == 0 {
-		options.ProposalHardTimeout = DefaultProposalHardTimeout
-	}
-
-	if proposerDelay > 0 {
-		options.ProposalSoftTimeout -= proposerDelay
-		options.ProposalHardTimeout -= proposerDelay
-	}
-
-	if options.ProposalSoftTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal soft timeout: %s", options.ProposalSoftTimeout)
-	}
-
-	if options.ProposalHardTimeout < options.ProposalSoftTimeout ||
-		options.ProposalHardTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal hard timeout: %s", options.ProposalHardTimeout)
-	}
+	// Note: There is no hard timeout for proposals. The parent context from the
+	// duty runner (bounded by slot timing) serves as the ultimate deadline.
+	// This ensures we never give up early on getting a block proposal.
 
 	return options, nil
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
 	// set, the value is used as-is without proposer delay reduction (power user mode).
-	DefaultProposalSoftTimeout = time.Millisecond * 3000
+	DefaultProposalSoftTimeout = time.Millisecond * 1800
 
 	// MinProposalSoftTimeout is the minimum collection period, even with maximum
 	// proposer delay. This ensures we always have some time to compare proposals.
@@ -65,11 +65,11 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 		// collection period. This ensures consensus starts at roughly the same
 		// time regardless of proposer delay configuration.
 		//
-		// Examples (with default 3000ms soft timeout):
-		//   - 0ms delay    → 3000ms collection
-		//   - 500ms delay  → 2500ms collection
-		//   - 1500ms delay → 1500ms collection
-		//   - 2500ms delay → 500ms collection (capped at minimum)
+		// Examples (with default 1800ms soft timeout):
+		//   - 0ms delay    → 1800ms collection
+		//   - 500ms delay  → 1300ms collection
+		//   - 1000ms delay → 800ms collection
+		//   - 1300ms delay → 500ms collection (capped at minimum)
 		if proposerDelay > 0 {
 			options.ProposalSoftTimeout -= proposerDelay
 			if options.ProposalSoftTimeout < MinProposalSoftTimeout {

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -6,28 +6,12 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+// Various Client timeouts are defined below.
 const (
-	// Client timeouts.
-	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
-	DefaultLongTimeout   = time.Second * 60 // For long requests.
-
-	// DefaultProposalSoftTimeout is the base collection period during which we
-	// gather proposals from multiple beacon nodes to select the best one.
-	// This value is reduced by the proposer delay to maintain consistent timing.
-	// After the soft timeout, we return the best proposal seen so far, or wait
-	// for the first valid proposal if none received yet.
-	// The parent context (duty deadline) serves as the hard timeout.
-	//
-	// Note: MEV (blinded) blocks return immediately, so this timeout mainly
-	// affects how long we wait for MEV when we first receive a vanilla block.
-	//
-	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
-	// set, the value is used as-is without proposer delay reduction (power user mode).
-	DefaultProposalSoftTimeout = time.Millisecond * 1800
-
-	// MinProposalSoftTimeout is the minimum collection period, even with maximum
-	// proposer delay. This ensures we always have some time to compare proposals.
-	MinProposalSoftTimeout = time.Millisecond * 500
+	// defaultCommonTimeout is the default timeout for dialing, and most client-requests.
+	defaultCommonTimeout = time.Second * 5
+	// defaultLongTimeout is the default timeout for certain specific operations the client performs.
+	defaultLongTimeout = time.Second * 60
 )
 
 // Options defines beacon client options
@@ -41,41 +25,41 @@ type Options struct {
 	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
 	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes)"`
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes to select the most profitable one). Note: the 1st MEV (blinded) block is accepted immediately, so this timeout mainly affects how long we wait for an MEV block before giving up deciding to use a vanilla block instead (if we got one already). This value cannot be set any lower than 500ms to ensure there is enough time for the Beacon node to serve the block-fetch request"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 	options := base
 
 	if options.CommonTimeout == 0 {
-		options.CommonTimeout = DefaultCommonTimeout
+		options.CommonTimeout = defaultCommonTimeout
 	}
 
 	if options.LongTimeout == 0 {
-		options.LongTimeout = DefaultLongTimeout
+		options.LongTimeout = defaultLongTimeout
 	}
 
 	// If user explicitly set ProposalSoftTimeout, use it as-is (power user mode).
-	// Otherwise, use default and reduce by proposer delay.
+	// Otherwise, use the default value and reduce it by proposer delay if needed.
 	if options.ProposalSoftTimeout == 0 {
-		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
-
-		// Reduce soft timeout by proposer delay to maintain consistent timing.
-		// Users with proposer delay start fetching later, so they get a shorter
-		// collection period. This ensures consensus starts at roughly the same
-		// time regardless of proposer delay configuration.
-		//
-		// Examples (with default 1800ms soft timeout):
-		//   - 0ms delay    → 1800ms collection
-		//   - 500ms delay  → 1300ms collection
-		//   - 1000ms delay → 800ms collection
-		//   - 1300ms delay → 500ms collection (capped at minimum)
+		// The default value shouldn't be too high because an operator might not be able to participate
+		// in QBFT round 2 (or finish it in time) if it is roughly > 2000 ms.
+		options.ProposalSoftTimeout = time.Millisecond * 1800
+		// Reduce soft timeout by proposer delay to maintain consistent duty-execution timelines
+		// for different operators in the cluster, ensuring QBFT consensus starts at roughly
+		// the same time (timing out round 1 at roughly the same time) regardless of proposer
+		// delay configuration a particular operator is using - operators with higher proposer
+		// delay start fetching blocks later, so they must have a shorter collection period.
 		if proposerDelay > 0 {
 			options.ProposalSoftTimeout -= proposerDelay
-			if options.ProposalSoftTimeout < MinProposalSoftTimeout {
-				options.ProposalSoftTimeout = MinProposalSoftTimeout
-			}
 		}
+	}
+
+	// minProposalSoftTimeout is the minimum soft timeout value allowed.
+	// It ensures we always have enough time to fetch and compare proposals.
+	const minProposalSoftTimeout = time.Millisecond * 500
+	if options.ProposalSoftTimeout < minProposalSoftTimeout {
+		options.ProposalSoftTimeout = minProposalSoftTimeout
 	}
 
 	// Note: There is no hard timeout for proposals. The parent context from the

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -166,6 +166,10 @@ func (gc *GoClient) GetBeaconBlock(
 // a proposal slot is worse than a nil fee recipient.
 // However, it has been observed that the first proposal is usually not the most
 // profitable, so we added a little slack time to collect proposals.
+//
+// The parent context (from duty runner, bounded by slot timing) serves as the hard
+// deadline. We never give up early on getting a block proposal - missing a proposal
+// is catastrophic, so we wait as long as the slot allows.
 func (gc *GoClient) getProposalParallel(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -173,15 +177,15 @@ func (gc *GoClient) getProposalParallel(
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
 ) (*api.VersionedProposal, error) {
-	// Create a context that we'll use to collect and evaluate proposals for a short time
-	// after this context expires, we will return the current best proposal or the first
-	// on we see if we have none
+	// Create a context for the collection period - during this time we gather
+	// proposals from multiple beacon nodes to select the best one.
+	// After this expires, we return the best seen so far or wait for the first valid one.
 	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalSoftTimeout)
 	defer cancelSoft()
 
-	// Create a context for hard proposal timeout; we fail if this timeout expires
-	hardCtx, cancelHard := context.WithTimeout(ctx, gc.proposalHardTimeout)
-	defer cancelHard()
+	// Note: We use the parent context (ctx) as the hard deadline, not a separate timeout.
+	// The parent context is bounded by the duty runner's slot timing, ensuring we never
+	// give up prematurely on getting a block proposal.
 
 	type result struct {
 		proposal *api.VersionedProposal
@@ -193,10 +197,10 @@ func (gc *GoClient) getProposalParallel(
 
 	for _, client := range gc.clients {
 		go func(c Client) {
-			proposal, err := gc.fetchProposal(hardCtx, c, slot, sig, graffiti)
+			proposal, err := gc.fetchProposal(ctx, c, slot, sig, graffiti)
 			select {
 			case resultCh <- result{proposal: proposal, err: err, client: c.Address()}:
-			case <-hardCtx.Done():
+			case <-ctx.Done():
 				// Context canceled, exit without blocking
 			}
 		}(client)
@@ -299,8 +303,9 @@ collect:
 			)
 			return res.proposal, nil
 
-		case <-hardCtx.Done():
-			return nil, hardCtx.Err()
+		case <-ctx.Done():
+			// Parent context canceled (duty deadline reached)
+			return nil, ctx.Err()
 		}
 	}
 


### PR DESCRIPTION

  ---
 ### Summary

  - Remove hard timeout for block proposals - parent context (duty deadline) now serves as the ultimate deadline
  - Reduce default proposal soft timeout from 1.6s to 1.8s
  - Adjust soft timeout dynamically based on proposer delay to maintain consistent timing
  - Add power user mode for explicit timeout override via environment variable

 ### Problem

  The previous timeout calculation could result in insufficient time for block fetching when combined with proposer delay. For example, with a 1.5s proposer delay and 1.6s soft timeout, operators had only 100ms remaining before hitting the hard timeout, causing missed proposals.

### Solution

  1. No hard timeout: The parent context from the duty runner (bounded by slot timing) serves as the ultimate deadline. We never give up early on getting a block.
  2. Dynamic soft timeout: Default 1800ms, reduced by proposer delay with 500ms minimum:
    - 0ms delay → 1800ms collection
    - 500ms delay → 1300ms collection
    - 1000ms delay → 800ms collection
    - 1300ms+ delay → 500ms collection (minimum)
  3. Power user mode: When WITH_PROPOSAL_SOFT_TIMEOUT is explicitly set, the value is used as-is without proposer delay reduction.

 ### Test plan

  - Unit tests pass
  - Deploy to stage with proposer delay and verify proposals complete successfully
  - Monitor proposal timing and success rates