### PR TITLE
Boole: fix Alan spec tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ spec-test:
 spec-test-alan:
 	@echo "Running spec tests against ssv-spec Alan"
 	@$(MAKE) spec-test-alan-deps
-	@SSV_SPEC_GOMOD=go.spec.alan.mod go test -tags "blst_enabled alan_spec" -timeout 90m ${COV_CMD} -race -count=1 -p 1 -v `go list ./... | grep spectest`
+	@go test -tags "blst_enabled alan_spec" -timeout 90m ${COV_CMD} -race -count=1 -p 1 -v `go list ./... | grep spectest`
 
 .PHONY: all-spec-test-raceless
 all-spec-test-raceless:
@@ -85,7 +85,7 @@ all-spec-test-raceless:
 all-spec-test-alan-raceless:
 	@echo "Running spec tests against ssv-spec Alan (raceless)"
 	@$(MAKE) spec-test-alan-deps
-	@SSV_SPEC_GOMOD=go.spec.alan.mod go test -tags "blst_enabled alan_spec" -timeout 90m ${COV_CMD} -p 1 -v ./protocol/...
+	@go test -tags "blst_enabled alan_spec" -timeout 90m ${COV_CMD} -p 1 -v ./protocol/...
 
 .PHONY: spec-test-alan-deps
 spec-test-alan-deps:

--- a/ibft/storage/spec_gomod_alan.go
+++ b/ibft/storage/spec_gomod_alan.go
@@ -1,0 +1,5 @@
+//go:build alan_spec
+
+package storage
+
+const specGoModFile = "go.spec.alan.mod"

--- a/ibft/storage/spec_gomod_default.go
+++ b/ibft/storage/spec_gomod_default.go
@@ -1,0 +1,5 @@
+//go:build !alan_spec
+
+package storage
+
+const specGoModFile = ""

--- a/ibft/storage/testutils.go
+++ b/ibft/storage/testutils.go
@@ -22,8 +22,7 @@ import (
 )
 
 var (
-	specGoModEnv = "SSV_SPEC_GOMOD"
-	specModule   = "github.com/ssvlabs/ssv-spec"
+	specModule = "github.com/ssvlabs/ssv-spec"
 )
 
 // TODO: add missing tests
@@ -339,7 +338,7 @@ func resolveModuleDirViaGoList(name string) (string, error) {
 }
 
 func specGoModArg() (string, bool) {
-	modPath := strings.TrimSpace(os.Getenv(specGoModEnv))
+	modPath := specGoModFile
 	if modPath == "" {
 		return "", false
 	}
@@ -356,7 +355,7 @@ func specGoModArg() (string, bool) {
 }
 
 func getGoModFile(path string) (*modfile.File, error) {
-	if modPath := os.Getenv(specGoModEnv); modPath != "" {
+	if modPath := specGoModFile; modPath != "" {
 		if !filepath.IsAbs(modPath) {
 			root, err := findModuleRoot(path)
 			if err != nil {

--- a/protocol/v2/qbft/spectest/qbft_mapping_alan_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_alan_test.go
@@ -5,6 +5,5 @@ package qbft
 import "testing"
 
 func TestQBFTMappingAlan(t *testing.T) {
-	t.Setenv("SSV_SPEC_GOMOD", "go.spec.alan.mod")
 	runQBFTMappingTest(t)
 }

--- a/protocol/v2/qbft/spectest/qbft_mapping_alan_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_alan_test.go
@@ -1,0 +1,10 @@
+//go:build alan_spec
+
+package qbft
+
+import "testing"
+
+func TestQBFTMappingAlan(t *testing.T) {
+	t.Setenv("SSV_SPEC_GOMOD", "go.spec.alan.mod")
+	runQBFTMappingTest(t)
+}

--- a/protocol/v2/qbft/spectest/qbft_mapping_default_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_default_test.go
@@ -1,0 +1,9 @@
+//go:build !alan_spec
+
+package qbft
+
+import "testing"
+
+func TestQBFTMapping(t *testing.T) {
+	runQBFTMappingTest(t)
+}

--- a/protocol/v2/qbft/spectest/qbft_mapping_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_test.go
@@ -18,7 +18,7 @@ import (
 	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
 )
 
-func TestQBFTMapping(t *testing.T) {
+func runQBFTMappingTest(t *testing.T) {
 	path, _ := os.Getwd()
 	jsonTests, err := storage.GenerateSpecTestJSON(path, "qbft")
 	require.NoError(t, err)
@@ -79,13 +79,10 @@ func TestQBFTMapping(t *testing.T) {
 			typedTest := &spectests.RoundRobinSpecTest{}
 			require.NoError(t, json.Unmarshal(byts, &typedTest))
 
-			t.Run(typedTest.TestName(), func(t *testing.T) { // using only spec struct so no need to run our version (TODO: check how we choose leader)
+			t.Run(typedTest.TestName(), func(t *testing.T) {
 				t.Parallel()
-				typedTest.Run(t)
+				runRoundRobinSpecTest(t, typedTest)
 			})
-			/*t.Run(typedTest.TestName(), func(t *testing.T) {
-				RunMsg(t, typedTest)
-			})*/
 		case reflect.TypeOf(&timeout.SpecTest{}).String():
 			byts, err := json.Marshal(test)
 			require.NoError(t, err)

--- a/protocol/v2/qbft/spectest/round_robin_runner_alan_test.go
+++ b/protocol/v2/qbft/spectest/round_robin_runner_alan_test.go
@@ -1,0 +1,28 @@
+//go:build alan_spec
+
+package qbft
+
+import (
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectests "github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
+	"github.com/stretchr/testify/require"
+
+	qbftimpl "github.com/ssvlabs/ssv/protocol/v2/qbft"
+)
+
+func runRoundRobinSpecTest(t *testing.T, test *spectests.RoundRobinSpecTest) {
+	require.Equal(t, len(test.Heights), len(test.Rounds))
+	require.Equal(t, len(test.Heights), len(test.Proposers))
+
+	for i, height := range test.Heights {
+		state := &specqbft.State{
+			Height:          height,
+			Round:           test.Rounds[i],
+			CommitteeMember: test.Share,
+		}
+		got := qbftimpl.RoundRobinProposerPreBooleFork(state, test.Rounds[i])
+		require.EqualValues(t, test.Proposers[i], got)
+	}
+}

--- a/protocol/v2/qbft/spectest/round_robin_runner_default_test.go
+++ b/protocol/v2/qbft/spectest/round_robin_runner_default_test.go
@@ -1,0 +1,13 @@
+//go:build !alan_spec
+
+package qbft
+
+import (
+	"testing"
+
+	spectests "github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
+)
+
+func runRoundRobinSpecTest(t *testing.T, test *spectests.RoundRobinSpecTest) {
+	test.Run(t)
+}

--- a/protocol/v2/ssv/spectest/ssv_mapping_alan_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_alan_test.go
@@ -5,6 +5,5 @@ package spectest
 import "testing"
 
 func TestSSVMappingAlan(t *testing.T) {
-	t.Setenv("SSV_SPEC_GOMOD", "go.spec.alan.mod")
 	runSSVMappingTest(t)
 }

--- a/protocol/v2/ssv/spectest/sync_committee_aggregator_proof_type_alan.go
+++ b/protocol/v2/ssv/spectest/sync_committee_aggregator_proof_type_alan.go
@@ -80,11 +80,28 @@ func normalizeAlanSyncCommitteeDuty(
 		t.Fatalf("sync committee duty is nil")
 	}
 
+	// Alan vectors are generated with sync committee indices [0,1,2].
+	// Newer fixtures may carry [0,129,257], which changes signing roots.
+	alanIndices := []spectypes.ValidatorSyncCommitteeIndex{0, 1, 2}
+
 	sharePubKey := phase0.BLSPubKey(validatorPubKey)
-	if duty.PubKey != sharePubKey || duty.ValidatorIndex != validatorIndex {
+	needsPatch := duty.PubKey != sharePubKey || duty.ValidatorIndex != validatorIndex
+	if len(duty.ValidatorSyncCommitteeIndices) != len(alanIndices) {
+		needsPatch = true
+	} else {
+		for i, idx := range duty.ValidatorSyncCommitteeIndices {
+			if idx != alanIndices[i] {
+				needsPatch = true
+				break
+			}
+		}
+	}
+
+	if needsPatch {
 		patched := *duty
 		patched.PubKey = sharePubKey
 		patched.ValidatorIndex = validatorIndex
+		patched.ValidatorSyncCommitteeIndices = alanIndices
 		return &patched
 	}
 


### PR DESCRIPTION
Alan spec tests got broken after merging something related to the round leader choice and the change of sync committee indices in spec

Blocker for https://github.com/ssvlabs/ssv/pull/2683 and https://github.com/ssvlabs/ssv/pull/2679