### PR TITLE
Adjustments by iurii to #2659 (part 3)

### DIFF
--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -81,6 +81,15 @@ type DoppelgangerProvider interface {
 var _ Runner = new(CommitteeRunner)
 
 type BaseRunner struct {
+	// State stores the current runner state, this state corresponds to 1 particular duty the runner is
+	// currently busy with at the moment. The BaseRunner is not responsible for synchronizing any updates
+	// State might need to record - the caller is responsible to ensure the updates/reads (these can happen
+	// whenever runner's method is called to process a p2p message, or an event) are applied sequentially,
+	// plus the caller is also responsible for ensuring there is no race with moving on to the next duty
+	// (the baseSetupForNewDuty call).
+	// Note, the current implementation achieves concurrent safety by making sure every State read/update
+	// is done by the same go-routing, handling all the messages in queue.SSVMessage (p2p messages and events)
+	// sequentially.
 	State *State
 
 	Share          map[phase0.ValidatorIndex]*spectypes.Share

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
@@ -82,8 +81,8 @@ type DoppelgangerProvider interface {
 var _ Runner = new(CommitteeRunner)
 
 type BaseRunner struct {
-	mtx            sync.RWMutex
-	State          *State
+	State *State
+
 	Share          map[phase0.ValidatorIndex]*spectypes.Share
 	QBFTController *controller.Controller
 	NetworkConfig  *networkconfig.Network
@@ -209,16 +208,7 @@ func (b *BaseRunner) SetHighestDecidedSlot(slot phase0.Slot) {
 
 // baseSetupForNewDuty is sets the runner for a new duty
 func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
-	// start new state
-	// start new state
-	// TODO nicer way to get quorum
-	state := NewRunnerState(quorum, duty)
-
-	// TODO: potentially incomplete locking of b.State. runner.Execute(duty) has access to
-	// b.State but currently does not write to it
-	b.mtx.Lock() // writes to b.State
-	b.State = state
-	b.mtx.Unlock()
+	b.State = NewRunnerState(quorum, duty)
 
 	if logSummaryOnly(duty) {
 		b.resetPreConsensusLogSummary(duty.DutySlot())
@@ -502,9 +492,6 @@ func (b *BaseRunner) decide(
 
 // hasRunningDuty returns true if a new duty didn't start or an existing duty marked as finished
 func (b *BaseRunner) hasRunningDuty() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
 	if b.State == nil {
 		return false
 	}
@@ -513,16 +500,10 @@ func (b *BaseRunner) hasRunningDuty() bool {
 }
 
 func (b *BaseRunner) hasDutyAssigned() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
 	return b.State != nil
 }
 
 func (b *BaseRunner) hasDutyFinished() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
 	if b.State == nil {
 		return false
 	}

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -325,7 +325,11 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 			dutyRunner, found := c.Runners[slot]
 			c.mtx.RUnlock()
 			if !found {
-				logger.Debug("no committee runner found for slot, likely the runner got pruned due to being old")
+				// Old runners are pruned, timeout-event issuer is unaware of that - that's why we can end up here
+				return nil
+			}
+			if !dutyRunner.HasRunningDuty() {
+				// Duties terminate eventually, timeout-event issuer is unaware of that - that's why we can end up here
 				return nil
 			}
 

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -325,7 +325,8 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 			dutyRunner, found := c.Runners[slot]
 			c.mtx.RUnlock()
 			if !found {
-				return fmt.Errorf("no committee runner found for slot %d", slot)
+				logger.Debug("no committee runner found for slot, likely the runner got pruned due to being old")
+				return nil
 			}
 
 			timeoutData, err := eventMsg.GetTimeoutData()

--- a/protocol/v2/ssv/validator/timer.go
+++ b/protocol/v2/ssv/validator/timer.go
@@ -22,36 +22,26 @@ func (v *Validator) onTimeout(ctx context.Context, logger *zap.Logger, identifie
 		v.mtx.RLock() // read-lock for v.Queues
 		defer v.mtx.RUnlock()
 
-		// The relevant queue might not have been initialized yet, hence we need to check for nil here
+		// If the relevant queue hasn't been initialized yet, there probably isn't a running duty we can issue a
+		// timeout for, in practice this should never happen - but we need to handle this just in case.
 		q := v.Queues[identifier.GetRoleType()]
 		if q == nil {
 			return
 		}
 
-		runner := v.DutyRunners[identifier.GetRoleType()]
-		if runner == nil {
-			logger.Error("❗no duty runner found for role", fields.RunnerRole(identifier.GetRoleType()))
-			return
-		}
-		if !runner.HasRunningDuty() {
-			return
-		}
-
 		msg, err := v.createTimerMessage(identifier, height, round)
 		if err != nil {
-			logger.Debug("❗ failed to create timer msg", zap.Error(err))
+			logger.Error("❗ failed to create timer msg", zap.Error(err))
 			return
 		}
 		dec, err := queue.DecodeSSVMessage(msg)
 		if err != nil {
-			logger.Debug("❌ failed to decode timer msg", zap.Error(err))
+			logger.Error("❌ failed to decode timer msg", zap.Error(err))
 			return
 		}
 
 		if pushed := q.TryPush(dec); !pushed {
-			logger.Warn("❗️ dropping timeout message because the queue is full",
-				fields.RunnerRole(identifier.GetRoleType()),
-			)
+			logger.Error("❗️ dropping timeout message because the queue is full", fields.RunnerRole(identifier.GetRoleType()))
 			return
 		}
 	}
@@ -84,33 +74,30 @@ func (v *Validator) createTimerMessage(identifier spectypes.MessageID, height sp
 
 func (c *Committee) onTimeout(ctx context.Context, logger *zap.Logger, identifier spectypes.MessageID, height specqbft.Height) roundtimer.OnRoundTimeoutF {
 	return func(round specqbft.Round) {
-		c.mtx.RLock() // read-lock for c.Queues, c.Runners
+		c.mtx.RLock() // read-lock for c.Queues
 		defer c.mtx.RUnlock()
 
-		dr := c.Runners[phase0.Slot(height)]
-		if dr == nil { // only happens when we prune expired runners
-			logger.Debug("❗no committee runner found for slot")
-			return
-		}
-
-		hasDuty := dr.HasRunningDuty()
-		if !hasDuty {
+		// If the relevant queue hasn't been initialized yet, there probably isn't a running duty we can issue a
+		// timeout for, in practice this should never happen - but we need to handle this just in case.
+		// This is also possible if the queue got pruned already (due to becoming old and irrelevant).
+		q := c.Queues[phase0.Slot(height)]
+		if q.Q == nil {
 			return
 		}
 
 		msg, err := c.createTimerMessage(identifier, height, round)
 		if err != nil {
-			logger.Debug("❗ failed to create timer msg", zap.Error(err))
+			logger.Error("❗ failed to create timer msg", zap.Error(err))
 			return
 		}
 		dec, err := queue.DecodeSSVMessage(msg)
 		if err != nil {
-			logger.Debug("❌ failed to decode timer msg", zap.Error(err))
+			logger.Error("❌ failed to decode timer msg", zap.Error(err))
 			return
 		}
 
-		if pushed := c.Queues[phase0.Slot(height)].Q.TryPush(dec); !pushed {
-			logger.Warn("❗️ dropping timeout message because the queue is full", fields.RunnerRole(identifier.GetRoleType()))
+		if pushed := q.Q.TryPush(dec); !pushed {
+			logger.Error("❗️ dropping timeout message because the queue is full", fields.RunnerRole(identifier.GetRoleType()))
 		}
 	}
 }

--- a/protocol/v2/ssv/validator/timer.go
+++ b/protocol/v2/ssv/validator/timer.go
@@ -28,14 +28,12 @@ func (v *Validator) onTimeout(ctx context.Context, logger *zap.Logger, identifie
 			return
 		}
 
-		dr := v.DutyRunners[identifier.GetRoleType()]
-		if dr == nil {
-			// runner can be nil: expired committee runners are removed, but timeout event can still be. in this case we should just skip it
-			logger.Warn("❗no duty runner found for role", fields.RunnerRole(identifier.GetRoleType()))
+		runner := v.DutyRunners[identifier.GetRoleType()]
+		if runner == nil {
+			logger.Error("❗no duty runner found for role", fields.RunnerRole(identifier.GetRoleType()))
 			return
 		}
-		hasDuty := dr.HasRunningDuty()
-		if !hasDuty {
+		if !runner.HasRunningDuty() {
 			return
 		}
 

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -210,6 +210,11 @@ func (v *Validator) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 		case ssvtypes.Timeout:
 			span.AddEvent("process validator message = event(timeout)")
 
+			if !dutyRunner.HasRunningDuty() {
+				// Duties terminate eventually, timeout-event issuer is unaware of that - that's why we can end up here
+				return nil
+			}
+
 			timeoutData, err := eventMsg.GetTimeoutData()
 			if err != nil {
 				return fmt.Errorf("get timeout data: %w", err)


### PR DESCRIPTION
As per https://github.com/ssvlabs/ssv/pull/2659#discussion_r2704528406 there is no need for `BaseRunner.mtx` to exist,

this PR:
- removes `BaseRunner.mtx`
- documents the assumptions `BaseRunner`relies on to work correctly in the concurrent setting

This PR also supercedes https://github.com/ssvlabs/ssv/pull/2663 (+ #2663 would be an incomplete solution anyway).
