### PR TITLE
message-validation: cleanup & clarify

### DIFF
--- a/message/validation/consensus_state_test.go
+++ b/message/validation/consensus_state_test.go
@@ -22,8 +22,8 @@ func TestOperatorState(t *testing.T) {
 		const epoch = 1
 		signerState := &SignerState{Slot: slot}
 
-		os.SetSignerState(slot, epoch, signerState)
-		retrievedState := os.GetSignerState(slot)
+		os.SetSignerStateForSlot(slot, epoch, signerState)
+		retrievedState := os.GetSignerStateForSlot(slot)
 
 		require.NotNil(t, retrievedState)
 		require.EqualValues(t, retrievedState.Slot, slot)
@@ -34,7 +34,7 @@ func TestOperatorState(t *testing.T) {
 		os := newOperatorState(size)
 
 		const slot = 5
-		retrievedState := os.GetSignerState(slot)
+		retrievedState := os.GetSignerStateForSlot(slot)
 
 		require.Nil(t, retrievedState)
 	})
@@ -47,7 +47,7 @@ func TestOperatorState(t *testing.T) {
 		const epoch = 1
 		signerState := &SignerState{Slot: slot}
 
-		os.SetSignerState(slot, epoch, signerState)
+		os.SetSignerStateForSlot(slot, epoch, signerState)
 		require.EqualValues(t, os.MaxSlot(), slot)
 	})
 
@@ -59,7 +59,7 @@ func TestOperatorState(t *testing.T) {
 		const epoch = 1
 		signerState1 := &SignerState{Slot: slot}
 
-		os.SetSignerState(slot, epoch, signerState1)
+		os.SetSignerStateForSlot(slot, epoch, signerState1)
 
 		require.Equal(t, os.DutyCount(epoch), uint64(1))
 		require.Equal(t, os.DutyCount(epoch-1), uint64(0))
@@ -68,7 +68,7 @@ func TestOperatorState(t *testing.T) {
 		const epoch2 = 2
 		signerState2 := &SignerState{Slot: slot2}
 
-		os.SetSignerState(slot2, epoch2, signerState2)
+		os.SetSignerStateForSlot(slot2, epoch2, signerState2)
 
 		require.Equal(t, os.DutyCount(epoch2), uint64(1))
 		require.Equal(t, os.DutyCount(epoch), uint64(1))
@@ -83,12 +83,12 @@ func TestOperatorState(t *testing.T) {
 		const epoch = 1
 		signerState1 := &SignerState{Slot: slot}
 
-		os.SetSignerState(slot, epoch, signerState1)
+		os.SetSignerStateForSlot(slot, epoch, signerState1)
 		require.Equal(t, os.DutyCount(epoch), uint64(1))
 
 		const slot2 = 6
 		signerState2 := &SignerState{Slot: slot2}
-		os.SetSignerState(slot2, epoch, signerState2)
+		os.SetSignerStateForSlot(slot2, epoch, signerState2)
 
 		require.Equal(t, os.DutyCount(epoch), uint64(2))
 	})

--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -237,8 +237,7 @@ func (mv *messageValidator) validateQBFTLogic(
 			// Rule: Decided msg can't have the same signers as previously sent before for the same duty
 			if signerState.SeenSigners != nil {
 				if _, ok := signerState.SeenSigners[quorum.ToBitMask()]; ok {
-					e := ErrDecidedWithSameSigners
-					return e
+					return ErrDecidedWithSameSigners
 				}
 			}
 		}
@@ -339,7 +338,8 @@ func (mv *messageValidator) processSignerState(
 	signerState *SignerState,
 ) error {
 	if len(signedSSVMessage.FullData) != 0 && consensusMessage.MsgType == specqbft.ProposalMsgType {
-		signerState.HashedProposalData = &consensusMessage.Root
+		rootCopy := consensusMessage.Root // optimization: allows GC to collect consensusMessage
+		signerState.HashedProposalData = &rootCopy
 	}
 
 	signerCount := len(signedSSVMessage.OperatorIDs)

--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -216,8 +217,8 @@ func (mv *messageValidator) validateQBFTLogic(
 				if len(signedSSVMessage.FullData) != 0 && signerState.HashedProposalData != nil {
 					if *signerState.HashedProposalData != consensusMessage.Root {
 						e := ErrDifferentProposalData
-						e.want = "0x" + hex.EncodeToString((*signerState.HashedProposalData)[:])
-						e.got = "0x" + hex.EncodeToString(consensusMessage.Root[:])
+						e.want = hexutil.Bytes((*signerState.HashedProposalData)[:]).String()
+						e.got = hexutil.Bytes(consensusMessage.Root[:]).String()
 						return e
 					}
 				}

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -86,6 +86,7 @@ var (
 	ErrEstimatedRoundNotInAllowedSpread = Error{text: "message round is too far from estimated"}
 	ErrUnknownOperator                  = Error{text: "operator is unknown"}
 	ErrOperatorValidation               = Error{text: "failed to validate operator data"}
+	ErrDecidedWithSameSigners           = Error{text: "decided with same number of signers"}
 )
 
 // Messages with these errors are rejected (regardless of what peer they come from).
@@ -135,7 +136,6 @@ var (
 	ErrDuplicatedMessage                       = Error{text: "got duplicate message", reject: true}
 	ErrTooManyPartialSigMessage                = Error{text: "got more partial signature messages of a certain type than allowed", reject: true}
 	ErrDifferentProposalData                   = Error{text: "got different proposal data", reject: true}
-	ErrDecidedWithSameSigners                  = Error{text: "decided with same number of signers", reject: true}
 )
 
 func (mv *messageValidator) handleValidationError(ctx context.Context, peerID peer.ID, decodedMessage *queue.SSVMessage, err error) pubsub.ValidationResult {

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -65,7 +65,7 @@ func (e Error) Is(target error) bool {
 	return e.text == t.text
 }
 
-// Ignored errors.
+// Messages with these errors are ignored (or rejected if they come from the same peer as duplicates).
 var (
 	ErrWrongDomain                      = Error{text: "wrong domain"}
 	ErrNoShareMetadata                  = Error{text: "share has no metadata"}
@@ -76,7 +76,6 @@ var (
 	ErrLateSlotMessage                  = Error{text: "current time is above duty's start +34(committee and aggregator) or +3(else) slots"}
 	ErrSlotAlreadyAdvanced              = Error{text: "signer has already advanced to a later slot"}
 	ErrRoundAlreadyAdvanced             = Error{text: "signer has already advanced to a later round"}
-	ErrDecidedWithSameSigners           = Error{text: "decided with same number of signers"}
 	ErrPubSubDataTooBig                 = Error{text: "pub-sub message data too big"}
 	ErrIncorrectTopic                   = Error{text: "incorrect topic"}
 	ErrNonExistentCommitteeID           = Error{text: "committee ID doesn't exist"}
@@ -89,7 +88,7 @@ var (
 	ErrOperatorValidation               = Error{text: "failed to validate operator data"}
 )
 
-// Rejected errors.
+// Messages with these errors are rejected (regardless of what peer they come from).
 var (
 	ErrEmptyData                               = Error{text: "empty data", reject: true}
 	ErrMismatchedIdentifier                    = Error{text: "identifier mismatch", reject: true}
@@ -119,23 +118,24 @@ var (
 	ErrPartialSignatureTypeRoleMismatch        = Error{text: "partial signature type and role don't match", reject: true}
 	ErrNonDecidedWithMultipleSigners           = Error{text: "non-decided with multiple signers", reject: true}
 	ErrDecidedNotEnoughSigners                 = Error{text: "not enough signers in decided message", reject: true}
-	ErrDifferentProposalData                   = Error{text: "different proposal data", reject: true}
 	ErrMalformedPrepareJustifications          = Error{text: "malformed prepare justifications", reject: true}
 	ErrUnexpectedPrepareJustifications         = Error{text: "prepare justifications unexpected for this message type", reject: true}
 	ErrMalformedRoundChangeJustifications      = Error{text: "malformed round change justifications", reject: true}
 	ErrUnexpectedRoundChangeJustifications     = Error{text: "round change justifications unexpected for this message type", reject: true}
-	ErrNoPartialSignatureMessages              = Error{text: "no partial signature messages", reject: true}
+	ErrNoMessagesInPartialSigMessage           = Error{text: "no messages in partial signature messages", reject: true}
 	ErrNoValidators                            = Error{text: "no validators for this committee ID", reject: true}
 	ErrNoSignatures                            = Error{text: "no signatures", reject: true}
+	ErrTooManySignaturesInPartialSigMessage    = Error{text: "too many signatures in a partial-signature message", reject: true}
 	ErrSignersAndSignaturesWithDifferentLength = Error{text: "signature and operator ID length mismatch", reject: true}
-	ErrPartialSigOneSigner                     = Error{text: "partial signature message must have only one signer", reject: true}
+	ErrPartialSigMessageMustHaveOneSigner      = Error{text: "partial signature message must have exactly one signer", reject: true}
 	ErrPrepareOrCommitWithFullData             = Error{text: "prepare or commit with full data", reject: true}
 	ErrFullDataNotInConsensusMessage           = Error{text: "full data not in consensus message", reject: true}
 	ErrTripleValidatorIndexInPartialSignatures = Error{text: "triple validator index in partial signatures", reject: true}
 	ErrZeroRound                               = Error{text: "zero round", reject: true}
-	ErrDuplicatedMessage                       = Error{text: "message is duplicated", reject: true}
-	ErrInvalidPartialSignatureTypeCount        = Error{text: "sent more partial signature messages of a certain type than allowed", reject: true}
-	ErrTooManyPartialSignatureMessages         = Error{text: "too many partial signature messages", reject: true}
+	ErrDuplicatedMessage                       = Error{text: "got duplicate message", reject: true}
+	ErrTooManyPartialSigMessage                = Error{text: "got more partial signature messages of a certain type than allowed", reject: true}
+	ErrDifferentProposalData                   = Error{text: "got different proposal data", reject: true}
+	ErrDecidedWithSameSigners                  = Error{text: "decided with same number of signers", reject: true}
 )
 
 func (mv *messageValidator) handleValidationError(ctx context.Context, peerID peer.ID, decodedMessage *queue.SSVMessage, err error) pubsub.ValidationResult {

--- a/message/validation/signed_ssv_message.go
+++ b/message/validation/signed_ssv_message.go
@@ -101,10 +101,10 @@ func (mv *messageValidator) validateSSVMessage(ssvMessage *spectypes.SSVMessage)
 
 	// SSVMessage.Data must respect the size limit
 	if len(ssvMessage.Data) > maxPayloadDataSize {
-		err := ErrSSVDataTooBig
-		err.got = len(ssvMessage.Data)
-		err.want = maxPayloadDataSize
-		return err
+		e := ErrSSVDataTooBig
+		e.got = len(ssvMessage.Data)
+		e.want = maxPayloadDataSize
+		return e
 	}
 
 	switch ssvMessage.MsgType {

--- a/message/validation/signer_state.go
+++ b/message/validation/signer_state.go
@@ -7,15 +7,23 @@ import (
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 )
 
-// SignerState represents the state of a signer, including its start time, slot, round,
-// message counts, proposal data, and the number of duties performed in the current epoch.
+// SignerState represents the current state of a signer (an Operator running a Runner that performs partial-signing
+// for duties of some type: proposer, committee, etc.) for a particular slot.
 type SignerState struct {
-	Slot         phase0.Slot // index stores slot modulo, so we also need to store slot here
-	Round        specqbft.Round
+	// Slot records current slot of the signer.
+	Slot phase0.Slot
+
+	// Round records current QBFT round (relevant for duties that have QBFT consensus phase) of the signer.
+	Round specqbft.Round
+
+	// SeenMsgTypes tracks what messages we've seen from this signer so far.
 	SeenMsgTypes SeenMsgTypes
-	// Storing pointer to byte array instead of slice to reduce memory consumption when we don't need the hash.
+
+	// HashedProposalData records the 1st proposal we've seen from this signer.
+	// Storing a pointer to byte array instead of slice to reduce memory consumption when we don't need the hash.
 	// A nil slice could be an alternative, but it'd consume more memory, and we'd need to cast [32]byte returned by sha256.Sum256() to slice.
 	HashedProposalData *[32]byte
+
 	// Max possible map size for committee sizes:
 	//  4 (f=1): C(4,3)+C(4,4)=5
 	//  7 (f=2): C(7,5)+C(7,6)+C(7,7)=29

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -93,32 +93,33 @@ func (handler *msgIDHandler) Start() {
 
 // MsgID returns the msg_id function that calculates msg_id based on it's content.
 func (handler *msgIDHandler) MsgID(logger *zap.Logger) func(pmsg *ps_pb.Message) string {
-	return func(pmsg *ps_pb.Message) string {
-		if pmsg == nil {
+	return func(pMsg *ps_pb.Message) string {
+		if pMsg == nil {
 			return MsgIDEmptyMessage
 		}
 
-		messageData := pmsg.GetData()
+		messageData := pMsg.GetData()
 		if len(messageData) == 0 {
 			return MsgIDEmptyMessage
 		}
 
-		pid, err := peer.IDFromBytes(pmsg.GetFrom())
+		peerID, err := peer.IDFromBytes(pMsg.GetFrom())
 		if err != nil {
 			return MsgIDBadPeerID
 		}
 
-		mid := handler.pubsubMsgToMsgID(messageData)
+		msgID := handler.pubsubMsgToMsgID(messageData)
 
-		if len(mid) == 0 {
+		if len(msgID) == 0 {
 			logger.Debug("could not create msg_id",
-				zap.ByteString("seq_no", pmsg.GetSeqno()),
-				fields.PeerID(pid))
+				zap.ByteString("seq_no", pMsg.GetSeqno()),
+				fields.PeerID(peerID),
+			)
 			return MsgIDError
 		}
 
-		handler.Add(mid, pid)
-		return mid
+		handler.Add(msgID, peerID)
+		return msgID
 	}
 }
 


### PR DESCRIPTION
This PR implements simple refactoring of some message-validation code (pulled out of https://github.com/ssvlabs/ssv/pull/2635) preserving the same behavior, with the goal of making it more consistent, readable and better documented (clearing the ground for the follow-up validation-rules updates).

The only notable change (an optimization) in this PR is that, per Oleg's suggestion, we can [re-use the readily-available `consensusMessage.Root` value instead of re-computing fhe `FullDatasignedSSVMessage.FullData` hash from scratch](https://github.com/ssvlabs/ssv/pull/2635#discussion_r2672156832)