### PR TITLE
fix(leaks) - interval timer leak and p2p context cancellations

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -472,10 +472,8 @@ func (n *p2pNetwork) UpdateSubnets() {
 
 	// Run immediately and then every second.
 	for {
-		select {
-		case <-n.ctx.Done():
+		if n.ctx.Err() != nil {
 			return
-		default:
 		}
 
 		start := time.Now()

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -471,7 +471,13 @@ func (n *p2pNetwork) UpdateSubnets() {
 	defer ticker.Stop()
 
 	// Run immediately and then every second.
-	for ; true; <-ticker.C {
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		default:
+		}
+
 		start := time.Now()
 
 		updatedSubnets := n.SubscribedSubnets()
@@ -495,58 +501,63 @@ func (n *p2pNetwork) UpdateSubnets() {
 
 		registeredSubnets = updatedSubnets
 
-		if len(addedSubnets) == 0 && len(removedSubnets) == 0 {
-			continue
-		}
+		if len(addedSubnets) > 0 || len(removedSubnets) > 0 {
+			n.idx.UpdateSelfRecord(func(self *records.NodeInfo) *records.NodeInfo {
+				self.Metadata.Subnets = n.currentSubnets.StringHex()
+				return self
+			})
 
-		n.idx.UpdateSelfRecord(func(self *records.NodeInfo) *records.NodeInfo {
-			self.Metadata.Subnets = n.currentSubnets.StringHex()
-			return self
-		})
-
-		// Register/unregister subnets for discovery.
-		var errs error
-		var hasAdded, hasRemoved bool
-		if len(addedSubnets) > 0 {
-			var err error
-			hasAdded, err = n.disc.RegisterSubnets(addedSubnets...)
-			if err != nil {
-				n.logger.Debug("could not register subnets", zap.Error(err))
-				errs = errors.Join(errs, err)
-			}
-		}
-		if len(removedSubnets) > 0 {
-			var err error
-			hasRemoved, err = n.disc.DeregisterSubnets(removedSubnets...)
-			if err != nil {
-				n.logger.Debug("could not unregister subnets", zap.Error(err))
-				errs = errors.Join(errs, err)
-			}
-
-			// Unsubscribe from the removed subnets.
-			for _, removedSubnet := range removedSubnets {
-				if err := n.unsubscribeSubnet(removedSubnet); err != nil {
-					n.logger.Debug("could not unsubscribe from subnet", zap.Uint64("subnet", removedSubnet), zap.Error(err))
+			var (
+				errs                 error
+				hasAdded, hasRemoved bool
+			)
+			if len(addedSubnets) > 0 {
+				var err error
+				hasAdded, err = n.disc.RegisterSubnets(addedSubnets...)
+				if err != nil {
+					n.logger.Debug("could not register subnets", zap.Error(err))
 					errs = errors.Join(errs, err)
-				} else {
-					n.logger.Debug("unsubscribed from subnet", zap.Uint64("subnet", removedSubnet))
 				}
 			}
-		}
-		if hasAdded || hasRemoved {
-			go n.disc.PublishENR()
+			if len(removedSubnets) > 0 {
+				var err error
+				hasRemoved, err = n.disc.DeregisterSubnets(removedSubnets...)
+				if err != nil {
+					n.logger.Debug("could not unregister subnets", zap.Error(err))
+					errs = errors.Join(errs, err)
+				}
+
+				// Unsubscribe from the removed subnets.
+				for _, removedSubnet := range removedSubnets {
+					if err := n.unsubscribeSubnet(removedSubnet); err != nil {
+						n.logger.Debug("could not unsubscribe from subnet", zap.Uint64("subnet", removedSubnet), zap.Error(err))
+						errs = errors.Join(errs, err)
+					} else {
+						n.logger.Debug("unsubscribed from subnet", zap.Uint64("subnet", removedSubnet))
+					}
+				}
+			}
+			if hasAdded || hasRemoved {
+				go n.disc.PublishENR()
+			}
+
+			subnetsList := commons.AllSubnets.SharedSubnets(n.currentSubnets)
+			n.logger.Debug("updated subnets",
+				zap.Any("added", addedSubnets),
+				zap.Any("removed", removedSubnets),
+				zap.Any("subnets", subnetsList),
+				zap.Any("subscribed_topics", n.topicsCtrl.Topics()),
+				zap.Int("total_subnets", len(subnetsList)),
+				fields.Took(time.Since(start)),
+				zap.Error(errs),
+			)
 		}
 
-		subnetsList := commons.AllSubnets.SharedSubnets(n.currentSubnets)
-		n.logger.Debug("updated subnets",
-			zap.Any("added", addedSubnets),
-			zap.Any("removed", removedSubnets),
-			zap.Any("subnets", subnetsList),
-			zap.Any("subscribed_topics", n.topicsCtrl.Topics()),
-			zap.Int("total_subnets", len(subnetsList)),
-			fields.Took(time.Since(start)),
-			zap.Error(errs),
-		)
+		select {
+		case <-n.ctx.Done():
+			return
+		case <-ticker.C:
+		}
 	}
 }
 
@@ -563,13 +574,17 @@ func (n *p2pNetwork) UpdateScoreParams() {
 		return n.cfg.NetworkConfig.EpochStartTime(nextEpoch)
 	}
 
-	// Create timer that triggers on the beginning of the next epoch
-	timer := time.NewTimer(time.Until(nextEpochStartingTime()))
+	timer := time.NewTimer(0)
 	defer timer.Stop()
 
-	// Run immediately and then once every epoch
-	for ; true; <-timer.C {
-		// Update score parameters
+	// Run immediately and then once every epoch.
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		case <-timer.C:
+		}
+
 		err := n.topicsCtrl.UpdateScoreParams()
 		if err != nil {
 			n.logger.Debug("score parameters update failed", zap.Error(err))

--- a/network/p2p/p2p_shutdown_test.go
+++ b/network/p2p/p2p_shutdown_test.go
@@ -1,0 +1,105 @@
+package p2pv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/utils/hashmap"
+)
+
+type mockTopicsController struct {
+	updateCalled chan struct{}
+}
+
+func (f *mockTopicsController) Subscribe(string) error {
+	return nil
+}
+
+func (f *mockTopicsController) Unsubscribe(string, bool) error {
+	return nil
+}
+
+func (f *mockTopicsController) Peers(string) ([]peer.ID, error) {
+	return nil, nil
+}
+
+func (f *mockTopicsController) Topics() []string {
+	return nil
+}
+
+func (f *mockTopicsController) Broadcast(string, []byte, time.Duration) error {
+	return nil
+}
+
+func (f *mockTopicsController) UpdateScoreParams() error {
+	select {
+	case f.updateCalled <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (f *mockTopicsController) Close() error {
+	return nil
+}
+
+func TestUpdateSubnetsStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	n := &p2pNetwork{
+		ctx:                  ctx,
+		subscribedCommittees: hashmap.New[string, committeeSubscriptionStatus](),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n.UpdateSubnets()
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		require.Fail(t, "UpdateSubnets did not stop after context cancellation")
+	}
+}
+
+func TestUpdateScoreParamsStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	topicsCtrl := &mockTopicsController{updateCalled: make(chan struct{}, 1)}
+
+	n := &p2pNetwork{
+		ctx:        ctx,
+		logger:     zap.NewNop(),
+		cfg:        &Config{NetworkConfig: networkconfig.TestNetwork},
+		topicsCtrl: topicsCtrl,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n.UpdateScoreParams()
+	}()
+
+	select {
+	case <-topicsCtrl.updateCalled:
+	case <-time.After(200 * time.Millisecond):
+		require.Fail(t, "UpdateScoreParams did not run its initial update")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		require.Fail(t, "UpdateScoreParams did not stop after context cancellation")
+	}
+}

--- a/network/p2p/p2p_shutdown_test.go
+++ b/network/p2p/p2p_shutdown_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
+const timeout = 400 * time.Millisecond
+
 type mockTopicsController struct {
 	updateCalled chan struct{}
 }
@@ -67,7 +69,7 @@ func TestUpdateSubnetsStopsOnContextCancel(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(timeout):
 		require.Fail(t, "UpdateSubnets did not stop after context cancellation")
 	}
 }
@@ -91,7 +93,7 @@ func TestUpdateScoreParamsStopsOnContextCancel(t *testing.T) {
 
 	select {
 	case <-topicsCtrl.updateCalled:
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(timeout):
 		require.Fail(t, "UpdateScoreParams did not run its initial update")
 	}
 
@@ -99,7 +101,7 @@ func TestUpdateScoreParamsStopsOnContextCancel(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(timeout):
 		require.Fail(t, "UpdateScoreParams did not stop after context cancellation")
 	}
 }

--- a/utils/async/interval.go
+++ b/utils/async/interval.go
@@ -7,8 +7,8 @@ import (
 
 // Interval runs the provided function periodically every period
 func Interval(ctx context.Context, interval time.Duration, f func()) {
-	ticker := time.NewTicker(interval)
 	go func() {
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		for {

--- a/utils/async/interval.go
+++ b/utils/async/interval.go
@@ -6,11 +6,11 @@ import (
 )
 
 // Interval runs the provided function periodically every period
-func Interval(pctx context.Context, interval time.Duration, f func()) {
+func Interval(ctx context.Context, interval time.Duration, f func()) {
 	ticker := time.NewTicker(interval)
 	go func() {
-		ctx, cancel := context.WithCancel(pctx)
-		defer cancel()
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
# Summary

This PR fixes goroutine and timer leak paths in the network layer by making periodic background loops respect shutdown and by stopping the interval ticker when the loop exits.

Specifically:

- `utils/async/interval.go`: stop the internal `time.Ticker` on exit to avoid leaking timer resources
- `network/p2p/p2p.go`: make `UpdateSubnets` and `UpdateScoreParams` exit when the P2P network context is cancelled

This keeps shutdown behavior aligned with `p2pNetwork.Close()`, which already cancels `n.ctx`.

# Problem

Two periodic loop patterns were not fully tied to shutdown:

- `Interval(...)` created a `time.Ticker` but never called `ticker.Stop()`
- `UpdateSubnets()` and `UpdateScoreParams()` were launched as background goroutines, but their loop wait paths did not consistently observe `n.ctx.Done()`