### PR TITLE
spec tests: enable msg processing root check

### DIFF
--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -218,9 +218,10 @@ func (test *MsgProcessingSpecTest) RunAsPartOfMultiTest(t *testing.T, logger *za
 	postRoot, err := test.Runner.GetRoot()
 	require.NoError(t, err)
 
-	if test.PostDutyRunnerStateRoot != hex.EncodeToString(postRoot[:]) {
+	actualPostRoot := hex.EncodeToString(postRoot[:])
+	if test.PostDutyRunnerStateRoot != actualPostRoot {
 		diff := dumpState(t, test.Name, test.Runner, test.PostDutyRunnerState)
-		logger.Error("post runner state not equal", zap.String("state", diff))
+		require.EqualValues(t, test.PostDutyRunnerStateRoot, actualPostRoot, "post runner state not equal\n%s\n", diff)
 	}
 }
 

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -148,8 +148,13 @@ func (test *MsgProcessingSpecTest) runPreTesting(ctx context.Context, logger *za
 				lastErr = err
 			}
 			if test.DecidedSlashable && IsQBFTProposalMessage(msg) {
+				consensusMsg, err := specqbft.DecodeMessage(msg.SSVMessage.Data)
+				if err != nil {
+					panic(err)
+				}
+				slot := phase0.Slot(consensusMsg.Height)
 				for _, validatorShare := range test.Runner.GetShares() {
-					test.Runner.GetSigner().(*ekm.TestingKeyManagerAdapter).AddSlashableSlot(validatorShare.SharePubKey, spectestingutils.TestingDutySlot)
+					test.Runner.GetSigner().(*ekm.TestingKeyManagerAdapter).AddSlashableSlot(validatorShare.SharePubKey, slot)
 				}
 			}
 		}
@@ -185,6 +190,7 @@ func (test *MsgProcessingSpecTest) RunAsPartOfMultiTest(t *testing.T, logger *za
 	network := &spectestingutils.TestingNetwork{}
 	var beaconNetwork *protocoltesting.BeaconNodeWrapped
 	var committee []*spectypes.Operator
+	actualRunner := test.Runner
 
 	switch test.Runner.(type) {
 	case *runner.CommitteeRunner:
@@ -193,6 +199,7 @@ func (test *MsgProcessingSpecTest) RunAsPartOfMultiTest(t *testing.T, logger *za
 			runnerInstance = runner
 			break
 		}
+		actualRunner = runnerInstance
 		network = runnerInstance.GetNetwork().(*spectestingutils.TestingNetwork)
 		beaconNetwork = runnerInstance.GetBeaconNode().(*protocoltesting.BeaconNodeWrapped)
 		committee = c.CommitteeMember.Committee
@@ -215,12 +222,17 @@ func (test *MsgProcessingSpecTest) RunAsPartOfMultiTest(t *testing.T, logger *za
 	assertRootsRelaxed(t, test.BeaconBroadcastedRoots, beaconNetwork.GetBroadcastedRoots())
 
 	// post root
-	postRoot, err := test.Runner.GetRoot()
+	if !test.DontStartDuty {
+		if proposerRunner, ok := actualRunner.(*runner.ProposerRunner); ok {
+			normalizeExpectedProposerStartValues(proposerRunner)
+		}
+	}
+	postRoot, err := actualRunner.GetRoot()
 	require.NoError(t, err)
 
 	actualPostRoot := hex.EncodeToString(postRoot[:])
 	if test.PostDutyRunnerStateRoot != actualPostRoot {
-		diff := dumpState(t, test.Name, test.Runner, test.PostDutyRunnerState)
+		diff := dumpState(t, test.Name, actualRunner, test.PostDutyRunnerState)
 		require.EqualValues(t, test.PostDutyRunnerStateRoot, actualPostRoot, "post runner state not equal\n%s\n", diff)
 	}
 }
@@ -233,6 +245,11 @@ func (test *MsgProcessingSpecTest) overrideStateComparison(t *testing.T) {
 
 func overrideStateComparison(t *testing.T, test *MsgProcessingSpecTest, name string, testType string) {
 	r := runnerForTest(t, test.Runner, name, testType)
+	if !test.DontStartDuty {
+		if proposerRunner, ok := r.(*runner.ProposerRunner); ok {
+			normalizeExpectedProposerStartValues(proposerRunner)
+		}
+	}
 
 	test.PostDutyRunnerState = r
 


### PR DESCRIPTION
We currently don't fail spec tests on root mismatch in `MsgProcessingSpecTest`