### PR TITLE
message/validation: avoid nil SSVMessage panic in Validate defer

### DIFF
--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -169,6 +169,6 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 }
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {
-	recordAcceptedMessage(ctx, decodedMessage.GetID().GetRoleType())
+	recordAcceptedMessage(ctx, messageRole(decodedMessage))
 	return pubsub.ValidationAccept
 }

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -127,11 +127,7 @@ func (mv *messageValidator) Validate(ctx context.Context, peerID peer.ID, pmsg *
 	decodedMessage, err := mv.handlePubsubMessage(pmsg, time.Now())
 
 	defer func() {
-		role := spectypes.RunnerRole(spectypes.RoleUnknown)
-		if decodedMessage != nil {
-			role = decodedMessage.GetID().GetRoleType()
-		}
-		recordMessageDuration(ctx, role, time.Since(validationStart))
+		recordMessageDuration(ctx, messageRole(decodedMessage), time.Since(validationStart))
 	}()
 
 	if err != nil {
@@ -141,6 +137,13 @@ func (mv *messageValidator) Validate(ctx context.Context, peerID peer.ID, pmsg *
 	pmsg.ValidatorData = decodedMessage
 
 	return mv.handleValidationSuccess(ctx, decodedMessage)
+}
+
+func messageRole(decodedMessage *queue.SSVMessage) spectypes.RunnerRole {
+	if decodedMessage == nil || decodedMessage.SSVMessage == nil {
+		return spectypes.RunnerRole(spectypes.RoleUnknown)
+	}
+	return decodedMessage.SSVMessage.GetID().GetRoleType()
 }
 
 func (mv *messageValidator) handlePubsubMessage(pMsg *pubsub.Message, receivedAt time.Time) (*queue.SSVMessage, error) {

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/hex"
@@ -1809,6 +1810,30 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, "", peerID, receivedAt)
 		require.ErrorContains(t, err, ErrNilSSVMessage.Error())
+	})
+
+	t.Run("validate handles nil ssv message without panic", func(t *testing.T) {
+		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := netCfg.FirstSlotAtEpoch(1)
+		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+		signedSSVMessage.SSVMessage = nil
+
+		encoded, err := signedSSVMessage.Encode()
+		require.NoError(t, err)
+
+		topic := "ssv.v2.0"
+		pmsg := &pubsub.Message{
+			Message: &pspb.Message{
+				Data:  encoded,
+				Topic: &topic,
+			},
+		}
+
+		require.NotPanics(t, func() {
+			result := validator.Validate(context.Background(), peerID, pmsg)
+			require.Equal(t, pubsub.ValidationReject, result)
+		})
 	})
 
 	// Receive zero round


### PR DESCRIPTION
I caught a panic running `p2p` tests locally

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1038fbb88]

github.com/ssvlabs/ssv-spec/types.(*SSVMessage).GetID(...)
  .../ssv-spec/types/messages.go:108
github.com/ssvlabs/ssv/message/validation.(*messageValidator).Validate.func1()
  .../message/validation/validation.go:132
github.com/ssvlabs/ssv/message/validation.(*messageValidator).Validate(...)
  .../message/validation/validation.go:138
...
FAIL    github.com/ssvlabs/ssv/network/p2p    6.689s
```