### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/operator/duties/beacon_adapter.go
+++ b/operator/duties/beacon_adapter.go
@@ -203,10 +203,7 @@ func (p *prefetchingBeacon) ensureProposerEpoch(ctx context.Context, epoch phase
 	const batch = 2048
 	collected := make(map[phase0.ValidatorIndex]*eth2apiv1.ProposerDuty)
 	for i := 0; i < len(indices); i += batch {
-		end := i + batch
-		if end > len(indices) {
-			end = len(indices)
-		}
+		end := min(i+batch, len(indices))
 		part := indices[i:end]
 		start := time.Now()
 		duties, err := p.inner.ProposerDuties(ctx, epoch, part)
@@ -238,10 +235,7 @@ func (p *prefetchingBeacon) ensureSyncPeriod(ctx context.Context, epoch phase0.E
 	const batch = 2048
 	collected := make(map[phase0.ValidatorIndex]*eth2apiv1.SyncCommitteeDuty)
 	for i := 0; i < len(indices); i += batch {
-		end := i + batch
-		if end > len(indices) {
-			end = len(indices)
-		}
+		end := min(i+batch, len(indices))
 		part := indices[i:end]
 		start := time.Now()
 		duties, err := p.inner.SyncCommitteeDuties(ctx, epoch, part)


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.