### PR TITLE
sync-committee-contribution: use the correct root(s) when calculating SyncCommitteeSubnetID

### DIFF
--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -39,6 +39,9 @@ type SyncCommitteeAggregatorRunner struct {
 
 	// ValCheck is used to validate the qbft-value(s) proposed by other Operators.
 	ValCheck ssv.ValueChecker
+
+	// rootToValidatorIdx is the root->validator mapping for the current duty.
+	rootToValidatorIdx map[phase0.Root]phase0.ValidatorIndex
 }
 
 func NewSyncCommitteeAggregatorRunner(
@@ -105,13 +108,13 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	r.measurements.EndPreConsensus()
 	recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleSyncCommitteeContribution)
 
-	// collect selection proofs and subnets
+	// Collect selection proofs and subnets. We must iterate the
 	//nolint: prealloc
 	var (
 		selectionProofs []phase0.BLSSignature
 		subnets         []uint64
 	)
-	for i, root := range roots {
+	for _, root := range roots {
 		// reconstruct selection proof sig
 		span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
 		sig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
@@ -132,8 +135,10 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 		}
 
 		// fetch sync committee contribution
-		span.AddEvent("fetching sync committee subnet ID")
-		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices[i]))
+		vIdx := r.rootToValidatorIdx[root]
+		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(
+			phase0.CommitteeIndex(r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices[vIdx]),
+		)
 
 		selectionProofs = append(selectionProofs, blsSigSelectionProof)
 		subnets = append(subnets, subnet)
@@ -481,8 +486,11 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 		Messages: []*spectypes.PartialSignatureMessage{},
 	}
 
-	for _, index := range r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices {
-		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(index))
+	// re-build the root->validator mapping for this duty
+	r.rootToValidatorIdx = make(map[phase0.Root]phase0.ValidatorIndex)
+
+	for _, vIdx := range r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices {
+		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(vIdx))
 		data := &altair.SyncAggregatorSelectionData{
 			Slot:              duty.DutySlot(),
 			SubcommitteeIndex: subnet,
@@ -501,6 +509,8 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 		}
 
 		msgs.Messages = append(msgs.Messages, msg)
+
+		r.rootToValidatorIdx[msg.SigningRoot] = phase0.ValidatorIndex(vIdx)
 	}
 
 	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -40,8 +40,8 @@ type SyncCommitteeAggregatorRunner struct {
 	// ValCheck is used to validate the qbft-value(s) proposed by other Operators.
 	ValCheck ssv.ValueChecker
 
-	// rootToValidatorIdx is the root->validator mapping for the current duty.
-	rootToValidatorIdx map[phase0.Root]phase0.ValidatorIndex
+	// rootToSyncCommitteeIdx is the root->validator_sync_committee_index mapping for the current duty.
+	rootToSyncCommitteeIdx map[phase0.Root]phase0.ValidatorIndex
 }
 
 func NewSyncCommitteeAggregatorRunner(
@@ -135,10 +135,8 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 		}
 
 		// fetch sync committee contribution
-		vIdx := r.rootToValidatorIdx[root]
-		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(
-			phase0.CommitteeIndex(r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices[vIdx]),
-		)
+		vIdx := r.rootToSyncCommitteeIdx[root]
+		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(vIdx))
 
 		selectionProofs = append(selectionProofs, blsSigSelectionProof)
 		subnets = append(subnets, subnet)
@@ -487,7 +485,7 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 	}
 
 	// re-build the root->validator mapping for this duty
-	r.rootToValidatorIdx = make(map[phase0.Root]phase0.ValidatorIndex)
+	r.rootToSyncCommitteeIdx = make(map[phase0.Root]phase0.ValidatorIndex)
 
 	for _, vIdx := range r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices {
 		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(vIdx))
@@ -510,7 +508,7 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 
 		msgs.Messages = append(msgs.Messages, msg)
 
-		r.rootToValidatorIdx[msg.SigningRoot] = phase0.ValidatorIndex(vIdx)
+		r.rootToSyncCommitteeIdx[msg.SigningRoot] = phase0.ValidatorIndex(vIdx)
 	}
 
 	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -135,7 +135,11 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 		}
 
 		// fetch sync committee contribution
-		vIdx := r.rootToSyncCommitteeIdx[root]
+		vIdx, ok := r.rootToSyncCommitteeIdx[root]
+		if !ok {
+			logger.Warn("root got a quorum, but is unknown to us", fields.Root(root))
+			continue
+		}
 		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(vIdx))
 
 		selectionProofs = append(selectionProofs, blsSigSelectionProof)


### PR DESCRIPTION
As per this find - https://github.com/ssvlabs/ssv/pull/2674#discussion_r2732719892 - we need to find correct/reliable way to calculate `SyncCommitteeSubnetID`