### PR TITLE
proposals: scoring + fine-tuned timeouts

### DIFF
--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -45,7 +45,7 @@ var (
 		"/eth/v1/node/syncing": []byte(`{
 			"data": {
 				"head_slot": "4239945",
-				"sync_distance": "1", 
+				"sync_distance": "1",
 				"is_syncing": false,
 				"is_optimistic": false,
 				"el_offline": false
@@ -492,17 +492,18 @@ func createClient(
 	ctx context.Context,
 	beaconServerURL string,
 	withWeightedAttestationData bool) (*GoClient, error) {
-	client, err := New(
-		ctx,
-		zap.NewNop(),
+	opt, err := NewOptions(
 		Options{
 			BeaconNodeAddr:              beaconServerURL,
 			CommonTimeout:               defaultHardTimeout,
 			LongTimeout:                 time.Second,
 			WithWeightedAttestationData: withWeightedAttestationData,
-		},
-	)
-	return client, err
+		}, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(ctx, zap.NewNop(), opt)
 }
 
 type beaconServerResponseOptions struct {

--- a/beacon/goclient/events_test.go
+++ b/beacon/goclient/events_test.go
@@ -78,14 +78,11 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 }
 
 func eventsTestClient(t *testing.T, serverURL string) *GoClient {
-	server, err := New(
-		t.Context(),
-		zap.NewNop(),
-		Options{
-			BeaconNodeAddr: serverURL,
-		},
-	)
-
+	opt, err := NewOptions(Options{BeaconNodeAddr: serverURL}, 0)
 	require.NoError(t, err)
+
+	server, err := New(t.Context(), zap.NewNop(), opt)
+	require.NoError(t, err)
+
 	return server
 }

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -192,6 +192,9 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	if longTimeout == 0 {
 		longTimeout = DefaultLongTimeout
 	}
+
+	// TODO this can be removed once we have confirmed that all instantiations
+	// (mainly tests) use the NewOptions constructions, that properly sets though.
 	proposalSoftTimeout := opt.ProposalSoftTimeout
 	if proposalSoftTimeout == 0 {
 		proposalSoftTimeout = DefaultProposalSoftTimeout

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -39,8 +39,8 @@ const (
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
 	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Second * 3
-	DefaultProposalHardTimeout = time.Second * 4
+	DefaultProposalSoftTimeout = time.Millisecond * 1600
+	DefaultProposalHardTimeout = time.Millisecond * 2600
 
 	BlockRootToSlotCacheCapacityEpochs = 64
 
@@ -195,10 +195,19 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	proposalSoftTimeout := opt.ProposalSoftTimeout
 	if proposalSoftTimeout == 0 {
 		proposalSoftTimeout = DefaultProposalSoftTimeout
+		if opt.ProposerDelay < proposalSoftTimeout {
+			proposalSoftTimeout -= opt.ProposerDelay
+		}
 	}
 	proposalHardTimeout := opt.ProposalHardTimeout
 	if proposalHardTimeout == 0 {
 		proposalHardTimeout = DefaultProposalHardTimeout
+		if opt.ProposerDelay < proposalHardTimeout {
+			proposalHardTimeout -= opt.ProposerDelay
+		}
+		if proposalHardTimeout < proposalSoftTimeout {
+			proposalHardTimeout = proposalSoftTimeout
+		}
 	}
 
 	client := &GoClient{

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -39,8 +39,8 @@ const (
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
 	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Second
-	DefaultProposalHardTimeout = time.Second * 2
+	DefaultProposalSoftTimeout = 1500 * time.Millisecond
+	DefaultProposalHardTimeout = 2500 * time.Millisecond
 
 	BlockRootToSlotCacheCapacityEpochs = 64
 

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -193,17 +193,6 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		longTimeout = DefaultLongTimeout
 	}
 
-	// TODO this can be removed once we have confirmed that all instantiations
-	// (mainly tests) use the NewOptions constructions, that properly sets though.
-	proposalSoftTimeout := opt.ProposalSoftTimeout
-	if proposalSoftTimeout == 0 {
-		proposalSoftTimeout = DefaultProposalSoftTimeout
-	}
-	proposalHardTimeout := opt.ProposalHardTimeout
-	if proposalHardTimeout == 0 {
-		proposalHardTimeout = DefaultProposalHardTimeout
-	}
-
 	client := &GoClient{
 		log:                                logger.Named(log.NameConsensusClient),
 		beaconConfigInit:                   make(chan struct{}),
@@ -214,8 +203,8 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
-		proposalSoftTimeout:                proposalSoftTimeout,
-		proposalHardTimeout:                proposalHardTimeout,
+		proposalSoftTimeout:                opt.ProposalSoftTimeout,
+		proposalHardTimeout:                opt.ProposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -39,8 +39,8 @@ const (
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
 	// Proposal timeouts
-	DefaultProposalCollectTimeout = time.Second
-	DefaultProposalHardTimeout    = time.Second * 2
+	DefaultProposalSoftTimeout = time.Second
+	DefaultProposalHardTimeout = time.Second * 2
 
 	BlockRootToSlotCacheCapacityEpochs = 64
 
@@ -138,14 +138,14 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
-	// proposalCollectTimeout is the maximum time to wait for multiple block proposals in
+	// proposalSoftTimeout is the maximum time to wait for multiple block proposals in
 	// order to select the best one from multiple clients.
 	// If no proposal has been received after this time elapses, the first valid proposal
 	// seen is returned
 	// proposalHardTimeout is the hard timeout for retrieving any proposals.
 	// TODO these should be configurable by the operator
-	proposalCollectTimeout time.Duration
-	proposalHardTimeout    time.Duration
+	proposalSoftTimeout time.Duration
+	proposalHardTimeout time.Duration
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
@@ -193,9 +193,9 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	if longTimeout == 0 {
 		longTimeout = DefaultLongTimeout
 	}
-	proposalCollectTimeout := opt.ProposalCollectTimeout
-	if proposalCollectTimeout == 0 {
-		proposalCollectTimeout = DefaultProposalCollectTimeout
+	proposalSoftTimeout := opt.ProposalSoftTimeout
+	if proposalSoftTimeout == 0 {
+		proposalSoftTimeout = DefaultProposalSoftTimeout
 	}
 	proposalHardTimeout := opt.ProposalHardTimeout
 	if proposalHardTimeout == 0 {
@@ -212,7 +212,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
-		proposalCollectTimeout:             proposalCollectTimeout,
+		proposalSoftTimeout:                proposalSoftTimeout,
 		proposalHardTimeout:                proposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -130,13 +130,11 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
-	// proposalSoftTimeout is the maximum time to wait for multiple block proposals in
-	// order to select the best one from multiple clients.
-	// If no proposal has been received after this time elapses, the first valid proposal
-	// seen is returned
-	// proposalHardTimeout is the hard timeout for retrieving any proposals.
+	// proposalSoftTimeout is the collection period during which we gather proposals
+	// from multiple beacon nodes to select the best one. After this timeout, we return
+	// the best proposal seen so far, or wait for the first valid proposal if none
+	// received yet. The parent context (duty deadline) serves as the hard timeout.
 	proposalSoftTimeout time.Duration
-	proposalHardTimeout time.Duration
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
@@ -187,7 +185,6 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		weightedAttestationDataSoftTimeout: time.Duration(float64(opt.CommonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: opt.CommonTimeout,
 		proposalSoftTimeout:                opt.ProposalSoftTimeout,
-		proposalHardTimeout:                opt.ProposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -143,7 +143,6 @@ type GoClient struct {
 	// If no proposal has been received after this time elapses, the first valid proposal
 	// seen is returned
 	// proposalHardTimeout is the hard timeout for retrieving any proposals.
-	// TODO these should be configurable by the operator
 	proposalSoftTimeout time.Duration
 	proposalHardTimeout time.Duration
 

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -39,8 +39,8 @@ const (
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
 	// Proposal timeouts
-	DefaultProposalSoftTimeout = 1500 * time.Millisecond
-	DefaultProposalHardTimeout = 2500 * time.Millisecond
+	DefaultProposalSoftTimeout = time.Second * 3
+	DefaultProposalHardTimeout = time.Second * 4
 
 	BlockRootToSlotCacheCapacityEpochs = 64
 

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -34,14 +34,6 @@ const (
 	// Don't check for it, check for errors or nil data instead.
 	DataVersionNil spec.DataVersion = math.MaxUint64
 
-	// Client timeouts.
-	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
-	DefaultLongTimeout   = time.Second * 60 // For long requests.
-
-	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Millisecond * 1600
-	DefaultProposalHardTimeout = time.Millisecond * 2600
-
 	BlockRootToSlotCacheCapacityEpochs = 64
 
 	// ProposalPreparationBatchSize is the maximum number of preparations to submit in a single request
@@ -184,25 +176,16 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 
 	beaconAddrList := strings.Split(opt.BeaconNodeAddr, ";")
 
-	commonTimeout := opt.CommonTimeout
-	if commonTimeout == 0 {
-		commonTimeout = DefaultCommonTimeout
-	}
-	longTimeout := opt.LongTimeout
-	if longTimeout == 0 {
-		longTimeout = DefaultLongTimeout
-	}
-
 	client := &GoClient{
 		log:                                logger.Named(log.NameConsensusClient),
 		beaconConfigInit:                   make(chan struct{}),
 		syncDistanceTolerance:              phase0.Slot(opt.SyncDistanceTolerance),
-		commonTimeout:                      commonTimeout,
-		longTimeout:                        longTimeout,
+		commonTimeout:                      opt.CommonTimeout,
+		longTimeout:                        opt.LongTimeout,
 		withWeightedAttestationData:        opt.WithWeightedAttestationData,
 		withParallelSubmissions:            opt.WithParallelSubmissions,
-		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
-		weightedAttestationDataHardTimeout: commonTimeout,
+		weightedAttestationDataSoftTimeout: time.Duration(float64(opt.CommonTimeout) / 2.5),
+		weightedAttestationDataHardTimeout: opt.CommonTimeout,
 		proposalSoftTimeout:                opt.ProposalSoftTimeout,
 		proposalHardTimeout:                opt.ProposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -138,7 +138,10 @@ type GoClient struct {
 	// order to select the best one from multiple clients.
 	// If no proposal has been received after this time elapses, the first valid proposal
 	// seen is returned
+	// proposalHardTimeout is the hard timeout for retrieving any proposals.
+	// TODO these should be configurable by the operator
 	proposalCollectTimeout time.Duration
+	proposalHardTimeout    time.Duration
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
@@ -198,6 +201,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
 		proposalCollectTimeout:             time.Duration(float64(commonTimeout) / 5),
+		proposalHardTimeout:                commonTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}
@@ -233,6 +237,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	client.log.Debug("fetched beacon config successfully")
 
 	client.blockRootToSlotCache = ttlcache.New(
+
 		ttlcache.WithCapacity[phase0.Root, phase0.Slot](config.SlotsPerEpoch * BlockRootToSlotCacheCapacityEpochs),
 	)
 

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -134,6 +134,12 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
+	// proposalCollectTimeout is the maximum time to wait for multiple block proposals in
+	// order to select the best one from multiple clients.
+	// If no proposal has been received after this time elapses, the first valid proposal
+	// seen is returned
+	proposalCollectTimeout time.Duration
+
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
 	// that successfully fetched attestation data and proceeded to the scoring phase. Capacity is rather an arbitrary number,
@@ -191,6 +197,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
+		proposalCollectTimeout:             time.Duration(float64(commonTimeout) / 5),
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -200,8 +200,8 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
-		proposalCollectTimeout:             time.Duration(float64(commonTimeout) / 5),
-		proposalHardTimeout:                commonTimeout,
+		proposalCollectTimeout:             time.Second,
+		proposalHardTimeout:                2 * time.Second,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -38,6 +38,10 @@ const (
 	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
+	// Proposal timeouts
+	DefaultProposalCollectTimeout = time.Second
+	DefaultProposalHardTimeout    = time.Second * 2
+
 	BlockRootToSlotCacheCapacityEpochs = 64
 
 	// ProposalPreparationBatchSize is the maximum number of preparations to submit in a single request
@@ -189,6 +193,14 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	if longTimeout == 0 {
 		longTimeout = DefaultLongTimeout
 	}
+	proposalCollectTimeout := opt.ProposalCollectTimeout
+	if proposalCollectTimeout == 0 {
+		proposalCollectTimeout = DefaultProposalCollectTimeout
+	}
+	proposalHardTimeout := opt.ProposalHardTimeout
+	if proposalHardTimeout == 0 {
+		proposalHardTimeout = DefaultProposalHardTimeout
+	}
 
 	client := &GoClient{
 		log:                                logger.Named(log.NameConsensusClient),
@@ -200,8 +212,8 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
-		proposalCollectTimeout:             time.Second,
-		proposalHardTimeout:                2 * time.Second,
+		proposalCollectTimeout:             proposalCollectTimeout,
+		proposalHardTimeout:                proposalHardTimeout,
 		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -195,19 +195,10 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	proposalSoftTimeout := opt.ProposalSoftTimeout
 	if proposalSoftTimeout == 0 {
 		proposalSoftTimeout = DefaultProposalSoftTimeout
-		if opt.ProposerDelay < proposalSoftTimeout {
-			proposalSoftTimeout -= opt.ProposerDelay
-		}
 	}
 	proposalHardTimeout := opt.ProposalHardTimeout
 	if proposalHardTimeout == 0 {
 		proposalHardTimeout = DefaultProposalHardTimeout
-		if opt.ProposerDelay < proposalHardTimeout {
-			proposalHardTimeout -= opt.ProposerDelay
-		}
-		if proposalHardTimeout < proposalSoftTimeout {
-			proposalHardTimeout = proposalSoftTimeout
-		}
 	}
 
 	client := &GoClient{

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -237,7 +237,6 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	client.log.Debug("fetched beacon config successfully")
 
 	client.blockRootToSlotCache = ttlcache.New(
-
 		ttlcache.WithCapacity[phase0.Root, phase0.Slot](config.SlotsPerEpoch * BlockRootToSlotCacheCapacityEpochs),
 	)
 

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -1,6 +1,7 @@
 package goclient
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -17,7 +18,33 @@ type Options struct {
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.
 
-	// TODO these should be configurable by the operator
-	ProposalSoftTimeout time.Duration // Optional
-	ProposalHardTimeout time.Duration // Optional
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout"`
+	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout"`
+}
+
+func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
+	options := base
+	if options.ProposalSoftTimeout == 0 {
+		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
+	}
+
+	if options.ProposalHardTimeout == 0 {
+		options.ProposalHardTimeout = DefaultProposalHardTimeout
+	}
+
+	if proposerDelay > 0 {
+		options.ProposalSoftTimeout -= proposerDelay
+		options.ProposalHardTimeout -= proposerDelay
+	}
+
+	if options.ProposalSoftTimeout < 0 {
+		return Options{}, fmt.Errorf("invalid proposal soft timeout: %s", options.ProposalSoftTimeout)
+	}
+
+	if options.ProposalHardTimeout < options.ProposalSoftTimeout ||
+		options.ProposalHardTimeout < 0 {
+		return Options{}, fmt.Errorf("invalid proposal hard timeout: %s", options.ProposalHardTimeout)
+	}
+
+	return options, nil
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -20,4 +20,5 @@ type Options struct {
 	// TODO these should be configurable by the operator
 	ProposalSoftTimeout time.Duration // Optional
 	ProposalHardTimeout time.Duration // Optional
+	ProposerDelay       time.Duration // Optional
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -24,6 +24,7 @@ type Options struct {
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 	options := base
+
 	if options.ProposalSoftTimeout == 0 {
 		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
 	}

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -16,4 +16,7 @@ type Options struct {
 
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.
+
+	ProposalCollectTimeout time.Duration // Optional
+	ProposalHardTimeout    time.Duration // Optional
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.
 
+	// TODO these should be configurable by the operator
 	ProposalSoftTimeout time.Duration // Optional
 	ProposalHardTimeout time.Duration // Optional
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -7,6 +7,16 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+const (
+	// Client timeouts.
+	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
+	DefaultLongTimeout   = time.Second * 60 // For long requests.
+
+	// Proposal timeouts
+	DefaultProposalSoftTimeout = time.Millisecond * 1600
+	DefaultProposalHardTimeout = time.Millisecond * 2600
+)
+
 // Options defines beacon client options
 type Options struct {
 	BeaconConfig                *networkconfig.Beacon
@@ -15,8 +25,8 @@ type Options struct {
 	WithWeightedAttestationData bool   `yaml:"WithWeightedAttestationData" env:"WITH_WEIGHTED_ATTESTATION_DATA" env-default:"false" env-description:"Enable attestation data scoring across multiple beacon nodes"`
 	WithParallelSubmissions     bool   `yaml:"WithParallelSubmissions" env:"WITH_PARALLEL_SUBMISSIONS" env-default:"false" env-description:"Enables parallel Attestation and Sync Committee submissions to all Beacon nodes (as opposed to submitting to a single Beacon node via multiclient instance)"`
 
-	CommonTimeout time.Duration // Optional.
-	LongTimeout   time.Duration // Optional.
+	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
+	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
 	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
 	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD_TIMEOUT" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
@@ -24,6 +34,14 @@ type Options struct {
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 	options := base
+
+	if options.CommonTimeout == 0 {
+		options.CommonTimeout = DefaultCommonTimeout
+	}
+
+	if options.LongTimeout == 0 {
+		options.LongTimeout = DefaultLongTimeout
+	}
 
 	if options.ProposalSoftTimeout == 0 {
 		options.ProposalSoftTimeout = DefaultProposalSoftTimeout

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -1,7 +1,6 @@
 package goclient
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -12,9 +11,23 @@ const (
 	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 
-	// Proposal timeouts
-	DefaultProposalSoftTimeout = time.Millisecond * 1600
-	DefaultProposalHardTimeout = time.Millisecond * 2600
+	// DefaultProposalSoftTimeout is the base collection period during which we
+	// gather proposals from multiple beacon nodes to select the best one.
+	// This value is reduced by the proposer delay to maintain consistent timing.
+	// After the soft timeout, we return the best proposal seen so far, or wait
+	// for the first valid proposal if none received yet.
+	// The parent context (duty deadline) serves as the hard timeout.
+	//
+	// Note: MEV (blinded) blocks return immediately, so this timeout mainly
+	// affects how long we wait for MEV when we first receive a vanilla block.
+	//
+	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
+	// set, the value is used as-is without proposer delay reduction (power user mode).
+	DefaultProposalSoftTimeout = time.Millisecond * 3000
+
+	// MinProposalSoftTimeout is the minimum collection period, even with maximum
+	// proposer delay. This ensures we always have some time to compare proposals.
+	MinProposalSoftTimeout = time.Millisecond * 500
 )
 
 // Options defines beacon client options
@@ -28,8 +41,7 @@ type Options struct {
 	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
 	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
-	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD_TIMEOUT" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes)"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
@@ -43,27 +55,32 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 		options.LongTimeout = DefaultLongTimeout
 	}
 
+	// If user explicitly set ProposalSoftTimeout, use it as-is (power user mode).
+	// Otherwise, use default and reduce by proposer delay.
 	if options.ProposalSoftTimeout == 0 {
 		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
+
+		// Reduce soft timeout by proposer delay to maintain consistent timing.
+		// Users with proposer delay start fetching later, so they get a shorter
+		// collection period. This ensures consensus starts at roughly the same
+		// time regardless of proposer delay configuration.
+		//
+		// Examples (with default 3000ms soft timeout):
+		//   - 0ms delay    → 3000ms collection
+		//   - 500ms delay  → 2500ms collection
+		//   - 1500ms delay → 1500ms collection
+		//   - 2500ms delay → 500ms collection (capped at minimum)
+		if proposerDelay > 0 {
+			options.ProposalSoftTimeout -= proposerDelay
+			if options.ProposalSoftTimeout < MinProposalSoftTimeout {
+				options.ProposalSoftTimeout = MinProposalSoftTimeout
+			}
+		}
 	}
 
-	if options.ProposalHardTimeout == 0 {
-		options.ProposalHardTimeout = DefaultProposalHardTimeout
-	}
-
-	if proposerDelay > 0 {
-		options.ProposalSoftTimeout -= proposerDelay
-		options.ProposalHardTimeout -= proposerDelay
-	}
-
-	if options.ProposalSoftTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal soft timeout: %s", options.ProposalSoftTimeout)
-	}
-
-	if options.ProposalHardTimeout < options.ProposalSoftTimeout ||
-		options.ProposalHardTimeout < 0 {
-		return Options{}, fmt.Errorf("invalid proposal hard timeout: %s", options.ProposalHardTimeout)
-	}
+	// Note: There is no hard timeout for proposals. The parent context from the
+	// duty runner (bounded by slot timing) serves as the ultimate deadline.
+	// This ensures we never give up early on getting a block proposal.
 
 	return options, nil
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -19,7 +19,7 @@ type Options struct {
 	LongTimeout   time.Duration // Optional.
 
 	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
-	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
+	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD_TIMEOUT" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -20,5 +20,4 @@ type Options struct {
 	// TODO these should be configurable by the operator
 	ProposalSoftTimeout time.Duration // Optional
 	ProposalHardTimeout time.Duration // Optional
-	ProposerDelay       time.Duration // Optional
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
 	// set, the value is used as-is without proposer delay reduction (power user mode).
-	DefaultProposalSoftTimeout = time.Millisecond * 3000
+	DefaultProposalSoftTimeout = time.Millisecond * 1800
 
 	// MinProposalSoftTimeout is the minimum collection period, even with maximum
 	// proposer delay. This ensures we always have some time to compare proposals.
@@ -65,11 +65,11 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 		// collection period. This ensures consensus starts at roughly the same
 		// time regardless of proposer delay configuration.
 		//
-		// Examples (with default 3000ms soft timeout):
-		//   - 0ms delay    → 3000ms collection
-		//   - 500ms delay  → 2500ms collection
-		//   - 1500ms delay → 1500ms collection
-		//   - 2500ms delay → 500ms collection (capped at minimum)
+		// Examples (with default 1800ms soft timeout):
+		//   - 0ms delay    → 1800ms collection
+		//   - 500ms delay  → 1300ms collection
+		//   - 1000ms delay → 800ms collection
+		//   - 1300ms delay → 500ms collection (capped at minimum)
 		if proposerDelay > 0 {
 			options.ProposalSoftTimeout -= proposerDelay
 			if options.ProposalSoftTimeout < MinProposalSoftTimeout {

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -6,28 +6,12 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+// Various Client timeouts are defined below.
 const (
-	// Client timeouts.
-	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
-	DefaultLongTimeout   = time.Second * 60 // For long requests.
-
-	// DefaultProposalSoftTimeout is the base collection period during which we
-	// gather proposals from multiple beacon nodes to select the best one.
-	// This value is reduced by the proposer delay to maintain consistent timing.
-	// After the soft timeout, we return the best proposal seen so far, or wait
-	// for the first valid proposal if none received yet.
-	// The parent context (duty deadline) serves as the hard timeout.
-	//
-	// Note: MEV (blinded) blocks return immediately, so this timeout mainly
-	// affects how long we wait for MEV when we first receive a vanilla block.
-	//
-	// Can be overridden via WITH_PROPOSAL_SOFT_TIMEOUT env var. When explicitly
-	// set, the value is used as-is without proposer delay reduction (power user mode).
-	DefaultProposalSoftTimeout = time.Millisecond * 1800
-
-	// MinProposalSoftTimeout is the minimum collection period, even with maximum
-	// proposer delay. This ensures we always have some time to compare proposals.
-	MinProposalSoftTimeout = time.Millisecond * 500
+	// defaultCommonTimeout is the default timeout for dialing, and most client-requests.
+	defaultCommonTimeout = time.Second * 5
+	// defaultLongTimeout is the default timeout for certain specific operations the client performs.
+	defaultLongTimeout = time.Second * 60
 )
 
 // Options defines beacon client options
@@ -41,41 +25,41 @@ type Options struct {
 	CommonTimeout time.Duration `yaml:"CommonTimeout" env:"WITH_COMMON_TIMEOUT" env-description:"Specifies the common timeout for network operations"`
 	LongTimeout   time.Duration `yaml:"LongTimeout" env:"WITH_LONG_TIMEOUT" env-description:"Specifies the long timeout for network operations"`
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes)"`
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout (collection period for comparing proposals from multiple beacon nodes to select the most profitable one). Note: the 1st MEV (blinded) block is accepted immediately, so this timeout mainly affects how long we wait for an MEV block before giving up deciding to use a vanilla block instead (if we got one already). This value cannot be set any lower than 500ms to ensure there is enough time for the Beacon node to serve the block-fetch request"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 	options := base
 
 	if options.CommonTimeout == 0 {
-		options.CommonTimeout = DefaultCommonTimeout
+		options.CommonTimeout = defaultCommonTimeout
 	}
 
 	if options.LongTimeout == 0 {
-		options.LongTimeout = DefaultLongTimeout
+		options.LongTimeout = defaultLongTimeout
 	}
 
 	// If user explicitly set ProposalSoftTimeout, use it as-is (power user mode).
-	// Otherwise, use default and reduce by proposer delay.
+	// Otherwise, use the default value and reduce it by proposer delay if needed.
 	if options.ProposalSoftTimeout == 0 {
-		options.ProposalSoftTimeout = DefaultProposalSoftTimeout
-
-		// Reduce soft timeout by proposer delay to maintain consistent timing.
-		// Users with proposer delay start fetching later, so they get a shorter
-		// collection period. This ensures consensus starts at roughly the same
-		// time regardless of proposer delay configuration.
-		//
-		// Examples (with default 1800ms soft timeout):
-		//   - 0ms delay    → 1800ms collection
-		//   - 500ms delay  → 1300ms collection
-		//   - 1000ms delay → 800ms collection
-		//   - 1300ms delay → 500ms collection (capped at minimum)
+		// The default value shouldn't be too high because an operator might not be able to participate
+		// in QBFT round 2 (or finish it in time) if it is roughly > 2000 ms.
+		options.ProposalSoftTimeout = time.Millisecond * 1800
+		// Reduce soft timeout by proposer delay to maintain consistent duty-execution timelines
+		// for different operators in the cluster, ensuring QBFT consensus starts at roughly
+		// the same time (timing out round 1 at roughly the same time) regardless of proposer
+		// delay configuration a particular operator is using - operators with higher proposer
+		// delay start fetching blocks later, so they must have a shorter collection period.
 		if proposerDelay > 0 {
 			options.ProposalSoftTimeout -= proposerDelay
-			if options.ProposalSoftTimeout < MinProposalSoftTimeout {
-				options.ProposalSoftTimeout = MinProposalSoftTimeout
-			}
 		}
+	}
+
+	// minProposalSoftTimeout is the minimum soft timeout value allowed.
+	// It ensures we always have enough time to fetch and compare proposals.
+	const minProposalSoftTimeout = time.Millisecond * 500
+	if options.ProposalSoftTimeout < minProposalSoftTimeout {
+		options.ProposalSoftTimeout = minProposalSoftTimeout
 	}
 
 	// Note: There is no hard timeout for proposals. The parent context from the

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -17,6 +17,6 @@ type Options struct {
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.
 
-	ProposalCollectTimeout time.Duration // Optional
-	ProposalHardTimeout    time.Duration // Optional
+	ProposalSoftTimeout time.Duration // Optional
+	ProposalHardTimeout time.Duration // Optional
 }

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -44,7 +44,8 @@ func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {
 	if options.ProposalSoftTimeout == 0 {
 		// The default value shouldn't be too high because an operator might not be able to participate
 		// in QBFT round 2 (or finish it in time) if it is roughly > 2000 ms.
-		options.ProposalSoftTimeout = time.Millisecond * 1800
+		const defaultProposalSoftTimeout = time.Millisecond * 1800
+		options.ProposalSoftTimeout = defaultProposalSoftTimeout
 		// Reduce soft timeout by proposer delay to maintain consistent duty-execution timelines
 		// for different operators in the cluster, ensuring QBFT consensus starts at roughly
 		// the same time (timing out round 1 at roughly the same time) regardless of proposer

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -18,8 +18,8 @@ type Options struct {
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.
 
-	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout"`
-	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout"`
+	ProposalSoftTimeout time.Duration `yaml:"ProposalSoftTimeout" env:"WITH_PROPOSAL_SOFT_TIMEOUT" env-description:"Specifies the beacon proposal collection soft timeout; it will be adjusted for the proposer delay"`
+	ProposalHardTimeout time.Duration `yaml:"ProposalHardTimeout" env:"WITH_PROPOSAL_HARD" env-description:"Specifies the beacon proposal collection hard timeout; it will be adjusted for the proposer delay"`
 }
 
 func NewOptions(base Options, proposerDelay time.Duration) (Options, error) {

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -248,7 +248,13 @@ collectBest:
 		return bestProposal, nil
 	}
 
-	// there are still some collectors running, just return the frist valid one
+	gc.log.Debug("did not receive any valid proposals during the collection period",
+		zap.Int("clients", len(gc.clients)),
+		zap.Int("pending", pendingClients),
+		fields.Slot(slot),
+	)
+
+	// there are potentially still some collectors running, just return the frist valid one
 collectFirst:
 	for pendingClients > 0 {
 		select {

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -201,7 +201,7 @@ func (gc *GoClient) getProposalParallel(
 
 	pendingClients := len(gc.clients)
 collectBest:
-	for {
+	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
 			pendingClients--
@@ -230,11 +230,6 @@ collectBest:
 				bestClient = res.client
 			}
 
-			if pendingClients == 0 {
-				// we are not expecing more proposals
-				break collectBest
-			}
-
 		case <-collectCtx.Done():
 			// we are done collecting;
 			break collectBest
@@ -253,16 +248,13 @@ collectBest:
 		return bestProposal, nil
 	}
 
-	// if we have no more pending clients, they all failed during collection
-	if pendingClients == 0 {
-		goto fail
-	}
-
 	// there are still some collectors running, just return the frist valid one
 collectFirst:
-	for {
+	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
+			pendingClients--
+
 			if res.err != nil {
 				errs = errors.Join(errs, res.err)
 
@@ -287,7 +279,6 @@ collectFirst:
 		}
 	}
 
-fail:
 	return nil, fmt.Errorf("all %d clients failed to get proposal for slot %d, encountered errors: %w", len(gc.clients), slot, errs)
 }
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -168,7 +168,7 @@ func (gc *GoClient) getProposalParallel(
 	// Create a context that we'll use to collect and evaluate proposals for a short time
 	// after this context expires, we will return the current best proposal or the first
 	// on we see if we have none
-	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalCollectTimeout)
+	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalSoftTimeout)
 	defer cancelSoft()
 
 	// Create a context for hard proposal timeout; we fail if this timeout expires

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -200,7 +200,6 @@ func (gc *GoClient) getProposalParallel(
 	var bestClient string
 
 	pendingClients := len(gc.clients)
-collectBest:
 	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
@@ -208,13 +207,7 @@ collectBest:
 
 			if res.err != nil {
 				errs = errors.Join(errs, res.err)
-
-				if pendingClients > 0 {
-					continue collectBest
-				}
-
-				// we are not expecting any more proposals
-				break collectBest
+				continue
 			}
 
 			proposalScore := gc.scoreProposal(res.proposal)
@@ -232,7 +225,7 @@ collectBest:
 
 		case <-collectCtx.Done():
 			// we are done collecting;
-			break collectBest
+			break
 		}
 	}
 
@@ -255,7 +248,6 @@ collectBest:
 	)
 
 	// there are potentially still some collectors running, just return the frist valid one
-collectFirst:
 	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
@@ -263,13 +255,7 @@ collectFirst:
 
 			if res.err != nil {
 				errs = errors.Join(errs, res.err)
-
-				if pendingClients > 0 {
-					continue collectFirst
-				}
-
-				// we are not expecting any more proposals
-				break collectFirst
+				continue
 			}
 
 			// Got a successful response, cancel other requests and return.

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -154,7 +154,7 @@ func (gc *GoClient) GetBeaconBlock(
 
 // getProposalParallel races all beacon nodes and collects proposals for a short time
 // and returns the best one according to our score function.
-// If no valud proposals are collected in this time it returns the first valid one
+// If no valid proposals are collected in this time it returns the first valid one
 // it sees.
 //
 // This minimizes latency for time-critical block proposals, while still affording
@@ -276,7 +276,7 @@ collect:
 		fields.Slot(slot),
 	)
 
-	// there are potentially still some collectors running, just return the frist valid one
+	// there are potentially still some collectors running, just return the first valid one
 	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -166,6 +166,10 @@ func (gc *GoClient) GetBeaconBlock(
 // a proposal slot is worse than a nil fee recipient.
 // However, it has been observed that the first proposal is usually not the most
 // profitable, so we added a little slack time to collect proposals.
+//
+// The parent context (from duty runner, bounded by slot timing) serves as the hard
+// deadline. We never give up early on getting a block proposal - missing a proposal
+// is catastrophic, so we wait as long as the slot allows.
 func (gc *GoClient) getProposalParallel(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -173,15 +177,15 @@ func (gc *GoClient) getProposalParallel(
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
 ) (*api.VersionedProposal, error) {
-	// Create a context that we'll use to collect and evaluate proposals for a short time
-	// after this context expires, we will return the current best proposal or the first
-	// on we see if we have none
+	// Create a context for the collection period - during this time we gather
+	// proposals from multiple beacon nodes to select the best one.
+	// After this expires, we return the best seen so far or wait for the first valid one.
 	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalSoftTimeout)
 	defer cancelSoft()
 
-	// Create a context for hard proposal timeout; we fail if this timeout expires
-	hardCtx, cancelHard := context.WithTimeout(ctx, gc.proposalHardTimeout)
-	defer cancelHard()
+	// Note: We use the parent context (ctx) as the hard deadline, not a separate timeout.
+	// The parent context is bounded by the duty runner's slot timing, ensuring we never
+	// give up prematurely on getting a block proposal.
 
 	type result struct {
 		proposal *api.VersionedProposal
@@ -193,10 +197,10 @@ func (gc *GoClient) getProposalParallel(
 
 	for _, client := range gc.clients {
 		go func(c Client) {
-			proposal, err := gc.fetchProposal(hardCtx, c, slot, sig, graffiti)
+			proposal, err := gc.fetchProposal(ctx, c, slot, sig, graffiti)
 			select {
 			case resultCh <- result{proposal: proposal, err: err, client: c.Address()}:
-			case <-hardCtx.Done():
+			case <-ctx.Done():
 				// Context canceled, exit without blocking
 			}
 		}(client)
@@ -299,8 +303,9 @@ collect:
 			)
 			return res.proposal, nil
 
-		case <-hardCtx.Done():
-			return nil, hardCtx.Err()
+		case <-ctx.Done():
+			// Parent context canceled (duty deadline reached)
+			return nil, ctx.Err()
 		}
 	}
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -221,6 +221,7 @@ collect:
 				zap.String("client", res.client),
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),
+				zap.Int("pending", pendingClients),
 				fields.Slot(slot),
 			)
 
@@ -266,8 +267,12 @@ collect:
 			}
 
 			// Got a successful response, cancel other requests and return.
-			gc.log.Debug("received proposal, canceling other requests",
+			proposalScore := gc.scoreProposal(res.proposal)
+			gc.log.Debug("received proposal",
 				zap.String("client", res.client),
+				zap.Float64("score", proposalScore),
+				zap.Duration("latency", time.Since(startCollect)),
+				zap.Int("pending", pendingClients),
 				fields.Slot(slot),
 			)
 			return res.proposal, nil

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -169,11 +169,15 @@ func (gc *GoClient) getProposalParallel(
 	parallelCtx, cancelParallel := context.WithCancel(ctx)
 	defer cancelParallel()
 
-	// Create a contet that we 'll use to collect and evaluate proposals for a short time
+	// Create a contet that we'll use to collect and evaluate proposals for a short time
 	// after this context expires, we will return the current best proposal or the first
 	// on we see if we have none
 	collectCtx, cancelCollect := context.WithTimeout(ctx, gc.proposalCollectTimeout)
 	defer cancelCollect()
+
+	// Create a context for hard proposal timeout; we fail if this timeout expires
+	hardTimeoutCtx, cancelHardTimeout := context.WithTimeout(ctx, gc.proposalHardTimeout)
+	defer cancelHardTimeout()
 
 	type result struct {
 		proposal *api.VersionedProposal
@@ -199,6 +203,7 @@ func (gc *GoClient) getProposalParallel(
 	var bestScore float64
 	var bestClient string
 
+	startCollect := time.Now()
 	pendingClients := len(gc.clients)
 collect:
 	for pendingClients > 0 {
@@ -215,6 +220,7 @@ collect:
 			gc.log.Debug("received proposal",
 				zap.String("client", res.client),
 				zap.Float64("score", proposalScore),
+				zap.Duration("latency", time.Since(startCollect)),
 				fields.Slot(slot),
 			)
 
@@ -266,8 +272,8 @@ collect:
 			)
 			return res.proposal, nil
 
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		case <-hardTimeoutCtx.Done():
+			return nil, hardTimeoutCtx.Err()
 		}
 	}
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -222,6 +222,20 @@ collect:
 				fields.Slot(slot),
 			)
 
+			if res.proposal.Blinded && proposalScore >= bestScore {
+				// this is a blinded proposal that is at least as good as any proposal
+				// we've seen so far.
+				// We immediately return this as an optimization, under the assumption
+				// that this is a MEV block; it is a reasonable assumption to make in
+				// the usual operating environment.
+				// Note: We may want to add an operator option to disable this behavior
+				// in the future.
+				bestProposal = res.proposal
+				bestScore = proposalScore
+				bestClient = res.client
+				break collect
+			}
+
 			if bestProposal == nil || proposalScore > bestScore {
 				bestProposal = res.proposal
 				bestScore = proposalScore

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -268,7 +268,7 @@ collect:
 
 			// Got a successful response, cancel other requests and return.
 			proposalScore := gc.scoreProposal(res.proposal)
-			gc.log.Debug("received proposal",
+			gc.log.Debug("received proposal; selected first proposal",
 				zap.String("client", res.client),
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -165,20 +165,15 @@ func (gc *GoClient) getProposalParallel(
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
 ) (*api.VersionedProposal, error) {
-	// Create a context that we'll cancel if we return early so that we don't have
-	// lingering goroutines.
-	parallelCtx, cancelParallel := context.WithCancel(ctx)
-	defer cancelParallel()
-
 	// Create a context that we'll use to collect and evaluate proposals for a short time
 	// after this context expires, we will return the current best proposal or the first
 	// on we see if we have none
-	collectCtx, cancelCollect := context.WithTimeout(ctx, gc.proposalCollectTimeout)
-	defer cancelCollect()
+	softCtx, cancelSoft := context.WithTimeout(ctx, gc.proposalCollectTimeout)
+	defer cancelSoft()
 
 	// Create a context for hard proposal timeout; we fail if this timeout expires
-	hardTimeoutCtx, cancelHardTimeout := context.WithTimeout(ctx, gc.proposalHardTimeout)
-	defer cancelHardTimeout()
+	hardCtx, cancelHard := context.WithTimeout(ctx, gc.proposalHardTimeout)
+	defer cancelHard()
 
 	type result struct {
 		proposal *api.VersionedProposal
@@ -190,10 +185,10 @@ func (gc *GoClient) getProposalParallel(
 
 	for _, client := range gc.clients {
 		go func(c Client) {
-			proposal, err := gc.fetchProposal(parallelCtx, c, slot, sig, graffiti)
+			proposal, err := gc.fetchProposal(hardCtx, c, slot, sig, graffiti)
 			select {
 			case resultCh <- result{proposal: proposal, err: err, client: c.Address()}:
-			case <-parallelCtx.Done():
+			case <-hardCtx.Done():
 				// Context canceled, exit without blocking
 			}
 		}(client)
@@ -232,7 +227,7 @@ collect:
 				bestClient = res.client
 			}
 
-		case <-collectCtx.Done():
+		case <-softCtx.Done():
 			// we are done collecting;
 			break collect
 		}
@@ -278,8 +273,8 @@ collect:
 			)
 			return res.proposal, nil
 
-		case <-hardTimeoutCtx.Done():
-			return nil, hardTimeoutCtx.Err()
+		case <-hardCtx.Done():
+			return nil, hardCtx.Err()
 		}
 	}
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"slices"
 	"time"
@@ -144,13 +145,20 @@ func (gc *GoClient) GetBeaconBlock(
 	}
 }
 
-// getProposalParallel races all beacon nodes and returns the first successful response.
-// This minimizes latency for time-critical block proposals. Remaining requests are
+// getProposalParallel races all beacon nodes and collects proposals for a short time
+// and returns the best one according to our score function.
+// If no valud proposals are collected in this time it returns the first valid one
+// it sees.
+//
+// This minimizes latency for time-critical block proposals, while still affording
+// some time for selecting maximally profitable proposals. Remaining requests are
 // canceled immediately to reduce load.
 //
-// Note: We prioritize speed over fee recipient validation - returning the first response
-// rather than waiting to compare fee recipients, as missing a proposal slot is worse
-// than a nil fee recipient.
+// Note: We used to prioritize speed over fee recipient validation - returning
+// the first response rather than waiting to compare fee recipients, as missing
+// a proposal slot is worse than a nil fee recipient.
+// However, it has been observed that the first proposal is usually not the most
+// profitable, so we added a little slack time to collect proposals.
 func (gc *GoClient) getProposalParallel(
 	ctx context.Context,
 	slot phase0.Slot,
@@ -160,6 +168,12 @@ func (gc *GoClient) getProposalParallel(
 	// Create a context that we'll cancel as soon as we get the first successful response
 	parallelCtx, cancelParallel := context.WithCancel(ctx)
 	defer cancelParallel()
+
+	// Create a contet that we 'll use to collect and evaluate proposals for a short time
+	// after this context expires, we will return the current best proposal or the first
+	// on we see if we have none
+	collectCtx, cancelCollect := context.WithTimeout(parallelCtx, gc.proposalCollectTimeout)
+	defer cancelCollect()
 
 	type result struct {
 		proposal *api.VersionedProposal
@@ -181,13 +195,85 @@ func (gc *GoClient) getProposalParallel(
 	}
 
 	var errs error
-	for range gc.clients {
+	var bestProposal *api.VersionedProposal
+	var bestScore float64
+	var bestClient string
+
+	pendingClients := len(gc.clients)
+collectBest:
+	for {
+		select {
+		case res := <-resultCh:
+			pendingClients--
+
+			if res.err != nil {
+				errs = errors.Join(errs, res.err)
+
+				if pendingClients > 0 {
+					continue collectBest
+				}
+
+				// we are not expecting any more proposals
+				break collectBest
+			}
+
+			proposalScore := gc.scoreProposal(res.proposal)
+			gc.log.Debug("received proposal",
+				zap.String("client", res.client),
+				zap.Float64("score", proposalScore),
+				fields.Slot(slot),
+			)
+
+			if bestProposal == nil || proposalScore > bestScore {
+				bestProposal = res.proposal
+				bestScore = proposalScore
+				bestClient = res.client
+			}
+
+			if pendingClients == 0 {
+				// we are not expecing more proposals
+				break collectBest
+			}
+
+		case <-collectCtx.Done():
+			// we are done collecting;
+			break collectBest
+		}
+	}
+
+	// at this point if we have a proposal, we can just return it, it is the
+	// best one we've seen
+	if bestProposal != nil {
+		gc.log.Debug("selected best proposal",
+			zap.String("client", bestClient),
+			zap.Float64("score", bestScore),
+			fields.Slot(slot),
+		)
+
+		return bestProposal, nil
+	}
+
+	// if we have no more pending clients, they all failed during collection
+	if pendingClients == 0 {
+		goto fail
+	}
+
+	// there are still some collectors running, just return the frist valid one
+collectFirst:
+	for {
 		select {
 		case res := <-resultCh:
 			if res.err != nil {
 				errs = errors.Join(errs, res.err)
-				continue
+
+				if pendingClients > 0 {
+					continue collectFirst
+				}
+
+				// we are not expecting any more proposals
+				break collectFirst
 			}
+
 			// Got a successful response, cancel other requests and return.
 			gc.log.Debug("received proposal, canceling other requests",
 				zap.String("client", res.client),
@@ -195,12 +281,23 @@ func (gc *GoClient) getProposalParallel(
 			)
 			cancelParallel()
 			return res.proposal, nil
+
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
 	}
 
+fail:
 	return nil, fmt.Errorf("all %d clients failed to get proposal for slot %d, encountered errors: %w", len(gc.clients), slot, errs)
+}
+
+// scoreProposal computes a score for a beacon proposal.
+// see https://github.com/attestantio/vouch/blob/master/strategies/beaconblockproposal/best/score.go as well
+func (gc *GoClient) scoreProposal(
+	proposal *api.VersionedProposal,
+) float64 {
+	score, _ := new(big.Int).Add(proposal.ConsensusValue, proposal.ExecutionValue).Float64()
+	return score
 }
 
 // SubmitBeaconBlock submit the block to the node

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -170,7 +170,7 @@ func (gc *GoClient) getProposalParallel(
 	parallelCtx, cancelParallel := context.WithCancel(ctx)
 	defer cancelParallel()
 
-	// Create a contet that we'll use to collect and evaluate proposals for a short time
+	// Create a context that we'll use to collect and evaluate proposals for a short time
 	// after this context expires, we will return the current best proposal or the first
 	// on we see if we have none
 	collectCtx, cancelCollect := context.WithTimeout(ctx, gc.proposalCollectTimeout)

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -165,7 +165,8 @@ func (gc *GoClient) getProposalParallel(
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
 ) (*api.VersionedProposal, error) {
-	// Create a context that we'll cancel as soon as we get the first successful response
+	// Create a context that we'll cancel if we return early so that we don't have
+	// lingering goroutines.
 	parallelCtx, cancelParallel := context.WithCancel(ctx)
 	defer cancelParallel()
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -236,6 +236,8 @@ collect:
 				// We immediately return as an optimization, under the assumption
 				// that this is a MEV block; it is a reasonable assumption to make in
 				// the usual operating environment.
+				// Returning as soon as we fetch at least 1 MEV block is good enough,
+				// see https://github.com/ssvlabs/ssv/pull/2631#issuecomment-3678879204
 				// Note: We may want to add an operator option to disable this behavior
 				// in the future.
 				break collect

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -200,6 +200,7 @@ func (gc *GoClient) getProposalParallel(
 	var bestClient string
 
 	pendingClients := len(gc.clients)
+collect:
 	for pendingClients > 0 {
 		select {
 		case res := <-resultCh:
@@ -225,7 +226,7 @@ func (gc *GoClient) getProposalParallel(
 
 		case <-collectCtx.Done():
 			// we are done collecting;
-			break
+			break collect
 		}
 	}
 

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -222,24 +222,23 @@ collect:
 				fields.Slot(slot),
 			)
 
-			if res.proposal.Blinded && proposalScore >= bestScore {
-				// this is a blinded proposal that is at least as good as any proposal
-				// we've seen so far.
-				// We immediately return this as an optimization, under the assumption
+			if bestProposal == nil ||
+				proposalScore > bestScore ||
+				// this condition prefers the blinded proposal even if same score
+				// as the best we have observed so far
+				(res.proposal.Blinded && proposalScore == bestScore) {
+				bestProposal = res.proposal
+				bestScore = proposalScore
+				bestClient = res.client
+			}
+
+			if res.proposal.Blinded {
+				// We immediately return as an optimization, under the assumption
 				// that this is a MEV block; it is a reasonable assumption to make in
 				// the usual operating environment.
 				// Note: We may want to add an operator option to disable this behavior
 				// in the future.
-				bestProposal = res.proposal
-				bestScore = proposalScore
-				bestClient = res.client
 				break collect
-			}
-
-			if bestProposal == nil || proposalScore > bestScore {
-				bestProposal = res.proposal
-				bestScore = proposalScore
-				bestClient = res.client
 			}
 
 		case <-softCtx.Done():

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -172,7 +172,7 @@ func (gc *GoClient) getProposalParallel(
 	// Create a contet that we 'll use to collect and evaluate proposals for a short time
 	// after this context expires, we will return the current best proposal or the first
 	// on we see if we have none
-	collectCtx, cancelCollect := context.WithTimeout(parallelCtx, gc.proposalCollectTimeout)
+	collectCtx, cancelCollect := context.WithTimeout(ctx, gc.proposalCollectTimeout)
 	defer cancelCollect()
 
 	type result struct {

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/observability/log/fields"
+	"github.com/ssvlabs/ssv/observability/traces"
 )
 
 // ProposerDuties returns proposer duties for the given epoch.
@@ -83,6 +84,12 @@ func (gc *GoClient) GetBeaconBlock(
 	graffitiBytes []byte,
 	randao []byte,
 ) (*api.VersionedProposal, ssz.Marshaler, error) {
+	// Enrich logger with duty ID if available in context.
+	logger := gc.log
+	if dutyID, ok := traces.DutyIDFromContext(ctx); ok {
+		logger = logger.With(fields.DutyID(dutyID))
+	}
+
 	sig := phase0.BLSSignature{}
 	copy(sig[:], randao[:])
 
@@ -100,7 +107,7 @@ func (gc *GoClient) GetBeaconBlock(
 		}
 	} else {
 		// For multiple clients, race them in parallel for the fastest response
-		beaconBlock, err = gc.getProposalParallel(ctx, slot, sig, graffiti)
+		beaconBlock, err = gc.getProposalParallel(ctx, logger, slot, sig, graffiti)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -112,7 +119,7 @@ func (gc *GoClient) GetBeaconBlock(
 		return nil, nil, fmt.Errorf("failed to get fee recipient: %w", err)
 	}
 	if feeRecipient.IsZero() {
-		gc.log.Warn("proposal missing fee recipient - fees will be burned",
+		logger.Warn("proposal missing fee recipient - fees will be burned",
 			fields.Slot(slot),
 			zap.Bool("blinded", beaconBlock.Blinded))
 	}
@@ -161,6 +168,7 @@ func (gc *GoClient) GetBeaconBlock(
 // profitable, so we added a little slack time to collect proposals.
 func (gc *GoClient) getProposalParallel(
 	ctx context.Context,
+	logger *zap.Logger,
 	slot phase0.Slot,
 	sig phase0.BLSSignature,
 	graffiti [32]byte,
@@ -213,7 +221,7 @@ collect:
 			}
 
 			proposalScore := gc.scoreProposal(res.proposal)
-			gc.log.Debug("received proposal",
+			logger.Debug("received proposal",
 				zap.String("client", res.client),
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),
@@ -252,7 +260,7 @@ collect:
 	// at this point if we have a proposal, we can just return it, it is the
 	// best one we've seen
 	if bestProposal != nil {
-		gc.log.Debug("selected best proposal",
+		logger.Debug("selected best proposal",
 			zap.String("client", bestClient),
 			zap.Float64("score", bestScore),
 			zap.Bool("blinded", bestProposal.Blinded),
@@ -262,7 +270,7 @@ collect:
 		return bestProposal, nil
 	}
 
-	gc.log.Debug("did not receive any valid proposals during the collection period",
+	logger.Debug("did not receive any valid proposals during the collection period",
 		zap.Int("clients", len(gc.clients)),
 		zap.Int("pending", pendingClients),
 		fields.Slot(slot),
@@ -281,7 +289,7 @@ collect:
 
 			// Got a successful response, cancel other requests and return.
 			proposalScore := gc.scoreProposal(res.proposal)
-			gc.log.Debug("received proposal; selected first proposal",
+			logger.Debug("received proposal; selected first proposal",
 				zap.String("client", res.client),
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -271,7 +271,6 @@ collectFirst:
 				zap.String("client", res.client),
 				fields.Slot(slot),
 			)
-			cancelParallel()
 			return res.proposal, nil
 
 		case <-ctx.Done():

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -218,6 +218,7 @@ collect:
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),
 				zap.Int("pending", pendingClients),
+				zap.Bool("blinded", res.proposal.Blinded),
 				fields.Slot(slot),
 			)
 
@@ -239,6 +240,7 @@ collect:
 		gc.log.Debug("selected best proposal",
 			zap.String("client", bestClient),
 			zap.Float64("score", bestScore),
+			zap.Bool("blinded", bestProposal.Blinded),
 			fields.Slot(slot),
 		)
 
@@ -269,6 +271,7 @@ collect:
 				zap.Float64("score", proposalScore),
 				zap.Duration("latency", time.Since(startCollect)),
 				zap.Int("pending", pendingClients),
+				zap.Bool("blinded", res.proposal.Blinded),
 				fields.Slot(slot),
 			)
 			return res.proposal, nil

--- a/beacon/goclient/proposer_test.go
+++ b/beacon/goclient/proposer_test.go
@@ -502,12 +502,9 @@ func TestProposalPreparationReconnectLogic_SkipsOnProviderError(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	client, err := New(t.Context(), log.TestLogger(t), Options{
-		BeaconNodeAddr: server.URL,
-		CommonTimeout:  time.Second * 2,
-		LongTimeout:    time.Second * 5,
-	})
+	client, err := createClientForProposerTest(t, server.URL)
 	require.NoError(t, err)
+
 	var providerCalled atomic.Bool
 	client.SetProposalPreparationsProvider(func() ([]*eth2apiv1.ProposalPreparation, error) {
 		providerCalled.Store(true)
@@ -537,12 +534,9 @@ func TestProposalPreparationReconnectLogic_SkipsOnEmptyPreparations(t *testing.T
 		origHandler.ServeHTTP(w, r)
 	})
 
-	client, err := New(t.Context(), log.TestLogger(t), Options{
-		BeaconNodeAddr: server.URL,
-		CommonTimeout:  time.Second * 2,
-		LongTimeout:    time.Second * 5,
-	})
+	client, err := createClientForProposerTest(t, server.URL)
 	require.NoError(t, err)
+
 	var providerCalled atomic.Bool
 	client.SetProposalPreparationsProvider(func() ([]*eth2apiv1.ProposalPreparation, error) {
 		providerCalled.Store(true)
@@ -595,11 +589,7 @@ func TestProposalPreparationReconnectLogic_SubmitsSuccessfully(t *testing.T) {
 	})
 
 	// First create client without provider - OnActive will skip
-	client, err := New(t.Context(), log.TestLogger(t), Options{
-		BeaconNodeAddr: server.URL,
-		CommonTimeout:  time.Second * 2,
-		LongTimeout:    time.Second * 5,
-	})
+	client, err := createClientForProposerTest(t, server.URL)
 	require.NoError(t, err)
 
 	// Set the provider for testing
@@ -638,11 +628,7 @@ func TestProposalPreparationReconnectLogic_HandlesSubmissionError(t *testing.T) 
 		origHandler.ServeHTTP(w, r)
 	})
 
-	client, err := New(t.Context(), log.TestLogger(t), Options{
-		BeaconNodeAddr: server.URL,
-		CommonTimeout:  time.Second * 2,
-		LongTimeout:    time.Second * 5,
-	})
+	client, err := createClientForProposerTest(t, server.URL)
 	require.NoError(t, err)
 
 	client.SetProposalPreparationsProvider(func() ([]*eth2apiv1.ProposalPreparation, error) {
@@ -690,4 +676,18 @@ func TestProposalPreparationReconnectLogic_SkipsOnNilProvider(t *testing.T) {
 
 	// Should not have made any requests since provider is nil
 	require.Equal(t, 0, requestCounter, "should not have made any requests when provider is nil")
+}
+
+func createClientForProposerTest(t *testing.T, serverURL string) (*GoClient, error) {
+	opt, err := NewOptions(
+		Options{
+			BeaconNodeAddr: serverURL,
+			CommonTimeout:  time.Second * 2,
+			LongTimeout:    time.Second * 5,
+		}, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(t.Context(), log.TestLogger(t), opt)
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -190,7 +190,14 @@ var StartNodeCmd = &cobra.Command{
 			zap.Bool("with_parallel_submissions", cfg.ConsensusClient.WithParallelSubmissions),
 		)
 
-		consensusClient, err := goclient.New(cmd.Context(), logger, cfg.ConsensusClient)
+		cliopt, err := goclient.NewOptions(cfg.ConsensusClient, cfg.ProposerDelay)
+		if err != nil {
+			logger.Fatal("failed to create beacon client options",
+				zap.Error(err),
+				fields.Address(cfg.ConsensusClient.BeaconNodeAddr),
+			)
+		}
+		consensusClient, err := goclient.New(cmd.Context(), logger, cliopt)
 		if err != nil {
 			logger.Fatal("failed to create beacon go-client",
 				zap.Error(err),


### PR DESCRIPTION
Replaces https://github.com/ssvlabs/ssv/pull/2631 (finalizing the work started in there) and https://github.com/ssvlabs/ssv/pull/2638

This PR implements "smart proposal selection" as opposed to "taking the 1st proposal we got" (the behavior we had previously) which works roughly as follows:
- all Beacon requests are sent in parallel
- a certain time-window (can be configured by `WITH_PROPOSAL_SOFT_TIMEOUT`, and defaults to `1800ms` otherwise) is waited out to collect the Beacon responses (block-proposals)
- once that time-window has passed, every response gets scored so that the best one can be chosen as the block to propose
- if MEV block-proposal arrived before that time-window has passed/expired - that block-proposal is taken as is (no scoring needed, early termination is preferable because it would provide a larger time-buffer for QBFT consensus/post-consensus phases to complete)