### PR TITLE
fix(ci): remove make tools to prevent uncontrolled tool upgrades

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,8 @@ jobs:
           cache: true
           cache-dependency-path: |
             go.sum
+            tool.sum
             ssvsigner/go.sum
-
-      - name: Run tools
-        run: make tools
 
       - name: Run make lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ ifeq ($(COVERAGE),true)
 	COV_CMD=-coverpkg=./... -covermode="atomic" -coverprofile="coverage.out"
 endif
 
-GET_TOOL=go get -modfile=tool.mod -tool
 RUN_TOOL=go tool -modfile=tool.mod
 SSVSIGNER_RUN_TOOL=go tool -modfile=../tool.mod
 
@@ -187,17 +186,6 @@ openapi:
 
 openapi-lint:
 	@SWAG='$(SWAG)' bash scripts/openapi.sh --lint
-
-.PHONY: tools
-tools:
-	$(GET_TOOL) golang.org/x/tools/cmd/goimports
-	$(GET_TOOL) go.uber.org/mock/mockgen
-	$(GET_TOOL) github.com/ferranbt/fastssz/sszgen
-	$(GET_TOOL) github.com/ethereum/go-ethereum/cmd/abigen
-	$(GET_TOOL) github.com/golangci/golangci-lint/v2/cmd/golangci-lint
-	$(GET_TOOL) golang.org/x/tools/cmd/deadcode
-	$(GET_TOOL) github.com/swaggo/swag/cmd/swag
-	$(RUN_TOOL)
 
 .PHONY: format
 format:


### PR DESCRIPTION
## Summary

- Removed `make tools` target that ran `go get -tool` for every tool on each CI run, upgrading them to latest unconditionally
- Removed `make tools` step from `lint.yml` — unnecessary with Go 1.24+ tool directives
- Added `tool.sum` to CI cache for faster builds

## Why

`golangci-lint` v2.9.0 was released requiring Go >= 1.25.0, which broke CI for all branches because `make tools` auto-upgraded it from the pinned v2.8.0.

With Go 1.24+ tool directives, `go tool -modfile=tool.mod <name>` automatically downloads and builds the tool at the version pinned in `tool.mod`. The `go get` calls were redundant and harmful.

## How tool upgrades work now

**Automated:** Renovate will open PRs when new tool versions are available — reviewed, tested, merged deliberately.

**Manual:**
```bash
go get -modfile=tool.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
# commit tool.mod + tool.sum
```
