### PR TITLE
chore: fix incorrect comment in ssvNodeFilter function

### DIFF
--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -36,7 +36,7 @@ func (dvs *DiscV5Service) badNodeFilter() func(node *enode.Node) bool {
 	}
 }
 
-// badNodeFilter checks if the node was pruned or have a bad score
+// ssvNodeFilter checks if the node is an SSV node
 func (dvs *DiscV5Service) ssvNodeFilter() func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {
 		var isSSV = new(bool)


### PR DESCRIPTION
This commit corrects a misleading comment that was referencing the wrong function name, ensuring the documentation accurately describes the ssvNodeFilter functionality.