### PR TITLE
feat(runner): log signature on duty submission

### DIFF
--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash"
@@ -163,7 +164,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 		return fmt.Errorf("failed to submit aggregate and proof: %w", err)
 	}
 	const submittedAggregateAndProofEvent = "submitted aggregate and proof"
-	logger.Debug(submittedAggregateAndProofEvent)
+	logger.Debug(submittedAggregateAndProofEvent, zap.String("signature", hex.EncodeToString(fullSig)))
 	span.AddEvent(submittedAggregateAndProofEvent)
 
 	byts, err := res.MarshalSSZ()
@@ -325,7 +326,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	}
 
 	const submittingSignedAggregateProofEvent = "submitting signed aggregate and proof"
-	logger.Debug(submittingSignedAggregateProofEvent)
+	logger.Debug(submittingSignedAggregateProofEvent, zap.String("signature", hex.EncodeToString(specSig[:])))
 	span.AddEvent(submittingSignedAggregateProofEvent)
 
 	start := time.Now()

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -648,7 +648,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					return
 				}
 
-				vLogger.Debug("🧩 reconstructed partial signature")
+				vLogger.Debug("🧩 reconstructed partial signature", zap.String("signature", hex.EncodeToString(sig)))
 
 				signatureCh <- signatureResult{
 					validatorIndex: validatorIndex,

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -359,7 +359,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 
 	const submittingBlockProposalEvent = "submitting block proposal"
 	span.AddEvent(submittingBlockProposalEvent)
-	logger.Info(submittingBlockProposalEvent)
+	logger.Info(submittingBlockProposalEvent, zap.String("signature", hex.EncodeToString(specSig[:])))
 
 	// If this operator is the leader of the decided round and it originally
 	// fetched a full (non-blinded) block, prefer submitting the full locally

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -362,7 +363,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 
 			const submittingSyncCommitteeEvent = "submitting sync committee contribution"
 			span.AddEvent(submittingSyncCommitteeEvent)
-			logger.Debug(submittingSyncCommitteeEvent)
+			logger.Debug(submittingSyncCommitteeEvent, zap.String("signature", hex.EncodeToString(blsSignedContribAndProof[:])))
 
 			reqStart := time.Now()
 			err = r.GetBeaconNode().SubmitSignedContributionAndProof(ctx, signedContribAndProof)


### PR DESCRIPTION
Adds hex-encoded BLS signature to existing log lines when duties are submitted to the beacon chain, so you can actually see what signature was broadcast without having to dig through beacon node logs or add temporary logging.

Closes #2519.

**Notes**
In the committee runner, signatures are logged per-validator at reconstruction time. The submission happens later as a batch and the signatures are already embedded by that point. The aggregator selection proof logs post-submission because there's no existing pre-submission log line to attach it to.

Open to adjusting either if the team prefers a different placement.