### PR TITLE
Remove obsolete majority fork flags

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -89,10 +89,9 @@ type ControllerOptions struct {
 	ProposerDelay                  time.Duration
 
 	// worker flags
-	WorkersCount                 int    `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of message processing workers"`
-	QueueBufferSize              int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
-	GasLimit                     uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
-	MajorityForkProtectionStrict bool   `yaml:"MajorityForkProtectionStrict" env:"MAJORITY_FORK_PROTECTION_STRICT" env-description:"Refuse to sign attestations with different target roots than your own. This does not increase validator safety. Instead, this is potentially more beneficial for Ethereum (area of active research), at the cost of potentially decrease validator performance during transitory disagreements between operators (e.g., when some of the operators' Beacon nodes are behind, and during re-orgs)."`
+	WorkersCount    int    `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of message processing workers"`
+	QueueBufferSize int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
+	GasLimit        uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
 }
 
 type Nonce uint16
@@ -171,8 +170,7 @@ type Controller struct {
 
 // NewController creates a new validator controller instance.
 func NewController(logger *zap.Logger, options ControllerOptions, exporterOptions exporter.Options) *Controller {
-	logger.Debug("setting up validator controller",
-		zap.Bool("mfp_strict", options.MajorityForkProtectionStrict))
+	logger.Debug("setting up validator controller")
 
 	// lookup in a map that holds all relevant operators
 	operatorsIDs := &sync.Map{}
@@ -199,7 +197,6 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 		options.MessageValidator,
 		options.Graffiti,
 		options.ProposerDelay,
-		options.MajorityForkProtectionStrict,
 	)
 
 	cacheTTL := 2 * options.NetworkConfig.EpochDuration() // #nosec G115
@@ -1053,7 +1050,6 @@ func SetupCommitteeRunners(
 			options.OperatorSigner,
 			dutyGuard,
 			options.DoppelgangerHandler,
-			options.MajorityForkProtectionStrict,
 		)
 		if err != nil {
 			return nil, err

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -54,7 +54,6 @@ type CommitteeRunner struct {
 	DutyGuard           CommitteeDutyGuard
 	doppelgangerHandler DoppelgangerProvider
 	measurements        *dutyMeasurements
-	mfpStrict           bool
 
 	// ValCheck is used to validate the qbft-value(s) proposed by other Operators.
 	ValCheck ssv.ValueChecker
@@ -73,7 +72,6 @@ func NewCommitteeRunner(
 	operatorSigner ssvtypes.OperatorSigner,
 	dutyGuard CommitteeDutyGuard,
 	doppelgangerHandler DoppelgangerProvider,
-	mfpStrict bool,
 ) (Runner, error) {
 	if len(share) == 0 {
 		return nil, errors.New("no shares")
@@ -96,7 +94,6 @@ func NewCommitteeRunner(
 		DutyGuard:           dutyGuard,
 		doppelgangerHandler: doppelgangerHandler,
 		measurements:        newMeasurementsStore(),
-		mfpStrict:           mfpStrict,
 	}, nil
 }
 
@@ -1045,9 +1042,7 @@ func (r *CommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, d
 		r.signer,
 		slot,
 		r.attestingValidators,
-		r.GetNetworkConfig().EstimatedCurrentEpoch(),
 		vote,
-		r.mfpStrict,
 	)
 	if err := r.BaseRunner.decide(ctx, logger, duty.DutySlot(), vote, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -280,7 +280,6 @@ var baseCommitteeWithRunnerSample = func(
 			runnerSample.GetOperatorSigner(),
 			committeeDutyGuard,
 			runnerSample.GetDoppelgangerHandler(),
-			false,
 		)
 		return r.(*runner.CommitteeRunner), err
 	}

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -89,7 +89,7 @@ var ConstructBaseRunner = func(
 	switch role {
 	case spectypes.RoleCommittee:
 		valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
-			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)}, spectestingutils.TestingDutyEpoch, vote, false)
+			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)}, vote)
 	case spectypes.RoleProposer:
 		valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 			(spectypes.ValidatorPK)(spectestingutils.TestingValidatorPubKey), spectestingutils.TestingValidatorIndex,
@@ -138,7 +138,6 @@ var ConstructBaseRunner = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
-			false,
 		)
 	case spectypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(
@@ -222,7 +221,6 @@ var ConstructBaseRunner = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
-			false,
 		)
 		r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType
 	default:
@@ -358,7 +356,7 @@ var ConstructBaseRunnerWithShareMap = func(
 		switch role {
 		case spectypes.RoleCommittee:
 			valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
-				sharePubKeys, spectestingutils.TestingDutyEpoch, vote, false)
+				sharePubKeys, vote)
 		case spectypes.RoleProposer:
 			valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 				shareInstance.ValidatorPubKey, shareInstance.ValidatorIndex, phase0.BLSPubKey(shareInstance.SharePubKey))
@@ -402,7 +400,6 @@ var ConstructBaseRunnerWithShareMap = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
-			false,
 		)
 	case spectypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(
@@ -486,7 +483,6 @@ var ConstructBaseRunnerWithShareMap = func(
 			opSigner,
 			dutyGuard,
 			dgHandler,
-			false,
 		)
 		if r != nil {
 			r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -29,22 +29,21 @@ type Options struct {
 
 // CommonOptions represents options that all validators share.
 type CommonOptions struct {
-	NetworkConfig                *networkconfig.Network
-	Network                      specqbft.Network
-	Beacon                       beacon.BeaconNode
-	Storage                      *storage.ParticipantStores
-	Signer                       ekm.BeaconSigner
-	OperatorSigner               ssvtypes.OperatorSigner
-	DoppelgangerHandler          runner.DoppelgangerProvider
-	NewDecidedHandler            qbftctrl.NewDecidedHandler
-	FullNode                     bool
-	ExporterOptions              exporter.Options
-	QueueSize                    int
-	GasLimit                     uint64
-	MessageValidator             validation.MessageValidator
-	Graffiti                     []byte
-	ProposerDelay                time.Duration
-	MajorityForkProtectionStrict bool
+	NetworkConfig       *networkconfig.Network
+	Network             specqbft.Network
+	Beacon              beacon.BeaconNode
+	Storage             *storage.ParticipantStores
+	Signer              ekm.BeaconSigner
+	OperatorSigner      ssvtypes.OperatorSigner
+	DoppelgangerHandler runner.DoppelgangerProvider
+	NewDecidedHandler   qbftctrl.NewDecidedHandler
+	FullNode            bool
+	ExporterOptions     exporter.Options
+	QueueSize           int
+	GasLimit            uint64
+	MessageValidator    validation.MessageValidator
+	Graffiti            []byte
+	ProposerDelay       time.Duration
 }
 
 func NewCommonOptions(
@@ -63,25 +62,23 @@ func NewCommonOptions(
 	messageValidator validation.MessageValidator,
 	graffiti []byte,
 	proposerDelay time.Duration,
-	mfpStrict bool,
 ) *CommonOptions {
 	result := &CommonOptions{
-		NetworkConfig:                networkConfig,
-		Network:                      network,
-		Beacon:                       beacon,
-		Storage:                      storage,
-		Signer:                       signer,
-		OperatorSigner:               operatorSigner,
-		DoppelgangerHandler:          doppelgangerHandler,
-		NewDecidedHandler:            newDecidedHandler,
-		FullNode:                     fullNode,
-		ExporterOptions:              exporterOptions,
-		QueueSize:                    1000,
-		GasLimit:                     gasLimit,
-		MessageValidator:             messageValidator,
-		Graffiti:                     graffiti,
-		ProposerDelay:                proposerDelay,
-		MajorityForkProtectionStrict: mfpStrict,
+		NetworkConfig:       networkConfig,
+		Network:             network,
+		Beacon:              beacon,
+		Storage:             storage,
+		Signer:              signer,
+		OperatorSigner:      operatorSigner,
+		DoppelgangerHandler: doppelgangerHandler,
+		NewDecidedHandler:   newDecidedHandler,
+		FullNode:            fullNode,
+		ExporterOptions:     exporterOptions,
+		QueueSize:           1000,
+		GasLimit:            gasLimit,
+		MessageValidator:    messageValidator,
+		Graffiti:            graffiti,
+		ProposerDelay:       proposerDelay,
 	}
 
 	// If full node, increase the queue size to make enough room for history sync batches to be pushed whole.


### PR DESCRIPTION
This is an attempt to resolve [this ticket](https://blox-ensemble.monday.com/boards/7946005181/views/170673882/pulses/10771967259).

I tried to infer what needs to be done from [this comment](https://blox-ensemble.monday.com/boards/7946005181/pulses/10771967259/posts/4807153277) since the ticket has no description.

Please review and specify what else the ticket entails if anything is missing.

P.S Linter is failing due to something unrelated to these changes. Maybe a tool version changed in the CI.