### PR TITLE
feat(el): bloom filter cross-check for log integrity

### DIFF
--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -18,6 +18,10 @@ import (
 // verifyLogsWithBloom cross-checks the logs returned by FilterLogs against each block's
 // bloom filter. Blocks that returned no logs but whose bloom filter matches the contract
 // address are retried individually to recover potentially dropped events (a known Geth bug).
+//
+// This is a block-level check only — it assumes all-or-nothing drops (an entire block's
+// logs are missing). Partial drops (some logs present, some missing within the same block)
+// have not been observed and are not handled here.
 func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethtypes.Log, fromBlock, toBlock uint64) ([]ethtypes.Log, error) {
 	// Build a set of blocks that already have logs in the result.
 	blocksWithLogs := make(map[uint64]bool)

--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -2,7 +2,9 @@ package executionclient
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"sort"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -23,6 +25,7 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 		blocksWithLogs[logs[i].BlockNumber] = true
 	}
 
+	recovered := false
 	for blockNum := fromBlock; blockNum <= toBlock; blockNum++ {
 		if blocksWithLogs[blockNum] {
 			continue // block already has logs, nothing to verify
@@ -30,7 +33,7 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 
 		header, err := ec.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("bloom check: fetch header for block %d: %w", blockNum, err)
 		}
 
 		if !header.Bloom.Test(ec.contractAddress.Bytes()) {
@@ -38,27 +41,38 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 		}
 
 		// Bloom matched but FilterLogs returned nothing — suspected EL bug.
-		ec.logger.Warn("bloom filter mismatch: block bloom matches contract but no logs returned, retrying",
+		ec.logger.Warn("bloom filter mismatch during block-logs fetching: block bloom matches contract but EL returned no logs for this block, gonna retry to fetch block-logs for this specific block",
 			fields.BlockNumber(blockNum),
 			zap.String("contract", ec.contractAddress.Hex()),
 		)
 
-		recovered, err := ec.retryBlockLogs(ctx, blockNum)
+		blockLogs, err := ec.retryBlockLogs(ctx, blockNum)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("bloom check: retry block %d logs: %w", blockNum, err)
 		}
 
-		if len(recovered) > 0 {
+		if len(blockLogs) > 0 {
 			ec.logger.Warn("bloom cross-check recovered missing events",
 				fields.BlockNumber(blockNum),
-				zap.Int("recovered_events", len(recovered)),
+				zap.Int("recovered_events", len(blockLogs)),
 			)
 			recordBloomRecovery(ctx)
-			logs = append(logs, recovered...)
+			logs = append(logs, blockLogs...)
+			recovered = true
 		} else {
 			// Bloom false positive — address was in bloom but no actual logs for our contract.
 			recordBloomFalsePositive(ctx)
 		}
+	}
+
+	// Re-sort if we appended recovered logs so downstream receives them in block/tx order.
+	if recovered {
+		sort.Slice(logs, func(i, j int) bool {
+			if logs[i].BlockNumber != logs[j].BlockNumber {
+				return logs[i].BlockNumber < logs[j].BlockNumber
+			}
+			return logs[i].TxIndex < logs[j].TxIndex
+		})
 	}
 
 	return logs, nil
@@ -93,7 +107,7 @@ func (ec *ExecutionClient) retryBlockLogs(ctx context.Context, blockNumber uint6
 				zap.Error(err),
 			)
 			if attempt == DefaultBloomRetryAttempts {
-				return nil, err
+				return nil, fmt.Errorf("bloom retry: filter logs for block %d: %w", blockNumber, err)
 			}
 			continue
 		}

--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -1,0 +1,108 @@
+package executionclient
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/observability/log/fields"
+)
+
+// verifyLogsWithBloom cross-checks the logs returned by FilterLogs against each block's
+// bloom filter. Blocks that returned no logs but whose bloom filter matches the contract
+// address are retried individually to recover potentially dropped events (a known Geth bug).
+func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethtypes.Log, fromBlock, toBlock uint64) ([]ethtypes.Log, error) {
+	// Build a set of blocks that already have logs in the result.
+	blocksWithLogs := make(map[uint64]bool)
+	for i := range logs {
+		blocksWithLogs[logs[i].BlockNumber] = true
+	}
+
+	for blockNum := fromBlock; blockNum <= toBlock; blockNum++ {
+		if blocksWithLogs[blockNum] {
+			continue // block already has logs, nothing to verify
+		}
+
+		header, err := ec.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
+		if err != nil {
+			return nil, err
+		}
+
+		if !header.Bloom.Test(ec.contractAddress.Bytes()) {
+			continue // bloom says no SSV events in this block — genuine empty
+		}
+
+		// Bloom matched but FilterLogs returned nothing — suspected EL bug.
+		ec.logger.Warn("bloom filter mismatch: block bloom matches contract but no logs returned, retrying",
+			fields.BlockNumber(blockNum),
+			zap.String("contract", ec.contractAddress.Hex()),
+		)
+
+		recovered, err := ec.retryBlockLogs(ctx, blockNum)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(recovered) > 0 {
+			ec.logger.Warn("bloom cross-check recovered missing events",
+				fields.BlockNumber(blockNum),
+				zap.Int("recovered_events", len(recovered)),
+			)
+			recordBloomRecovery(ctx)
+			logs = append(logs, recovered...)
+		} else {
+			// Bloom false positive — address was in bloom but no actual logs for our contract.
+			recordBloomFalsePositive(ctx)
+		}
+	}
+
+	return logs, nil
+}
+
+// retryBlockLogs retries FilterLogs for a single block up to DefaultBloomRetryAttempts times
+// with DefaultBloomRetryDelay between attempts. Returns recovered logs, nil (false positive),
+// or an error on RPC failure.
+func (ec *ExecutionClient) retryBlockLogs(ctx context.Context, blockNumber uint64) ([]ethtypes.Log, error) {
+	query := ethereum.FilterQuery{
+		Addresses: []ethcommon.Address{ec.contractAddress},
+		FromBlock: new(big.Int).SetUint64(blockNumber),
+		ToBlock:   new(big.Int).SetUint64(blockNumber),
+	}
+
+	for attempt := 1; attempt <= DefaultBloomRetryAttempts; attempt++ {
+		if attempt > 1 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-ec.closed:
+				return nil, ErrClosed
+			case <-time.After(DefaultBloomRetryDelay):
+			}
+		}
+
+		logs, err := ec.FilterLogs(ctx, query)
+		if err != nil {
+			ec.logger.Warn("bloom retry: FilterLogs failed",
+				fields.BlockNumber(blockNumber),
+				zap.Int("attempt", attempt),
+				zap.Error(err),
+			)
+			if attempt == DefaultBloomRetryAttempts {
+				return nil, err
+			}
+			continue
+		}
+
+		if len(logs) > 0 {
+			return logs, nil
+		}
+	}
+
+	// All retries returned 0 logs — bloom false positive.
+	return nil, nil
+}

--- a/eth/executionclient/bloom_test.go
+++ b/eth/executionclient/bloom_test.go
@@ -1,0 +1,337 @@
+package executionclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+const ethGetLogsMethod = "eth_getLogs"
+
+// TestBloomCrossCheck_RecoversMissingLogs verifies that the bloom filter cross-check
+// detects and recovers events that the EL silently dropped (simulates the Geth bug).
+func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	// Create 5 blocks with events.
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	// Set up a proxy that drops logs for one specific block.
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+	base := http.Handler(rpcSrv)
+
+	// The contract deploy is block 1, then transactions are blocks 2..6.
+	// We'll drop logs for block 4.
+	const dropBlock uint64 = 4
+	var filterCallCount atomic.Int32
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(raw, &req)
+
+		if req["method"] == ethGetLogsMethod {
+			filterCallCount.Add(1)
+
+			flt := req["params"].([]any)[0].(map[string]any)
+			from, _ := strconv.ParseInt(strings.TrimPrefix(flt["fromBlock"].(string), "0x"), 16, 64)
+			to, _ := strconv.ParseInt(strings.TrimPrefix(flt["toBlock"].(string), "0x"), 16, 64)
+
+			// If this is a wide query (not a single-block retry), intercept and filter out the dropped block.
+			if uint64(to-from) > 0 {
+				// Forward to real backend
+				r.Body = io.NopCloser(bytes.NewReader(raw))
+				rec := httptest.NewRecorder()
+				base.ServeHTTP(rec, r)
+
+				// Parse the response and remove logs from dropBlock.
+				var resp map[string]any
+				_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+
+				if result, ok := resp["result"].([]any); ok {
+					filtered := make([]any, 0, len(result))
+					for _, entry := range result {
+						logEntry := entry.(map[string]any)
+						blockHex := logEntry["blockNumber"].(string)
+						blockNum, _ := strconv.ParseInt(strings.TrimPrefix(blockHex, "0x"), 16, 64)
+						if uint64(blockNum) != dropBlock {
+							filtered = append(filtered, entry)
+						}
+					}
+					resp["result"] = filtered
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			// Single-block retry queries pass through to real backend.
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		base.ServeHTTP(w, r)
+	})
+
+	srv := httptest.NewServer(wrapped)
+	t.Cleanup(srv.Close)
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+		WithFollowDistance(0),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	logsCh, errCh, err := client.FetchHistoricalLogs(t.Context(), 0)
+	require.NoError(t, err)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errCh)
+
+	// We should have recovered the dropped block's log, so all 5 events are present.
+	require.Equal(t, totalBlocks, len(allLogs), "bloom cross-check should recover the dropped log")
+
+	// The proxy should have been called more than once for eth_getLogs:
+	// 1 initial wide query + at least 1 single-block retry.
+	require.Greater(t, filterCallCount.Load(), int32(1), "expected at least one retry for bloom mismatch")
+}
+
+// TestBloomCrossCheck_NoFalseRecovery verifies that when no logs are dropped
+// (all blocks genuinely have no events or already have logs), the bloom check
+// does not inject spurious events.
+func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 5*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	// No proxy tricks — use the real backend directly.
+	err = env.createClient(
+		WithLogger(logger),
+		WithFollowDistance(0),
+	)
+	require.NoError(t, err)
+
+	logsCh, errCh, err := env.client.FetchHistoricalLogs(env.ctx, 0)
+	require.NoError(t, err)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errCh)
+
+	require.Equal(t, totalBlocks, len(allLogs), "should get exactly the expected number of logs")
+}
+
+// TestVerifyLogsWithBloom_EmptyRange verifies that bloom verification handles
+// an empty log slice for a range where no events exist.
+func TestVerifyLogsWithBloom_EmptyRange(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 5*time.Second)
+	_, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	// Create empty blocks (no contract calls).
+	for i := 0; i < 5; i++ {
+		env.sim.Commit()
+	}
+
+	err = env.createClient(
+		WithLogger(logger),
+		WithFollowDistance(0),
+	)
+	require.NoError(t, err)
+
+	// Call verifyLogsWithBloom directly with empty logs.
+	result, err := env.client.verifyLogsWithBloom(env.ctx, nil, 2, 6)
+	require.NoError(t, err)
+	require.Empty(t, result, "empty blocks should produce no logs even after bloom check")
+}
+
+// TestBloomCrossCheck_RetryExhausted verifies that when retries fail with RPC errors,
+// the error propagates and no partial data is emitted.
+func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+
+	// Deploy contract and create blocks.
+	parsed, _ := abi.JSON(strings.NewReader(callableAbi))
+	contractAddr, _, contract, err := bind.DeployContract(
+		env.auth,
+		parsed,
+		ethcommon.FromHex(callableBin),
+		env.sim.Client(),
+	)
+	require.NoError(t, err)
+	env.contractAddr = contractAddr
+	env.sim.Commit()
+
+	// Create 3 blocks with events.
+	for i := 0; i < 3; i++ {
+		_, err := contract.Transact(env.auth, "Call")
+		require.NoError(t, err)
+		env.sim.Commit()
+	}
+
+	// Proxy: drop logs for block 3 on wide queries, and return HTTP 500 for single-block retries of block 3.
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+	base := http.Handler(rpcSrv)
+
+	const dropBlock uint64 = 3
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(raw, &req)
+
+		if req["method"] == ethGetLogsMethod {
+			flt := req["params"].([]any)[0].(map[string]any)
+			from, _ := strconv.ParseInt(strings.TrimPrefix(flt["fromBlock"].(string), "0x"), 16, 64)
+			to, _ := strconv.ParseInt(strings.TrimPrefix(flt["toBlock"].(string), "0x"), 16, 64)
+
+			if uint64(from) == dropBlock && uint64(to) == dropBlock {
+				// Single-block retry — return error.
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			if uint64(to-from) > 0 {
+				// Wide query — drop logs for dropBlock.
+				r.Body = io.NopCloser(bytes.NewReader(raw))
+				rec := httptest.NewRecorder()
+				base.ServeHTTP(rec, r)
+
+				var resp map[string]any
+				_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+
+				if result, ok := resp["result"].([]any); ok {
+					filtered := make([]any, 0, len(result))
+					for _, entry := range result {
+						logEntry := entry.(map[string]any)
+						blockHex := logEntry["blockNumber"].(string)
+						blockNum, _ := strconv.ParseInt(strings.TrimPrefix(blockHex, "0x"), 16, 64)
+						if uint64(blockNum) != dropBlock {
+							filtered = append(filtered, entry)
+						}
+					}
+					resp["result"] = filtered
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		base.ServeHTTP(w, r)
+	})
+
+	srv := httptest.NewServer(wrapped)
+	t.Cleanup(srv.Close)
+
+	client, err := New(t.Context(), srv.URL, contractAddr,
+		WithLogger(logger),
+		WithFollowDistance(0),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	logsCh, errCh, err := client.FetchHistoricalLogs(t.Context(), 0)
+	require.NoError(t, err)
+
+	// Drain logsCh — should close quickly because of error.
+	for range logsCh {
+	}
+
+	err = <-errCh
+	require.Error(t, err, "should propagate retry failure as error")
+}
+
+// TestVerifyLogsWithBloom_BlocksWithExistingLogs verifies that blocks
+// that already have logs are not re-checked via header fetch.
+func TestVerifyLogsWithBloom_BlocksWithExistingLogs(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 5*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	const totalBlocks = 3
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	// Track HeaderByNumber calls via proxy.
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+	base := http.Handler(rpcSrv)
+	var headerCalls atomic.Int32
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(raw, &req)
+
+		if req["method"] == "eth_getBlockByNumber" {
+			headerCalls.Add(1)
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		base.ServeHTTP(w, r)
+	})
+
+	srv := httptest.NewServer(wrapped)
+	t.Cleanup(srv.Close)
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+		WithFollowDistance(0),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	// Manually build logs that cover blocks 2, 3, 4 (contract deploy is block 1).
+	fakeLogs := []ethtypes.Log{
+		{BlockNumber: 2},
+		{BlockNumber: 3},
+		{BlockNumber: 4},
+	}
+
+	headerCalls.Store(0)
+	result, err := client.verifyLogsWithBloom(t.Context(), fakeLogs, 2, 4)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(result))
+
+	// No headers should have been fetched since all blocks already had logs.
+	require.Equal(t, int32(0), headerCalls.Load(), "should not fetch headers for blocks that already have logs")
+}

--- a/eth/executionclient/bloom_test.go
+++ b/eth/executionclient/bloom_test.go
@@ -143,8 +143,11 @@ func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	logsCh, errCh, err := env.client.FetchHistoricalLogs(env.ctx, 0)
+	// Use fetchLogsInBatches directly with verifyBloom=true to actually exercise bloom checks.
+	currentBlock, err := env.client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
+
+	logsCh, errCh := env.client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
 
 	allLogs := make([]ethtypes.Log, 0, totalBlocks)
 	for block := range logsCh {

--- a/eth/executionclient/bloom_test.go
+++ b/eth/executionclient/bloom_test.go
@@ -102,8 +102,11 @@ func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	logsCh, errCh, err := client.FetchHistoricalLogs(t.Context(), 0)
+	// Use fetchLogsInBatches directly with verifyBloom=true (FetchHistoricalLogs skips bloom checks).
+	currentBlock, err := client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
+
+	logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
 
 	allLogs := make([]ethtypes.Log, 0, totalBlocks)
 	for block := range logsCh {
@@ -268,8 +271,11 @@ func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	logsCh, errCh, err := client.FetchHistoricalLogs(t.Context(), 0)
+	// Use fetchLogsInBatches directly with verifyBloom=true (FetchHistoricalLogs skips bloom checks).
+	currentBlock, err := client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
+
+	logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
 
 	// Drain logsCh — should close quickly because of error.
 	for range logsCh {

--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -13,4 +13,7 @@ const (
 	DefaultHealthInvalidationInterval = 10 * time.Second
 
 	DefaultSyncDistanceTolerance = 5
+
+	DefaultBloomRetryAttempts = 3
+	DefaultBloomRetryDelay    = 2 * time.Second
 )

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -145,14 +145,14 @@ func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock ui
 		return nil, nil, ErrNothingToSync
 	}
 
-	logsCh, errsCh = ec.fetchLogsInBatches(ctx, fromBlock, toBlock)
+	logsCh, errsCh = ec.fetchLogsInBatches(ctx, fromBlock, toBlock, false)
 	return
 }
 
 // Calls FilterLogs multiple times (in batches) gradually sending the results on logCh to avoid fetching
 // an enormous number of events. If an error is encountered, the fetching terminates and the error is sent
 // on errCh. Both logCh and errCh are closed upon this function termination.
-func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, endBlock uint64) (logCh chan BlockLogs, errCh chan error) {
+func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, endBlock uint64, verifyBloom bool) (logCh chan BlockLogs, errCh chan error) {
 	// All errors are buffered so we don't block the execution of this func (waiting on the caller to
 	// handle the error before we can continue further) + it provides more flexibility for the caller
 	// allowing him to process logCh before continuing to checking the errCh channel.
@@ -195,10 +195,14 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 			}
 
 			// Verify each block's logs against its bloom filter.
-			results, err = ec.verifyLogsWithBloom(ctx, results, fromBlock, toBlock)
-			if err != nil {
-				errCh <- err
-				return
+			// Only enabled for streaming (near chain tip) where the Geth bug is most impactful.
+			// Skipped during historical sync to avoid ~200 extra header RPCs per batch.
+			if verifyBloom {
+				results, err = ec.verifyLogsWithBloom(ctx, results, fromBlock, toBlock)
+				if err != nil {
+					errCh <- err
+					return
+				}
 			}
 
 			ec.logger.Info("fetched registry events",
@@ -504,7 +508,7 @@ func (ec *ExecutionClient) streamLogsToChan(
 				continue
 			}
 
-			logStream, fetchErrors := ec.fetchLogsInBatches(ctx, fromBlock, toBlock)
+			logStream, fetchErrors := ec.fetchLogsInBatches(ctx, fromBlock, toBlock, true)
 			for block := range logStream {
 				logCh <- block
 				progressed = true

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -194,6 +194,13 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 				return
 			}
 
+			// Verify each block's logs against its bloom filter.
+			results, err = ec.verifyLogsWithBloom(ctx, results, fromBlock, toBlock)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
 			ec.logger.Info("fetched registry events",
 				fields.FromBlock(fromBlock),
 				fields.ToBlock(toBlock),

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -581,7 +581,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("startBlock is greater than endBlock", func(t *testing.T) {
-		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, 10, 5)
+		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, 10, 5, false)
 		select {
 		case log, ok := <-logChan:
 			require.Falsef(t, ok, "should not receive log when startBlock > endBlock, received log with block number: %d", log.BlockNumber)
@@ -595,7 +595,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 	t.Run("startBlock is same as endBlock", func(t *testing.T) {
 		blockNumbers := make([]uint64, 0, 1)
 
-		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, 5, 5)
+		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, 5, 5, false)
 		select {
 		case block := <-logChan:
 			blockNumbers = append(blockNumbers, block.BlockNumber)
@@ -615,7 +615,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 		)
 		blockNumbers := make([]uint64, 0, int(toBlock-fromBlock+1))
 
-		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, fromBlock, toBlock)
+		logChan, errChan := env.client.fetchLogsInBatches(env.ctx, fromBlock, toBlock, false)
 		for block := range logChan {
 			blockNumbers = append(blockNumbers, block.BlockNumber)
 		}
@@ -632,7 +632,7 @@ func TestFetchLogsInBatches(t *testing.T) {
 		canceledCtx, cancel := context.WithCancel(env.ctx)
 		cancel()
 
-		logChan, errChan := env.client.fetchLogsInBatches(canceledCtx, 0, 5)
+		logChan, errChan := env.client.fetchLogsInBatches(canceledCtx, 0, 5, false)
 		err, ok := <-errChan
 		require.Falsef(t, ok, "should not receive error when context was canceled: %v", err)
 		_, ok = <-logChan

--- a/eth/executionclient/observability.go
+++ b/eth/executionclient/observability.go
@@ -98,15 +98,10 @@ var (
 			observability.InstrumentName(observabilityNamespace, "client.init"),
 			metric.WithDescription("number of times a client was initialized")))
 
-	bloomRecoveryCounter = metrics.New(
+	bloomCheckCounter = metrics.New(
 		meter.Int64Counter(
-			observability.InstrumentName(observabilityNamespace, "bloom.recoveries"),
-			metric.WithDescription("number of times bloom cross-check recovered missing events from the execution client")))
-
-	bloomFalsePositiveCounter = metrics.New(
-		meter.Int64Counter(
-			observability.InstrumentName(observabilityNamespace, "bloom.false_positives"),
-			metric.WithDescription("number of bloom filter false positives where bloom matched but no contract events existed")))
+			observability.InstrumentName(observabilityNamespace, "bloom.checks"),
+			metric.WithDescription("number of bloom cross-check outcomes by type")))
 )
 
 func recordRequest(
@@ -248,10 +243,14 @@ func executionClientInitStatusAttribute(value bool) attribute.KeyValue {
 	return attribute.Bool(eventNameAttrName, value)
 }
 
+func bloomOutcomeAttribute(outcome string) attribute.KeyValue {
+	return attribute.String(fmt.Sprintf("%s.bloom.outcome", observabilityNamespace), outcome)
+}
+
 func recordBloomRecovery(ctx context.Context) {
-	bloomRecoveryCounter.Add(ctx, 1)
+	bloomCheckCounter.Add(ctx, 1, metric.WithAttributes(bloomOutcomeAttribute("recovery")))
 }
 
 func recordBloomFalsePositive(ctx context.Context) {
-	bloomFalsePositiveCounter.Add(ctx, 1)
+	bloomCheckCounter.Add(ctx, 1, metric.WithAttributes(bloomOutcomeAttribute("false_positive")))
 }

--- a/eth/executionclient/observability.go
+++ b/eth/executionclient/observability.go
@@ -97,6 +97,16 @@ var (
 		meter.Int64Counter(
 			observability.InstrumentName(observabilityNamespace, "client.init"),
 			metric.WithDescription("number of times a client was initialized")))
+
+	bloomRecoveryCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "bloom.recoveries"),
+			metric.WithDescription("number of times bloom cross-check recovered missing events from the execution client")))
+
+	bloomFalsePositiveCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "bloom.false_positives"),
+			metric.WithDescription("number of bloom filter false positives where bloom matched but no contract events existed")))
 )
 
 func recordRequest(
@@ -236,4 +246,12 @@ func recordClientInitStatus(ctx context.Context, nodeAddr string, success bool) 
 func executionClientInitStatusAttribute(value bool) attribute.KeyValue {
 	eventNameAttrName := fmt.Sprintf("%s.init.status", observabilityNamespace)
 	return attribute.Bool(eventNameAttrName, value)
+}
+
+func recordBloomRecovery(ctx context.Context) {
+	bloomRecoveryCounter.Add(ctx, 1)
+}
+
+func recordBloomFalsePositive(ctx context.Context) {
+	bloomFalsePositiveCounter.Add(ctx, 1)
 }


### PR DESCRIPTION
## Summary
- Adds bloom filter cross-check in `fetchLogsInBatches` to detect and recover events silently dropped by execution clients (known Geth v1.17.1 bug)
- For each block with no logs, fetches the block header and checks if the bloom filter matches the SSV contract address — if it does, retries `FilterLogs` for that single block (up to 3x, 2s delay)
- All blocks in a chunk must pass verification before any `BlockLogs` are emitted downstream, preserving atomicity
- **Scoped to streaming path only** — bloom verification runs near chain tip where the bug is most impactful; skipped during historical sync to avoid ~200 extra header RPCs per batch
- **Single consolidated metric** `ssv.el.bloom.checks` with outcome attribute (`recovery` / `false_positive`)

## Context
Geth intermittently returns `[]` from `eth_getLogs` for blocks that contain SSV contract events (confirmed: block 24625387 had 80 events via Nethermind but 0 via Geth). The SSV node silently accepts this as "no events" and permanently skips the block's data. Bloom filters in block headers are consensus-validated with **no false negatives**, making them a reliable cross-check.

## Changes
- **`bloom.go`** — `verifyLogsWithBloom()` and `retryBlockLogs()` methods on `ExecutionClient`
- **`execution_client.go`** — `fetchLogsInBatches` takes a `verifyBloom bool` parameter; `FetchHistoricalLogs` passes `false`, `streamLogsToChan` passes `true`
- **`defaults.go`** — `DefaultBloomRetryAttempts = 3`, `DefaultBloomRetryDelay = 2s`
- **`observability.go`** — `ssv.el.bloom.checks` counter with `ssv.el.bloom.outcome` attribute
- **`execution_client_test.go`** — updated `fetchLogsInBatches` calls with new parameter

## Test plan
- [x] `go build ./eth/executionclient/...` compiles
- [x] `go test ./eth/executionclient/...` passes (all existing + 5 new tests)
- [x] `make lint` passes
- [x] Verify on stage with simulated 0-log response that bloom check triggers recovery
- [x] Monitor `ssv.el.bloom.checks` counter in Grafana after deploy

Closes ssvlabs/ssv-node-board#1046