### PR TITLE
operator/duties: fix deadline for attester/aggregator duties

### DIFF
--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -91,7 +91,7 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			h.logger.Debug("🛠 ticker event", zap.String("epoch_slot_pos", buildStr))
 
 			func() {
-				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, slot)
+				tickCtx, cancel := h.ctxWithDeadlineInOneEpoch(ctx, slot)
 				defer cancel()
 
 				h.executeAggregatorDuties(tickCtx, currentEpoch, slot)
@@ -117,7 +117,7 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			h.logger.Info("🔀 reorg event received", zap.String("epoch_slot_pos", buildStr), zap.Any("event", reorgEvent))
 
 			func() {
-				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, reorgEvent.Slot)
+				tickCtx, cancel := h.ctxWithDeadlineInOneEpoch(ctx, reorgEvent.Slot)
 				defer cancel()
 
 				// reset current epoch duties

--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -91,10 +91,7 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			h.logger.Debug("🛠 ticker event", zap.String("epoch_slot_pos", buildStr))
 
 			func() {
-				// Aggregates submissions are rewarded as long as they are finished within 2 slots after the target slot
-				// (the target slot itself, plus the next slot after that), hence we are setting the deadline here to
-				// target slot + 2.
-				tickCtx, cancel := h.ctxWithDeadlineOnNextSlot(ctx, slot+1)
+				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, slot)
 				defer cancel()
 
 				h.executeAggregatorDuties(tickCtx, currentEpoch, slot)
@@ -120,7 +117,7 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			h.logger.Info("🔀 reorg event received", zap.String("epoch_slot_pos", buildStr), zap.Any("event", reorgEvent))
 
 			func() {
-				tickCtx, cancel := h.ctxWithDeadlineOnNextSlot(ctx, reorgEvent.Slot)
+				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, reorgEvent.Slot)
 				defer cancel()
 
 				// reset current epoch duties

--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -82,8 +82,21 @@ func (h *baseHandler) HandleInitialDuties(context.Context) {
 	// Do nothing
 }
 
-// ctxWithDeadlineOnNextSlot returns the derived context with deadline set to next slot (+ some safety margin
-// to account for clock skews).
 func (h *baseHandler) ctxWithDeadlineOnNextSlot(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
-	return context.WithDeadline(ctx, h.beaconConfig.SlotStartTime(slot+1).Add(100*time.Millisecond))
+	return h.ctxWithDeadlineOnSlot(ctx, slot+1)
+}
+
+func (h *baseHandler) ctxWithDeadlineOnNextEpoch(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
+	// Attestation and aggregation submissions are rewarded as long as they are finished within
+	// 1 epoch after the target slot: the target slot itself, plus the next epoch after that
+	// (https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards), hence
+	// we are setting the deadline here to target slot + slots per epoch + 1 (deadline slot is excluded).
+	slotsPerEpoch := phase0.Slot(h.beaconConfig.SlotsPerEpoch)
+	return h.ctxWithDeadlineOnSlot(ctx, slot+slotsPerEpoch+1)
+}
+
+// ctxWithDeadlineOnSlot returns the derived context with a deadline set to the beginning of the passed slot
+// with some safety margin to account for clock skews.
+func (h *baseHandler) ctxWithDeadlineOnSlot(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(ctx, h.beaconConfig.SlotStartTime(slot).Add(100*time.Millisecond))
 }

--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -87,10 +87,10 @@ func (h *baseHandler) ctxWithDeadlineOnNextSlot(ctx context.Context, slot phase0
 }
 
 func (h *baseHandler) ctxWithDeadlineOnNextEpoch(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
-	// Attestation and aggregation submissions are rewarded as long as they are finished within
-	// 1 epoch after the target slot: the target slot itself, plus the next epoch after that
-	// (https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards), hence
-	// we are setting the deadline here to target slot + slots per epoch + 1 (deadline slot is excluded).
+	// Attestation and aggregation submissions are rewarded as long as they are included within
+	// SLOTS_PER_EPOCH slots of their target slot (i.e., from target slot up to and including target + SLOTS_PER_EPOCH).
+	// See https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards
+	// We set the deadline to target slot + SLOTS_PER_EPOCH + 1 (since the deadline slot itself is excluded).
 	slotsPerEpoch := phase0.Slot(h.beaconConfig.SlotsPerEpoch)
 	return h.ctxWithDeadlineOnSlot(ctx, slot+slotsPerEpoch+1)
 }

--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -86,7 +86,7 @@ func (h *baseHandler) ctxWithDeadlineOnNextSlot(ctx context.Context, slot phase0
 	return h.ctxWithDeadlineOnSlot(ctx, slot+1)
 }
 
-func (h *baseHandler) ctxWithDeadlineOnNextEpoch(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
+func (h *baseHandler) ctxWithDeadlineInOneEpoch(ctx context.Context, slot phase0.Slot) (context.Context, context.CancelFunc) {
 	// Attestation and aggregation submissions are rewarded as long as they are included within
 	// SLOTS_PER_EPOCH slots of their target slot (i.e., from target slot up to and including target + SLOTS_PER_EPOCH).
 	// See https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards

--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -90,6 +90,7 @@ func (h *baseHandler) ctxWithDeadlineOnNextEpoch(ctx context.Context, slot phase
 	// Attestation and aggregation submissions are rewarded as long as they are included within
 	// SLOTS_PER_EPOCH slots of their target slot (i.e., from target slot up to and including target + SLOTS_PER_EPOCH).
 	// See https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards
+	// Sync committee duties have to use the same deadline because they are part of the committee role.
 	// We set the deadline to target slot + SLOTS_PER_EPOCH + 1 (since the deadline slot itself is excluded).
 	slotsPerEpoch := phase0.Slot(h.beaconConfig.SlotsPerEpoch)
 	return h.ctxWithDeadlineOnSlot(ctx, slot+slotsPerEpoch+1)

--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -64,10 +64,7 @@ func (h *CommitteeHandler) HandleDuties(ctx context.Context) {
 			h.logger.Debug("🛠 ticker event", zap.String("period_epoch_slot_pos", buildStr))
 
 			func() {
-				// Attestations and sync-committee submissions are rewarded as long as they are finished within
-				// 2 slots after the target slot (the target slot itself, plus the next slot after that), hence
-				// we are setting the deadline here to target slot + 2.
-				tickCtx, cancel := h.ctxWithDeadlineOnNextSlot(ctx, slot+1)
+				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, slot)
 				defer cancel()
 
 				h.processExecution(tickCtx, period, epoch, slot)

--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -64,7 +64,7 @@ func (h *CommitteeHandler) HandleDuties(ctx context.Context) {
 			h.logger.Debug("🛠 ticker event", zap.String("period_epoch_slot_pos", buildStr))
 
 			func() {
-				tickCtx, cancel := h.ctxWithDeadlineOnNextEpoch(ctx, slot)
+				tickCtx, cancel := h.ctxWithDeadlineInOneEpoch(ctx, slot)
 				defer cancel()
 
 				h.processExecution(tickCtx, period, epoch, slot)


### PR DESCRIPTION
Attestation and aggregator duties are rewarded within one epoch as per https://eth2book.info/latest/part2/incentives/rewards/#attestation-rewards, so the deadline needs to be adjusted. 

Also, the usage of `ctxWithDeadlineOnNextSlot` seems confusing when there are some actions on the passed slot (e.g., `ctxWithDeadlineOnNextSlot(ctx, slot+1)`, so the PR adds `ctxWithDeadlineOnNextEpoch` for such cases