### PR TITLE
tests: run on Boole fork

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -16,7 +16,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/protocol/v2/message"
-	qbft "github.com/ssvlabs/ssv/protocol/v2/qbft"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/casts"
@@ -189,7 +189,7 @@ func (mv *messageValidator) validateQBFTLogic(
 		if mv.netCfg.BooleForkAtSlot(phase0.Slot(consensusMessage.Height)) {
 			leader = qbft.RoundRobinProposer(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee, mv.netCfg)
 		} else {
-			leader = mv.roundRobinProposerPreBooleFork(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee)
+			leader = qbft.RoundRobinProposerPreBooleFork(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee)
 		}
 		if signedSSVMessage.OperatorIDs[0] != leader {
 			err := ErrSignerNotLeader
@@ -465,15 +465,4 @@ func (mv *messageValidator) roundBelongsToAllowedSpread(
 	}
 
 	return nil
-}
-
-// Deprecated - only for pre-Boole fork
-func (mv *messageValidator) roundRobinProposerPreBooleFork(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID) spectypes.OperatorID {
-	firstRoundIndex := uint64(0)
-	if height != specqbft.FirstHeight {
-		firstRoundIndex += uint64(height) % uint64(len(committee))
-	}
-
-	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(committee))
-	return committee[index]
 }

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/protocol/v2/message"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
@@ -159,7 +160,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -184,7 +185,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			require.NotNil(t, signerState)
 		}
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 
@@ -195,7 +196,10 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorContains(t, err, ErrDuplicatedMessage.Error())
 
-		stateBySlot := state.Signer(0)
+		leader := leaderForHeight(netCfg, specqbft.Height(slot), specqbft.FirstRound, committee)
+		signerIdx := slices.Index(committee, leader)
+		require.NotEqual(t, -1, signerIdx)
+		stateBySlot := state.Signer(signerIdx)
 		require.NotNil(t, stateBySlot)
 
 		storedState := stateBySlot.GetSignerState(slot)
@@ -207,7 +211,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			require.NotNil(t, state.Signer(i))
 		}
 
-		signedSSVMessage = generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.Round = 2
 			message.MsgType = specqbft.PrepareMsgType
 		})
@@ -216,6 +220,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.NoError(t, err)
 
+		signerIdx = slices.Index(committee, signedSSVMessage.OperatorIDs[0])
+		require.NotEqual(t, -1, signerIdx)
+		stateBySlot = state.Signer(signerIdx)
 		storedState = stateBySlot.GetSignerState(slot)
 		require.NotNil(t, storedState)
 		require.EqualValues(t, height, storedState.Slot)
@@ -225,13 +232,16 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorContains(t, err, ErrDuplicatedMessage.Error())
 
-		signedSSVMessage = generateSignedMessage(ks, committeeIdentifier, slot+1, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, committeeIdentifier, slot+1, func(message *specqbft.Message) {
 			message.MsgType = specqbft.CommitMsgType
 		})
 		signedSSVMessage.FullData = nil
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt.Add(netCfg.SlotDuration))
 		require.NoError(t, err)
 
+		signerIdx = slices.Index(committee, signedSSVMessage.OperatorIDs[0])
+		require.NotEqual(t, -1, signerIdx)
+		stateBySlot = state.Signer(signerIdx)
 		storedState = stateBySlot.GetSignerState(phase0.Slot(height) + 1)
 		require.NotNil(t, storedState)
 		require.EqualValues(t, 1, storedState.Round)
@@ -314,7 +324,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage.Data = bytes.Repeat([]byte{1}, 500)
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -330,7 +340,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage.Data = []byte{}
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -349,7 +359,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		tooBigMsgSize := maxPayloadDataSize * 2
 		signedSSVMessage.SSVMessage.Data = bytes.Repeat([]byte{1}, tooBigMsgSize)
@@ -370,7 +380,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage.Data = bytes.Repeat([]byte{1}, maxPayloadDataSize)
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -386,7 +396,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage.MsgType = math.MaxUint64
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -404,7 +414,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		unknown := spectypes.NewMsgID(netCfg.DomainType, sk.PublicKey().Marshal(), nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, unknown, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, unknown, slot)
 
 		_, exists := validatorStore.Validator(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID())
 		require.False(t, exists)
@@ -424,7 +434,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		unknownCommitteeID := bytes.Repeat([]byte{1}, 48)
 		unknownIdentifier := spectypes.NewMsgID(netCfg.DomainType, unknownCommitteeID, committeeRole)
-		signedSSVMessage := generateSignedMessage(ks, unknownIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, unknownIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, time.Now())
@@ -441,7 +451,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		wrongDomain := spectypes.DomainType{math.MaxUint8, math.MaxUint8, math.MaxUint8, math.MaxUint8}
 		badIdentifier := spectypes.NewMsgID(wrongDomain, encodedCommitteeID, committeeRole)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, badIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -460,7 +470,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		badIdentifier := spectypes.NewMsgID(netCfg.DomainType, encodedCommitteeID, math.MaxInt32)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, badIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -475,7 +485,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		badIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.active.ValidatorPubKey[:], spectypes.RoleValidatorRegistration)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, badIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(committeeID)[0]
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -485,7 +495,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 
 		badIdentifier = spectypes.NewMsgID(netCfg.DomainType, shares.active.ValidatorPubKey[:], spectypes.RoleVoluntaryExit)
-		signedSSVMessage = generateSignedMessage(ks, badIdentifier, slot)
+		signedSSVMessage = generateSignedMessage(ks, netCfg, badIdentifier, slot)
 
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		expectedErr.got = spectypes.RoleVoluntaryExit
@@ -499,7 +509,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		liquidatedIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.liquidated.ValidatorPubKey[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, liquidatedIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, liquidatedIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -515,7 +525,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		inactiveIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.inactive.ValidatorPubKey[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, inactiveIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, inactiveIdentifier, slot)
 
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -531,7 +541,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		nonUpdatedMetadataNextEpochIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.nonUpdatedMetadataNextEpoch.ValidatorPubKey[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, nonUpdatedMetadataNextEpochIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, nonUpdatedMetadataNextEpochIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -560,7 +570,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			PrepareJustification:     [][]byte{},
 		}
 
-		leader := validator.roundRobinProposerPreBooleFork(specqbft.Height(slot), specqbft.FirstRound, committee)
+		leader := leaderForHeight(netCfg, specqbft.Height(slot), specqbft.FirstRound, committee)
 		signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
 		signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
 
@@ -577,7 +587,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		noMetadataIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.noMetadata.ValidatorPubKey[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, noMetadataIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, noMetadataIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -600,7 +610,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		role := spectypes.RoleAggregator
 		identifier := spectypes.NewMsgID(netCfg.DomainType, ks.ValidatorPK.Serialize(), role)
-		signedSSVMessage := generateSignedMessage(ks, identifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, identifier, slot)
 
 		// First duty.
 		topicID := commons.CommitteeTopicID(committeeID)[0]
@@ -608,12 +618,12 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		// Second duty.
-		signedSSVMessage = generateSignedMessage(ks, identifier, slot+4)
+		signedSSVMessage = generateSignedMessage(ks, netCfg, identifier, slot+4)
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, netCfg.SlotStartTime(slot+4))
 		require.NoError(t, err)
 
 		// Third duty (exceeds the limit).
-		signedSSVMessage = generateSignedMessage(ks, identifier, slot+8)
+		signedSSVMessage = generateSignedMessage(ks, netCfg, identifier, slot+8)
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, netCfg.SlotStartTime(slot+8))
 		require.ErrorIs(t, err, ErrTooManyDutiesPerEpoch)
 	})
@@ -630,7 +640,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, ds, signatureVerifier).(*messageValidator)
 
 		identifier := spectypes.NewMsgID(netCfg.DomainType, ks.ValidatorPK.Serialize(), spectypes.RoleProposer)
-		signedSSVMessage := generateSignedMessage(ks, identifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, identifier, slot)
 
 		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, netCfg.SlotStartTime(slot))
@@ -956,7 +966,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.MsgType = math.MaxUint64
 		})
 
@@ -972,7 +982,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.Signatures = [][]byte{{0x1}}
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -986,7 +996,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.OperatorIDs = nil
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1001,7 +1011,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.OperatorIDs = []spectypes.OperatorID{1, 2, 3, 4, 5}
 		signedSSVMessage.Signatures = [][]byte{
 			signedSSVMessage.Signatures[0],
@@ -1022,7 +1032,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.OperatorIDs = []spectypes.OperatorID{0}
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1227,7 +1237,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 				}
 
 				msgID := spectypes.NewMsgID(netCfg.DomainType, dutyExecutorID, role)
-				signedSSVMessage := generateSignedMessage(ks, msgID, slot)
+				signedSSVMessage := generateSignedMessage(ks, netCfg, msgID, slot)
 
 				topicID := commons.CommitteeTopicID(committeeID)[0]
 				_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
@@ -1241,7 +1251,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot - 1)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -1255,8 +1265,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
-		signedSSVMessage.OperatorIDs = []spectypes.OperatorID{2}
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
+		leader := leaderForHeight(netCfg, specqbft.Height(slot), specqbft.FirstRound, committee)
+		signedSSVMessage.OperatorIDs = []spectypes.OperatorID{nonLeaderOperator(committee, leader)}
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -1269,10 +1280,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.PrepareJustification = [][]byte{{1}}
 		})
-		signedSSVMessage.OperatorIDs = []spectypes.OperatorID{2}
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -1287,9 +1297,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.PrepareJustification = spectestingutils.MarshalJustifications([]*spectypes.SignedSSVMessage{
-				generateSignedMessage(ks, committeeIdentifier, slot, func(justMsg *specqbft.Message) {
+				generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(justMsg *specqbft.Message) {
 					justMsg.MsgType = specqbft.RoundChangeMsgType
 				}),
 			})
@@ -1310,9 +1320,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.RoundChangeJustification = spectestingutils.MarshalJustifications([]*spectypes.SignedSSVMessage{
-				generateSignedMessage(ks, committeeIdentifier, slot, func(justMsg *specqbft.Message) {
+				generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(justMsg *specqbft.Message) {
 					justMsg.MsgType = specqbft.PrepareMsgType
 				}),
 			})
@@ -1333,7 +1343,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.RoundChangeJustification = [][]byte{{1}}
 		})
 		signedSSVMessage.FullData = nil
@@ -1351,7 +1361,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.FullData = []byte{1}
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1368,7 +1378,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -1376,7 +1386,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		anotherFullData := []byte{1}
-		signedSSVMessage = generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.Root, err = specqbft.HashDataRoot(anotherFullData)
 			require.NoError(t, err)
 		})
@@ -1394,7 +1404,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		identifier := spectypes.NewMsgID(netCfg.DomainType, ks.ValidatorPK.Serialize(), spectypes.RoleProposer)
-		signedSSVMessage := generateSignedMessage(ks, identifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, identifier, slot, func(message *specqbft.Message) {
 			message.MsgType = specqbft.PrepareMsgType
 		})
 		signedSSVMessage.FullData = nil
@@ -1416,7 +1426,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.MsgType = specqbft.CommitMsgType
 		})
 		signedSSVMessage.FullData = nil
@@ -1438,7 +1448,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.MsgType = specqbft.RoundChangeMsgType
 		})
 		signedSSVMessage.FullData = nil
@@ -1481,7 +1491,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, nonCommitteeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, nonCommitteeIdentifier, slot, func(message *specqbft.Message) {
 			message.Height = 8
 		})
 
@@ -1490,7 +1500,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.NoError(t, err)
 
-		signedSSVMessage = generateSignedMessage(ks, nonCommitteeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, nonCommitteeIdentifier, slot, func(message *specqbft.Message) {
 			message.Height = 4
 		})
 
@@ -1504,7 +1514,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.Round = 5
 		})
 
@@ -1513,7 +1523,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.NoError(t, err)
 
-		signedSSVMessage = generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.Round = 1
 		})
 
@@ -1551,7 +1561,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 				}
 
 				msgID := spectypes.NewMsgID(netCfg.DomainType, dutyExecutorID, role)
-				signedSSVMessage := generateSignedMessage(ks, msgID, slot, func(message *specqbft.Message) {
+				signedSSVMessage := generateSignedMessage(ks, netCfg, msgID, slot, func(message *specqbft.Message) {
 					message.MsgType = specqbft.PrepareMsgType
 					message.Round = round
 				})
@@ -1582,7 +1592,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage.MsgType = message.SSVEventMsgType
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1598,7 +1608,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		unknownType := spectypes.MsgType(12345)
 		signedSSVMessage.SSVMessage.MsgType = unknownType
 
@@ -1615,7 +1625,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
@@ -1630,7 +1640,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := "incorrect"
@@ -1657,7 +1667,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.SSVMessage = nil
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1672,7 +1682,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.Round = specqbft.NoRound
 		})
 
@@ -1688,7 +1698,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot)
 		signedSSVMessage.Signatures = [][]byte{}
 
 		receivedAt := netCfg.SlotStartTime(slot)
@@ -1703,7 +1713,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			wrongID := spectypes.NewMsgID(netCfg.DomainType, encodedCommitteeID[:], nonCommitteeRole)
 			message.Identifier = wrongID[:]
 		})
@@ -1721,7 +1731,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage := generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.MsgType = specqbft.PrepareMsgType
 		})
 
@@ -1730,7 +1740,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorContains(t, err, ErrPrepareOrCommitWithFullData.Error())
 
-		signedSSVMessage = generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
+		signedSSVMessage = generateSignedMessage(ks, netCfg, committeeIdentifier, slot, func(message *specqbft.Message) {
 			message.MsgType = specqbft.CommitMsgType
 		})
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
@@ -1965,6 +1975,7 @@ func generateShares(t *testing.T, ks *spectestingutils.TestKeySet, ns storage.St
 
 func generateSignedMessage(
 	ks *spectestingutils.TestKeySet,
+	netCfg *networkconfig.Network,
 	identifier spectypes.MessageID,
 	slot phase0.Slot,
 	opts ...func(message *specqbft.Message),
@@ -1987,10 +1998,42 @@ func generateSignedMessage(
 		opt(qbftMessage)
 	}
 
-	signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[1], 1, qbftMessage)
+	committee := sortedCommittee(ks)
+	leader := leaderForHeight(netCfg, qbftMessage.Height, qbftMessage.Round, committee)
+	signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
 	signedSSVMessage.FullData = fullData
 
 	return signedSSVMessage
+}
+
+func sortedCommittee(ks *spectestingutils.TestKeySet) []spectypes.OperatorID {
+	committee := slices.Collect(maps.Keys(ks.Shares))
+	slices.Sort(committee)
+	return committee
+}
+
+func leaderForHeight(
+	netCfg *networkconfig.Network,
+	height specqbft.Height,
+	round specqbft.Round,
+	committee []spectypes.OperatorID,
+) spectypes.OperatorID {
+	if netCfg.BooleForkAtSlot(phase0.Slot(height)) {
+		return qbft.RoundRobinProposer(height, round, committee, netCfg)
+	}
+	return qbft.RoundRobinProposerPreBooleFork(height, round, committee)
+}
+
+func nonLeaderOperator(
+	committee []spectypes.OperatorID,
+	leader spectypes.OperatorID,
+) spectypes.OperatorID {
+	for _, operatorID := range committee {
+		if operatorID != leader {
+			return operatorID
+		}
+	}
+	return leader
 }
 
 func generateMultiSignedMessage(

--- a/networkconfig/local-testnet.go
+++ b/networkconfig/local-testnet.go
@@ -1,7 +1,6 @@
 package networkconfig
 
 import (
-	"math"
 	"math/big"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -21,6 +20,6 @@ var LocalTestnetSSV = &SSV{
 	Forks: SSVForks{
 		Alan:       0,
 		GasLimit36: 0,
-		Boole:      math.MaxUint64,
+		Boole:      0,
 	},
 }

--- a/networkconfig/test-network.go
+++ b/networkconfig/test-network.go
@@ -1,7 +1,6 @@
 package networkconfig
 
 import (
-	"math"
 	"math/big"
 	"time"
 
@@ -76,7 +75,7 @@ var TestNetwork = &Network{
 		Forks: SSVForks{
 			Alan:       0,
 			GasLimit36: 0,
-			Boole:      math.MaxUint64,
+			Boole:      0,
 		},
 	},
 }

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1020,12 +1020,12 @@ func SetupCommitteeRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+				committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
 				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
-					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
 					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
 				}
 
-				return qbft.RoundRobinProposerPreBooleFork(state, round)
+				return qbft.RoundRobinProposerPreBooleFork(state.Height, round, committee)
 			},
 			Network:     options.Network,
 			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role, nil),
@@ -1085,12 +1085,12 @@ func SetupRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+				committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
 				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
-					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
 					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
 				}
 
-				return qbft.RoundRobinProposerPreBooleFork(state, round)
+				return qbft.RoundRobinProposerPreBooleFork(state.Height, round, committee)
 			},
 			Network:     options.Network,
 			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role, nil),

--- a/protocol/v2/qbft/round_robin_proposer.go
+++ b/protocol/v2/qbft/round_robin_proposer.go
@@ -10,14 +10,18 @@ import (
 )
 
 // Deprecated - only for pre-Boole fork
-func RoundRobinProposerPreBooleFork(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+func RoundRobinProposerPreBooleFork(
+	height specqbft.Height,
+	round specqbft.Round,
+	committee []spectypes.OperatorID,
+) spectypes.OperatorID {
 	firstRoundIndex := uint64(0)
-	if state.Height != specqbft.FirstHeight {
-		firstRoundIndex += uint64(state.Height) % uint64(len(state.CommitteeMember.Committee))
+	if height != specqbft.FirstHeight {
+		firstRoundIndex += uint64(height) % uint64(len(committee))
 	}
 
-	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(state.CommitteeMember.Committee))
-	return state.CommitteeMember.Committee[index].OperatorID
+	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(committee))
+	return committee[index]
 }
 
 type networkConfig interface {

--- a/protocol/v2/qbft/round_robin_proposer_test.go
+++ b/protocol/v2/qbft/round_robin_proposer_test.go
@@ -9,6 +9,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/networkconfig"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 func TestRoundRobinProposerPreBooleFork_MatchesStageLogic(t *testing.T) {
@@ -25,8 +26,10 @@ func TestRoundRobinProposerPreBooleFork_MatchesStageLogic(t *testing.T) {
 		},
 	}
 
+	committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
+
 	// height%4=0 so leader should be the first operator for FirstRound.
-	require.Equal(t, spectypes.OperatorID(1), RoundRobinProposerPreBooleFork(state, specqbft.FirstRound))
+	require.Equal(t, spectypes.OperatorID(1), RoundRobinProposerPreBooleFork(state.Height, specqbft.FirstRound, committee))
 }
 
 func TestRoundRobinProposer_PostBooleFork_OffsetFromSlotsPerEpoch(t *testing.T) {


### PR DESCRIPTION
Currently, the Boole fork epoch on `TestNetwork` is set to `math.MaxUint64`, so the unit tests run on the Alan fork. We need to run them on the Boole fork to make sure everything passes. Also, the Alan logic will be removed soon, so we need to make sure in advance that tests work there.

The PR sets the Boole fork epoch on `TestNetwork` to 0 to run all tests on the Boole fork.

The change broke message validation tests, so the PR has also fixed them.