### PR TITLE
observability: shutdown with the correct context

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -171,13 +171,15 @@ var StartNodeCmd = &cobra.Command{
 		logger := zap.L()
 		defer ssvlog.CapturePanic(logger)
 
-		logger.Info(fmt.Sprintf("starting %v", commons.GetBuildData()))
-
 		defer func() {
-			if err = observabilityShutdown(cmd.Context()); err != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err = observabilityShutdown(shutdownCtx); err != nil {
 				logger.Error("could not shutdown observability stack", zap.Error(err))
 			}
 		}()
+
+		logger.Info(fmt.Sprintf("starting %v", commons.GetBuildData()))
 
 		ssvNetworkConfig, err := setupSSVNetwork(logger)
 		if err != nil {


### PR DESCRIPTION
We shouldn't be using the `cmd.Context()` to perform tear-down procedures during SSV node shutdown because technically it might be already canceled (even though we currently never cancel it in practice, I think Cobra cancels it on process shutdown). Functions like `observabilityShutdown` won't be able to perform the shutdown with a canceled context.

Fixing that, seems like it was the only place where this could be an issue.