### PR TITLE
beacon/goclient: cache domain data by epoch

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -126,7 +126,12 @@ type GoClient struct {
 	// attestationDataCache helps reuse recently fetched attestation data.
 	// AttestationData is cached by slot only, because Beacon nodes should return the same
 	// data regardless of the requested committeeIndex.
-	attestationDataCache               *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
+	attestationDataCache *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
+	// domainDataReqInflight joins parallel requests for the same epoch/domain pair.
+	domainDataReqInflight singleflight.Group[domainDataCacheKey, phase0.Domain]
+	// domainDataCache helps reuse recently fetched domains. Domains change only at epoch boundaries,
+	// so an approximately two-epoch TTL is sufficient.
+	domainDataCache                    *ttlcache.Cache[domainDataCacheKey, phase0.Domain]
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
@@ -165,6 +170,11 @@ type GoClient struct {
 
 	// activatedClients tracks which clients have been activated before (for reconnection detection)
 	activatedClients *hashmap.Map[string, struct{}]
+}
+
+type domainDataCacheKey struct {
+	epoch      phase0.Epoch
+	domainType phase0.DomainType
 }
 
 func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error) {
@@ -232,9 +242,15 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	// Start automatic expired item deletion for attestationDataCache.
 	go client.attestationDataCache.Start()
 
-	// Initialize committees cache with TTL of ~2 epochs
-	committeeTTL := config.SlotDuration * time.Duration(config.SlotsPerEpoch) * 2 //nolint:gosec
-	client.committeesCache = ttlcache.New(ttlcache.WithTTL[phase0.Epoch, []*eth2apiv1.BeaconCommittee](committeeTTL))
+	// Domain data and committee assignments change at epoch boundaries, so keep both caches
+	// for approximately two epochs.
+	twoEpochTTL := config.SlotDuration * time.Duration(config.SlotsPerEpoch) * 2 //nolint:gosec
+	client.domainDataCache = ttlcache.New(
+		ttlcache.WithTTL[domainDataCacheKey, phase0.Domain](twoEpochTTL),
+	)
+	go client.domainDataCache.Start()
+
+	client.committeesCache = ttlcache.New(ttlcache.WithTTL[phase0.Epoch, []*eth2apiv1.BeaconCommittee](twoEpochTTL))
 	go client.committeesCache.Start()
 
 	client.log.Debug("starting event listener")

--- a/beacon/goclient/signing.go
+++ b/beacon/goclient/signing.go
@@ -85,7 +85,7 @@ func (gc *GoClient) DomainData(
 		fetchCtx := context.WithoutCancel(ctx)
 		start := time.Now()
 		data, err := gc.multiClient.Domain(fetchCtx, domain, epoch)
-		recordRequest(ctx, gc.log, "Domain", gc.multiClient, http.MethodGet, true, time.Since(start), err)
+		recordRequest(fetchCtx, gc.log, "Domain", gc.multiClient, http.MethodGet, true, time.Since(start), err)
 		if err != nil {
 			return phase0.Domain{}, errMultiClient(fmt.Errorf("fetch domain: %w", err), "Domain")
 		}

--- a/beacon/goclient/signing.go
+++ b/beacon/goclient/signing.go
@@ -82,8 +82,9 @@ func (gc *GoClient) DomainData(
 			return cached.Value(), nil
 		}
 
+		fetchCtx := context.WithoutCancel(ctx)
 		start := time.Now()
-		data, err := gc.multiClient.Domain(ctx, domain, epoch)
+		data, err := gc.multiClient.Domain(fetchCtx, domain, epoch)
 		recordRequest(ctx, gc.log, "Domain", gc.multiClient, http.MethodGet, true, time.Since(start), err)
 		if err != nil {
 			return phase0.Domain{}, errMultiClient(fmt.Errorf("fetch domain: %w", err), "Domain")

--- a/beacon/goclient/signing.go
+++ b/beacon/goclient/signing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/pkg/errors"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
@@ -74,11 +75,26 @@ func (gc *GoClient) DomainData(
 		return gc.voluntaryExitDomain()
 	}
 
-	start := time.Now()
-	data, err := gc.multiClient.Domain(ctx, domain, epoch)
-	recordRequest(ctx, gc.log, "Domain", gc.multiClient, http.MethodGet, true, time.Since(start), err)
+	key := domainDataCacheKey{epoch: epoch, domainType: domain}
+
+	data, err, _ := gc.domainDataReqInflight.Do(key, func() (phase0.Domain, error) {
+		if cached := gc.domainDataCache.Get(key); cached != nil {
+			return cached.Value(), nil
+		}
+
+		start := time.Now()
+		data, err := gc.multiClient.Domain(ctx, domain, epoch)
+		recordRequest(ctx, gc.log, "Domain", gc.multiClient, http.MethodGet, true, time.Since(start), err)
+		if err != nil {
+			return phase0.Domain{}, errMultiClient(fmt.Errorf("fetch domain: %w", err), "Domain")
+		}
+
+		gc.domainDataCache.Set(key, data, ttlcache.DefaultTTL)
+
+		return data, nil
+	})
 	if err != nil {
-		return phase0.Domain{}, errMultiClient(fmt.Errorf("fetch domain: %w", err), "Domain")
+		return phase0.Domain{}, err
 	}
 
 	return data, nil

--- a/beacon/goclient/signing_test.go
+++ b/beacon/goclient/signing_test.go
@@ -20,13 +20,13 @@ import (
 type countingMultiClient struct {
 	MultiClient
 	domainCalls atomic.Int32
-	onDomain    func()
+	onDomain    func(context.Context)
 }
 
 func (c *countingMultiClient) Domain(ctx context.Context, domainType phase0.DomainType, epoch phase0.Epoch) (phase0.Domain, error) {
 	c.domainCalls.Add(1)
 	if c.onDomain != nil {
-		c.onDomain()
+		c.onDomain(ctx)
 	}
 	return c.MultiClient.Domain(ctx, domainType, epoch)
 }
@@ -134,8 +134,11 @@ func TestDomainDataCoalescesConcurrentRequests(t *testing.T) {
 
 	countingClient := &countingMultiClient{
 		MultiClient: client.multiClient,
-		onDomain: func() {
-			time.Sleep(25 * time.Millisecond)
+		onDomain: func(ctx context.Context) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(25 * time.Millisecond):
+			}
 		},
 	}
 	client.multiClient = countingClient
@@ -164,5 +167,81 @@ func TestDomainDataCoalescesConcurrentRequests(t *testing.T) {
 		require.NoError(t, errs[i])
 		require.Equal(t, results[0], results[i])
 	}
+	require.EqualValues(t, 1, countingClient.domainCalls.Load())
+}
+
+func TestDomainDataCoalescedFetchSurvivesWinnerCancellation(t *testing.T) {
+	ctx := t.Context()
+
+	mockServer := mocks.NewServer(nil)
+	defer mockServer.Close()
+
+	client, err := New(
+		ctx,
+		zap.NewNop(),
+		Options{
+			BeaconConfig:   networkconfig.TestNetwork.Beacon,
+			BeaconNodeAddr: mockServer.URL,
+			CommonTimeout:  time.Second,
+			LongTimeout:    time.Second,
+		},
+	)
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	countingClient := &countingMultiClient{
+		MultiClient: client.multiClient,
+		onDomain: func(ctx context.Context) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+
+			select {
+			case <-ctx.Done():
+			case <-release:
+			}
+		},
+	}
+	client.multiClient = countingClient
+
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	firstResultCh := make(chan struct {
+		domain phase0.Domain
+		err    error
+	}, 1)
+	go func() {
+		domain, err := client.DomainData(firstCtx, 555, spectypes.DomainAttester)
+		firstResultCh <- struct {
+			domain phase0.Domain
+			err    error
+		}{domain: domain, err: err}
+	}()
+
+	<-started
+	cancelFirst()
+
+	secondResultCh := make(chan struct {
+		domain phase0.Domain
+		err    error
+	}, 1)
+	go func() {
+		domain, err := client.DomainData(ctx, 555, spectypes.DomainAttester)
+		secondResultCh <- struct {
+			domain phase0.Domain
+			err    error
+		}{domain: domain, err: err}
+	}()
+
+	close(release)
+
+	firstResult := <-firstResultCh
+	secondResult := <-secondResultCh
+
+	require.NoError(t, firstResult.err)
+	require.NoError(t, secondResult.err)
+	require.Equal(t, firstResult.domain, secondResult.domain)
 	require.EqualValues(t, 1, countingClient.domainCalls.Load())
 }

--- a/beacon/goclient/signing_test.go
+++ b/beacon/goclient/signing_test.go
@@ -1,7 +1,10 @@
 package goclient
 
 import (
+	"context"
 	"encoding/hex"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +16,20 @@ import (
 	"github.com/ssvlabs/ssv/beacon/goclient/mocks"
 	"github.com/ssvlabs/ssv/networkconfig"
 )
+
+type countingMultiClient struct {
+	MultiClient
+	domainCalls atomic.Int32
+	onDomain    func()
+}
+
+func (c *countingMultiClient) Domain(ctx context.Context, domainType phase0.DomainType, epoch phase0.Epoch) (phase0.Domain, error) {
+	c.domainCalls.Add(1)
+	if c.onDomain != nil {
+		c.onDomain()
+	}
+	return c.MultiClient.Domain(ctx, domainType, epoch)
+}
 
 func Test_computeVoluntaryExitDomain(t *testing.T) {
 	ctx := t.Context()
@@ -55,4 +72,97 @@ func Test_computeVoluntaryExitDomain(t *testing.T) {
 
 		require.EqualValues(t, append(spectypes.DomainVoluntaryExit[:], root[:]...), domain)
 	})
+}
+
+func TestDomainDataCachesByEpochAndDomain(t *testing.T) {
+	ctx := t.Context()
+
+	mockServer := mocks.NewServer(nil)
+	defer mockServer.Close()
+
+	client, err := New(
+		ctx,
+		zap.NewNop(),
+		Options{
+			BeaconConfig:   networkconfig.TestNetwork.Beacon,
+			BeaconNodeAddr: mockServer.URL,
+			CommonTimeout:  400 * time.Millisecond,
+			LongTimeout:    500 * time.Millisecond,
+		},
+	)
+	require.NoError(t, err)
+
+	countingClient := &countingMultiClient{MultiClient: client.multiClient}
+	client.multiClient = countingClient
+
+	first, err := client.DomainData(ctx, 123, spectypes.DomainAttester)
+	require.NoError(t, err)
+
+	second, err := client.DomainData(ctx, 123, spectypes.DomainAttester)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.EqualValues(t, 1, countingClient.domainCalls.Load())
+
+	third, err := client.DomainData(ctx, 123, spectypes.DomainSyncCommittee)
+	require.NoError(t, err)
+	require.NotEqual(t, phase0.Domain{}, third)
+	require.EqualValues(t, 2, countingClient.domainCalls.Load())
+
+	fourth, err := client.DomainData(ctx, 124, spectypes.DomainAttester)
+	require.NoError(t, err)
+	require.NotEqual(t, phase0.Domain{}, fourth)
+	require.EqualValues(t, 3, countingClient.domainCalls.Load())
+}
+
+func TestDomainDataCoalescesConcurrentRequests(t *testing.T) {
+	ctx := t.Context()
+
+	mockServer := mocks.NewServer(nil)
+	defer mockServer.Close()
+
+	client, err := New(
+		ctx,
+		zap.NewNop(),
+		Options{
+			BeaconConfig:   networkconfig.TestNetwork.Beacon,
+			BeaconNodeAddr: mockServer.URL,
+			CommonTimeout:  time.Second,
+			LongTimeout:    time.Second,
+		},
+	)
+	require.NoError(t, err)
+
+	countingClient := &countingMultiClient{
+		MultiClient: client.multiClient,
+		onDomain: func() {
+			time.Sleep(25 * time.Millisecond)
+		},
+	}
+	client.multiClient = countingClient
+
+	const goroutines = 16
+	var (
+		wg      sync.WaitGroup
+		results [goroutines]phase0.Domain
+		errs    [goroutines]error
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = client.DomainData(ctx, 321, spectypes.DomainAttester)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		require.NoError(t, errs[i])
+		require.Equal(t, results[0], results[i])
+	}
+	require.EqualValues(t, 1, countingClient.domainCalls.Load())
 }

--- a/beacon/goclient/signing_test.go
+++ b/beacon/goclient/signing_test.go
@@ -199,10 +199,7 @@ func TestDomainDataCoalescedFetchSurvivesWinnerCancellation(t *testing.T) {
 			default:
 			}
 
-			select {
-			case <-ctx.Done():
-			case <-release:
-			}
+			<-release
 		},
 	}
 	client.multiClient = countingClient


### PR DESCRIPTION
## Summary

Cache beacon `DomainData` lookups in `GoClient` by `(epoch, domainType)` and coalesce concurrent misses with `singleflight`.

## Changes

- add a domain-data cache to `GoClient`
- cache by `(epoch, domainType)`
- coalesce concurrent lookups with `singleflight`
- keep existing special handling for `DomainVoluntaryExit` and `DomainApplicationBuilder`
- add focused tests for cache reuse and concurrent requests

## Context

Common domains like attester and sync committee were repeatedly fetched from the beacon node even though they only change at epoch boundaries. This removes duplicate upstream calls on hot signing paths.