### PR TITLE
logs: reduce preconsensus msg logs

### DIFF
--- a/protocol/v2/ssv/runner/preconsensus_msg_log.go
+++ b/protocol/v2/ssv/runner/preconsensus_msg_log.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"sort"
+
+	"go.uber.org/zap"
+)
+
+type preConsensusMsgLogStats struct {
+	totalMessages uint64
+	messagesBySig map[uint64]uint64
+	summaryLogged bool
+}
+
+type preConsensusSignerMsgCount struct {
+	Signer   uint64 `json:"signer"`
+	Messages uint64 `json:"messages"`
+}
+
+func (b *BaseRunner) resetPreConsensusMsgLog() {
+	b.preConsensusMsgLogMu.Lock()
+	defer b.preConsensusMsgLogMu.Unlock()
+
+	b.preConsensusMsgLog.totalMessages = 0
+	b.preConsensusMsgLog.messagesBySig = make(map[uint64]uint64)
+	b.preConsensusMsgLog.summaryLogged = false
+}
+
+func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
+	b.preConsensusMsgLogMu.Lock()
+	defer b.preConsensusMsgLogMu.Unlock()
+
+	if b.preConsensusMsgLog.messagesBySig == nil {
+		b.preConsensusMsgLog.messagesBySig = make(map[uint64]uint64)
+	}
+
+	b.preConsensusMsgLog.totalMessages++
+	b.preConsensusMsgLog.messagesBySig[signer]++
+}
+
+func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce() []zap.Field {
+	b.preConsensusMsgLogMu.Lock()
+	defer b.preConsensusMsgLogMu.Unlock()
+
+	if b.preConsensusMsgLog.summaryLogged {
+		return nil
+	}
+	b.preConsensusMsgLog.summaryLogged = true
+
+	if len(b.preConsensusMsgLog.messagesBySig) == 0 {
+		return []zap.Field{
+			zap.Uint64("pre_consensus_msgs_total", b.preConsensusMsgLog.totalMessages),
+			zap.Uint64("pre_consensus_msgs_unique_signers", 0),
+		}
+	}
+
+	signers := make([]preConsensusSignerMsgCount, 0, len(b.preConsensusMsgLog.messagesBySig))
+	for signer, count := range b.preConsensusMsgLog.messagesBySig {
+		signers = append(signers, preConsensusSignerMsgCount{
+			Signer:   signer,
+			Messages: count,
+		})
+	}
+	sort.Slice(signers, func(i, j int) bool { return signers[i].Signer < signers[j].Signer })
+
+	return []zap.Field{
+		zap.Uint64("pre_consensus_msgs_total", b.preConsensusMsgLog.totalMessages),
+		zap.Uint64("pre_consensus_msgs_unique_signers", uint64(len(b.preConsensusMsgLog.messagesBySig))),
+		zap.Any("pre_consensus_msgs_by_signer", signers),
+	}
+}

--- a/protocol/v2/ssv/runner/preconsensus_msg_log.go
+++ b/protocol/v2/ssv/runner/preconsensus_msg_log.go
@@ -5,81 +5,67 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"go.uber.org/zap"
 )
 
 type preConsensusMsgLogStats struct {
-	slotStartTime time.Time
-	signerAt      map[uint64]time.Duration
-	summaryLogged bool
+	slotStartTime      time.Time
+	signerTimeIntoSlot map[uint64]time.Duration
 }
 
-type preConsensusSignerTiming struct {
-	Signer uint64 `json:"signer"`
-	At     string `json:"at"`
-
-	atDur time.Duration
-}
-
-func (b *BaseRunner) resetPreConsensusMsgLog(slotStartTime time.Time) {
-	b.preConsensusMsgLog.slotStartTime = slotStartTime
-	b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
-	b.preConsensusMsgLog.summaryLogged = false
+func (b *BaseRunner) resetPreConsensusLogSummary(nextSlot phase0.Slot) {
+	// b.NetworkConfig can only be nil in tests, this is fast & dirty work-around for it.
+	if b.NetworkConfig != nil {
+		b.preConsensusMsgLog.slotStartTime = b.NetworkConfig.SlotStartTime(nextSlot)
+	}
+	b.preConsensusMsgLog.signerTimeIntoSlot = make(map[uint64]time.Duration)
 }
 
 func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
-	now := time.Now()
-
-	if b.preConsensusMsgLog.signerAt == nil {
-		b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
-	}
-
-	if b.preConsensusMsgLog.slotStartTime.IsZero() {
-		b.preConsensusMsgLog.slotStartTime = now
-	}
-
-	if _, seen := b.preConsensusMsgLog.signerAt[signer]; seen {
+	// Duplicate message from the same signer should never arrive here, but handle it just in case.
+	if _, seen := b.preConsensusMsgLog.signerTimeIntoSlot[signer]; seen {
 		return
 	}
 
-	b.preConsensusMsgLog.signerAt[signer] = now.Sub(b.preConsensusMsgLog.slotStartTime)
+	// b.preConsensusMsgLog.signerTimeIntoSlot can only be nil in tests, this is fast & dirty work-around for it.
+	if b.preConsensusMsgLog.signerTimeIntoSlot == nil {
+		b.preConsensusMsgLog.signerTimeIntoSlot = make(map[uint64]time.Duration)
+	}
+
+	b.preConsensusMsgLog.signerTimeIntoSlot[signer] = time.Since(b.preConsensusMsgLog.slotStartTime)
 }
 
-func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce(quorumReachedBySigner uint64) []zap.Field {
-	now := time.Now()
-
-	if b.preConsensusMsgLog.summaryLogged {
-		return nil
-	}
-	b.preConsensusMsgLog.summaryLogged = true
-
-	if b.preConsensusMsgLog.slotStartTime.IsZero() {
-		b.preConsensusMsgLog.slotStartTime = now
-	}
-
-	timeToQuorum := now.Sub(b.preConsensusMsgLog.slotStartTime)
-	if at, ok := b.preConsensusMsgLog.signerAt[quorumReachedBySigner]; ok {
+func (b *BaseRunner) preConsensusMsgLogSummaryFields(quorumReachedBySigner uint64) []zap.Field {
+	timeToQuorum := time.Since(b.preConsensusMsgLog.slotStartTime)
+	if at, ok := b.preConsensusMsgLog.signerTimeIntoSlot[quorumReachedBySigner]; ok {
 		timeToQuorum = at
 	}
 
-	signers := make([]preConsensusSignerTiming, 0, len(b.preConsensusMsgLog.signerAt))
-	for signer, at := range b.preConsensusMsgLog.signerAt {
-		signers = append(signers, preConsensusSignerTiming{
-			Signer: signer,
-			At:     signedDurationToSecondsStr(at),
-			atDur:  at,
+	type preConsensusSignerTiming struct {
+		Signer       uint64 `json:"signer"`
+		TimeIntoSlot string `json:"time_into_slot"`
+
+		atDur time.Duration
+	}
+	signerTimings := make([]preConsensusSignerTiming, 0, len(b.preConsensusMsgLog.signerTimeIntoSlot))
+	for signer, at := range b.preConsensusMsgLog.signerTimeIntoSlot {
+		signerTimings = append(signerTimings, preConsensusSignerTiming{
+			Signer:       signer,
+			TimeIntoSlot: signedDurationToSecondsStr(at),
+			atDur:        at,
 		})
 	}
-	sort.Slice(signers, func(i, j int) bool {
-		if signers[i].atDur == signers[j].atDur {
-			return signers[i].Signer < signers[j].Signer
+	sort.Slice(signerTimings, func(i, j int) bool {
+		if signerTimings[i].atDur == signerTimings[j].atDur {
+			return signerTimings[i].Signer < signerTimings[j].Signer
 		}
-		return signers[i].atDur < signers[j].atDur
+		return signerTimings[i].atDur < signerTimings[j].atDur
 	})
 
 	return []zap.Field{
 		zap.String("time_to_quorum", durationToSecondsStr(timeToQuorum)),
-		zap.Any("signer_timings", signers),
+		zap.Any("signer_timings", signerTimings),
 		zap.Uint64("quorum_reached_by", quorumReachedBySigner),
 	}
 }

--- a/protocol/v2/ssv/runner/preconsensus_msg_log.go
+++ b/protocol/v2/ssv/runner/preconsensus_msg_log.go
@@ -22,9 +22,6 @@ type preConsensusSignerTiming struct {
 }
 
 func (b *BaseRunner) resetPreConsensusMsgLog(slotStartTime time.Time) {
-	b.preConsensusMsgLogMu.Lock()
-	defer b.preConsensusMsgLogMu.Unlock()
-
 	b.preConsensusMsgLog.slotStartTime = slotStartTime
 	b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
 	b.preConsensusMsgLog.summaryLogged = false
@@ -32,9 +29,6 @@ func (b *BaseRunner) resetPreConsensusMsgLog(slotStartTime time.Time) {
 
 func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
 	now := time.Now()
-
-	b.preConsensusMsgLogMu.Lock()
-	defer b.preConsensusMsgLogMu.Unlock()
 
 	if b.preConsensusMsgLog.signerAt == nil {
 		b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
@@ -53,9 +47,6 @@ func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
 
 func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce(quorumReachedBySigner uint64) []zap.Field {
 	now := time.Now()
-
-	b.preConsensusMsgLogMu.Lock()
-	defer b.preConsensusMsgLogMu.Unlock()
 
 	if b.preConsensusMsgLog.summaryLogged {
 		return nil

--- a/protocol/v2/ssv/runner/preconsensus_msg_log.go
+++ b/protocol/v2/ssv/runner/preconsensus_msg_log.go
@@ -2,43 +2,58 @@ package runner
 
 import (
 	"sort"
+	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 )
 
 type preConsensusMsgLogStats struct {
-	totalMessages uint64
-	messagesBySig map[uint64]uint64
+	slotStartTime time.Time
+	signerAt      map[uint64]time.Duration
 	summaryLogged bool
 }
 
-type preConsensusSignerMsgCount struct {
-	Signer   uint64 `json:"signer"`
-	Messages uint64 `json:"messages"`
+type preConsensusSignerTiming struct {
+	Signer uint64 `json:"signer"`
+	At     string `json:"at"`
+
+	atDur time.Duration
 }
 
-func (b *BaseRunner) resetPreConsensusMsgLog() {
+func (b *BaseRunner) resetPreConsensusMsgLog(slotStartTime time.Time) {
 	b.preConsensusMsgLogMu.Lock()
 	defer b.preConsensusMsgLogMu.Unlock()
 
-	b.preConsensusMsgLog.totalMessages = 0
-	b.preConsensusMsgLog.messagesBySig = make(map[uint64]uint64)
+	b.preConsensusMsgLog.slotStartTime = slotStartTime
+	b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
 	b.preConsensusMsgLog.summaryLogged = false
 }
 
 func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
+	now := time.Now()
+
 	b.preConsensusMsgLogMu.Lock()
 	defer b.preConsensusMsgLogMu.Unlock()
 
-	if b.preConsensusMsgLog.messagesBySig == nil {
-		b.preConsensusMsgLog.messagesBySig = make(map[uint64]uint64)
+	if b.preConsensusMsgLog.signerAt == nil {
+		b.preConsensusMsgLog.signerAt = make(map[uint64]time.Duration)
 	}
 
-	b.preConsensusMsgLog.totalMessages++
-	b.preConsensusMsgLog.messagesBySig[signer]++
+	if b.preConsensusMsgLog.slotStartTime.IsZero() {
+		b.preConsensusMsgLog.slotStartTime = now
+	}
+
+	if _, seen := b.preConsensusMsgLog.signerAt[signer]; seen {
+		return
+	}
+
+	b.preConsensusMsgLog.signerAt[signer] = now.Sub(b.preConsensusMsgLog.slotStartTime)
 }
 
-func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce() []zap.Field {
+func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce(quorumReachedBySigner uint64) []zap.Field {
+	now := time.Now()
+
 	b.preConsensusMsgLogMu.Lock()
 	defer b.preConsensusMsgLogMu.Unlock()
 
@@ -47,25 +62,46 @@ func (b *BaseRunner) preConsensusMsgLogSummaryFieldsOnce() []zap.Field {
 	}
 	b.preConsensusMsgLog.summaryLogged = true
 
-	if len(b.preConsensusMsgLog.messagesBySig) == 0 {
-		return []zap.Field{
-			zap.Uint64("pre_consensus_msgs_total", b.preConsensusMsgLog.totalMessages),
-			zap.Uint64("pre_consensus_msgs_unique_signers", 0),
-		}
+	if b.preConsensusMsgLog.slotStartTime.IsZero() {
+		b.preConsensusMsgLog.slotStartTime = now
 	}
 
-	signers := make([]preConsensusSignerMsgCount, 0, len(b.preConsensusMsgLog.messagesBySig))
-	for signer, count := range b.preConsensusMsgLog.messagesBySig {
-		signers = append(signers, preConsensusSignerMsgCount{
-			Signer:   signer,
-			Messages: count,
+	timeToQuorum := now.Sub(b.preConsensusMsgLog.slotStartTime)
+	if at, ok := b.preConsensusMsgLog.signerAt[quorumReachedBySigner]; ok {
+		timeToQuorum = at
+	}
+
+	signers := make([]preConsensusSignerTiming, 0, len(b.preConsensusMsgLog.signerAt))
+	for signer, at := range b.preConsensusMsgLog.signerAt {
+		signers = append(signers, preConsensusSignerTiming{
+			Signer: signer,
+			At:     signedDurationToSecondsStr(at),
+			atDur:  at,
 		})
 	}
-	sort.Slice(signers, func(i, j int) bool { return signers[i].Signer < signers[j].Signer })
+	sort.Slice(signers, func(i, j int) bool {
+		if signers[i].atDur == signers[j].atDur {
+			return signers[i].Signer < signers[j].Signer
+		}
+		return signers[i].atDur < signers[j].atDur
+	})
 
 	return []zap.Field{
-		zap.Uint64("pre_consensus_msgs_total", b.preConsensusMsgLog.totalMessages),
-		zap.Uint64("pre_consensus_msgs_unique_signers", uint64(len(b.preConsensusMsgLog.messagesBySig))),
-		zap.Any("pre_consensus_msgs_by_signer", signers),
+		zap.String("time_to_quorum", durationToSecondsStr(timeToQuorum)),
+		zap.Any("signer_timings", signers),
+		zap.Uint64("quorum_reached_by", quorumReachedBySigner),
 	}
+}
+
+func durationToSecondsStr(val time.Duration) string {
+	valStr := strconv.FormatFloat(val.Seconds(), 'f', 5, 64)
+	return valStr + "s"
+}
+
+func signedDurationToSecondsStr(val time.Duration) string {
+	valStr := strconv.FormatFloat(val.Seconds(), 'f', 5, 64)
+	if val >= 0 {
+		valStr = "+" + valStr
+	}
+	return valStr + "s"
 }

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -101,6 +101,11 @@ type BaseRunner struct {
 	preConsensusMsgLog   preConsensusMsgLogStats
 }
 
+func isAggregatorDuty(duty spectypes.Duty) bool {
+	validatorDuty, ok := duty.(*spectypes.ValidatorDuty)
+	return ok && validatorDuty.Type == spectypes.BNRoleAggregator
+}
+
 func (b *BaseRunner) HasRunningQBFTInstance() bool {
 	var runningInstance *instance.Instance
 	if b.hasRunningDuty() {
@@ -208,11 +213,13 @@ func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	b.State = state
 	b.mtx.Unlock()
 
-	var slotStartTime time.Time
-	if b.NetworkConfig != nil {
-		slotStartTime = b.NetworkConfig.SlotStartTime(duty.DutySlot())
+	if isAggregatorDuty(duty) {
+		var slotStartTime time.Time
+		if b.NetworkConfig != nil {
+			slotStartTime = b.NetworkConfig.SlotStartTime(duty.DutySlot())
+		}
+		b.resetPreConsensusMsgLog(slotStartTime)
 	}
-	b.resetPreConsensusMsgLog(slotStartTime)
 }
 
 // baseStartNewDuty is a base func that all runner implementation can call to start a duty
@@ -248,18 +255,42 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 	}
 
 	signer := ssvtypes.PartialSigMsgSigner(signedMsg)
-	b.observePreConsensusMsg(signer)
+
+	if isAggregatorDuty(b.State.CurrentDuty) {
+		b.observePreConsensusMsg(signer)
+
+		hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
+		if hasQuorum {
+			const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
+			summaryFields := b.preConsensusMsgLogSummaryFieldsOnce(signer)
+			if summaryFields != nil {
+				summaryFields = append(summaryFields, fields.QuorumRoots(quorumRoots))
+				logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
+				span.AddEvent(gotPreConsensusQuorumEvent)
+			}
+		}
+
+		return hasQuorum, slices.Collect(maps.Keys(quorumRoots)), nil
+	}
+
+	vIndices := make([]uint64, 0, len(signedMsg.Messages))
+	for _, msg := range signedMsg.Messages {
+		vIndices = append(vIndices, uint64(msg.ValidatorIndex))
+	}
+	const gotPreConsensusMsgEvent = "📬 got pre-consensus message"
+	logger.Debug(
+		gotPreConsensusMsgEvent,
+		zap.Uint64("signer", signer),
+		zap.Uint64s("validators", vIndices),
+	)
+	span.AddEvent(gotPreConsensusMsgEvent)
 
 	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
 
 	if hasQuorum {
 		const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
-		summaryFields := b.preConsensusMsgLogSummaryFieldsOnce(signer)
-		if summaryFields != nil {
-			summaryFields = append(summaryFields, fields.QuorumRoots(quorumRoots))
-			logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
-			span.AddEvent(gotPreConsensusQuorumEvent)
-		}
+		logger.Debug(gotPreConsensusQuorumEvent, fields.QuorumRoots(quorumRoots))
+		span.AddEvent(gotPreConsensusQuorumEvent)
 	}
 
 	return hasQuorum, slices.Collect(maps.Keys(quorumRoots)), nil

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -95,6 +95,9 @@ type BaseRunner struct {
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
+
+	preConsensusMsgLogMu sync.Mutex
+	preConsensusMsgLog   preConsensusMsgLogStats
 }
 
 func (b *BaseRunner) HasRunningQBFTInstance() bool {
@@ -203,6 +206,8 @@ func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	b.mtx.Lock() // writes to b.State
 	b.State = state
 	b.mtx.Unlock()
+
+	b.resetPreConsensusMsgLog()
 }
 
 // baseStartNewDuty is a base func that all runner implementation can call to start a duty
@@ -237,23 +242,16 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 		return false, nil, fmt.Errorf("invalid pre-consensus message: %w", err)
 	}
 
-	vIndices := make([]uint64, 0, len(signedMsg.Messages))
-	for _, msg := range signedMsg.Messages {
-		vIndices = append(vIndices, uint64(msg.ValidatorIndex))
-	}
-	const gotPreConsensusMsgEvent = "📬 got pre-consensus message"
-	logger.Debug(
-		gotPreConsensusMsgEvent,
-		zap.Uint64("signer", ssvtypes.PartialSigMsgSigner(signedMsg)),
-		zap.Uint64s("validators", vIndices),
-	)
-	span.AddEvent(gotPreConsensusMsgEvent)
+	signer := ssvtypes.PartialSigMsgSigner(signedMsg)
+	b.observePreConsensusMsg(signer)
 
 	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
 
 	if hasQuorum {
 		const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
-		logger.Debug(gotPreConsensusQuorumEvent, fields.QuorumRoots(quorumRoots))
+		summaryFields := b.preConsensusMsgLogSummaryFieldsOnce()
+		summaryFields = append(summaryFields, zap.Uint64("quorum_reached_by", signer), fields.QuorumRoots(quorumRoots))
+		logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
 		span.AddEvent(gotPreConsensusQuorumEvent)
 	}
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
@@ -100,7 +99,7 @@ type BaseRunner struct {
 	preConsensusMsgLog preConsensusMsgLogStats
 }
 
-func isTimingSummaryPreConsensusDuty(duty spectypes.Duty) bool {
+func logSummaryOnly(duty spectypes.Duty) bool {
 	validatorDuty, ok := duty.(*spectypes.ValidatorDuty)
 	if !ok {
 		return false
@@ -221,12 +220,8 @@ func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	b.State = state
 	b.mtx.Unlock()
 
-	if isTimingSummaryPreConsensusDuty(duty) {
-		var slotStartTime time.Time
-		if b.NetworkConfig != nil {
-			slotStartTime = b.NetworkConfig.SlotStartTime(duty.DutySlot())
-		}
-		b.resetPreConsensusMsgLog(slotStartTime)
+	if logSummaryOnly(duty) {
+		b.resetPreConsensusLogSummary(duty.DutySlot())
 	}
 }
 
@@ -264,18 +259,16 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 
 	signer := ssvtypes.PartialSigMsgSigner(signedMsg)
 
-	if isTimingSummaryPreConsensusDuty(b.State.CurrentDuty) {
+	if logSummaryOnly(b.State.CurrentDuty) {
 		b.observePreConsensusMsg(signer)
 
 		hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
 		if hasQuorum {
 			const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
-			summaryFields := b.preConsensusMsgLogSummaryFieldsOnce(signer)
-			if summaryFields != nil {
-				summaryFields = append(summaryFields, fields.QuorumRoots(quorumRoots))
-				logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
-				span.AddEvent(gotPreConsensusQuorumEvent)
-			}
+			summaryFields := b.preConsensusMsgLogSummaryFields(signer)
+			summaryFields = append(summaryFields, fields.QuorumRoots(quorumRoots))
+			logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
+			span.AddEvent(gotPreConsensusQuorumEvent)
 		}
 
 		return hasQuorum, slices.Collect(maps.Keys(quorumRoots)), nil

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -101,9 +101,18 @@ type BaseRunner struct {
 	preConsensusMsgLog   preConsensusMsgLogStats
 }
 
-func isAggregatorDuty(duty spectypes.Duty) bool {
+func isTimingSummaryPreConsensusDuty(duty spectypes.Duty) bool {
 	validatorDuty, ok := duty.(*spectypes.ValidatorDuty)
-	return ok && validatorDuty.Type == spectypes.BNRoleAggregator
+	if !ok {
+		return false
+	}
+
+	switch validatorDuty.Type {
+	case spectypes.BNRoleAggregator, spectypes.BNRoleSyncCommitteeContribution:
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *BaseRunner) HasRunningQBFTInstance() bool {
@@ -213,7 +222,7 @@ func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	b.State = state
 	b.mtx.Unlock()
 
-	if isAggregatorDuty(duty) {
+	if isTimingSummaryPreConsensusDuty(duty) {
 		var slotStartTime time.Time
 		if b.NetworkConfig != nil {
 			slotStartTime = b.NetworkConfig.SlotStartTime(duty.DutySlot())
@@ -256,7 +265,7 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 
 	signer := ssvtypes.PartialSigMsgSigner(signedMsg)
 
-	if isAggregatorDuty(b.State.CurrentDuty) {
+	if isTimingSummaryPreConsensusDuty(b.State.CurrentDuty) {
 		b.observePreConsensusMsg(signer)
 
 		hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -97,8 +97,7 @@ type BaseRunner struct {
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
 
-	preConsensusMsgLogMu sync.Mutex
-	preConsensusMsgLog   preConsensusMsgLogStats
+	preConsensusMsgLog preConsensusMsgLogStats
 }
 
 func isTimingSummaryPreConsensusDuty(duty spectypes.Duty) bool {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
@@ -207,7 +208,11 @@ func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	b.State = state
 	b.mtx.Unlock()
 
-	b.resetPreConsensusMsgLog()
+	var slotStartTime time.Time
+	if b.NetworkConfig != nil {
+		slotStartTime = b.NetworkConfig.SlotStartTime(duty.DutySlot())
+	}
+	b.resetPreConsensusMsgLog(slotStartTime)
 }
 
 // baseStartNewDuty is a base func that all runner implementation can call to start a duty
@@ -249,10 +254,12 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 
 	if hasQuorum {
 		const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
-		summaryFields := b.preConsensusMsgLogSummaryFieldsOnce()
-		summaryFields = append(summaryFields, zap.Uint64("quorum_reached_by", signer), fields.QuorumRoots(quorumRoots))
-		logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
-		span.AddEvent(gotPreConsensusQuorumEvent)
+		summaryFields := b.preConsensusMsgLogSummaryFieldsOnce(signer)
+		if summaryFields != nil {
+			summaryFields = append(summaryFields, fields.QuorumRoots(quorumRoots))
+			logger.Debug(gotPreConsensusQuorumEvent, summaryFields...)
+			span.AddEvent(gotPreConsensusQuorumEvent)
+		}
 	}
 
 	return hasQuorum, slices.Collect(maps.Keys(quorumRoots)), nil


### PR DESCRIPTION
### Summary

Reduces pre-consensus message log volume for aggregator and sync committee contribution duties by ~5M logs/hour on stage.

  *Before*: Logged every pre-consensus message received (per signer, per duty)
  📬 got pre-consensus message  signer=1  validators=[...]
  📬 got pre-consensus message  signer=2  validators=[...]
  📬 got pre-consensus message  signer=3  validators=[...]
  🎯 got pre-consensus quorum  quorum_roots=[...]

  8After*: Single summary log at quorum with timing information
  🎯 got pre-consensus quorum
     time_to_quorum=0.82500s
     signer_timings=[{signer:1,at:+0.21000s},{signer:2,at:+0.55000s},{signer:3,at:+0.82500s}]
     quorum_reached_by=3
     quorum_roots=[...]

### Changes

  - Aggregator & Sync Committee Contribution duties: Replace per-message logs with a single timing summary at quorum
    - time_to_quorum: Time from slot start to quorum
    - signer_timings: When each signer's message arrived (relative to slot start)
    - Signers sorted by arrival time for easy latency debugging
  - Other duties (proposer, attester, etc.): Keep original per-message logging behavior (low volume, useful for debugging)

### Why

  - Aggregator duties generate massive log volume (~5M logs/hour on stage)
  - Per-message logs provided little value - timing information is more useful for debugging
  - Proposer/attester duties are lower volume and benefit from detailed per-message logs