### PR TITLE
Adjustments by iurii to #2659 (part 2)

### DIFF
--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -218,7 +218,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	msg, err := signBeaconObject(
 		ctx,
 		r,
-		r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty),
+		r.BaseRunner.State.Load().CurrentDuty.(*spectypes.ValidatorDuty),
 		aggregateAndProofHashRoot,
 		decidedValue.Duty.Slot,
 		spectypes.DomainAggregateAndProof,
@@ -466,7 +466,7 @@ func (r *AggregatorRunner) GetShare() *spectypes.Share {
 }
 
 func (r *AggregatorRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *AggregatorRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -245,7 +245,7 @@ func (r *CommitteeRunner) GetBeaconSigner() ekm.BeaconSigner {
 }
 
 func (r *CommitteeRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *CommitteeRunner) HasRunningDuty() bool {
@@ -274,7 +274,7 @@ func (r *CommitteeRunner) ProcessConsensus(ctx context.Context, logger *zap.Logg
 	r.measurements.EndConsensus()
 	recordConsensusDuration(ctx, r.measurements.ConsensusTime(), spectypes.RoleCommittee)
 
-	duty := r.BaseRunner.State.CurrentDuty
+	duty := r.BaseRunner.State.Load().CurrentDuty
 	postConsensusMsg := &spectypes.PartialSignatureMessages{
 		Type:     spectypes.PostConsensusPartialSig,
 		Slot:     duty.DutySlot(),
@@ -595,7 +595,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		span.AddEvent("constructing sync-committee and attestations signature messages", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
 		for _, validator := range validators {
 			// Skip if no quorum - We know that a root has quorum but not necessarily for the validator
-			gotQuorum, quorumSigners := r.BaseRunner.State.PostConsensusContainer.HasQuorum(validator, root)
+			gotQuorum, quorumSigners := r.BaseRunner.State.Load().PostConsensusContainer.HasQuorum(validator, root)
 			if !gotQuorum {
 				continue
 			}
@@ -618,11 +618,11 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					zap.Uint64s("quorum_signers", quorumSigners),
 				)
 
-				sig, err := r.BaseRunner.State.ReconstructBeaconSig(r.BaseRunner.State.PostConsensusContainer, root, pubKey[:], validatorIndex)
+				sig, err := r.BaseRunner.State.Load().ReconstructBeaconSig(r.BaseRunner.State.Load().PostConsensusContainer, root, pubKey[:], validatorIndex)
 				// If the reconstructed signature verification failed, fall back to verifying each partial signature
 				if err != nil {
 					for _, root := range roots {
-						r.BaseRunner.FallBackAndVerifyEachSignature(r.BaseRunner.State.PostConsensusContainer, root, share.Committee, validatorIndex)
+						r.BaseRunner.FallBackAndVerifyEachSignature(r.BaseRunner.State.Load().PostConsensusContainer, root, share.Committee, validatorIndex)
 					}
 					const eventMsg = "got post-consensus quorum but it has invalid signatures"
 					span.AddEvent(eventMsg)
@@ -723,7 +723,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			return fmt.Errorf("%s: %w", errMsg, err)
 		}
 
-		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot()), spectypes.BNRoleAttester)
+		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.Load().CurrentDuty.DutySlot()), spectypes.BNRoleAttester)
 		attData, err := attestations[0].Data()
 		if err != nil {
 			return fmt.Errorf("could not get attestation data: %w", err)
@@ -731,7 +731,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		const eventMsg = "✅ successfully submitted attestations"
 		span.AddEvent(eventMsg, trace.WithAttributes(
 			observability.BeaconBlockRootAttribute(attData.BeaconBlockRoot),
-			observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+			observability.DutyRoundAttribute(r.BaseRunner.State.Load().RunningInstance.State.Round),
 			observability.ValidatorCountAttribute(len(attestations)),
 		))
 		aLogger.Info(eventMsg,
@@ -775,15 +775,15 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordSuccessfulSubmission(
 				ctx,
 				int64(syncMsgsCount),
-				r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot()),
+				r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.Load().CurrentDuty.DutySlot()),
 				spectypes.BNRoleSyncCommittee,
 			)
 		}
 
 		const eventMsg = "✅ successfully submitted sync committee"
 		span.AddEvent(eventMsg, trace.WithAttributes(
-			observability.BeaconSlotAttribute(r.BaseRunner.State.CurrentDuty.DutySlot()),
-			observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+			observability.BeaconSlotAttribute(r.BaseRunner.State.Load().CurrentDuty.DutySlot()),
+			observability.DutyRoundAttribute(r.BaseRunner.State.Load().RunningInstance.State.Round),
 			observability.BeaconBlockRootAttribute(syncCommitteeMessages[0].BeaconBlockRoot),
 			observability.ValidatorCountAttribute(len(syncCommitteeMessages)),
 			attribute.Float64("ssv.validator.duty.submission_time", time.Since(submissionStart).Seconds()),
@@ -806,9 +806,9 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	}
 
 	if r.HasSubmittedAllValidatorDuties(attestationMap, committeeMap) {
-		r.BaseRunner.State.Finished = true
+		r.BaseRunner.State.Load().Finished = true
 		r.measurements.EndDutyFlow()
-		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleCommittee, r.BaseRunner.State.RunningInstance.State.Round)
+		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleCommittee, r.BaseRunner.State.Load().RunningInstance.State.Round)
 		const dutyFinishedEvent = "✔️finished duty processing (100% success)"
 		logger.Info(dutyFinishedEvent,
 			fields.ConsensusTime(r.measurements.ConsensusTime()),
@@ -923,8 +923,8 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context
 	attestationMap = make(map[phase0.ValidatorIndex][32]byte)
 	syncCommitteeMap = make(map[phase0.ValidatorIndex][32]byte)
 	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]any)
-	duty := r.BaseRunner.State.CurrentDuty
-	beaconVoteData := r.BaseRunner.State.DecidedValue
+	duty := r.BaseRunner.State.Load().CurrentDuty
+	beaconVoteData := r.BaseRunner.State.Load().DecidedValue
 	beaconVote := &spectypes.BeaconVote{}
 	if err := beaconVote.Decode(beaconVoteData); err != nil {
 		return nil, nil, nil, fmt.Errorf("could not decode beacon vote: %w", err)

--- a/protocol/v2/ssv/runner/preconsensus_msg_log.go
+++ b/protocol/v2/ssv/runner/preconsensus_msg_log.go
@@ -15,30 +15,36 @@ type preConsensusMsgLogStats struct {
 }
 
 func (b *BaseRunner) resetPreConsensusLogSummary(nextSlot phase0.Slot) {
+	summary := &preConsensusMsgLogStats{
+		slotStartTime:      time.Time{},
+		signerTimeIntoSlot: make(map[uint64]time.Duration),
+	}
+
 	// b.NetworkConfig can only be nil in tests, this is fast & dirty work-around for it.
 	if b.NetworkConfig != nil {
-		b.preConsensusMsgLog.slotStartTime = b.NetworkConfig.SlotStartTime(nextSlot)
+		summary.slotStartTime = b.NetworkConfig.SlotStartTime(nextSlot)
 	}
-	b.preConsensusMsgLog.signerTimeIntoSlot = make(map[uint64]time.Duration)
+
+	b.preConsensusMsgLog.Store(summary)
 }
 
 func (b *BaseRunner) observePreConsensusMsg(signer uint64) {
 	// Duplicate message from the same signer should never arrive here, but handle it just in case.
-	if _, seen := b.preConsensusMsgLog.signerTimeIntoSlot[signer]; seen {
+	if _, seen := b.preConsensusMsgLog.Load().signerTimeIntoSlot[signer]; seen {
 		return
 	}
 
-	// b.preConsensusMsgLog.signerTimeIntoSlot can only be nil in tests, this is fast & dirty work-around for it.
-	if b.preConsensusMsgLog.signerTimeIntoSlot == nil {
-		b.preConsensusMsgLog.signerTimeIntoSlot = make(map[uint64]time.Duration)
+	// b.preConsensusMsgLog.Load().signerTimeIntoSlot can only be nil in tests, this is fast & dirty work-around for it.
+	if b.preConsensusMsgLog.Load().signerTimeIntoSlot == nil {
+		b.preConsensusMsgLog.Load().signerTimeIntoSlot = make(map[uint64]time.Duration)
 	}
 
-	b.preConsensusMsgLog.signerTimeIntoSlot[signer] = time.Since(b.preConsensusMsgLog.slotStartTime)
+	b.preConsensusMsgLog.Load().signerTimeIntoSlot[signer] = time.Since(b.preConsensusMsgLog.Load().slotStartTime)
 }
 
 func (b *BaseRunner) preConsensusMsgLogSummaryFields(quorumReachedBySigner uint64) []zap.Field {
-	timeToQuorum := time.Since(b.preConsensusMsgLog.slotStartTime)
-	if at, ok := b.preConsensusMsgLog.signerTimeIntoSlot[quorumReachedBySigner]; ok {
+	timeToQuorum := time.Since(b.preConsensusMsgLog.Load().slotStartTime)
+	if at, ok := b.preConsensusMsgLog.Load().signerTimeIntoSlot[quorumReachedBySigner]; ok {
 		timeToQuorum = at
 	}
 
@@ -48,8 +54,8 @@ func (b *BaseRunner) preConsensusMsgLogSummaryFields(quorumReachedBySigner uint6
 
 		atDur time.Duration
 	}
-	signerTimings := make([]preConsensusSignerTiming, 0, len(b.preConsensusMsgLog.signerTimeIntoSlot))
-	for signer, at := range b.preConsensusMsgLog.signerTimeIntoSlot {
+	signerTimings := make([]preConsensusSignerTiming, 0, len(b.preConsensusMsgLog.Load().signerTimeIntoSlot))
+	for signer, at := range b.preConsensusMsgLog.Load().signerTimeIntoSlot {
 		signerTimings = append(signerTimings, preConsensusSignerTiming{
 			Signer:       signer,
 			TimeIntoSlot: signedDurationToSecondsStr(at),

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -265,7 +265,7 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 		span.AddEvent("decided has a vanilla block")
 	}
 
-	duty := r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty)
+	duty := r.BaseRunner.State.Load().CurrentDuty.(*spectypes.ValidatorDuty)
 	if !r.doppelgangerHandler.CanSign(duty.ValidatorIndex) {
 		logger.Warn("Signing not permitted due to Doppelganger protection", fields.ValidatorIndex(duty.ValidatorIndex))
 		return nil
@@ -420,8 +420,8 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	recordSuccessfulSubmission(ctx, 1, r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleProposer)
 	const submittedBlockProposalEvent = "✅ successfully submitted block proposal"
 	span.AddEvent(submittedBlockProposalEvent, trace.WithAttributes(
-		observability.BeaconSlotAttribute(r.BaseRunner.State.CurrentDuty.DutySlot()),
-		observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+		observability.BeaconSlotAttribute(r.BaseRunner.State.Load().CurrentDuty.DutySlot()),
+		observability.DutyRoundAttribute(r.BaseRunner.State.Load().RunningInstance.State.Round),
 		observability.BeaconBlockHashAttribute(blockHash),
 		observability.BeaconBlockIsBlindedAttribute(vBlk.Blinded),
 	))
@@ -595,7 +595,7 @@ func (r *ProposerRunner) GetShare() *spectypes.Share {
 }
 
 func (r *ProposerRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *ProposerRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sync"
+	"sync/atomic"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
@@ -82,8 +82,14 @@ type DoppelgangerProvider interface {
 var _ Runner = new(CommitteeRunner)
 
 type BaseRunner struct {
-	mtx            sync.RWMutex
-	State          *State
+	// State stores the current runner state, this state corresponds to 1 particular duty the runner is
+	// currently busy with at the moment.
+	// It is an atomic pointer because it needs to be re-initialized (reset) whenever new duty starts,
+	// and stay accessible to other go-routines. Importantly, BaseRunner doesn't make any effort
+	// to synchronize the updates to the State value itself (the value atomic pointer is referencing),
+	// so it's the caller's responsibility to make sure those updates are applied sequentially.
+	State atomic.Pointer[State]
+
 	Share          map[phase0.ValidatorIndex]*spectypes.Share
 	QBFTController *controller.Controller
 	NetworkConfig  *networkconfig.Network
@@ -96,7 +102,13 @@ type BaseRunner struct {
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
 
-	preConsensusMsgLog preConsensusMsgLogStats
+	// preConsensusMsgLog can be used to reduce the logs volume a runner emits by aggregating the data to log
+	// it all with a single log-call.
+	// It is an atomic pointer because similar to State it needs to be re-initialized (reset) whenever new
+	// duty starts, and stay accessible to other go-routines. Importantly, BaseRunner doesn't make any effort
+	// to synchronize the updates to the preConsensusMsgLogStats value itself (the value atomic pointer is
+	// referencing), so it's the caller's responsibility to make sure those updates are applied sequentially.
+	preConsensusMsgLog atomic.Pointer[preConsensusMsgLogStats]
 }
 
 func logSummaryOnly(duty spectypes.Duty) bool {
@@ -116,7 +128,7 @@ func logSummaryOnly(duty spectypes.Duty) bool {
 func (b *BaseRunner) HasRunningQBFTInstance() bool {
 	var runningInstance *instance.Instance
 	if b.hasRunningDuty() {
-		runningInstance = b.State.RunningInstance
+		runningInstance = b.State.Load().RunningInstance
 		if runningInstance != nil {
 			decided, _ := runningInstance.IsDecided()
 			return !decided
@@ -128,7 +140,7 @@ func (b *BaseRunner) HasRunningQBFTInstance() bool {
 func (b *BaseRunner) HasAcceptedProposalForCurrentRound() bool {
 	var runningInstance *instance.Instance
 	if b.hasRunningDuty() {
-		runningInstance = b.State.RunningInstance
+		runningInstance = b.State.Load().RunningInstance
 		if runningInstance != nil {
 			return runningInstance.State.ProposalAcceptedForCurrentRound != nil
 		}
@@ -153,7 +165,7 @@ func (b *BaseRunner) GetLastHeight() specqbft.Height {
 
 func (b *BaseRunner) GetLastRound() specqbft.Round {
 	if b.hasRunningDuty() {
-		inst := b.State.RunningInstance
+		inst := b.State.Load().RunningInstance
 		if inst != nil {
 			return inst.State.Round
 		}
@@ -162,7 +174,7 @@ func (b *BaseRunner) GetLastRound() specqbft.Round {
 }
 
 func (b *BaseRunner) GetStateRoot() ([32]byte, error) {
-	return b.State.GetRoot()
+	return b.State.Load().GetRoot()
 }
 
 func (b *BaseRunner) SetTimeoutFunc(fn TimeoutF) {
@@ -189,7 +201,7 @@ func (b *BaseRunner) MarshalJSON() ([]byte, error) {
 
 	// Create object and marshal
 	alias := &BaseRunnerAlias{
-		State:              b.State,
+		State:              b.State.Load(),
 		Share:              b.Share,
 		QBFTController:     b.QBFTController,
 		BeaconConfig:       b.NetworkConfig.Beacon,
@@ -209,16 +221,7 @@ func (b *BaseRunner) SetHighestDecidedSlot(slot phase0.Slot) {
 
 // baseSetupForNewDuty is sets the runner for a new duty
 func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
-	// start new state
-	// start new state
-	// TODO nicer way to get quorum
-	state := NewRunnerState(quorum, duty)
-
-	// TODO: potentially incomplete locking of b.State. runner.Execute(duty) has access to
-	// b.State but currently does not write to it
-	b.mtx.Lock() // writes to b.State
-	b.State = state
-	b.mtx.Unlock()
+	b.State.Store(NewRunnerState(quorum, duty))
 
 	if logSummaryOnly(duty) {
 		b.resetPreConsensusLogSummary(duty.DutySlot())
@@ -259,10 +262,10 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 
 	signer := ssvtypes.PartialSigMsgSigner(signedMsg)
 
-	if logSummaryOnly(b.State.CurrentDuty) {
+	if logSummaryOnly(b.State.Load().CurrentDuty) {
 		b.observePreConsensusMsg(signer)
 
-		hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
+		hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.Load().PreConsensusContainer)
 		if hasQuorum {
 			const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
 			summaryFields := b.preConsensusMsgLogSummaryFields(signer)
@@ -286,7 +289,7 @@ func (b *BaseRunner) basePreConsensusMsgProcessing(ctx context.Context, logger *
 	)
 	span.AddEvent(gotPreConsensusMsgEvent)
 
-	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PreConsensusContainer)
+	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.Load().PreConsensusContainer)
 
 	if hasQuorum {
 		const gotPreConsensusQuorumEvent = "🎯 got pre-consensus quorum"
@@ -303,8 +306,8 @@ func (b *BaseRunner) baseConsensusMsgProcessing(ctx context.Context, logger *zap
 	span := trace.SpanFromContext(ctx)
 
 	prevDecided := false
-	if b.hasRunningDuty() && b.State != nil && b.State.RunningInstance != nil {
-		prevDecided, _ = b.State.RunningInstance.IsDecided()
+	if b.hasRunningDuty() && b.State.Load() != nil && b.State.Load().RunningInstance != nil {
+		prevDecided, _ = b.State.Load().RunningInstance.IsDecided()
 	}
 	if prevDecided {
 		return true, nil, spectypes.NewError(spectypes.SkipConsensusMessageAsConsensusHasFinishedErrorCode, "not processing consensus message since consensus has already finished")
@@ -350,8 +353,8 @@ func (b *BaseRunner) baseConsensusMsgProcessing(ctx context.Context, logger *zap
 	span.AddEvent(qbftInstanceIsDecidedEvent)
 
 	// update the decided and the highest decided slot
-	b.State.DecidedValue = decidedValueEncoded
-	b.highestDecidedSlot = b.State.CurrentDuty.DutySlot()
+	b.State.Load().DecidedValue = decidedValueEncoded
+	b.highestDecidedSlot = b.State.Load().CurrentDuty.DutySlot()
 
 	return true, decidedValue, nil
 }
@@ -382,7 +385,7 @@ func (b *BaseRunner) basePostConsensusMsgProcessing(
 	)
 	span.AddEvent(gotPostConsensusMsgEvent)
 
-	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.PostConsensusContainer)
+	hasQuorum, quorumRoots := b.basePartialSigMsgProcessing(signedMsg, b.State.Load().PostConsensusContainer)
 
 	if hasQuorum {
 		const gotPostConsensusQuorumEvent = "🎯 got post-consensus quorum"
@@ -439,15 +442,15 @@ func (b *BaseRunner) didDecideCorrectly(prevDecided bool, signedMessage *spectyp
 		return false, nil
 	}
 
-	if b.State.RunningInstance == nil {
+	if b.State.Load().RunningInstance == nil {
 		return false, spectypes.NewError(spectypes.DecidedWrongInstanceErrorCode, "decided wrong instance (running instance is nil)")
 	}
 
-	if decidedMessage.Height != b.State.RunningInstance.GetHeight() {
+	if decidedMessage.Height != b.State.Load().RunningInstance.GetHeight() {
 		return false, spectypes.WrapError(spectypes.DecidedWrongInstanceErrorCode, fmt.Errorf(
 			"decided wrong instance (msg_height = %d, running_instance_height = %d)",
 			decidedMessage.Height,
-			b.State.RunningInstance.GetHeight(),
+			b.State.Load().RunningInstance.GetHeight(),
 		))
 	}
 
@@ -492,7 +495,7 @@ func (b *BaseRunner) decide(
 		return fmt.Errorf("could not start new QBFT instance: instance is nil")
 	}
 
-	b.State.RunningInstance = newInstance
+	b.State.Load().RunningInstance = newInstance
 
 	span.AddEvent("register timeout handler")
 	b.registerTimeoutHandler(ctx, logger, newInstance, b.QBFTController.Height)
@@ -502,32 +505,23 @@ func (b *BaseRunner) decide(
 
 // hasRunningDuty returns true if a new duty didn't start or an existing duty marked as finished
 func (b *BaseRunner) hasRunningDuty() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
-	if b.State == nil {
+	if b.State.Load() == nil {
 		return false
 	}
 
-	return !b.State.Finished
+	return !b.State.Load().Finished
 }
 
 func (b *BaseRunner) hasDutyAssigned() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
-	return b.State != nil
+	return b.State.Load() != nil
 }
 
 func (b *BaseRunner) hasDutyFinished() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
-	if b.State == nil {
+	if b.State.Load() == nil {
 		return false
 	}
 
-	return b.State.Finished
+	return b.State.Load().Finished
 }
 
 func (b *BaseRunner) ShouldProcessDuty(duty spectypes.Duty) error {
@@ -542,10 +536,10 @@ func (b *BaseRunner) ShouldProcessDuty(duty spectypes.Duty) error {
 
 func (b *BaseRunner) ShouldProcessNonBeaconDuty(duty spectypes.Duty) error {
 	// assume CurrentDuty is not nil if state is not nil
-	if b.State != nil && b.State.CurrentDuty.DutySlot() >= duty.DutySlot() {
+	if b.State.Load() != nil && b.State.Load().CurrentDuty.DutySlot() >= duty.DutySlot() {
 		return spectypes.NewError(
 			spectypes.DutyAlreadyPassedErrorCode,
-			fmt.Sprintf("duty for slot %d already passed. Current slot is %d", duty.DutySlot(), b.State.CurrentDuty.DutySlot()),
+			fmt.Sprintf("duty for slot %d already passed. Current slot is %d", duty.DutySlot(), b.State.Load().CurrentDuty.DutySlot()),
 		)
 	}
 	return nil

--- a/protocol/v2/ssv/runner/runner_validations.go
+++ b/protocol/v2/ssv/runner/runner_validations.go
@@ -28,7 +28,7 @@ func (b *BaseRunner) ValidatePreConsensusMsg(
 		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutyFinished)
 	}
 
-	if err := b.validatePartialSigMsg(psigMsgs, b.State.CurrentDuty.DutySlot()); err != nil {
+	if err := b.validatePartialSigMsg(psigMsgs, b.State.Load().CurrentDuty.DutySlot()); err != nil {
 		return err
 	}
 
@@ -66,8 +66,8 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 	// messages as soon as possible (so we can drop non-retryable messages ASAP), the exact slot validation
 	// occurs below.
 	slotIsRelevant := func(slot phase0.Slot) error {
-		minSlot := b.State.CurrentDuty.DutySlot() - 1
-		maxSlot := b.State.CurrentDuty.DutySlot()
+		minSlot := b.State.Load().CurrentDuty.DutySlot() - 1
+		maxSlot := b.State.Load().CurrentDuty.DutySlot()
 		if psigMsgs.Slot < minSlot {
 			// This message is targeting a slot that's already too far in the past to matter.
 			return spectypes.WrapError(spectypes.PartialSigMessageInvalidSlotErrorCode, fmt.Errorf(
@@ -90,13 +90,13 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 		return err
 	}
 
-	if b.State.RunningInstance == nil {
+	if b.State.Load().RunningInstance == nil {
 		return NewRetryableError(spectypes.WrapError(spectypes.NoRunningConsensusInstanceErrorCode, ErrInstanceNotFound))
 	}
 
 	// TODO https://github.com/ssvlabs/ssv-spec/issues/142 need to fix with this issue solution instead.
-	decided, decidedValueBytes := b.State.RunningInstance.IsDecided()
-	if !decided || len(b.State.DecidedValue) == 0 {
+	decided, decidedValueBytes := b.State.Load().RunningInstance.IsDecided()
+	if !decided || len(b.State.Load().DecidedValue) == 0 {
 		return NewRetryableError(spectypes.WrapError(spectypes.NoDecidedValueErrorCode, ErrNoDecidedValue))
 	}
 
@@ -134,7 +134,7 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 
 			// Use b.State.CurrentDuty.DutySlot() since CurrentDuty never changes for CommitteeRunner
 			// by design, hence there is no need to store slot number on decidedValue for CommitteeRunner.
-			expectedSlot := b.State.CurrentDuty.DutySlot()
+			expectedSlot := b.State.Load().CurrentDuty.DutySlot()
 			return b.validatePartialSigMsg(psigMsgs, expectedSlot)
 		}
 	}
@@ -167,7 +167,7 @@ func (b *BaseRunner) verifyExpectedRoot(
 
 	// convert expected roots to map and mark unique roots when verified
 	sortedExpectedRoots, err := func(expectedRootObjs []ssz.HashRoot) ([][32]byte, error) {
-		epoch := b.NetworkConfig.EstimatedEpochAtSlot(b.State.CurrentDuty.DutySlot())
+		epoch := b.NetworkConfig.EstimatedEpochAtSlot(b.State.Load().CurrentDuty.DutySlot())
 		d, err := runner.GetBeaconNode().DomainData(ctx, epoch, domain)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get pre consensus root domain")

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -221,7 +221,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 		signed, err := signBeaconObject(
 			ctx,
 			r,
-			r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty),
+			r.BaseRunner.State.Load().CurrentDuty.(*spectypes.ValidatorDuty),
 			contribAndProof,
 			cd.Duty.Slot,
 			spectypes.DomainContributionAndProof,
@@ -589,7 +589,7 @@ func (r *SyncCommitteeAggregatorRunner) GetShare() *spectypes.Share {
 }
 
 func (r *SyncCommitteeAggregatorRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *SyncCommitteeAggregatorRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -123,7 +123,7 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], fullSig)
 
-	registration, err := r.buildValidatorRegistration(r.BaseRunner.State.CurrentDuty.DutySlot())
+	registration, err := r.buildValidatorRegistration(r.BaseRunner.State.Load().CurrentDuty.DutySlot())
 	if err != nil {
 		return fmt.Errorf("could not calculate validator registration: %w", err)
 	}
@@ -169,10 +169,10 @@ func (r *ValidatorRegistrationRunner) ProcessPostConsensus(ctx context.Context, 
 }
 
 func (r *ValidatorRegistrationRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	if r.BaseRunner.State == nil || r.BaseRunner.State.CurrentDuty == nil {
+	if r.BaseRunner.State.Load() == nil || r.BaseRunner.State.Load().CurrentDuty == nil {
 		return nil, spectypes.DomainError, fmt.Errorf("no running duty to compute preconsensus roots and domain")
 	}
-	vr, err := r.buildValidatorRegistration(r.BaseRunner.State.CurrentDuty.DutySlot())
+	vr, err := r.buildValidatorRegistration(r.BaseRunner.State.Load().CurrentDuty.DutySlot())
 	if err != nil {
 		return nil, spectypes.DomainError, fmt.Errorf("could not calculate validator registration: %w", err)
 	}
@@ -326,7 +326,7 @@ func (r *ValidatorRegistrationRunner) GetShare() *spectypes.Share {
 }
 
 func (r *ValidatorRegistrationRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *ValidatorRegistrationRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -230,7 +230,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 
 // Returns *phase0.VoluntaryExit object with current epoch and own validator index
 func (r *VoluntaryExitRunner) calculateVoluntaryExit() (*phase0.VoluntaryExit, error) {
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot())
+	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.Load().CurrentDuty.DutySlot())
 	validatorIndex := r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex
 	return &phase0.VoluntaryExit{
 		Epoch:          epoch,
@@ -290,7 +290,7 @@ func (r *VoluntaryExitRunner) GetShare() *spectypes.Share {
 }
 
 func (r *VoluntaryExitRunner) state() *State {
-	return r.BaseRunner.State
+	return r.BaseRunner.State.Load()
 }
 
 func (r *VoluntaryExitRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -117,8 +117,8 @@ func (test *MsgProcessingSpecTest) runPreTesting(ctx context.Context, logger *za
 			c.Runners[test.Duty.DutySlot()] = r
 
 			// Inform the duty guard of the running duty, if any, so that it won't reject it.
-			if r.BaseRunner.State != nil && r.BaseRunner.State.CurrentDuty != nil {
-				duty, ok := r.BaseRunner.State.CurrentDuty.(*spectypes.CommitteeDuty)
+			if r.BaseRunner.State.Load() != nil && r.BaseRunner.State.Load().CurrentDuty != nil {
+				duty, ok := r.BaseRunner.State.Load().CurrentDuty.(*spectypes.CommitteeDuty)
 				if !ok {
 					panic("starting duty not found")
 				}

--- a/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
+++ b/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
@@ -96,29 +96,29 @@ func (test *StartNewRunnerDutySpecTest) RunAsPartOfMultiTest(t *testing.T, logge
 		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.BaseRunner.State.Load().RunningInstance != nil {
+			r.BaseRunner.State.Load().RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.AggregatorRunner:
 		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.BaseRunner.State.Load().RunningInstance != nil {
+			r.BaseRunner.State.Load().RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.ProposerRunner:
 		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.BaseRunner.State.Load().RunningInstance != nil {
+			r.BaseRunner.State.Load().RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.SyncCommitteeAggregatorRunner:
 		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.BaseRunner.State.Load().RunningInstance != nil {
+			r.BaseRunner.State.Load().RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	}
 

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -390,10 +390,10 @@ func fixRunnerForRun(t *testing.T, runnerMap map[string]any, ks *spectestingutil
 
 	if baseRunner.QBFTController != nil {
 		baseRunner.QBFTController = fixControllerForRun(logger, baseRunner.QBFTController, ks)
-		if baseRunner.State != nil {
-			if baseRunner.State.RunningInstance != nil {
+		if baseRunner.State.Load() != nil {
+			if baseRunner.State.Load().RunningInstance != nil {
 				operator := spectestingutils.TestingCommitteeMember(ks)
-				baseRunner.State.RunningInstance = fixInstanceForRun(logger, ks, baseRunner.State.RunningInstance, baseRunner.QBFTController, operator)
+				baseRunner.State.Load().RunningInstance = fixInstanceForRun(logger, ks, baseRunner.State.Load().RunningInstance, baseRunner.QBFTController, operator)
 			}
 		}
 	}

--- a/protocol/v2/ssv/spectest/util.go
+++ b/protocol/v2/ssv/spectest/util.go
@@ -47,8 +47,8 @@ func runnerForTest(t *testing.T, runnerType runner.Runner, name string, testType
 		for _, inst := range cr.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if cr.BaseRunner.State != nil && cr.BaseRunner.State.RunningInstance != nil {
-			cr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if cr.BaseRunner.State.Load() != nil && cr.BaseRunner.State.Load().RunningInstance != nil {
+			cr.BaseRunner.State.Load().RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.AggregatorRunner:
 		ar := r.(*runner.AggregatorRunner)
@@ -58,8 +58,8 @@ func runnerForTest(t *testing.T, runnerType runner.Runner, name string, testType
 		for _, inst := range ar.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if ar.BaseRunner.State != nil && ar.BaseRunner.State.RunningInstance != nil {
-			ar.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if ar.BaseRunner.State.Load() != nil && ar.BaseRunner.State.Load().RunningInstance != nil {
+			ar.BaseRunner.State.Load().RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.ProposerRunner:
 		pr := r.(*runner.ProposerRunner)
@@ -69,8 +69,8 @@ func runnerForTest(t *testing.T, runnerType runner.Runner, name string, testType
 		for _, inst := range pr.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if pr.BaseRunner.State != nil && pr.BaseRunner.State.RunningInstance != nil {
-			pr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if pr.BaseRunner.State.Load() != nil && pr.BaseRunner.State.Load().RunningInstance != nil {
+			pr.BaseRunner.State.Load().RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.SyncCommitteeAggregatorRunner:
 		scr := r.(*runner.SyncCommitteeAggregatorRunner)
@@ -80,8 +80,8 @@ func runnerForTest(t *testing.T, runnerType runner.Runner, name string, testType
 		for _, inst := range scr.BaseRunner.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if scr.BaseRunner.State != nil && scr.BaseRunner.State.RunningInstance != nil {
-			scr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if scr.BaseRunner.State.Load() != nil && scr.BaseRunner.State.Load().RunningInstance != nil {
+			scr.BaseRunner.State.Load().RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.ValidatorRegistrationRunner:
 		r.(*runner.ValidatorRegistrationRunner).BaseRunner.NetworkConfig = networkconfig.TestNetwork

--- a/protocol/v2/ssv/spectest/value_checker.go
+++ b/protocol/v2/ssv/spectest/value_checker.go
@@ -228,8 +228,8 @@ func createValueChecker(r runner.Runner, signerSource ...runner.Runner) ssv.Valu
 
 		// Get slot from state or use testing default
 		slot := phase0.Slot(spectestingutils.TestingDutySlot)
-		if typedRunner.BaseRunner.State != nil && typedRunner.BaseRunner.State.CurrentDuty != nil {
-			slot = typedRunner.BaseRunner.State.CurrentDuty.DutySlot()
+		if typedRunner.BaseRunner.State.Load() != nil && typedRunner.BaseRunner.State.Load().CurrentDuty != nil {
+			slot = typedRunner.BaseRunner.State.Load().CurrentDuty.DutySlot()
 		}
 
 		// Construct expected vote from TestingAttestationData (same pattern as testing/runner.go:69-73)

--- a/protocol/v2/ssv/validator/committee_queue_test.go
+++ b/protocol/v2/ssv/validator/committee_queue_test.go
@@ -262,18 +262,17 @@ func TestConsumeQueueBasic(t *testing.T) {
 	}
 
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         false,
-						ProposalAcceptedForCurrentRound: proposalMsg,
-						Round:                           1,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         false,
+				ProposalAcceptedForCurrentRound: proposalMsg,
+				Round:                           1,
 			},
 		},
-	}
+	})
 
 	msgChannel, handler := setupMessageCollection(2)
 	runConsumeQueueAsync(t, ctx, committee, q, logger, handler, committeeRunner)
@@ -367,18 +366,17 @@ func TestFilterNoProposalAccepted(t *testing.T) {
 	}
 
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         false,
-						ProposalAcceptedForCurrentRound: nil,
-						Round:                           currentRound,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         false,
+				ProposalAcceptedForCurrentRound: nil,
+				Round:                           currentRound,
 			},
 		},
-	}
+	})
 
 	msgChannel, handler := setupMessageCollection(4)
 	runConsumeQueueAsync(t, ctx, committee, q, logger, handler, committeeRunner)
@@ -476,18 +474,17 @@ func TestFilterNotDecidedSkipsPartialSignatures(t *testing.T) {
 	}
 
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         false,
-						ProposalAcceptedForCurrentRound: proposalMsg,
-						Round:                           1,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         false,
+				ProposalAcceptedForCurrentRound: proposalMsg,
+				Round:                           1,
 			},
 		},
-	}
+	})
 
 	msgChannel, handler := setupMessageCollection(2)
 	runConsumeQueueAsync(t, ctx, committee, q, logger, handler, committeeRunner)
@@ -556,18 +553,17 @@ func TestFilterDecidedAllowsAll(t *testing.T) {
 	}
 
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         true,
-						ProposalAcceptedForCurrentRound: proposalMsg,
-						Round:                           1,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         true,
+				ProposalAcceptedForCurrentRound: proposalMsg,
+				Round:                           1,
 			},
 		},
-	}
+	})
 
 	msgChannel, handler := setupMessageCollection(2)
 	runConsumeQueueAsync(t, ctx, committee, q, logger, handler, committeeRunner)
@@ -640,35 +636,33 @@ func TestChangingFilterState(t *testing.T) {
 
 	// 1) No proposal accepted => Prepare should be filtered out
 	r1 := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         false,
-						ProposalAcceptedForCurrentRound: nil,
-						Round:                           round,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	r1.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         false,
+				ProposalAcceptedForCurrentRound: nil,
+				Round:                           round,
 			},
 		},
-	}
+	})
 	seen1 := runOnce(r1)
 	assert.Nil(t, seen1)
 
 	// 2) Proposal accepted => now we should see exactly one Prepare
 	r2 := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         false,
-						ProposalAcceptedForCurrentRound: &specqbft.ProcessingMessage{QBFTMessage: prepareBody},
-						Round:                           round,
-					},
-				},
+		BaseRunner: &runner.BaseRunner{},
+	}
+	r2.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         false,
+				ProposalAcceptedForCurrentRound: &specqbft.ProcessingMessage{QBFTMessage: prepareBody},
+				Round:                           round,
 			},
 		},
-	}
+	})
 	seen2 := runOnce(r2)
 
 	require.NotNil(t, seen2)
@@ -765,22 +759,21 @@ func TestCommitteeQueueFilteringScenarios(t *testing.T) {
 			}
 
 			committeeRunner := &runner.CommitteeRunner{
-				BaseRunner: &runner.BaseRunner{
-					State: &runner.State{
-						RunningInstance: &instance.Instance{
-							State: &specqbft.State{
-								Decided:                         tc.decided,
-								ProposalAcceptedForCurrentRound: proposalMsg,
-								Round:                           1,
-							},
-						},
+				BaseRunner: &runner.BaseRunner{},
+			}
+			committeeRunner.BaseRunner.State.Store(&runner.State{
+				RunningInstance: &instance.Instance{
+					State: &specqbft.State{
+						Decided:                         tc.decided,
+						ProposalAcceptedForCurrentRound: proposalMsg,
+						Round:                           1,
 					},
 				},
-			}
+			})
 
 			// Set runner state based on hasRunningDuty parameter
 			if !tc.hasRunningDuty {
-				committeeRunner.BaseRunner.State.Finished = true // This makes HasRunningDuty() return false
+				committeeRunner.BaseRunner.State.Load().Finished = true // This makes HasRunningDuty() return false
 			}
 
 			msgChannel := make(chan *queue.SSVMessage, len(tc.messagesTypes))
@@ -920,18 +913,17 @@ func TestFilterPartialSignatureMessages(t *testing.T) {
 			}
 
 			committeeRunner := &runner.CommitteeRunner{
-				BaseRunner: &runner.BaseRunner{
-					State: &runner.State{
-						RunningInstance: &instance.Instance{
-							State: &specqbft.State{
-								Decided:                         tc.decided,
-								ProposalAcceptedForCurrentRound: &specqbft.ProcessingMessage{},
-								Round:                           1,
-							},
-						},
+				BaseRunner: &runner.BaseRunner{},
+			}
+			committeeRunner.BaseRunner.State.Store(&runner.State{
+				RunningInstance: &instance.Instance{
+					State: &specqbft.State{
+						Decided:                         tc.decided,
+						ProposalAcceptedForCurrentRound: &specqbft.ProcessingMessage{},
+						Round:                           1,
 					},
 				},
-			}
+			})
 
 			msgID := spectypes.MessageID{0x10}
 			partialSigMsg := &spectypes.PartialSignatureMessages{
@@ -1034,14 +1026,13 @@ func TestConsumeQueuePrioritization(t *testing.T) {
 	// Runner with a proposal already accepted, not yet decided
 	acceptedProposal := &specqbft.ProcessingMessage{QBFTMessage: proposalMsgBody}
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{RunningInstance: &instance.Instance{State: &specqbft.State{
-				Decided:                         false,
-				ProposalAcceptedForCurrentRound: acceptedProposal,
-				Round:                           currentRound,
-			}}},
-		},
+		BaseRunner: &runner.BaseRunner{},
 	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{RunningInstance: &instance.Instance{State: &specqbft.State{
+		Decided:                         false,
+		ProposalAcceptedForCurrentRound: acceptedProposal,
+		Round:                           currentRound,
+	}}})
 
 	msgChannel := make(chan *queue.SSVMessage, len(testMessages))
 
@@ -1239,8 +1230,9 @@ func TestConsumeQueueStopsOnErrNoValidDuties(t *testing.T) {
 	q.Q.TryPush(msg3)
 
 	committeeRunner := &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{State: &runner.State{RunningInstance: &instance.Instance{State: &specqbft.State{}}}},
+		BaseRunner: &runner.BaseRunner{},
 	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{RunningInstance: &instance.Instance{State: &specqbft.State{}}})
 
 	var processedMessagesCount int32
 	handler := func(ctx context.Context, _ *zap.Logger, msg *queue.SSVMessage) error {
@@ -1306,19 +1298,19 @@ func TestConsumeQueueBurstTraffic(t *testing.T) {
 			MsgType: specqbft.ProposalMsgType,
 		},
 	}
-	committee.Runners[slot] = &runner.CommitteeRunner{
-		BaseRunner: &runner.BaseRunner{
-			State: &runner.State{
-				RunningInstance: &instance.Instance{
-					State: &specqbft.State{
-						Decided:                         true,
-						ProposalAcceptedForCurrentRound: acceptedProposal,
-						Round:                           1,
-					},
-				},
+	committeeRunner := &runner.CommitteeRunner{
+		BaseRunner: &runner.BaseRunner{},
+	}
+	committeeRunner.BaseRunner.State.Store(&runner.State{
+		RunningInstance: &instance.Instance{
+			State: &specqbft.State{
+				Decided:                         true,
+				ProposalAcceptedForCurrentRound: acceptedProposal,
+				Round:                           1,
 			},
 		},
-	}
+	})
+	committee.Runners[slot] = committeeRunner
 
 	// --- Build 200 randomized messages and count expected per priority bucket ---
 	var (
@@ -1676,18 +1668,17 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 		currentRound := specqbft.Round(1)
 
 		committeeRunner := &runner.CommitteeRunner{
-			BaseRunner: &runner.BaseRunner{
-				State: &runner.State{
-					RunningInstance: &instance.Instance{
-						State: &specqbft.State{
-							Decided:                         false,
-							ProposalAcceptedForCurrentRound: nil,
-							Round:                           currentRound,
-						},
-					},
+			BaseRunner: &runner.BaseRunner{},
+		}
+		committeeRunner.BaseRunner.State.Store(&runner.State{
+			RunningInstance: &instance.Instance{
+				State: &specqbft.State{
+					Decided:                         false,
+					ProposalAcceptedForCurrentRound: nil,
+					Round:                           currentRound,
 				},
 			},
-		}
+		})
 
 		slot := phase0.Slot(456)
 
@@ -1766,7 +1757,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 		ctx2, cancel2 := context.WithCancel(ctx)
 		defer cancel2()
 
-		committeeRunner.BaseRunner.State.RunningInstance.State.ProposalAcceptedForCurrentRound =
+		committeeRunner.BaseRunner.State.Load().RunningInstance.State.ProposalAcceptedForCurrentRound =
 			&specqbft.ProcessingMessage{QBFTMessage: proposal}
 
 		// Restart consumption


### PR DESCRIPTION
This should resolve a potential concurrency bug we have in `BaseRunner` code (+ documenting some assumptions that code relies on),

I'm saying "potential" because in practice we seemingly always call at least 1 of `BaseRunner.hasRunningDuty`, `BaseRunner.hasDutyAssigned`, `BaseRunner.hasDutyFinished` prior to reading/writing the `BaseRunner.State`, which means it is safe to access `BaseRunner.State` (read & write to it) as long as it's done sequentially after any of those 3 calls. That's most likely why we don't see any of our tests failing with "race detected". But it's a very implicit and bug-prone way of going about it ... so in this PR I suggest we explicitly use `atomic.Pointer` instead.

This PR is also fixing the https://github.com/ssvlabs/ssv/pull/2659#discussion_r2694792480 in similar manner.