### PR TITLE
feat(api): add pagination to validators list

### DIFF
--- a/api/handlers/validators/model.go
+++ b/api/handlers/validators/model.go
@@ -11,10 +11,13 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
-// requestClusters is a space-separated list of comma-separated lists of operator IDs.
-type requestClusters [][]uint64
+// Clusters represents clusters of operator IDs.
+//
+// Query format: space-separated list of comma-separated operator IDs (e.g. "1,2,3,4 5,6,7,8").
+// JSON format: array of arrays (e.g. [[1,2,3,4],[5,6,7,8]]).
+type Clusters [][]uint64
 
-func (c *requestClusters) Bind(value string) error {
+func (c *Clusters) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
@@ -32,22 +35,39 @@ func (c *requestClusters) Bind(value string) error {
 	return nil
 }
 
-type validatorJSON struct {
+// ValidatorsRequest represents the filters accepted by the validators endpoint.
+type ValidatorsRequest struct {
+	Owners      api.HexSlice          `json:"owners" form:"owners" swaggertype:"array,string" format:"hex"`
+	Operators   api.Uint64Slice       `json:"operators" form:"operators" swaggertype:"array,integer" format:"int64" minimum:"0"`
+	Clusters    Clusters              `json:"clusters" form:"clusters"`
+	Subclusters Clusters              `json:"subclusters" form:"subclusters"`
+	PubKeys     api.HexSlice          `json:"pubkeys" form:"pubkeys" swaggertype:"array,string" format:"hex"`
+	Indices     api.Uint64Slice       `json:"indices" form:"indices" swaggertype:"array,integer" format:"int64" minimum:"0"`
+	Pagination  api.PaginationRequest `json:"pagination" form:"pagination"`
+}
+
+// ValidatorsResponse represents the response from the validators endpoint.
+type ValidatorsResponse struct {
+	Data       []*Validator            `json:"data"`
+	Pagination *api.PaginationResponse `json:"pagination,omitempty"`
+}
+
+type Validator struct {
 	PubKey          api.Hex                `json:"public_key"`
-	Index           phase0.ValidatorIndex  `json:"index"`
+	Index           phase0.ValidatorIndex  `json:"index" swaggertype:"string" example:"123"`
 	Status          string                 `json:"status"`
-	ActivationEpoch phase0.Epoch           `json:"activation_epoch"`
-	ExitEpoch       phase0.Epoch           `json:"exit_epoch"`
+	ActivationEpoch phase0.Epoch           `json:"activation_epoch" swaggertype:"string" example:"0"`
+	ExitEpoch       phase0.Epoch           `json:"exit_epoch" swaggertype:"string" example:"0"`
 	Owner           api.Hex                `json:"owner"`
-	Committee       []spectypes.OperatorID `json:"committee"`
+	Committee       []spectypes.OperatorID `json:"committee" swaggertype:"array,integer" format:"int64" minimum:"0"`
 	Quorum          uint64                 `json:"quorum"`
 	PartialQuorum   uint64                 `json:"partial_quorum"`
 	Graffiti        string                 `json:"graffiti"`
 	Liquidated      bool                   `json:"liquidated"`
 }
 
-func validatorFromShare(share *types.SSVShare) *validatorJSON {
-	v := &validatorJSON{
+func validatorFromShare(share *types.SSVShare) *Validator {
+	v := &Validator{
 		PubKey: api.Hex(share.ValidatorPubKey[:]),
 		Owner:  api.Hex(share.OwnerAddress[:]),
 		Committee: func() []spectypes.OperatorID {

--- a/api/handlers/validators/validators.go
+++ b/api/handlers/validators/validators.go
@@ -2,7 +2,9 @@ package validators
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -18,21 +20,37 @@ type Validators struct {
 }
 
 func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
-	var request struct {
-		Owners      api.HexSlice    `json:"owners" form:"owners"`
-		Operators   api.Uint64Slice `json:"operators" form:"operators"`
-		Clusters    requestClusters `json:"clusters" form:"clusters"`
-		Subclusters requestClusters `json:"subclusters" form:"subclusters"`
-		PubKeys     api.HexSlice    `json:"pubkeys" form:"pubkeys"`
-		Indices     api.Uint64Slice `json:"indices" form:"indices"`
+	const (
+		defaultPerPage = uint64(1000)
+		maxPerPage     = uint64(10000)
+	)
+
+	if r.URL.Query().Has("page") || r.URL.Query().Has("per_page") || r.URL.Query().Has("pagination") {
+		return api.BadRequestError(fmt.Errorf("pagination must be provided in request body"))
 	}
-	var response struct {
-		Data []*validatorJSON `json:"data"`
+
+	var request struct {
+		Owners      api.HexSlice           `json:"owners" form:"owners"`
+		Operators   api.Uint64Slice        `json:"operators" form:"operators"`
+		Clusters    requestClusters        `json:"clusters" form:"clusters"`
+		Subclusters requestClusters        `json:"subclusters" form:"subclusters"`
+		PubKeys     api.HexSlice           `json:"pubkeys" form:"pubkeys"`
+		Indices     api.Uint64Slice        `json:"indices" form:"indices"`
+		Pagination  api.OptionalPagination `json:"pagination" form:"pagination"`
 	}
 
 	if err := api.Bind(r, &request); err != nil {
-		return err
+		return api.BadRequestError(err)
 	}
+
+	paginationRequest, err := request.Pagination.ToRequest(api.PaginationOptions{
+		DefaultPerPage: defaultPerPage,
+		MaxPerPage:     maxPerPage,
+	})
+	if err != nil {
+		return api.BadRequestError(err)
+	}
+	paginationRequested := paginationRequest != nil
 
 	var filters []registrystorage.SharesFilter
 	if len(request.Owners) > 0 {
@@ -55,10 +73,40 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	shares := h.Shares.List(nil, filters...)
-	response.Data = make([]*validatorJSON, len(shares))
-	for i, share := range shares {
+
+	// If no pagination requested, keep retro-compatibility with old response format
+	if !paginationRequested {
+		var response struct {
+			Data []*validatorJSON `json:"data"`
+		}
+		response.Data = make([]*validatorJSON, len(shares))
+		for i, share := range shares {
+			response.Data[i] = validatorFromShare(share)
+		}
+		return api.Render(w, r, response)
+	}
+
+	// Ensure deterministic ordering for pagination.
+	sort.Slice(shares, func(i, j int) bool {
+		return bytes.Compare(shares[i].ValidatorPubKey[:], shares[j].ValidatorPubKey[:]) < 0
+	})
+
+	total := uint64(len(shares))
+	start, end := paginationRequest.SliceBounds(total)
+
+	var response struct {
+		Data       []*validatorJSON `json:"data"`
+		Pagination api.Pagination   `json:"pagination"`
+	}
+
+	pagedShares := shares[start:end]
+	response.Data = make([]*validatorJSON, len(pagedShares))
+	for i, share := range pagedShares {
 		response.Data[i] = validatorFromShare(share)
 	}
+
+	response.Pagination = api.PaginationFromRequest(*paginationRequest, total)
+
 	return api.Render(w, r, response)
 }
 

--- a/api/handlers/validators/validators.go
+++ b/api/handlers/validators/validators.go
@@ -19,6 +19,18 @@ type Validators struct {
 	Shares registrystorage.Shares
 }
 
+// List godoc
+// @Summary Get validators
+// @Description Returns the list of validators managed by the SSV node. Pagination is provided via the JSON request body under "pagination".
+// @Tags Validators
+// @Accept json
+// @Produce json
+// @Param request body ValidatorsRequest false "Filters and pagination as JSON body"
+// @Success 200 {object} ValidatorsResponse
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 429 {object} api.ErrorResponse "Too Many Requests"
+// @Failure 500 {object} api.ErrorResponse
+// @Router /v1/validators [get]
 func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	const (
 		defaultPerPage = uint64(1000)
@@ -29,21 +41,12 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 		return api.BadRequestError(fmt.Errorf("pagination must be provided in request body"))
 	}
 
-	var request struct {
-		Owners            api.HexSlice          `json:"owners" form:"owners"`
-		Operators         api.Uint64Slice       `json:"operators" form:"operators"`
-		Clusters          requestClusters       `json:"clusters" form:"clusters"`
-		Subclusters       requestClusters       `json:"subclusters" form:"subclusters"`
-		PubKeys           api.HexSlice          `json:"pubkeys" form:"pubkeys"`
-		Indices           api.Uint64Slice       `json:"indices" form:"indices"`
-		PaginationRequest api.PaginationRequest `json:"pagination" form:"pagination"`
-	}
-
+	var request ValidatorsRequest
 	if err := api.Bind(r, &request); err != nil {
 		return api.BadRequestError(err)
 	}
 
-	pagination, err := request.PaginationRequest.ToPagination(api.PaginationOptions{
+	pagination, err := request.Pagination.ToPagination(api.PaginationOptions{
 		DefaultPerPage: defaultPerPage,
 		MaxPerPage:     maxPerPage,
 	})
@@ -74,12 +77,10 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 
 	shares := h.Shares.List(nil, filters...)
 
-	// If no pagination requested, keep retro-compatibility with old response format
+	var response ValidatorsResponse
+
 	if !paginationRequested {
-		var response struct {
-			Data []*validatorJSON `json:"data"`
-		}
-		response.Data = make([]*validatorJSON, len(shares))
+		response.Data = make([]*Validator, len(shares))
 		for i, share := range shares {
 			response.Data[i] = validatorFromShare(share)
 		}
@@ -94,18 +95,14 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	total := uint64(len(shares))
 	start, end := pagination.SliceBounds(total)
 
-	var response struct {
-		Data               []*validatorJSON       `json:"data"`
-		PaginationResponse api.PaginationResponse `json:"pagination"`
-	}
-
 	pagedShares := shares[start:end]
-	response.Data = make([]*validatorJSON, len(pagedShares))
+	response.Data = make([]*Validator, len(pagedShares))
 	for i, share := range pagedShares {
 		response.Data[i] = validatorFromShare(share)
 	}
 
-	response.PaginationResponse = api.PaginationResponseFromPagination(*pagination, total)
+	p := api.PaginationResponseFromPagination(*pagination, total)
+	response.Pagination = &p
 
 	return api.Render(w, r, response)
 }
@@ -135,7 +132,7 @@ func byOperators(operators []uint64) registrystorage.SharesFilter {
 }
 
 // byClusters returns a filter that matches shares that match or contain any of the given clusters.
-func byClusters(clusters requestClusters, contains bool) registrystorage.SharesFilter {
+func byClusters(clusters Clusters, contains bool) registrystorage.SharesFilter {
 	return func(share *types.SSVShare) bool {
 		shareCommittee := make([]string, len(share.Committee))
 		for i, c := range share.Committee {

--- a/api/handlers/validators/validators.go
+++ b/api/handlers/validators/validators.go
@@ -30,27 +30,27 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var request struct {
-		Owners      api.HexSlice           `json:"owners" form:"owners"`
-		Operators   api.Uint64Slice        `json:"operators" form:"operators"`
-		Clusters    requestClusters        `json:"clusters" form:"clusters"`
-		Subclusters requestClusters        `json:"subclusters" form:"subclusters"`
-		PubKeys     api.HexSlice           `json:"pubkeys" form:"pubkeys"`
-		Indices     api.Uint64Slice        `json:"indices" form:"indices"`
-		Pagination  api.OptionalPagination `json:"pagination" form:"pagination"`
+		Owners            api.HexSlice          `json:"owners" form:"owners"`
+		Operators         api.Uint64Slice       `json:"operators" form:"operators"`
+		Clusters          requestClusters       `json:"clusters" form:"clusters"`
+		Subclusters       requestClusters       `json:"subclusters" form:"subclusters"`
+		PubKeys           api.HexSlice          `json:"pubkeys" form:"pubkeys"`
+		Indices           api.Uint64Slice       `json:"indices" form:"indices"`
+		PaginationRequest api.PaginationRequest `json:"pagination" form:"pagination"`
 	}
 
 	if err := api.Bind(r, &request); err != nil {
 		return api.BadRequestError(err)
 	}
 
-	paginationRequest, err := request.Pagination.ToRequest(api.PaginationOptions{
+	pagination, err := request.PaginationRequest.ToPagination(api.PaginationOptions{
 		DefaultPerPage: defaultPerPage,
 		MaxPerPage:     maxPerPage,
 	})
 	if err != nil {
 		return api.BadRequestError(err)
 	}
-	paginationRequested := paginationRequest != nil
+	paginationRequested := pagination != nil
 
 	var filters []registrystorage.SharesFilter
 	if len(request.Owners) > 0 {
@@ -92,11 +92,11 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 	})
 
 	total := uint64(len(shares))
-	start, end := paginationRequest.SliceBounds(total)
+	start, end := pagination.SliceBounds(total)
 
 	var response struct {
-		Data       []*validatorJSON `json:"data"`
-		Pagination api.Pagination   `json:"pagination"`
+		Data               []*validatorJSON       `json:"data"`
+		PaginationResponse api.PaginationResponse `json:"pagination"`
 	}
 
 	pagedShares := shares[start:end]
@@ -105,7 +105,7 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 		response.Data[i] = validatorFromShare(share)
 	}
 
-	response.Pagination = api.PaginationFromRequest(*paginationRequest, total)
+	response.PaginationResponse = api.PaginationResponseFromPagination(*pagination, total)
 
 	return api.Render(w, r, response)
 }

--- a/api/handlers/validators/validators.go
+++ b/api/handlers/validators/validators.go
@@ -79,6 +79,7 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 
 	var response ValidatorsResponse
 
+	// if no pagination requested, return retro-compatible response without pagination metadata
 	if !paginationRequested {
 		response.Data = make([]*Validator, len(shares))
 		for i, share := range shares {

--- a/api/handlers/validators/validators.go
+++ b/api/handlers/validators/validators.go
@@ -102,7 +102,7 @@ func (h *Validators) List(w http.ResponseWriter, r *http.Request) error {
 		response.Data[i] = validatorFromShare(share)
 	}
 
-	p := api.PaginationResponseFromPagination(*pagination, total)
+	p := api.PaginationResponseFromPagination(pagination, total)
 	response.Pagination = &p
 
 	return api.Render(w, r, response)

--- a/api/handlers/validators/validators_test.go
+++ b/api/handlers/validators/validators_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
@@ -459,7 +460,7 @@ func newMockShares(shares []*types.SSVShare) *mockShares {
 // List returns shares that match all the given filters.
 func (m *mockShares) List(_ basedb.Reader, filters ...storage.SharesFilter) []*types.SSVShare {
 	if len(filters) == 0 {
-		return m.shares
+		return slices.Clone(m.shares)
 	}
 
 	var result []*types.SSVShare
@@ -628,4 +629,139 @@ func TestValidatorsList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidatorsList_Pagination(t *testing.T) {
+	t.Parallel()
+
+	makeShare := func(pubKeyFirstByte byte) *types.SSVShare {
+		share := mockFullShare()
+		share.ValidatorPubKey[0] = pubKeyFirstByte
+		share.ValidatorIndex = phase0.ValidatorIndex(pubKeyFirstByte)
+		return share
+	}
+
+	shares := []*types.SSVShare{
+		makeShare(5),
+		makeShare(1),
+		makeShare(3),
+		makeShare(2),
+		makeShare(4),
+	}
+
+	t.Run("backwards compatible without pagination params", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", "/validators", strings.NewReader(`{}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &Validators{Shares: newMockShares(shares)}
+
+		err = handler.List(rr, req)
+		require.NoError(t, err)
+
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+		_, hasPagination := raw["pagination"]
+		require.False(t, hasPagination)
+	})
+
+	t.Run("page and per_page", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", "/validators", strings.NewReader(`{"pagination":{"page":1,"per_page":2}}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &Validators{Shares: newMockShares(shares)}
+
+		err = handler.List(rr, req)
+		require.NoError(t, err)
+
+		var response struct {
+			Data       []*validatorJSON `json:"data"`
+			Pagination struct {
+				Page       uint64 `json:"page"`
+				PerPage    uint64 `json:"per_page"`
+				Total      uint64 `json:"total"`
+				TotalPages uint64 `json:"total_pages"`
+			} `json:"pagination"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+		require.Len(t, response.Data, 2)
+		require.Equal(t, uint64(1), response.Pagination.Page)
+		require.Equal(t, uint64(2), response.Pagination.PerPage)
+		require.Equal(t, uint64(5), response.Pagination.Total)
+		require.Equal(t, uint64(3), response.Pagination.TotalPages)
+
+		// Sorted by public key, so 1 then 2.
+		require.Equal(t, byte(1), response.Data[0].PubKey[0])
+		require.Equal(t, byte(2), response.Data[1].PubKey[0])
+	})
+
+	t.Run("per_page without page defaults to page 1", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", "/validators", strings.NewReader(`{"pagination":{"per_page":2}}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &Validators{Shares: newMockShares(shares)}
+
+		err = handler.List(rr, req)
+		require.NoError(t, err)
+
+		var response struct {
+			Pagination struct {
+				Page    uint64 `json:"page"`
+				PerPage uint64 `json:"per_page"`
+			} `json:"pagination"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		require.Equal(t, uint64(1), response.Pagination.Page)
+		require.Equal(t, uint64(2), response.Pagination.PerPage)
+	})
+
+	t.Run("page without per_page defaults to per_page 1000", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", "/validators", strings.NewReader(`{"pagination":{"page":1}}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &Validators{Shares: newMockShares(shares)}
+
+		err = handler.List(rr, req)
+		require.NoError(t, err)
+
+		var response struct {
+			Pagination struct {
+				Page    uint64 `json:"page"`
+				PerPage uint64 `json:"per_page"`
+			} `json:"pagination"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		require.Equal(t, uint64(1), response.Pagination.Page)
+		require.Equal(t, uint64(1000), response.Pagination.PerPage)
+	})
+
+	t.Run("page 0 is invalid when provided", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", "/validators", strings.NewReader(`{"pagination":{"page":0,"per_page":2}}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &Validators{Shares: newMockShares(shares)}
+
+		err = handler.List(rr, req)
+		require.Error(t, err)
+	})
 }

--- a/api/handlers/validators/validators_test.go
+++ b/api/handlers/validators/validators_test.go
@@ -91,49 +91,49 @@ func TestByClusters(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		clusters  requestClusters
+		clusters  Clusters
 		contains  bool
 		shares    []*types.SSVShare
 		expectRes []bool
 	}{
 		{
 			name:      "exact match",
-			clusters:  requestClusters{{10, 20, 30}},
+			clusters:  Clusters{{10, 20, 30}},
 			contains:  false,
 			shares:    []*types.SSVShare{mockShare(10, 20, 30), mockShare(40, 50, 60)},
 			expectRes: []bool{true, false},
 		},
 		{
 			name:      "substring match",
-			clusters:  requestClusters{{10, 20}},
+			clusters:  Clusters{{10, 20}},
 			contains:  true,
 			shares:    []*types.SSVShare{mockShare(10, 20, 30), mockShare(40, 50, 60)},
 			expectRes: []bool{true, false},
 		},
 		{
 			name:      "no match",
-			clusters:  requestClusters{{40, 50}},
+			clusters:  Clusters{{40, 50}},
 			contains:  false,
 			shares:    []*types.SSVShare{mockShare(10, 20, 30), mockShare(40, 50, 60)},
 			expectRes: []bool{false, false},
 		},
 		{
 			name:      "no match with contains",
-			clusters:  requestClusters{{70, 80}},
+			clusters:  Clusters{{70, 80}},
 			contains:  true,
 			shares:    []*types.SSVShare{mockShare(10, 20, 30), mockShare(40, 50, 60)},
 			expectRes: []bool{false, false},
 		},
 		{
 			name:      "mismatch lengths",
-			clusters:  requestClusters{{10, 20, 30}},
+			clusters:  Clusters{{10, 20, 30}},
 			contains:  false,
 			shares:    []*types.SSVShare{mockShare(10, 20), mockShare(40, 50, 60)},
 			expectRes: []bool{false, false},
 		},
 		{
 			name:     "multiple clusters",
-			clusters: requestClusters{{20, 30, 40}, {80, 90, 100}},
+			clusters: Clusters{{20, 30, 40}, {80, 90, 100}},
 			contains: false,
 			shares: []*types.SSVShare{
 				mockShare(20, 30, 40),
@@ -147,7 +147,7 @@ func TestByClusters(t *testing.T) {
 		},
 		{
 			name:     "multiple clusters with contains",
-			clusters: requestClusters{{20, 30, 40}, {80, 90, 100}},
+			clusters: Clusters{{20, 30, 40}, {80, 90, 100}},
 			contains: true,
 			shares: []*types.SSVShare{
 				mockShare(10, 20, 30, 40, 50),
@@ -395,15 +395,15 @@ func TestValidatorFromShare(t *testing.T) {
 	})
 }
 
-// TestRequestClustersBind tests the Bind method of requestClusters.
-func TestRequestClustersBind(t *testing.T) {
+// TestClustersBind tests the Bind method of Clusters.
+func TestClustersBind(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
 		input     string
 		wantError bool
-		expected  requestClusters
+		expected  Clusters
 	}{
 		{
 			name:      "empty string",
@@ -415,13 +415,13 @@ func TestRequestClustersBind(t *testing.T) {
 			name:      "single cluster",
 			input:     "1,2,3",
 			wantError: false,
-			expected:  requestClusters{{1, 2, 3}},
+			expected:  Clusters{{1, 2, 3}},
 		},
 		{
 			name:      "multiple clusters",
 			input:     "1,2,3 4,5,6 7,8,9",
 			wantError: false,
-			expected:  requestClusters{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+			expected:  Clusters{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 		},
 		{
 			name:      "invalid number",
@@ -434,7 +434,7 @@ func TestRequestClustersBind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var clusters requestClusters
+			var clusters Clusters
 			err := clusters.Bind(tt.input)
 
 			if tt.wantError {
@@ -603,7 +603,7 @@ func TestValidatorsList(t *testing.T) {
 			require.Equal(t, tc.wantStatus, rr.Code)
 
 			var response struct {
-				Data []*validatorJSON `json:"data"`
+				Data []*Validator `json:"data"`
 			}
 
 			err = json.Unmarshal(rr.Body.Bytes(), &response)
@@ -682,7 +682,7 @@ func TestValidatorsList_Pagination(t *testing.T) {
 		require.NoError(t, err)
 
 		var response struct {
-			Data       []*validatorJSON `json:"data"`
+			Data       []*Validator `json:"data"`
 			Pagination struct {
 				Page       uint64 `json:"page"`
 				PerPage    uint64 `json:"per_page"`

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/bits"
+)
+
+type PaginationOptions struct {
+	DefaultPerPage uint64
+	MaxPerPage     uint64
+}
+
+type OptionalPagination struct {
+	Set bool `json:"-"`
+
+	Page    *uint64 `json:"page,omitempty"`
+	PerPage *uint64 `json:"per_page,omitempty"`
+}
+
+func (p *OptionalPagination) Bind(value string) error {
+	if value == "" {
+		return nil
+	}
+	return fmt.Errorf("pagination must be provided in request body")
+}
+
+func (p *OptionalPagination) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*p = OptionalPagination{}
+		return nil
+	}
+
+	var tmp struct {
+		Page    *uint64 `json:"page"`
+		PerPage *uint64 `json:"per_page"`
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	p.Set = true
+	p.Page = tmp.Page
+	p.PerPage = tmp.PerPage
+	return nil
+}
+
+func (p OptionalPagination) ToRequest(opts PaginationOptions) (*PaginationRequest, error) {
+	if !p.Set {
+		return nil, nil
+	}
+
+	var req PaginationRequest
+
+	if p.Page != nil {
+		if *p.Page == 0 {
+			return nil, fmt.Errorf("page must be >= 1")
+		}
+		req.Page = *p.Page
+	}
+	if p.PerPage != nil {
+		if *p.PerPage == 0 {
+			return nil, fmt.Errorf("per_page must be >= 1")
+		}
+		req.PerPage = *p.PerPage
+	}
+
+	if req.Page == 0 {
+		req.Page = 1
+	}
+	if req.PerPage == 0 {
+		req.PerPage = opts.DefaultPerPage
+	}
+	if opts.MaxPerPage > 0 && req.PerPage > opts.MaxPerPage {
+		return nil, fmt.Errorf("per_page must be <= %d", opts.MaxPerPage)
+	}
+
+	return &req, nil
+}
+
+type PaginationRequest struct {
+	Page    uint64
+	PerPage uint64
+}
+
+type Pagination struct {
+	Page       uint64 `json:"page"`
+	PerPage    uint64 `json:"per_page"`
+	Total      uint64 `json:"total"`
+	TotalPages uint64 `json:"total_pages"`
+}
+
+// SliceBounds returns safe [start,end) bounds for slicing a collection with the given total length.
+func (p PaginationRequest) SliceBounds(total uint64) (start, end uint64) {
+	if p.Page == 0 || p.PerPage == 0 {
+		return 0, 0
+	}
+
+	pageIndex := p.Page - 1
+	hi, start := bits.Mul64(pageIndex, p.PerPage)
+	if hi != 0 || start > total {
+		start = total
+	}
+
+	end, carry := bits.Add64(start, p.PerPage, 0)
+	if carry != 0 || end > total {
+		end = total
+	}
+
+	return start, end
+}
+
+func PaginationFromRequest(p PaginationRequest, total uint64) Pagination {
+	out := Pagination{
+		Page:    p.Page,
+		PerPage: p.PerPage,
+		Total:   total,
+	}
+	if total > 0 && p.PerPage > 0 {
+		out.TotalPages = total / p.PerPage
+		if total%p.PerPage != 0 {
+			out.TotalPages++
+		}
+	}
+	return out
+}

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -11,23 +11,23 @@ type PaginationOptions struct {
 	MaxPerPage     uint64
 }
 
-type OptionalPagination struct {
+type PaginationRequest struct {
 	Set bool `json:"-"`
 
 	Page    *uint64 `json:"page,omitempty"`
 	PerPage *uint64 `json:"per_page,omitempty"`
 }
 
-func (p *OptionalPagination) Bind(value string) error {
+func (p *PaginationRequest) Bind(value string) error {
 	if value == "" {
 		return nil
 	}
 	return fmt.Errorf("pagination must be provided in request body")
 }
 
-func (p *OptionalPagination) UnmarshalJSON(data []byte) error {
+func (p *PaginationRequest) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
-		*p = OptionalPagination{}
+		*p = PaginationRequest{}
 		return nil
 	}
 
@@ -45,45 +45,45 @@ func (p *OptionalPagination) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p OptionalPagination) ToRequest(opts PaginationOptions) (*PaginationRequest, error) {
+func (p PaginationRequest) ToPagination(opts PaginationOptions) (*Pagination, error) {
 	if !p.Set {
 		return nil, nil
 	}
 
-	var req PaginationRequest
+	var pagination Pagination
 
 	if p.Page != nil {
 		if *p.Page == 0 {
 			return nil, fmt.Errorf("page must be >= 1")
 		}
-		req.Page = *p.Page
+		pagination.Page = *p.Page
 	}
 	if p.PerPage != nil {
 		if *p.PerPage == 0 {
 			return nil, fmt.Errorf("per_page must be >= 1")
 		}
-		req.PerPage = *p.PerPage
+		pagination.PerPage = *p.PerPage
 	}
 
-	if req.Page == 0 {
-		req.Page = 1
+	if pagination.Page == 0 {
+		pagination.Page = 1
 	}
-	if req.PerPage == 0 {
-		req.PerPage = opts.DefaultPerPage
+	if pagination.PerPage == 0 {
+		pagination.PerPage = opts.DefaultPerPage
 	}
-	if opts.MaxPerPage > 0 && req.PerPage > opts.MaxPerPage {
+	if opts.MaxPerPage > 0 && pagination.PerPage > opts.MaxPerPage {
 		return nil, fmt.Errorf("per_page must be <= %d", opts.MaxPerPage)
 	}
 
-	return &req, nil
+	return &pagination, nil
 }
 
-type PaginationRequest struct {
+type Pagination struct {
 	Page    uint64
 	PerPage uint64
 }
 
-type Pagination struct {
+type PaginationResponse struct {
 	Page       uint64 `json:"page"`
 	PerPage    uint64 `json:"per_page"`
 	Total      uint64 `json:"total"`
@@ -91,7 +91,7 @@ type Pagination struct {
 }
 
 // SliceBounds returns safe [start,end) bounds for slicing a collection with the given total length.
-func (p PaginationRequest) SliceBounds(total uint64) (start, end uint64) {
+func (p Pagination) SliceBounds(total uint64) (start, end uint64) {
 	if p.Page == 0 || p.PerPage == 0 {
 		return 0, 0
 	}
@@ -110,8 +110,8 @@ func (p PaginationRequest) SliceBounds(total uint64) (start, end uint64) {
 	return start, end
 }
 
-func PaginationFromRequest(p PaginationRequest, total uint64) Pagination {
-	out := Pagination{
+func PaginationResponseFromPagination(p Pagination, total uint64) PaginationResponse {
+	out := PaginationResponse{
 		Page:    p.Page,
 		PerPage: p.PerPage,
 		Total:   total,

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -11,6 +11,15 @@ type PaginationOptions struct {
 	MaxPerPage     uint64
 }
 
+// Pagination is the resolved (non-optional) pagination configuration.
+// It is only constructible outside this package via PaginationRequest.ToPagination.
+type Pagination interface {
+	Page() uint64
+	PerPage() uint64
+	// SliceBounds returns safe [start,end) bounds for slicing a collection with the given total length.
+	SliceBounds(total uint64) (start, end uint64)
+}
+
 type PaginationRequest struct {
 	Set bool `json:"-"`
 
@@ -45,42 +54,69 @@ func (p *PaginationRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p PaginationRequest) ToPagination(opts PaginationOptions) (*Pagination, error) {
+type pagination struct {
+	page    uint64
+	perPage uint64
+}
+
+func (p pagination) Page() uint64    { return p.page }
+func (p pagination) PerPage() uint64 { return p.perPage }
+
+func (p pagination) SliceBounds(total uint64) (start, end uint64) {
+	if p.page == 0 || p.perPage == 0 {
+		// unreachable by construction
+		panic("invalid pagination state with page=0 or per_page=0")
+	}
+
+	pageIndex := p.page - 1
+	hi, start := bits.Mul64(pageIndex, p.perPage)
+	if hi != 0 || start > total {
+		start = total
+	}
+
+	end, carry := bits.Add64(start, p.perPage, 0)
+	if carry != 0 || end > total {
+		end = total
+	}
+
+	return start, end
+}
+
+func (p PaginationRequest) ToPagination(opts PaginationOptions) (Pagination, error) {
 	if !p.Set {
 		return nil, nil
 	}
 
-	var pagination Pagination
+	var page uint64
+	var perPage uint64
 
 	if p.Page != nil {
 		if *p.Page == 0 {
 			return nil, fmt.Errorf("page must be >= 1")
 		}
-		pagination.Page = *p.Page
+		page = *p.Page
 	}
 	if p.PerPage != nil {
 		if *p.PerPage == 0 {
 			return nil, fmt.Errorf("per_page must be >= 1")
 		}
-		pagination.PerPage = *p.PerPage
+		perPage = *p.PerPage
 	}
 
-	if pagination.Page == 0 {
-		pagination.Page = 1
+	if page == 0 {
+		page = 1
 	}
-	if pagination.PerPage == 0 {
-		pagination.PerPage = opts.DefaultPerPage
+	if perPage == 0 {
+		if opts.DefaultPerPage == 0 {
+			return nil, fmt.Errorf("default per_page must be >= 1")
+		}
+		perPage = opts.DefaultPerPage
 	}
-	if opts.MaxPerPage > 0 && pagination.PerPage > opts.MaxPerPage {
+	if opts.MaxPerPage > 0 && perPage > opts.MaxPerPage {
 		return nil, fmt.Errorf("per_page must be <= %d", opts.MaxPerPage)
 	}
 
-	return &pagination, nil
-}
-
-type Pagination struct {
-	Page    uint64
-	PerPage uint64
+	return pagination{page: page, perPage: perPage}, nil
 }
 
 type PaginationResponse struct {
@@ -90,35 +126,20 @@ type PaginationResponse struct {
 	TotalPages uint64 `json:"total_pages"`
 }
 
-// SliceBounds returns safe [start,end) bounds for slicing a collection with the given total length.
-func (p Pagination) SliceBounds(total uint64) (start, end uint64) {
-	if p.Page == 0 || p.PerPage == 0 {
-		return 0, 0
-	}
-
-	pageIndex := p.Page - 1
-	hi, start := bits.Mul64(pageIndex, p.PerPage)
-	if hi != 0 || start > total {
-		start = total
-	}
-
-	end, carry := bits.Add64(start, p.PerPage, 0)
-	if carry != 0 || end > total {
-		end = total
-	}
-
-	return start, end
-}
-
 func PaginationResponseFromPagination(p Pagination, total uint64) PaginationResponse {
+	if p.Page() == 0 || p.PerPage() == 0 {
+		// unreachable by construction
+		panic("invalid pagination state with page=0 or per_page=0")
+	}
+
 	out := PaginationResponse{
-		Page:    p.Page,
-		PerPage: p.PerPage,
+		Page:    p.Page(),
+		PerPage: p.PerPage(),
 		Total:   total,
 	}
-	if total > 0 && p.PerPage > 0 {
-		out.TotalPages = total / p.PerPage
-		if total%p.PerPage != 0 {
+	if total > 0 {
+		out.TotalPages = total / p.PerPage()
+		if total%p.PerPage() != 0 {
 			out.TotalPages++
 		}
 	}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalPagination_ToRequest(t *testing.T) {
+	t.Parallel()
+
+	opts := PaginationOptions{DefaultPerPage: 1000, MaxPerPage: 10000}
+
+	t.Run("unset returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := (OptionalPagination{}).ToRequest(opts)
+		require.NoError(t, err)
+		require.Nil(t, req)
+	})
+
+	t.Run("empty object defaults", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{}`), &p))
+
+		req, err := p.ToRequest(opts)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), req.Page)
+		require.Equal(t, uint64(1000), req.PerPage)
+	})
+
+	t.Run("per_page only defaults page to 1", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{"per_page":2}`), &p))
+
+		req, err := p.ToRequest(opts)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), req.Page)
+		require.Equal(t, uint64(2), req.PerPage)
+	})
+
+	t.Run("page only defaults per_page", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{"page":2}`), &p))
+
+		req, err := p.ToRequest(opts)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), req.Page)
+		require.Equal(t, uint64(1000), req.PerPage)
+	})
+
+	t.Run("page 0 invalid when provided", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{"page":0}`), &p))
+
+		_, err := p.ToRequest(opts)
+		require.Error(t, err)
+	})
+
+	t.Run("per_page 0 invalid when provided", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{"per_page":0}`), &p))
+
+		_, err := p.ToRequest(opts)
+		require.Error(t, err)
+	})
+
+	t.Run("per_page too large invalid", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`{"per_page":10001}`), &p))
+
+		_, err := p.ToRequest(opts)
+		require.Error(t, err)
+	})
+
+	t.Run("null treated as unset", func(t *testing.T) {
+		t.Parallel()
+
+		var p OptionalPagination
+		require.NoError(t, json.Unmarshal([]byte(`null`), &p))
+
+		req, err := p.ToRequest(opts)
+		require.NoError(t, err)
+		require.Nil(t, req)
+	})
+}
+
+func TestPaginationRequest_SliceBounds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("per_page larger than total", func(t *testing.T) {
+		t.Parallel()
+
+		p := PaginationRequest{Page: 1, PerPage: 10}
+		start, end := p.SliceBounds(5)
+		require.Equal(t, uint64(0), start)
+		require.Equal(t, uint64(5), end)
+	})
+
+	t.Run("page beyond total returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		p := PaginationRequest{Page: 100, PerPage: 2}
+		start, end := p.SliceBounds(5)
+		require.Equal(t, uint64(5), start)
+		require.Equal(t, uint64(5), end)
+	})
+
+	t.Run("very large page clamps via overflow protection", func(t *testing.T) {
+		t.Parallel()
+
+		p := PaginationRequest{Page: ^uint64(0), PerPage: 1000}
+		start, end := p.SliceBounds(5)
+		require.Equal(t, uint64(5), start)
+		require.Equal(t, uint64(5), end)
+	})
+
+	t.Run("total zero always empty", func(t *testing.T) {
+		t.Parallel()
+
+		p := PaginationRequest{Page: 1, PerPage: 2}
+		start, end := p.SliceBounds(0)
+		require.Equal(t, uint64(0), start)
+		require.Equal(t, uint64(0), end)
+	})
+}
+
+func TestPaginationFromRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("total zero", func(t *testing.T) {
+		t.Parallel()
+
+		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 10}, 0)
+		require.Equal(t, uint64(0), out.TotalPages)
+	})
+
+	t.Run("ceil division", func(t *testing.T) {
+		t.Parallel()
+
+		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 2}, 5)
+		require.Equal(t, uint64(3), out.TotalPages)
+	})
+
+	t.Run("no overflow for very large totals", func(t *testing.T) {
+		t.Parallel()
+
+		maxUint64 := ^uint64(0)
+		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 2}, maxUint64)
+		require.Equal(t, (maxUint64/2)+1, out.TotalPages)
+	})
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOptionalPagination_ToRequest(t *testing.T) {
+func TestPaginationRequest_ToPagination(t *testing.T) {
 	t.Parallel()
 
 	opts := PaginationOptions{DefaultPerPage: 1000, MaxPerPage: 10000}
@@ -15,96 +15,96 @@ func TestOptionalPagination_ToRequest(t *testing.T) {
 	t.Run("unset returns nil", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := (OptionalPagination{}).ToRequest(opts)
+		pagination, err := (PaginationRequest{}).ToPagination(opts)
 		require.NoError(t, err)
-		require.Nil(t, req)
+		require.Nil(t, pagination)
 	})
 
 	t.Run("empty object defaults", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{}`), &p))
 
-		req, err := p.ToRequest(opts)
+		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), req.Page)
-		require.Equal(t, uint64(1000), req.PerPage)
+		require.Equal(t, uint64(1), pagination.Page)
+		require.Equal(t, uint64(1000), pagination.PerPage)
 	})
 
 	t.Run("per_page only defaults page to 1", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{"per_page":2}`), &p))
 
-		req, err := p.ToRequest(opts)
+		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), req.Page)
-		require.Equal(t, uint64(2), req.PerPage)
+		require.Equal(t, uint64(1), pagination.Page)
+		require.Equal(t, uint64(2), pagination.PerPage)
 	})
 
 	t.Run("page only defaults per_page", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{"page":2}`), &p))
 
-		req, err := p.ToRequest(opts)
+		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(2), req.Page)
-		require.Equal(t, uint64(1000), req.PerPage)
+		require.Equal(t, uint64(2), pagination.Page)
+		require.Equal(t, uint64(1000), pagination.PerPage)
 	})
 
 	t.Run("page 0 invalid when provided", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{"page":0}`), &p))
 
-		_, err := p.ToRequest(opts)
+		_, err := p.ToPagination(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("per_page 0 invalid when provided", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{"per_page":0}`), &p))
 
-		_, err := p.ToRequest(opts)
+		_, err := p.ToPagination(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("per_page too large invalid", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`{"per_page":10001}`), &p))
 
-		_, err := p.ToRequest(opts)
+		_, err := p.ToPagination(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("null treated as unset", func(t *testing.T) {
 		t.Parallel()
 
-		var p OptionalPagination
+		var p PaginationRequest
 		require.NoError(t, json.Unmarshal([]byte(`null`), &p))
 
-		req, err := p.ToRequest(opts)
+		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Nil(t, req)
+		require.Nil(t, pagination)
 	})
 }
 
-func TestPaginationRequest_SliceBounds(t *testing.T) {
+func TestPagination_SliceBounds(t *testing.T) {
 	t.Parallel()
 
 	t.Run("per_page larger than total", func(t *testing.T) {
 		t.Parallel()
 
-		p := PaginationRequest{Page: 1, PerPage: 10}
+		p := Pagination{Page: 1, PerPage: 10}
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(0), start)
 		require.Equal(t, uint64(5), end)
@@ -113,7 +113,7 @@ func TestPaginationRequest_SliceBounds(t *testing.T) {
 	t.Run("page beyond total returns empty", func(t *testing.T) {
 		t.Parallel()
 
-		p := PaginationRequest{Page: 100, PerPage: 2}
+		p := Pagination{Page: 100, PerPage: 2}
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(5), start)
 		require.Equal(t, uint64(5), end)
@@ -122,7 +122,7 @@ func TestPaginationRequest_SliceBounds(t *testing.T) {
 	t.Run("very large page clamps via overflow protection", func(t *testing.T) {
 		t.Parallel()
 
-		p := PaginationRequest{Page: ^uint64(0), PerPage: 1000}
+		p := Pagination{Page: ^uint64(0), PerPage: 1000}
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(5), start)
 		require.Equal(t, uint64(5), end)
@@ -131,27 +131,27 @@ func TestPaginationRequest_SliceBounds(t *testing.T) {
 	t.Run("total zero always empty", func(t *testing.T) {
 		t.Parallel()
 
-		p := PaginationRequest{Page: 1, PerPage: 2}
+		p := Pagination{Page: 1, PerPage: 2}
 		start, end := p.SliceBounds(0)
 		require.Equal(t, uint64(0), start)
 		require.Equal(t, uint64(0), end)
 	})
 }
 
-func TestPaginationFromRequest(t *testing.T) {
+func TestPaginationResponseFromPagination(t *testing.T) {
 	t.Parallel()
 
 	t.Run("total zero", func(t *testing.T) {
 		t.Parallel()
 
-		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 10}, 0)
+		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 10}, 0)
 		require.Equal(t, uint64(0), out.TotalPages)
 	})
 
 	t.Run("ceil division", func(t *testing.T) {
 		t.Parallel()
 
-		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 2}, 5)
+		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 2}, 5)
 		require.Equal(t, uint64(3), out.TotalPages)
 	})
 
@@ -159,7 +159,7 @@ func TestPaginationFromRequest(t *testing.T) {
 		t.Parallel()
 
 		maxUint64 := ^uint64(0)
-		out := PaginationFromRequest(PaginationRequest{Page: 1, PerPage: 2}, maxUint64)
+		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 2}, maxUint64)
 		require.Equal(t, (maxUint64/2)+1, out.TotalPages)
 	})
 }

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -28,8 +28,8 @@ func TestPaginationRequest_ToPagination(t *testing.T) {
 
 		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), pagination.Page)
-		require.Equal(t, uint64(1000), pagination.PerPage)
+		require.Equal(t, uint64(1), pagination.Page())
+		require.Equal(t, uint64(1000), pagination.PerPage())
 	})
 
 	t.Run("per_page only defaults page to 1", func(t *testing.T) {
@@ -40,8 +40,8 @@ func TestPaginationRequest_ToPagination(t *testing.T) {
 
 		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), pagination.Page)
-		require.Equal(t, uint64(2), pagination.PerPage)
+		require.Equal(t, uint64(1), pagination.Page())
+		require.Equal(t, uint64(2), pagination.PerPage())
 	})
 
 	t.Run("page only defaults per_page", func(t *testing.T) {
@@ -52,8 +52,8 @@ func TestPaginationRequest_ToPagination(t *testing.T) {
 
 		pagination, err := p.ToPagination(opts)
 		require.NoError(t, err)
-		require.Equal(t, uint64(2), pagination.Page)
-		require.Equal(t, uint64(1000), pagination.PerPage)
+		require.Equal(t, uint64(2), pagination.Page())
+		require.Equal(t, uint64(1000), pagination.PerPage())
 	})
 
 	t.Run("page 0 invalid when provided", func(t *testing.T) {
@@ -96,15 +96,40 @@ func TestPaginationRequest_ToPagination(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, pagination)
 	})
+
+	t.Run("default per_page must be >= 1", func(t *testing.T) {
+		t.Parallel()
+
+		var p PaginationRequest
+		require.NoError(t, json.Unmarshal([]byte(`{}`), &p))
+
+		_, err := p.ToPagination(PaginationOptions{DefaultPerPage: 0, MaxPerPage: 0})
+		require.Error(t, err)
+	})
 }
 
 func TestPagination_SliceBounds(t *testing.T) {
 	t.Parallel()
 
+	mustPagination := func(t *testing.T, page, perPage uint64) Pagination {
+		t.Helper()
+
+		pageCopy := page
+		perPageCopy := perPage
+		req := PaginationRequest{
+			Set:     true,
+			Page:    &pageCopy,
+			PerPage: &perPageCopy,
+		}
+		p, err := req.ToPagination(PaginationOptions{DefaultPerPage: 1, MaxPerPage: 0})
+		require.NoError(t, err)
+		return p
+	}
+
 	t.Run("per_page larger than total", func(t *testing.T) {
 		t.Parallel()
 
-		p := Pagination{Page: 1, PerPage: 10}
+		p := mustPagination(t, 1, 10)
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(0), start)
 		require.Equal(t, uint64(5), end)
@@ -113,7 +138,7 @@ func TestPagination_SliceBounds(t *testing.T) {
 	t.Run("page beyond total returns empty", func(t *testing.T) {
 		t.Parallel()
 
-		p := Pagination{Page: 100, PerPage: 2}
+		p := mustPagination(t, 100, 2)
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(5), start)
 		require.Equal(t, uint64(5), end)
@@ -122,7 +147,7 @@ func TestPagination_SliceBounds(t *testing.T) {
 	t.Run("very large page clamps via overflow protection", func(t *testing.T) {
 		t.Parallel()
 
-		p := Pagination{Page: ^uint64(0), PerPage: 1000}
+		p := mustPagination(t, ^uint64(0), 1000)
 		start, end := p.SliceBounds(5)
 		require.Equal(t, uint64(5), start)
 		require.Equal(t, uint64(5), end)
@@ -131,7 +156,7 @@ func TestPagination_SliceBounds(t *testing.T) {
 	t.Run("total zero always empty", func(t *testing.T) {
 		t.Parallel()
 
-		p := Pagination{Page: 1, PerPage: 2}
+		p := mustPagination(t, 1, 2)
 		start, end := p.SliceBounds(0)
 		require.Equal(t, uint64(0), start)
 		require.Equal(t, uint64(0), end)
@@ -141,17 +166,32 @@ func TestPagination_SliceBounds(t *testing.T) {
 func TestPaginationResponseFromPagination(t *testing.T) {
 	t.Parallel()
 
+	mustPagination := func(t *testing.T, page, perPage uint64) Pagination {
+		t.Helper()
+
+		pageCopy := page
+		perPageCopy := perPage
+		req := PaginationRequest{
+			Set:     true,
+			Page:    &pageCopy,
+			PerPage: &perPageCopy,
+		}
+		p, err := req.ToPagination(PaginationOptions{DefaultPerPage: 1, MaxPerPage: 0})
+		require.NoError(t, err)
+		return p
+	}
+
 	t.Run("total zero", func(t *testing.T) {
 		t.Parallel()
 
-		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 10}, 0)
+		out := PaginationResponseFromPagination(mustPagination(t, 1, 10), 0)
 		require.Equal(t, uint64(0), out.TotalPages)
 	})
 
 	t.Run("ceil division", func(t *testing.T) {
 		t.Parallel()
 
-		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 2}, 5)
+		out := PaginationResponseFromPagination(mustPagination(t, 1, 2), 5)
 		require.Equal(t, uint64(3), out.TotalPages)
 	})
 
@@ -159,7 +199,7 @@ func TestPaginationResponseFromPagination(t *testing.T) {
 		t.Parallel()
 
 		maxUint64 := ^uint64(0)
-		out := PaginationResponseFromPagination(Pagination{Page: 1, PerPage: 2}, maxUint64)
+		out := PaginationResponseFromPagination(mustPagination(t, 1, 2), maxUint64)
 		require.Equal(t, (maxUint64/2)+1, out.TotalPages)
 	})
 }

--- a/docs/api/ssvnode.openapi.json
+++ b/docs/api/ssvnode.openapi.json
@@ -590,6 +590,57 @@
                     }
                 }
             }
+        },
+        "/v1/validators": {
+            "get": {
+                "description": "Returns the list of validators managed by the SSV node. Pagination is provided via the JSON request body under \"pagination\".",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Validators"
+                ],
+                "summary": "Get validators",
+                "parameters": [
+                    {
+                        "description": "Filters and pagination as JSON body",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/validators.ValidatorsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/validators.ValidatorsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -603,6 +654,34 @@
                 "status": {
                     "description": "user-level status message",
                     "type": "string"
+                }
+            }
+        },
+        "api.PaginationRequest": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "per_page": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.PaginationResponse": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "per_page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
                 }
             }
         },
@@ -1182,6 +1261,130 @@
                     "items": {
                         "$ref": "#/definitions/exporter.ValidatorSchedule"
                     }
+                }
+            }
+        },
+        "validators.Validator": {
+            "type": "object",
+            "properties": {
+                "activation_epoch": {
+                    "type": "string",
+                    "example": "0"
+                },
+                "committee": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                    }
+                },
+                "exit_epoch": {
+                    "type": "string",
+                    "example": "0"
+                },
+                "graffiti": {
+                    "type": "string"
+                },
+                "index": {
+                    "type": "string",
+                    "example": "123"
+                },
+                "liquidated": {
+                    "type": "boolean"
+                },
+                "owner": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "partial_quorum": {
+                    "type": "integer"
+                },
+                "public_key": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "quorum": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "validators.ValidatorsRequest": {
+            "type": "object",
+            "properties": {
+                "clusters": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                },
+                "indices": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                    }
+                },
+                "operators": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                    }
+                },
+                "owners": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "hex"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/api.PaginationRequest"
+                },
+                "pubkeys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "hex"
+                    }
+                },
+                "subclusters": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                }
+            }
+        },
+        "validators.ValidatorsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/validators.Validator"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/api.PaginationResponse"
                 }
             }
         }

--- a/docs/api/ssvnode.openapi.yaml
+++ b/docs/api/ssvnode.openapi.yaml
@@ -9,6 +9,24 @@ definitions:
         description: user-level status message
         type: string
     type: object
+  api.PaginationRequest:
+    properties:
+      page:
+        type: integer
+      per_page:
+        type: integer
+    type: object
+  api.PaginationResponse:
+    properties:
+      page:
+        type: integer
+      per_page:
+        type: integer
+      total:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
   exporter.CommitteeMessage:
     properties:
       signer:
@@ -452,6 +470,92 @@ definitions:
           $ref: '#/definitions/exporter.ValidatorSchedule'
         type: array
     type: object
+  validators.Validator:
+    properties:
+      activation_epoch:
+        example: "0"
+        type: string
+      committee:
+        items:
+          format: int64
+          minimum: 0
+          type: integer
+        type: array
+      exit_epoch:
+        example: "0"
+        type: string
+      graffiti:
+        type: string
+      index:
+        example: "123"
+        type: string
+      liquidated:
+        type: boolean
+      owner:
+        items:
+          type: integer
+        type: array
+      partial_quorum:
+        type: integer
+      public_key:
+        items:
+          type: integer
+        type: array
+      quorum:
+        type: integer
+      status:
+        type: string
+    type: object
+  validators.ValidatorsRequest:
+    properties:
+      clusters:
+        items:
+          items:
+            format: int64
+            type: integer
+          type: array
+        type: array
+      indices:
+        items:
+          format: int64
+          minimum: 0
+          type: integer
+        type: array
+      operators:
+        items:
+          format: int64
+          minimum: 0
+          type: integer
+        type: array
+      owners:
+        items:
+          format: hex
+          type: string
+        type: array
+      pagination:
+        $ref: '#/definitions/api.PaginationRequest'
+      pubkeys:
+        items:
+          format: hex
+          type: string
+        type: array
+      subclusters:
+        items:
+          items:
+            format: int64
+            type: integer
+          type: array
+        type: array
+    type: object
+  validators.ValidatorsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/validators.Validator'
+        type: array
+      pagination:
+        $ref: '#/definitions/api.PaginationResponse'
+    type: object
 info:
   contact:
     email: info@ssv.network
@@ -872,6 +976,40 @@ paths:
       summary: Retrieve validator duty traces
       tags:
       - Exporter
+  /v1/validators:
+    get:
+      consumes:
+      - application/json
+      description: Returns the list of validators managed by the SSV node. Pagination
+        is provided via the JSON request body under "pagination".
+      parameters:
+      - description: Filters and pagination as JSON body
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/validators.ValidatorsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/validators.ValidatorsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Get validators
+      tags:
+      - Validators
 schemes:
 - http
 swagger: "2.0"


### PR DESCRIPTION
Add optional pagination to the validators http api with retro-compatibility

```
curl --request GET \
    --url 'http://ssv-node-exporter.stage.vnet.ops.ssvlabsinternal.com/v1/validators' \
    --header 'Content-Type: application/json' \
    --data '{
      "clusters": [
        [73,74,75,76]
      ],
      "pagination": {
        "page": 1,
        "per_page": 10
      }
    }'
```

Closes ssvlabs/ssv-node-board#1047