### PR TITLE
ci(lint): use explicit Go module/build cache for lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,14 +16,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
-          cache-dependency-path: |
-            go.sum
-            tool.sum
-            ssvsigner/go.sum
+          # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore
+          # behavior is consistent across workflows.
+          cache: false
+
+      - name: Restore Go cache (lint)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-lint-${{ hashFiles('go.sum', 'tool.mod', 'tool.sum', 'ssvsigner/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-lint-
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Run make lint
         run: make lint


### PR DESCRIPTION
https://github.com/ssvlabs/ssv/pull/2686 added caching for test pipelines, but not for the lint pipeline. Now it seems to take significant time, so it would benefit from caching