### PR TITLE
Exporter: Refactor WS endpoint to use the new exporter2 package (remove duplication)

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -48,6 +48,7 @@ import (
 	exporterapi "github.com/ssvlabs/ssv/exporter/api"
 	"github.com/ssvlabs/ssv/exporter/api/decided"
 	dutytracestore "github.com/ssvlabs/ssv/exporter/store"
+	"github.com/ssvlabs/ssv/exporter2"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	ssv_identity "github.com/ssvlabs/ssv/identity"
 	"github.com/ssvlabs/ssv/message/signatureverifier"
@@ -534,6 +535,7 @@ var StartNodeCmd = &cobra.Command{
 
 				go collector.Start(cmd.Context(), slotTickerProvider)
 				cfg.SSVOptions.ValidatorOptions.DutyTraceCollector = collector
+				cfg.SSVOptions.ExporterRead = exporter2.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
 			case exporter.ModeStandard:
 				logger.Info("exporter mode: standard")
 			default:

--- a/operator/node.go
+++ b/operator/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/api"
 	exporterstore "github.com/ssvlabs/ssv/exporter/store"
+	"github.com/ssvlabs/ssv/exporter2"
 	qbftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -50,15 +51,9 @@ type Options struct {
 	ValidatorStore      storage2.ValidatorStore
 	ValidatorOptions    validator.ControllerOptions `yaml:"ValidatorOptions"`
 	DutyStore           *dutystore.Store
+	ExporterRead        *exporter2.Exporter
 	WS                  api.WebSocketServer
 	WsAPIPort           int
-}
-
-// dutyTraceDecidedsProvider is the minimal interface used from the duty trace collector
-// to serve websocket /query decided lookups.
-type dutyTraceDecidedsProvider interface {
-	GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error)
-	GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error)
 }
 
 type Node struct {
@@ -79,7 +74,7 @@ type Node struct {
 	ws        api.WebSocketServer
 	wsAPIPort int
 
-	traceCollector dutyTraceDecidedsProvider
+	exporterRead *exporter2.Exporter
 }
 
 // New is the constructor of Node
@@ -136,9 +131,9 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 		}),
 		feeRecipientCtrl: feeRecipientCtrl,
 
-		ws:             opts.WS,
-		wsAPIPort:      opts.WsAPIPort,
-		traceCollector: opts.ValidatorOptions.DutyTraceCollector,
+		ws:           opts.WS,
+		wsAPIPort:    opts.WsAPIPort,
+		exporterRead: opts.ExporterRead,
 	}
 
 	// Wire the beacon client to the fee recipient controller
@@ -266,15 +261,13 @@ func (n *Node) handleQueryRequests(nm *api.NetworkMessage) {
 
 	switch nm.Msg.Type {
 	case api.TypeDecided:
-		// In exporter v2 (archive) mode we collect decided data via the duty trace collector
-		// instead of the legacy qbft storage. When the collector is available, serve queries
-		// from it to avoid empty responses while no validators are running locally.
-		// The check for `nil` allows backward compatibility when running without exporter v2.
-		if n.traceCollector != nil {
-			n.handleDecidedFromTraceCollector(nm)
-		} else {
-			h.HandleParticipantsQuery(n.qbftStorage, nm, n.network.DomainType)
+		// In exporter v2 (archive) mode we serve decided queries via exporter2 core.
+		// Fall back to legacy qbft storage when exporter2 isn't wired.
+		if n.exporterRead != nil {
+			n.handleDecidedViaExporter(nm)
+			break
 		}
+		h.HandleParticipantsQuery(n.qbftStorage, nm, n.network.DomainType)
 	case api.TypeError:
 		h.HandleErrorQuery(nm)
 	default:
@@ -282,8 +275,7 @@ func (n *Node) handleQueryRequests(nm *api.NetworkMessage) {
 	}
 }
 
-// handleDecidedFromTraceCollector responds to /query requests using duty trace data when available.
-func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
+func (n *Node) handleDecidedViaExporter(nm *api.NetworkMessage) {
 	res := api.Message{Type: nm.Msg.Type, Filter: nm.Msg.Filter}
 
 	pkBytes, err := hex.DecodeString(nm.Msg.Filter.PublicKey)
@@ -316,53 +308,40 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 		return
 	}
 
-	participations := make([]qbftstorage.Participation, 0)
-	var hasUnexpectedError bool
-	var lastUnexpectedErr error
+	coreQuery := &exporter2.DecidedsQuery{
+		From:    nm.Msg.Filter.From,
+		To:      nm.Msg.Filter.To,
+		Roles:   []spectypes.BeaconRole{role},
+		Indices: []phase0.ValidatorIndex{idx},
+	}
 
-	for slot := phase0.Slot(nm.Msg.Filter.From); slot <= phase0.Slot(nm.Msg.Filter.To); slot++ {
-		var entries []dutytracer.ParticipantsRangeIndexEntry
-		if role == spectypes.BNRoleAttester || role == spectypes.BNRoleSyncCommittee {
-			entries, err = n.traceCollector.GetCommitteeDecideds(slot, idx, role)
-		} else {
-			entries, err = n.traceCollector.GetValidatorDecideds(role, slot, []phase0.ValidatorIndex{idx})
-		}
+	result, errs := n.exporterRead.TraceDecidedsCore(coreQuery)
+	participations := wsParticipationsFromCore(result)
 
-		if err != nil {
-			var merr *multierror.Error
-			if errors.As(err, &merr) {
-				merr = filterOutDutyNotFoundErrors(merr)
-				if merr != nil && merr.ErrorOrNil() != nil {
-					hasUnexpectedError = true
-					lastUnexpectedErr = merr
-					n.logger.Warn("failed to get decided entries from collector", zap.Error(merr), fields.Slot(slot), fields.ValidatorIndex(idx), fields.BeaconRole(role))
+	var unexpectedErr error
+	if errs != nil && errs.ErrorOrNil() != nil {
+		filtered := filterOutDutyNotFoundErrors(errs)
+		if filtered != nil && filtered.ErrorOrNil() != nil {
+			var unexpected *multierror.Error
+			for _, e := range filtered.Errors {
+				if e == nil {
+					continue
 				}
-			} else if !isNotFoundError(err) {
-				hasUnexpectedError = true
-				lastUnexpectedErr = err
-				n.logger.Warn("failed to get decided entries from collector", zap.Error(err), fields.Slot(slot), fields.ValidatorIndex(idx), fields.BeaconRole(role))
+				// Preserve legacy WS leniency: treat validation errors as "no messages".
+				if isExporterValidationError(e) {
+					continue
+				}
+				unexpected = multierror.Append(unexpected, e)
 			}
-			continue
-		}
-
-		for _, e := range entries {
-			participations = append(participations, qbftstorage.Participation{
-				ParticipantsRangeEntry: qbftstorage.ParticipantsRangeEntry{
-					Slot:    e.Slot,
-					PubKey:  pk,
-					Signers: e.Signers,
-				},
-				Role:   role,
-				PubKey: pk,
-			})
+			unexpectedErr = unexpected.ErrorOrNil()
 		}
 	}
 
 	if len(participations) == 0 {
-		if hasUnexpectedError {
-			n.logger.Warn("failed to build participants api data due to collector errors", zap.Error(lastUnexpectedErr), fields.ValidatorIndex(idx))
+		if unexpectedErr != nil {
+			n.logger.Warn("failed to build participants api data due to exporter errors", zap.Error(unexpectedErr), fields.ValidatorIndex(idx))
 			res.Type = api.TypeError
-			res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", lastUnexpectedErr)}
+			res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", unexpectedErr)}
 		} else {
 			// Mirror legacy exporter behavior: empty range returns "no messages" as a decided response.
 			res.Data = []string{"no messages"}
@@ -382,6 +361,30 @@ func (n *Node) handleDecidedFromTraceCollector(nm *api.NetworkMessage) {
 
 	res.Data = data
 	nm.Msg = res
+}
+
+func wsParticipationsFromCore(result *exporter2.TraceDecidedsResult) []qbftstorage.Participation {
+	out := make([]qbftstorage.Participation, 0)
+	if result == nil {
+		return out
+	}
+	for _, p := range result.Participants {
+		out = append(out, qbftstorage.Participation{
+			ParticipantsRangeEntry: qbftstorage.ParticipantsRangeEntry{
+				Slot:    p.Slot,
+				PubKey:  p.PubKey,
+				Signers: p.Signers,
+			},
+			Role:   p.Role,
+			PubKey: p.PubKey,
+		})
+	}
+	return out
+}
+
+func isExporterValidationError(err error) bool {
+	var ve *exporter2.ValidationError
+	return errors.As(err, &ve)
 }
 
 // isNotFoundError returns true if the error represents an expected "no duty"

--- a/operator/node.go
+++ b/operator/node.go
@@ -319,21 +319,14 @@ func (n *Node) handleDecidedViaExporter(nm *api.NetworkMessage) {
 	participations := wsParticipationsFromCore(result)
 
 	var unexpectedErr error
-	if errs != nil && errs.ErrorOrNil() != nil {
-		filtered := filterOutDutyNotFoundErrors(errs)
-		if filtered != nil && filtered.ErrorOrNil() != nil {
-			var unexpected *multierror.Error
-			for _, e := range filtered.Errors {
-				if e == nil {
-					continue
-				}
-				// Preserve legacy WS leniency: treat validation errors as "no messages".
-				if isExporterValidationError(e) {
-					continue
-				}
-				unexpected = multierror.Append(unexpected, e)
+	filtered := filterOutDutyNotFoundErrors(errs)
+	if filtered.ErrorOrNil() != nil {
+		for _, e := range filtered.Errors {
+			// Preserve legacy WS leniency: treat validation errors as "no messages".
+			if isExporterValidationError(e) {
+				continue
 			}
-			unexpectedErr = unexpected.ErrorOrNil()
+			unexpectedErr = e
 		}
 	}
 
@@ -403,7 +396,7 @@ func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
 	}
 	var filtered *multierror.Error
 	for _, err := range e.Errors {
-		if !isNotFoundError(err) {
+		if err != nil && !isNotFoundError(err) {
 			filtered = multierror.Append(filtered, err)
 		}
 	}

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -8,77 +8,155 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/api"
-	exporterstore "github.com/ssvlabs/ssv/exporter/store"
+	dutytracestore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/networkconfig"
 	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
 	"github.com/ssvlabs/ssv/operator/validator"
 	registrystoragemocks "github.com/ssvlabs/ssv/registry/storage/mocks"
+	kv "github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-type traceCollectorStub struct {
-	entries map[phase0.Slot][]dutytracer.ParticipantsRangeIndexEntry
+type validatorDutyKey struct {
+	slot  phase0.Slot
+	role  spectypes.BeaconRole
+	index phase0.ValidatorIndex
 }
 
-func (t *traceCollectorStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return t.entries[slot], nil
+// faultingDutyTraceStore wraps the real duty trace store and can inject errors
+// for specific reads. This keeps tests realistic (real DB + SSZ) while still
+// letting us assert WS error mapping behavior deterministically.
+type faultingDutyTraceStore struct {
+	*dutytracestore.DutyTraceStore
+	getValidatorDutyErr map[validatorDutyKey]error
 }
 
-func (t *traceCollectorStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, dutytracer.ErrNotFound
+func newFaultingDutyTraceStore(inner *dutytracestore.DutyTraceStore) *faultingDutyTraceStore {
+	return &faultingDutyTraceStore{
+		DutyTraceStore:      inner,
+		getValidatorDutyErr: make(map[validatorDutyKey]error),
+	}
 }
 
-type traceCollectorErrStub struct {
-	err error
+func (s *faultingDutyTraceStore) SetGetValidatorDutyError(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex, err error) {
+	s.getValidatorDutyErr[validatorDutyKey{slot: slot, role: role, index: index}] = err
 }
 
-func (t *traceCollectorErrStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, t.err
+func (s *faultingDutyTraceStore) GetValidatorDuty(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex) (*exporter.ValidatorDutyTrace, error) {
+	if err := s.getValidatorDutyErr[validatorDutyKey{slot: slot, role: role, index: index}]; err != nil {
+		return nil, err
+	}
+	return s.DutyTraceStore.GetValidatorDuty(slot, role, index)
 }
 
-func (t *traceCollectorErrStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, t.err
+type wsQueryHarness struct {
+	t *testing.T
+
+	node *Node
+
+	ctrl          *gomock.Controller
+	validatorMock *registrystoragemocks.MockValidatorStore
+
+	db    basedb.Database
+	store *faultingDutyTraceStore
 }
 
-type traceCollectorNotFoundStub struct{}
+func newWSQueryHarness(t *testing.T) *wsQueryHarness {
+	t.Helper()
 
-func (t *traceCollectorNotFoundStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, dutytracer.ErrNotFound
-}
-
-func (t *traceCollectorNotFoundStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, dutytracer.ErrNotFound
-}
-
-type traceCollectorStoreNotFoundStub struct{}
-
-func (t *traceCollectorStoreNotFoundStub) GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, exporterstore.ErrNotFound
-}
-
-func (t *traceCollectorStoreNotFoundStub) GetCommitteeDecideds(slot phase0.Slot, index phase0.ValidatorIndex, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
-	return nil, exporterstore.ErrNotFound
-}
-
-func newNodeWithCollector(t *testing.T, collector dutyTraceDecidedsProvider, setupStore func(*registrystoragemocks.MockValidatorStore)) *Node {
 	logger := zaptest.NewLogger(t)
 	ctrl := gomock.NewController(t)
-	store := registrystoragemocks.NewMockValidatorStore(ctrl)
-	if setupStore != nil {
-		setupStore(store)
-	}
-	return &Node{
+	validatorMock := registrystoragemocks.NewMockValidatorStore(ctrl)
+
+	db, err := kv.NewInMemory(zap.NewNop(), basedb.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	realStore := dutytracestore.New(db)
+	store := newFaultingDutyTraceStore(realStore)
+
+	collector := dutytracer.New(zap.NewNop(), validatorMock, nil, store, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	node := &Node{
 		logger:         logger,
 		network:        networkconfig.TestNetwork,
 		traceCollector: collector,
 		validatorOptions: validator.ControllerOptions{
-			ValidatorStore: store,
+			ValidatorStore: validatorMock,
 		},
 	}
+
+	return &wsQueryHarness{
+		t:             t,
+		node:          node,
+		ctrl:          ctrl,
+		validatorMock: validatorMock,
+		db:            db,
+		store:         store,
+	}
+}
+
+func (h *wsQueryHarness) ExpectValidator(pk spectypes.ValidatorPK, idx phase0.ValidatorIndex, found bool) {
+	h.t.Helper()
+	h.validatorMock.EXPECT().ValidatorIndex(pk).Return(idx, found).AnyTimes()
+	if found {
+		h.validatorMock.EXPECT().ValidatorPubkey(idx).Return(pk, true).AnyTimes()
+	}
+}
+
+func (h *wsQueryHarness) SaveValidatorDuty(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex, decidedsSigners []spectypes.OperatorID) {
+	h.t.Helper()
+	duty := &exporter.ValidatorDutyTrace{
+		ConsensusTrace: exporter.ConsensusTrace{
+			Decideds: []*exporter.DecidedTrace{
+				{Signers: decidedsSigners},
+			},
+		},
+		Slot:      slot,
+		Role:      role,
+		Validator: index,
+	}
+	require.NoError(h.t, h.store.SaveValidatorDuty(duty))
+}
+
+func (h *wsQueryHarness) SaveValidatorDutyNoSigners(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex) {
+	h.t.Helper()
+	duty := &exporter.ValidatorDutyTrace{
+		ConsensusTrace: exporter.ConsensusTrace{},
+		Slot:           slot,
+		Role:           role,
+		Validator:      index,
+	}
+	require.NoError(h.t, h.store.SaveValidatorDuty(duty))
+}
+
+func (h *wsQueryHarness) SaveCommitteeDutyAttester(slot phase0.Slot, validatorIndex phase0.ValidatorIndex, committeeID spectypes.CommitteeID, signers []spectypes.OperatorID) {
+	h.t.Helper()
+	require.NoError(h.t, h.store.SaveCommitteeDutyLink(slot, validatorIndex, committeeID))
+	duty := &exporter.CommitteeDutyTrace{
+		ConsensusTrace: exporter.ConsensusTrace{},
+		Slot:           slot,
+		CommitteeID:    committeeID,
+		Attester:       make([]*exporter.SignerData, 0, len(signers)),
+	}
+	for _, s := range signers {
+		duty.Attester = append(duty.Attester, &exporter.SignerData{Signer: s})
+	}
+	require.NoError(h.t, h.store.SaveCommitteeDuty(duty))
+}
+
+func (h *wsQueryHarness) QueryDecided(from, to uint64, pkHex, role string) *api.NetworkMessage {
+	h.t.Helper()
+	nm := decidedMessage(from, to, pkHex, role)
+	h.node.handleQueryRequests(nm)
+	return nm
 }
 
 func decidedMessage(from, to uint64, pkHex, role string) *api.NetworkMessage {
@@ -99,121 +177,258 @@ func makePK(bytes []byte) spectypes.ValidatorPK {
 	return pk
 }
 
-func TestHandleQueryRequests_UsesTraceCollector(t *testing.T) {
+func TestWSQuery_Decided_Proposer_SingleSlot(t *testing.T) {
+	h := newWSQueryHarness(t)
 	pk := makePK([]byte{1, 2, 3, 4, 5})
 	idx := phase0.ValidatorIndex(7)
 
-	collector := &traceCollectorStub{
-		entries: map[phase0.Slot][]dutytracer.ParticipantsRangeIndexEntry{
-			phase0.Slot(10): {
-				{Slot: phase0.Slot(10), Index: idx, Signers: []spectypes.OperatorID{11, 12}},
-			},
-		},
-	}
+	h.ExpectValidator(pk, idx, true)
+	h.SaveValidatorDuty(phase0.Slot(10), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{11, 12})
 
-	node := newNodeWithCollector(t, collector, func(s *registrystoragemocks.MockValidatorStore) {
-		s.EXPECT().ValidatorIndex(pk).Return(idx, true).AnyTimes()
-	})
+	nm := h.QueryDecided(uint64(10), uint64(10), hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	require.Equal(t, nm.Msg.Filter.PublicKey, hex.EncodeToString(pk[:]))
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 1)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Equal(t, []spectypes.OperatorID{11, 12}, data[0].Signers)
+	require.Equal(t, spectypes.BNRoleProposer.String(), data[0].Role)
+	require.Equal(t, hex.EncodeToString(pk[:]), data[0].ValidatorPK)
+}
 
-	nm := decidedMessage(uint64(10), uint64(10), hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+func TestWSQuery_Decided_Attester_UsesCommitteeLookup(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{9, 9, 9, 9})
+	idx := phase0.ValidatorIndex(42)
+	committeeID := spectypes.CommitteeID{1}
 
-	node.handleQueryRequests(nm)
+	h.ExpectValidator(pk, idx, true)
+	h.SaveCommitteeDutyAttester(phase0.Slot(3), idx, committeeID, []spectypes.OperatorID{1, 2, 3})
+
+	nm := h.QueryDecided(3, 3, hex.EncodeToString(pk[:]), spectypes.BNRoleAttester.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 1)
+	require.Equal(t, uint64(3), uint64(data[0].Slot))
+	require.Equal(t, []spectypes.OperatorID{1, 2, 3}, data[0].Signers)
+	require.Equal(t, spectypes.BNRoleAttester.String(), data[0].Role)
+}
+
+func TestWSQuery_Decided_RangeMultipleSlots(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{8, 7, 6})
+	idx := phase0.ValidatorIndex(5)
+
+	h.ExpectValidator(pk, idx, true)
+	h.SaveValidatorDuty(phase0.Slot(10), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{11})
+	h.SaveValidatorDuty(phase0.Slot(11), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{12})
+	h.SaveValidatorDuty(phase0.Slot(12), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{13})
+
+	nm := h.QueryDecided(10, 12, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 3)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Equal(t, uint64(11), uint64(data[1].Slot))
+	require.Equal(t, uint64(12), uint64(data[2].Slot))
+}
+
+func TestWSQuery_InvalidPubKeyHex_ReturnsTypeError(t *testing.T) {
+	h := newWSQueryHarness(t)
+	nm := h.QueryDecided(1, 1, "zz-not-hex", spectypes.BNRoleProposer.String())
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0], "invalid publicKey")
+}
+
+func TestWSQuery_ValidatorNotFound_ReturnsTypeError(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pkBytes, err := hex.DecodeString("abcd")
+	require.NoError(t, err)
+	pk := makePK(pkBytes)
+
+	h.ExpectValidator(pk, 0, false)
+
+	nm := h.QueryDecided(1, 1, "abcd", spectypes.BNRoleProposer.String())
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, "validator not found for public key abcd", errs[0])
+}
+
+func TestWSQuery_InvalidRole_ReturnsTypeError(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3})
+	idx := phase0.ValidatorIndex(5)
+
+	h.ExpectValidator(pk, idx, true)
+
+	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), "NOT_A_ROLE")
+
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, `role doesn't exist: "NOT_A_ROLE"`, errs[0])
+}
+
+func TestWSQuery_TraceStoreError_NoEntries_ReturnsInternalError(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3})
+	idx := phase0.ValidatorIndex(5)
+
+	h.ExpectValidator(pk, idx, true)
+	h.store.SetGetValidatorDutyError(phase0.Slot(1), spectypes.BNRoleProposer, idx, errors.New("boom"))
+
+	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+	require.Equal(t, api.TypeError, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0], "internal error - could not build response")
+	require.Contains(t, errs[0], "boom")
+}
+
+func TestWSQuery_NoMessagesOnNotFound(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3, 4})
+	idx := phase0.ValidatorIndex(10)
+
+	h.ExpectValidator(pk, idx, true)
+
+	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, "no messages", errs[0])
+}
+
+func TestWSQuery_Decided_Attester_NoMessagesWhenCommitteeNotFound(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{7, 7, 7, 7})
+	idx := phase0.ValidatorIndex(99)
+
+	h.ExpectValidator(pk, idx, true)
+
+	// No committee duty link and no committee duty saved -> treated as "no messages".
+	nm := h.QueryDecided(3, 3, hex.EncodeToString(pk[:]), spectypes.BNRoleAttester.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, "no messages", errs[0])
+}
+
+func TestWSQuery_ErrorOnOneSlotButEntriesOnAnother_StillReturnsEntries(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3, 4})
+	idx := phase0.ValidatorIndex(10)
+
+	h.ExpectValidator(pk, idx, true)
+	h.SaveValidatorDuty(phase0.Slot(10), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{1})
+	h.store.SetGetValidatorDutyError(phase0.Slot(11), spectypes.BNRoleProposer, idx, errors.New("boom"))
+
+	nm := h.QueryDecided(10, 11, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
 	require.Equal(t, api.TypeDecided, nm.Msg.Type)
 	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
 	require.True(t, ok, "response data should be participants slice")
 	require.Len(t, data, 1)
 	require.Equal(t, uint64(10), uint64(data[0].Slot))
-	require.Equal(t, []spectypes.OperatorID{11, 12}, data[0].Signers)
 }
 
-func TestHandleQueryRequests_ValidatorNotFound(t *testing.T) {
-	node := newNodeWithCollector(t, &traceCollectorStub{}, func(s *registrystoragemocks.MockValidatorStore) {
-		s.EXPECT().ValidatorIndex(gomock.Any()).Return(phase0.ValidatorIndex(0), false).AnyTimes()
-	})
+func TestWSQuery_NetworkMessageParseError_GoesThroughErrorHandler(t *testing.T) {
+	h := newWSQueryHarness(t)
 
-	nm := decidedMessage(1, 1, "abcd", spectypes.BNRoleProposer.String())
-
-	node.handleQueryRequests(nm)
+	nm := &api.NetworkMessage{Err: errors.New("parsefail")}
+	h.node.handleQueryRequests(nm)
 
 	require.Equal(t, api.TypeError, nm.Msg.Type)
-	require.Contains(t, nm.Msg.Data.([]string)[0], "validator not found")
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 2)
+	require.Equal(t, "could not parse network message: parsefail", errs[0])
+	require.Equal(t, "parsefail", errs[1])
 }
 
-func TestHandleDecidedFromTraceCollector_InvalidPubKey(t *testing.T) {
-	node := newNodeWithCollector(t, &traceCollectorStub{}, nil)
+func TestWSQuery_UnknownMessageType_ReturnsBadRequest(t *testing.T) {
+	h := newWSQueryHarness(t)
 
-	nm := decidedMessage(1, 1, "zz-not-hex", spectypes.BNRoleProposer.String())
-
-	node.handleQueryRequests(nm)
+	nm := &api.NetworkMessage{Msg: api.Message{
+		Type:   "banana",
+		Filter: api.MessageFilter{From: 1, To: 1},
+	}}
+	h.node.handleQueryRequests(nm)
 
 	require.Equal(t, api.TypeError, nm.Msg.Type)
-	require.Contains(t, nm.Msg.Data.([]string)[0], "invalid publicKey")
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, "bad request - unknown message type 'banana'", errs[0])
 }
 
-func TestHandleDecidedFromTraceCollector_InvalidRole(t *testing.T) {
-	pk := makePK([]byte{1, 2, 3})
-	node := newNodeWithCollector(t, &traceCollectorStub{}, func(s *registrystoragemocks.MockValidatorStore) {
-		s.EXPECT().ValidatorIndex(pk).Return(phase0.ValidatorIndex(5), true).AnyTimes()
-	})
-
-	nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), "NOT_A_ROLE")
-
-	node.handleQueryRequests(nm)
-
-	require.Equal(t, api.TypeError, nm.Msg.Type)
-	require.Contains(t, nm.Msg.Data.([]string)[0], "role doesn't exist")
-}
-
-func TestHandleDecidedFromTraceCollector_CollectorError(t *testing.T) {
-	pk := makePK([]byte{1, 2, 3})
-	collector := &traceCollectorErrStub{err: errors.New("boom")}
-
-	node := newNodeWithCollector(t, collector, func(s *registrystoragemocks.MockValidatorStore) {
-		s.EXPECT().ValidatorIndex(pk).Return(phase0.ValidatorIndex(5), true).AnyTimes()
-	})
-
-	nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
-
-	node.handleQueryRequests(nm)
-
-	require.Equal(t, api.TypeError, nm.Msg.Type)
-	require.Contains(t, nm.Msg.Data.([]string)[0], "internal error - could not build response")
-}
-
-func TestHandleDecidedFromTraceCollector_NoMessagesOnNotFound(t *testing.T) {
+func TestWSQuery_FromGreaterThanTo_ReturnsNoMessages(t *testing.T) {
+	h := newWSQueryHarness(t)
 	pk := makePK([]byte{1, 2, 3, 4})
 	idx := phase0.ValidatorIndex(10)
 
-	tests := []struct {
-		name      string
-		collector dutyTraceDecidedsProvider
-	}{
-		{
-			name:      "dutytracer not found",
-			collector: &traceCollectorNotFoundStub{},
-		},
-		{
-			name:      "store not found",
-			collector: &traceCollectorStoreNotFoundStub{},
-		},
-	}
+	h.ExpectValidator(pk, idx, true)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			node := newNodeWithCollector(t, tt.collector, func(s *registrystoragemocks.MockValidatorStore) {
-				s.EXPECT().ValidatorIndex(pk).Return(idx, true).AnyTimes()
-			})
+	nm := h.QueryDecided(11, 10, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
-			nm := decidedMessage(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
+	require.Len(t, errs, 1)
+	require.Equal(t, "no messages", errs[0])
+}
 
-			node.handleQueryRequests(nm)
+func TestWSQuery_NoSignerEntry_IsReturned(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3, 4, 5})
+	idx := phase0.ValidatorIndex(7)
 
-			require.Equal(t, api.TypeDecided, nm.Msg.Type)
-			errs, ok := nm.Msg.Data.([]string)
-			require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
-			require.Len(t, errs, 1)
-			require.Equal(t, "no messages", errs[0])
-		})
-	}
+	h.ExpectValidator(pk, idx, true)
+	h.SaveValidatorDutyNoSigners(phase0.Slot(10), spectypes.BNRoleProposer, idx)
+
+	nm := h.QueryDecided(10, 10, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 1)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Empty(t, data[0].Signers)
+}
+
+func TestWSQuery_NoSignerEntry_MixedWithValidEntries(t *testing.T) {
+	h := newWSQueryHarness(t)
+	pk := makePK([]byte{1, 2, 3, 4, 5})
+	idx := phase0.ValidatorIndex(7)
+
+	h.ExpectValidator(pk, idx, true)
+	h.SaveValidatorDutyNoSigners(phase0.Slot(10), spectypes.BNRoleProposer, idx)
+	h.SaveValidatorDuty(phase0.Slot(11), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{1})
+
+	nm := h.QueryDecided(10, 11, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
+
+	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 2)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Empty(t, data[0].Signers)
+	require.Equal(t, uint64(11), uint64(data[1].Slot))
+	require.Equal(t, []spectypes.OperatorID{1}, data[1].Signers)
 }

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/api"
 	dutytracestore "github.com/ssvlabs/ssv/exporter/store"
+	"github.com/ssvlabs/ssv/exporter2"
+	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/networkconfig"
 	dutytracer "github.com/ssvlabs/ssv/operator/dutytracer"
 	"github.com/ssvlabs/ssv/operator/validator"
@@ -83,11 +85,12 @@ func newWSQueryHarness(t *testing.T) *wsQueryHarness {
 	store := newFaultingDutyTraceStore(realStore)
 
 	collector := dutytracer.New(zap.NewNop(), validatorMock, nil, store, networkconfig.TestNetwork.Beacon, nil, nil)
+	coreExporter := exporter2.NewExporter(zap.NewNop(), ibftstorage.NewStores(), collector, validatorMock)
 
 	node := &Node{
-		logger:         logger,
-		network:        networkconfig.TestNetwork,
-		traceCollector: collector,
+		logger:       logger,
+		network:      networkconfig.TestNetwork,
+		exporterRead: coreExporter,
 		validatorOptions: validator.ControllerOptions{
 			ValidatorStore: validatorMock,
 		},
@@ -392,43 +395,4 @@ func TestWSQuery_FromGreaterThanTo_ReturnsNoMessages(t *testing.T) {
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
 	require.Equal(t, "no messages", errs[0])
-}
-
-func TestWSQuery_NoSignerEntry_IsReturned(t *testing.T) {
-	h := newWSQueryHarness(t)
-	pk := makePK([]byte{1, 2, 3, 4, 5})
-	idx := phase0.ValidatorIndex(7)
-
-	h.ExpectValidator(pk, idx, true)
-	h.SaveValidatorDutyNoSigners(phase0.Slot(10), spectypes.BNRoleProposer, idx)
-
-	nm := h.QueryDecided(10, 10, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
-
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
-	require.True(t, ok, "response data should be participants slice")
-	require.Len(t, data, 1)
-	require.Equal(t, uint64(10), uint64(data[0].Slot))
-	require.Empty(t, data[0].Signers)
-}
-
-func TestWSQuery_NoSignerEntry_MixedWithValidEntries(t *testing.T) {
-	h := newWSQueryHarness(t)
-	pk := makePK([]byte{1, 2, 3, 4, 5})
-	idx := phase0.ValidatorIndex(7)
-
-	h.ExpectValidator(pk, idx, true)
-	h.SaveValidatorDutyNoSigners(phase0.Slot(10), spectypes.BNRoleProposer, idx)
-	h.SaveValidatorDuty(phase0.Slot(11), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{1})
-
-	nm := h.QueryDecided(10, 11, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
-
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
-	require.True(t, ok, "response data should be participants slice")
-	require.Len(t, data, 2)
-	require.Equal(t, uint64(10), uint64(data[0].Slot))
-	require.Empty(t, data[0].Signers)
-	require.Equal(t, uint64(11), uint64(data[1].Slot))
-	require.Equal(t, []spectypes.OperatorID{1}, data[1].Signers)
 }

--- a/tool.mod
+++ b/tool.mod
@@ -8,7 +8,7 @@ toolchain go1.24.10
 tool (
 	github.com/ethereum/go-ethereum/cmd/abigen
 	github.com/ferranbt/fastssz/sszgen
-	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint v2.4.0
 	github.com/swaggo/swag/cmd/swag
 	go.uber.org/mock/mockgen
 	golang.org/x/tools/cmd/deadcode

--- a/tool.mod
+++ b/tool.mod
@@ -8,7 +8,7 @@ toolchain go1.24.10
 tool (
 	github.com/ethereum/go-ethereum/cmd/abigen
 	github.com/ferranbt/fastssz/sszgen
-	github.com/golangci/golangci-lint/v2/cmd/golangci-lint v2.4.0
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/swaggo/swag/cmd/swag
 	go.uber.org/mock/mockgen
 	golang.org/x/tools/cmd/deadcode


### PR DESCRIPTION
This is part 1 of the WS endpoint refactoring. 

This PR aims to 
1. keep diff minimal
2. while using most of the processing logic from exporter2 package. 
 
Follow up PR will address finer refactoring of the leftover processing logic that will require a larger diff with more fine-grained behaviour tweaks. In particular, I have left some glue code `operator/node.go` that we can refactor in the follow up PR.

Known change in functional behaviour that we consider acceptable:

- WS `/query` now omits duties with empty signers.
- ~WS `/query` error handling internal errors now surfaces an aggregated multi-error rather than last error only~ (edit: old behaviour reestablished in latest commit for retro-compat)