### PR TITLE
Peer scoring algorithm

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -595,8 +595,9 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 	trimSnapshot := n.newPeerTrimSnapshot()
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
+		peerContribution := trimSnapshot.peerSubnetPeers[peerID]
 		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-		scores[peerID] = trimSnapshot.score(peerID, peerSubnets)
+		scores[peerID] = trimSnapshot.score(peerContribution, peerSubnets)
 	}
 	return scores
 }
@@ -628,6 +629,9 @@ func (n *p2pNetwork) newPeerTrimSnapshot() peerTrimSnapshot {
 		for _, peerID := range peers {
 			snapshot.totalSubnetPeers[subnet]++
 
+			// peerSubnetPeers is populated from the same topic membership snapshot as
+			// totalSubnetPeers, so each peer contribution count is a subset of the
+			// corresponding total and can be subtracted safely when scoring.
 			peerSubnetPeers := snapshot.peerSubnetPeers[peerID]
 			peerSubnetPeers[subnet]++
 			snapshot.peerSubnetPeers[peerID] = peerSubnetPeers
@@ -637,8 +641,8 @@ func (n *p2pNetwork) newPeerTrimSnapshot() peerTrimSnapshot {
 	return snapshot
 }
 
-func (s peerTrimSnapshot) score(peerID peer.ID, peerSubnets commons.Subnets) float64 {
-	subnetPeersExcluding := s.totalSubnetPeers.Subtract(s.peerSubnetPeers[peerID])
+func (s peerTrimSnapshot) score(peerContribution SubnetPeers, peerSubnets commons.Subnets) float64 {
+	subnetPeersExcluding := s.totalSubnetPeers.Subtract(peerContribution)
 	return subnetPeersExcluding.Score(s.ownSubnets, peerSubnets)
 }
 
@@ -665,9 +669,17 @@ func (a SubnetPeers) Add(b SubnetPeers) SubnetPeers {
 	return sum
 }
 
+// Subtract returns the element-wise difference between two subnet peer snapshots.
+// In trim scoring, b is expected to be a per-peer contribution derived from the
+// same topic membership snapshot as a, so each b[i] should be less than or equal
+// to a[i]. If a future caller violates that relationship, the result is clamped
+// to 0 for that subnet instead of allowing uint16 underflow.
 func (a SubnetPeers) Subtract(b SubnetPeers) SubnetPeers {
 	var diff SubnetPeers
 	for i := range a {
+		if b[i] > a[i] {
+			continue
+		}
 		diff[i] = a[i] - b[i]
 	}
 	return diff

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -381,7 +381,7 @@ func (n *p2pNetwork) peersTrimming() func() {
 }
 
 // choosePeersToTrim returns a map of peers that are least-valuable to us based on how much
-// (dead/solo/duo) they contribute to us (as defined by peerScore func).
+// (dead/solo/duo) they contribute to us.
 func (n *p2pNetwork) choosePeersToTrim(trimCnt int, trimInboundOnly bool) map[peer.ID]struct{} {
 	myPeers, err := n.topicsCtrl.Peers("")
 	if err != nil {
@@ -594,16 +594,22 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 // buildPeerTrimScores snapshots topic membership once and computes trim scores
 // for the given peers.
 //
-// ownSubnets is our local subscription bitset: which subnets this node cares
-// about when evaluating a peer's usefulness.
+// The peer-scores are calculated based on:
+//   - ownSubnets is the desired set of subnets we want to be connected to
+//   - ownSubnetPeers is our own currently connected peer count per subnet across all
+//     peers in our topic mesh
+//   - peerSubnets tracks all the subnets each of our peers is connected to
 //
-// totalSubnetPeers is the current connected peer count per subnet across all
-// peers in our topic mesh. For each candidate peer we subtract only that peer's
-// own contribution from this total before scoring it.
+// Algo:
+//   - calculate (take snapshot of) ownSubnets, ownSubnetPeers, peerSubnets
+//   - for each candidate peer we need to score:
+//   - calculate subnetPeersExcluding (currently connected subnets IF that candidate peer is excluded/disconnected)
+//   - use SubnetPeers.Score to calculate the final peer-score for each peer (based on: subnetPeersExcluding, desired
+//     set of subnets, subnets this peer is connected to)
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
 	ownSubnets := n.SubscribedSubnets()
-	totalSubnetPeers := newSubnetPeers()
-	peerSubnetPeers := make(map[peer.ID]SubnetPeers)
+	ownSubnetPeers := newSubnetPeers()
+	peerSubnets := make(map[peer.ID]commons.Subnets)
 
 	for topic, peers := range n.PeersByTopic() {
 		subnet, ok := n.topicSubnet(topic)
@@ -611,37 +617,35 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 			continue
 		}
 
-		totalSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
+		ownSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
 		for _, peerID := range peers {
-			peerContribution := peerSubnetPeers[peerID]
-			peerContribution[subnet]++
-			peerSubnetPeers[peerID] = peerContribution
+			peerContribution := peerSubnets[peerID]
+			peerContribution.Set(subnet)
+			peerSubnets[peerID] = peerContribution
 		}
 	}
 
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
-		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-		subnetPeersExcluding := totalSubnetPeers
-		for subnet := range subnetPeersExcluding {
-			peerContribution := peerSubnetPeers[peerID][subnet]
-			if peerContribution > subnetPeersExcluding[subnet] {
-				// peerSubnetPeers is built from the same topic membership snapshot as
-				// totalSubnetPeers, so underflow should be impossible. Clamp to zero if
-				// that invariant is ever broken by a future change.
-				subnetPeersExcluding[subnet] = 0
-				continue
+		pSubnets := peerSubnets[peerID]
+		subnetPeersExcluding := ownSubnetPeers
+		for subnet := range ownSubnetPeers {
+			if pSubnets.IsSet(uint64(subnet)) { //nolint: gosec
+				// This subtraction here should never result into an underflow in practice (by construction),
+				// clamp to zero just in case that invariant is ever broken by a future change.
+				if subnetPeersExcluding[subnet] >= 1 {
+					subnetPeersExcluding[subnet] -= 1
+				}
 			}
-			subnetPeersExcluding[subnet] -= peerContribution
 		}
 
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, peerSubnets)
+		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
 	}
 	return scores
 }
 
 // topicSubnet parses a topic name into a subnet index and logs malformed topics.
-func (n *p2pNetwork) topicSubnet(topic string) (int, bool) {
+func (n *p2pNetwork) topicSubnet(topic string) (uint64, bool) {
 	subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
 	if err != nil {
 		n.logger.Error("failed to parse topic", zap.String("topic", topic), zap.Error(err))
@@ -651,10 +655,10 @@ func (n *p2pNetwork) topicSubnet(topic string) (int, bool) {
 		n.logger.Error("invalid topic", zap.String("topic", topic), zap.Int("subnet", int(subnet)))
 		return 0, false
 	}
-	return int(subnet), true
+	return uint64(subnet), true
 }
 
-// SubnetPeers contains the number of peers we are connected to for each subnet.
+// SubnetPeers maps subnets to the number of peers connected to each of those subnets.
 type SubnetPeers [commons.SubnetsCount]uint16
 
 func newSubnetPeers() SubnetPeers {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -591,59 +591,67 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 	return n.cfg.TopicMaxPeers
 }
 
+// buildPeerTrimScores snapshots topic membership once and computes trim scores
+// for the given peers.
+//
+// ownSubnets is our local subscription bitset: which subnets this node cares
+// about when evaluating a peer's usefulness.
+//
+// totalSubnetPeers is the current connected peer count per subnet across all
+// peers in our topic mesh. For each candidate peer we subtract only that peer's
+// own contribution from this total before scoring it.
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
-	trimSnapshot := n.newPeerTrimSnapshot()
+	ownSubnets := n.SubscribedSubnets()
+	totalSubnetPeers := newSubnetPeers()
+	peerSubnetPeers := make(map[peer.ID]SubnetPeers)
+
+	for topic, peers := range n.PeersByTopic() {
+		subnet, ok := n.topicSubnet(topic)
+		if !ok {
+			continue
+		}
+
+		totalSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
+		for _, peerID := range peers {
+			peerContribution := peerSubnetPeers[peerID]
+			peerContribution[subnet]++
+			peerSubnetPeers[peerID] = peerContribution
+		}
+	}
+
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
-		peerContribution := trimSnapshot.peerSubnetPeers[peerID]
 		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-		scores[peerID] = trimSnapshot.score(peerContribution, peerSubnets)
+		subnetPeersExcluding := totalSubnetPeers
+		for subnet := range subnetPeersExcluding {
+			peerContribution := peerSubnetPeers[peerID][subnet]
+			if peerContribution > subnetPeersExcluding[subnet] {
+				// peerSubnetPeers is built from the same topic membership snapshot as
+				// totalSubnetPeers, so underflow should be impossible. Clamp to zero if
+				// that invariant is ever broken by a future change.
+				subnetPeersExcluding[subnet] = 0
+				continue
+			}
+			subnetPeersExcluding[subnet] -= peerContribution
+		}
+
+		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, peerSubnets)
 	}
 	return scores
 }
 
-type peerTrimSnapshot struct {
-	ownSubnets       commons.Subnets
-	totalSubnetPeers SubnetPeers
-	peerSubnetPeers  map[peer.ID]SubnetPeers
-}
-
-func (n *p2pNetwork) newPeerTrimSnapshot() peerTrimSnapshot {
-	snapshot := peerTrimSnapshot{
-		ownSubnets:       n.SubscribedSubnets(),
-		totalSubnetPeers: newSubnetPeers(),
-		peerSubnetPeers:  make(map[peer.ID]SubnetPeers),
+// topicSubnet parses a topic name into a subnet index and logs malformed topics.
+func (n *p2pNetwork) topicSubnet(topic string) (int, bool) {
+	subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
+	if err != nil {
+		n.logger.Error("failed to parse topic", zap.String("topic", topic), zap.Error(err))
+		return 0, false
 	}
-
-	for topic, peers := range n.PeersByTopic() {
-		subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
-		if err != nil {
-			n.logger.Error("failed to parse topic", zap.String("topic", topic), zap.Error(err))
-			continue
-		}
-		if subnet < 0 || subnet >= commons.SubnetsCount {
-			n.logger.Error("invalid topic", zap.String("topic", topic), zap.Int("subnet", int(subnet)))
-			continue
-		}
-
-		for _, peerID := range peers {
-			snapshot.totalSubnetPeers[subnet]++
-
-			// peerSubnetPeers is populated from the same topic membership snapshot as
-			// totalSubnetPeers, so each peer contribution count is a subset of the
-			// corresponding total and can be subtracted safely when scoring.
-			peerSubnetPeers := snapshot.peerSubnetPeers[peerID]
-			peerSubnetPeers[subnet]++
-			snapshot.peerSubnetPeers[peerID] = peerSubnetPeers
-		}
+	if subnet < 0 || subnet >= commons.SubnetsCount {
+		n.logger.Error("invalid topic", zap.String("topic", topic), zap.Int("subnet", int(subnet)))
+		return 0, false
 	}
-
-	return snapshot
-}
-
-func (s peerTrimSnapshot) score(peerContribution SubnetPeers, peerSubnets commons.Subnets) float64 {
-	subnetPeersExcluding := s.totalSubnetPeers.Subtract(peerContribution)
-	return subnetPeersExcluding.Score(s.ownSubnets, peerSubnets)
+	return int(subnet), true
 }
 
 // SubnetPeers contains the number of peers we are connected to for each subnet.
@@ -667,22 +675,6 @@ func (a SubnetPeers) Add(b SubnetPeers) SubnetPeers {
 		sum[i] = a[i] + b[i]
 	}
 	return sum
-}
-
-// Subtract returns the element-wise difference between two subnet peer snapshots.
-// In trim scoring, b is expected to be a per-peer contribution derived from the
-// same topic membership snapshot as a, so each b[i] should be less than or equal
-// to a[i]. If a future caller violates that relationship, the result is clamped
-// to 0 for that subnet instead of allowing uint16 underflow.
-func (a SubnetPeers) Subtract(b SubnetPeers) SubnetPeers {
-	var diff SubnetPeers
-	for i := range a {
-		if b[i] > a[i] {
-			continue
-		}
-		diff[i] = a[i] - b[i]
-	}
-	return diff
 }
 
 // Score estimates how many valuable subnets the given peer would contribute.

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -639,7 +639,8 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 			}
 		}
 
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
+		advertisedSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
+		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, advertisedSubnets)
 	}
 	return scores
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -389,10 +389,11 @@ func (n *p2pNetwork) choosePeersToTrim(trimCnt int, trimInboundOnly bool) map[pe
 		return nil
 	}
 
+	peerScores := n.buildPeerTrimScores(myPeers)
 	slices.SortFunc(myPeers, func(a, b peer.ID) int {
 		// sort in asc order (peers with the lowest scores come first)
-		aScore := n.peerScore(a)
-		bScore := n.peerScore(b)
+		aScore := peerScores[a]
+		bScore := peerScores[b]
 		if aScore < bScore {
 			return -1
 		}
@@ -590,34 +591,55 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 	return n.cfg.TopicMaxPeers
 }
 
-// peerScore calculates peer score based on how valuable this peer would have been if we didn't
-// have him, but then connected with.
-func (n *p2pNetwork) peerScore(peerID peer.ID) float64 {
-	// Compute number of peers we're connected to for each subnet excluding peer with peerID.
-	subnetPeersExcluding := newSubnetPeers()
+func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
+	trimSnapshot := n.newPeerTrimSnapshot()
+	scores := make(map[peer.ID]float64, len(peerIDs))
+	for _, peerID := range peerIDs {
+		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
+		scores[peerID] = trimSnapshot.score(peerID, peerSubnets)
+	}
+	return scores
+}
+
+type peerTrimSnapshot struct {
+	ownSubnets       commons.Subnets
+	totalSubnetPeers SubnetPeers
+	peerSubnetPeers  map[peer.ID]SubnetPeers
+}
+
+func (n *p2pNetwork) newPeerTrimSnapshot() peerTrimSnapshot {
+	snapshot := peerTrimSnapshot{
+		ownSubnets:       n.SubscribedSubnets(),
+		totalSubnetPeers: newSubnetPeers(),
+		peerSubnetPeers:  make(map[peer.ID]SubnetPeers),
+	}
+
 	for topic, peers := range n.PeersByTopic() {
 		subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
 		if err != nil {
-			n.logger.Error("failed to parse topic",
-				zap.String("topic", topic), zap.Error(err))
+			n.logger.Error("failed to parse topic", zap.String("topic", topic), zap.Error(err))
 			continue
 		}
 		if subnet < 0 || subnet >= commons.SubnetsCount {
-			n.logger.Error("invalid topic",
-				zap.String("topic", topic), zap.Int("subnet", int(subnet)))
+			n.logger.Error("invalid topic", zap.String("topic", topic), zap.Int("subnet", int(subnet)))
 			continue
 		}
-		for _, pID := range peers {
-			if pID == peerID {
-				continue
-			}
-			subnetPeersExcluding[subnet]++
+
+		for _, peerID := range peers {
+			snapshot.totalSubnetPeers[subnet]++
+
+			peerSubnetPeers := snapshot.peerSubnetPeers[peerID]
+			peerSubnetPeers[subnet]++
+			snapshot.peerSubnetPeers[peerID] = peerSubnetPeers
 		}
 	}
 
-	ownSubnets := n.SubscribedSubnets()
-	peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-	return subnetPeersExcluding.Score(ownSubnets, peerSubnets)
+	return snapshot
+}
+
+func (s peerTrimSnapshot) score(peerID peer.ID, peerSubnets commons.Subnets) float64 {
+	subnetPeersExcluding := s.totalSubnetPeers.Subtract(s.peerSubnetPeers[peerID])
+	return subnetPeersExcluding.Score(s.ownSubnets, peerSubnets)
 }
 
 // SubnetPeers contains the number of peers we are connected to for each subnet.
@@ -641,6 +663,14 @@ func (a SubnetPeers) Add(b SubnetPeers) SubnetPeers {
 		sum[i] = a[i] + b[i]
 	}
 	return sum
+}
+
+func (a SubnetPeers) Subtract(b SubnetPeers) SubnetPeers {
+	var diff SubnetPeers
+	for i := range a {
+		diff[i] = a[i] - b[i]
+	}
+	return diff
 }
 
 // Score estimates how many valuable subnets the given peer would contribute.

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -3,14 +3,12 @@ package p2pv1
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/oleiade/lane/v2"
 	"go.uber.org/zap"
 
-	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/discovery"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/utils/async"
@@ -68,15 +66,8 @@ func (n *p2pNetwork) startDiscovery() error {
 		ownSubnets := n.SubscribedSubnets()
 		currentSubnetPeers := newSubnetPeers()
 		for topic, peers := range n.PeersByTopic() {
-			subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
-			if err != nil {
-				n.logger.Error("failed to parse topic",
-					zap.String("topic", topic), zap.Error(err))
-				continue
-			}
-			if subnet < 0 || subnet >= commons.SubnetsCount {
-				n.logger.Error("invalid topic",
-					zap.String("topic", topic), zap.Int("subnet", int(subnet)))
+			subnet, ok := n.topicSubnet(topic)
+			if !ok {
 				continue
 			}
 			currentSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -337,16 +337,6 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	}, scores)
 }
 
-func TestSubnetPeersSubtract_ClampsUnderflow(t *testing.T) {
-	base := newSubnetPeers()
-	base[3] = 1
-
-	subtracted := newSubnetPeers()
-	subtracted[3] = 2
-
-	assert.Equal(t, uint16(0), base.Subtract(subtracted)[3])
-}
-
 func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	ctx := context.Background()
 	localHost := newBenchmarkHost(b)

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -2,6 +2,7 @@ package p2pv1
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -270,6 +271,31 @@ func singleTrimScore(network *p2pNetwork, peerID peer.ID) float64 {
 }
 
 func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.Index, ownSubnets commons.Subnets) *p2pNetwork {
+	if idx == nil {
+		if host != nil {
+			idx = peers.NewPeersIndex(zap.NewNop(), host.Network(), nil, func(string) int { return 0 }, nil, peers.NewGossipScoreIndex())
+		} else {
+			idx = peers.NewPeersIndex(zap.NewNop(), nil, nil, func(string) int { return 0 }, nil, peers.NewGossipScoreIndex())
+		}
+		if topicsCtrl != nil {
+			for _, topic := range topicsCtrl.Topics() {
+				subnet, err := strconv.ParseUint(commons.GetTopicBaseName(topic), 10, 64)
+				if err != nil || subnet >= commons.SubnetsCount {
+					continue
+				}
+				peersByTopic, err := topicsCtrl.Peers(topic)
+				if err != nil {
+					continue
+				}
+				for _, peerID := range peersByTopic {
+					subnets, _ := idx.GetPeerSubnets(peerID)
+					subnets.Set(subnet)
+					idx.UpdatePeerSubnets(peerID, subnets)
+				}
+			}
+		}
+	}
+
 	return &p2pNetwork{
 		logger:                  zap.NewNop(),
 		host:                    host,

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -1,0 +1,413 @@
+package p2pv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	p2pnet "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/network/peers"
+	"github.com/ssvlabs/ssv/network/records"
+	"github.com/ssvlabs/ssv/network/topics"
+	"github.com/ssvlabs/ssv/utils/hashmap"
+)
+
+type testTopicsController struct {
+	topics       []string
+	peersByTopic map[string][]peer.ID
+	allPeers     []peer.ID
+}
+
+func (c *testTopicsController) Subscribe(string) error {
+	return nil
+}
+
+func (c *testTopicsController) Unsubscribe(string, bool) error {
+	return nil
+}
+
+func (c *testTopicsController) Peers(topicName string) ([]peer.ID, error) {
+	if topicName == "" {
+		return append([]peer.ID(nil), c.allPeers...), nil
+	}
+	return append([]peer.ID(nil), c.peersByTopic[topicName]...), nil
+}
+
+func (c *testTopicsController) Topics() []string {
+	return append([]string(nil), c.topics...)
+}
+
+func (c *testTopicsController) Broadcast(string, []byte, time.Duration) error {
+	return nil
+}
+
+func (c *testTopicsController) UpdateScoreParams() error {
+	return nil
+}
+
+func (c *testTopicsController) Close() error {
+	return nil
+}
+
+var _ topics.Controller = (*testTopicsController)(nil)
+
+type testPeerIndex struct {
+	subnets peers.SubnetsIndex
+}
+
+func newTestPeerIndex() *testPeerIndex {
+	return &testPeerIndex{
+		subnets: peers.NewSubnetsIndex(),
+	}
+}
+
+func (i *testPeerIndex) Connectedness(peer.ID) p2pnet.Connectedness {
+	return p2pnet.NotConnected
+}
+
+func (i *testPeerIndex) CanConnect(peer.ID) error {
+	return nil
+}
+
+func (i *testPeerIndex) AtLimit(p2pnet.Direction) bool {
+	return false
+}
+
+func (i *testPeerIndex) IsBad(peer.ID) bool {
+	return false
+}
+
+func (i *testPeerIndex) Score(peer.ID, ...*peers.NodeScore) error {
+	return nil
+}
+
+func (i *testPeerIndex) GetScore(peer.ID, ...string) ([]peers.NodeScore, error) {
+	return nil, nil
+}
+
+func (i *testPeerIndex) SelfSealed() ([]byte, error) {
+	return nil, nil
+}
+
+func (i *testPeerIndex) Self() *records.NodeInfo {
+	return nil
+}
+
+func (i *testPeerIndex) UpdateSelfRecord(func(*records.NodeInfo) *records.NodeInfo) {
+}
+
+func (i *testPeerIndex) SetNodeInfo(peer.ID, *records.NodeInfo) {
+}
+
+func (i *testPeerIndex) NodeInfo(peer.ID) *records.NodeInfo {
+	return nil
+}
+
+func (i *testPeerIndex) PeerInfo(peer.ID) *peers.PeerInfo {
+	return nil
+}
+
+func (i *testPeerIndex) AddPeerInfo(peer.ID, ma.Multiaddr, p2pnet.Direction) {
+}
+
+func (i *testPeerIndex) UpdatePeerInfo(peer.ID, func(*peers.PeerInfo)) {
+}
+
+func (i *testPeerIndex) State(peer.ID) peers.PeerState {
+	return peers.StateUnknown
+}
+
+func (i *testPeerIndex) SetState(peer.ID, peers.PeerState) {
+}
+
+func (i *testPeerIndex) UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool {
+	return i.subnets.UpdatePeerSubnets(id, subnets)
+}
+
+func (i *testPeerIndex) GetSubnetPeers(subnet int) []peer.ID {
+	return i.subnets.GetSubnetPeers(subnet)
+}
+
+func (i *testPeerIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
+	return i.subnets.GetPeerSubnets(id)
+}
+
+func (i *testPeerIndex) GetSubnetsStats() *peers.SubnetsStats {
+	return i.subnets.GetSubnetsStats()
+}
+
+func (i *testPeerIndex) SetScores(map[peer.ID]float64) {
+}
+
+func (i *testPeerIndex) GetGossipScore(peer.ID) (float64, bool) {
+	return 0, false
+}
+
+func (i *testPeerIndex) HasBadGossipScore(peer.ID) (bool, float64) {
+	return false, 0
+}
+
+func (i *testPeerIndex) Close() error {
+	return nil
+}
+
+var _ peers.Index = (*testPeerIndex)(nil)
+
+func TestPeerScore_CharacterizesDeadSoloDuoScoring(t *testing.T) {
+	candidate := peer.ID("candidate")
+	other1 := peer.ID("other-1")
+	other2 := peer.ID("other-2")
+	other3 := peer.ID("other-3")
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0, 1, 2, 3)))
+
+	network := newTrimTestNetwork(
+		nil,
+		&testTopicsController{
+			topics: []string{"0", "1", "2", "3"},
+			peersByTopic: map[string][]peer.ID{
+				"0": {candidate},
+				"1": {candidate, other1},
+				"2": {candidate, other1, other2},
+				"3": {candidate, other1, other2, other3},
+			},
+		},
+		idx,
+		subnetsFor(0, 1, 2, 3),
+	)
+
+	assert.Equal(t, 21.0, network.peerScore(candidate))
+}
+
+func TestPeerScore_ExcludesCandidateFromSubnetCounts(t *testing.T) {
+	candidate := peer.ID("candidate")
+	other := peer.ID("other")
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(1)))
+
+	network := newTrimTestNetwork(
+		nil,
+		&testTopicsController{
+			topics: []string{"1"},
+			peersByTopic: map[string][]peer.ID{
+				"1": {candidate, other},
+			},
+		},
+		idx,
+		subnetsFor(1),
+	)
+
+	assert.Equal(t, 4.0, network.peerScore(candidate))
+}
+
+func TestPeerScore_IgnoresInvalidTopics(t *testing.T) {
+	candidate := peer.ID("candidate")
+	other := peer.ID("other")
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0)))
+
+	network := newTrimTestNetwork(
+		nil,
+		&testTopicsController{
+			topics: []string{"0", "not-a-subnet", "999"},
+			peersByTopic: map[string][]peer.ID{
+				"0":            {candidate, other},
+				"not-a-subnet": {candidate},
+				"999":          {candidate},
+			},
+		},
+		idx,
+		subnetsFor(0),
+	)
+
+	assert.Equal(t, 4.0, network.peerScore(candidate))
+}
+
+func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
+	ctx := t.Context()
+	localHost := newTestHost(t)
+	highValuePeer := newTestHost(t)
+	mediumValuePeer := newTestHost(t)
+	lowValuePeer := newTestHost(t)
+
+	connectHosts(t, ctx, localHost, highValuePeer)
+	connectHosts(t, ctx, localHost, mediumValuePeer)
+	connectHosts(t, ctx, localHost, lowValuePeer)
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(highValuePeer.ID(), subnetsFor(0)))
+	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer.ID(), subnetsFor(1)))
+	require.True(t, idx.UpdatePeerSubnets(lowValuePeer.ID(), subnetsFor(3)))
+
+	network := newTrimTestNetwork(
+		localHost,
+		&testTopicsController{
+			topics: []string{"0", "1", "3"},
+			peersByTopic: map[string][]peer.ID{
+				"0": {highValuePeer.ID()},
+				"1": {highValuePeer.ID(), mediumValuePeer.ID()},
+				"3": {lowValuePeer.ID()},
+			},
+			allPeers: []peer.ID{highValuePeer.ID(), mediumValuePeer.ID(), lowValuePeer.ID()},
+		},
+		idx,
+		subnetsFor(0, 1),
+	)
+
+	trimmed := network.choosePeersToTrim(1, false)
+	assert.Equal(t, map[peer.ID]struct{}{lowValuePeer.ID(): {}}, trimmed)
+}
+
+func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
+	ctx := t.Context()
+	localHost := newTestHost(t)
+	outboundPeer := newTestHost(t)
+	inboundPeer := newTestHost(t)
+	highValueInboundPeer := newTestHost(t)
+
+	connectHosts(t, ctx, localHost, outboundPeer)
+	connectHosts(t, ctx, inboundPeer, localHost)
+	connectHosts(t, ctx, highValueInboundPeer, localHost)
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(outboundPeer.ID(), subnetsFor(3)))
+	require.True(t, idx.UpdatePeerSubnets(inboundPeer.ID(), subnetsFor(1)))
+	require.True(t, idx.UpdatePeerSubnets(highValueInboundPeer.ID(), subnetsFor(0)))
+
+	network := newTrimTestNetwork(
+		localHost,
+		&testTopicsController{
+			topics: []string{"0", "1", "3"},
+			peersByTopic: map[string][]peer.ID{
+				"0": {highValueInboundPeer.ID()},
+				"1": {highValueInboundPeer.ID(), inboundPeer.ID()},
+				"3": {outboundPeer.ID()},
+			},
+			allPeers: []peer.ID{outboundPeer.ID(), inboundPeer.ID(), highValueInboundPeer.ID()},
+		},
+		idx,
+		subnetsFor(0, 1),
+	)
+
+	trimmed := network.choosePeersToTrim(1, true)
+	assert.Equal(t, map[peer.ID]struct{}{inboundPeer.ID(): {}}, trimmed)
+}
+
+func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
+	ctx := context.Background()
+	localHost := newBenchmarkHost(b)
+
+	const (
+		peerCount  = 150
+		topicCount = 16
+		trimCount  = 4
+	)
+
+	topicsByName := make(map[string][]peer.ID, topicCount)
+	topicNames := make([]string, 0, topicCount)
+	for subnet := range topicCount {
+		topicNames = append(topicNames, commons.SubnetTopicID(uint64(subnet)))
+	}
+
+	allPeers := make([]peer.ID, 0, peerCount)
+	idx := newTestPeerIndex()
+	for i := 0; i < peerCount; i++ {
+		remoteHost := newBenchmarkHost(b)
+		connectHostsForBenchmark(b, ctx, localHost, remoteHost)
+
+		peerID := remoteHost.ID()
+		subnet := uint64(i % topicCount)
+		require.True(b, idx.UpdatePeerSubnets(peerID, subnetsFor(subnet)))
+		topicsByName[commons.SubnetTopicID(subnet)] = append(topicsByName[commons.SubnetTopicID(subnet)], peerID)
+		allPeers = append(allPeers, peerID)
+	}
+
+	network := newTrimTestNetwork(
+		localHost,
+		&testTopicsController{
+			topics:       topicNames,
+			peersByTopic: topicsByName,
+			allPeers:     allPeers,
+		},
+		idx,
+		subnetsFor(0, 1, 2, 3, 4, 5, 6, 7),
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = network.choosePeersToTrim(trimCount, false)
+	}
+}
+
+func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.Index, ownSubnets commons.Subnets) *p2pNetwork {
+	return &p2pNetwork{
+		logger:                  zap.NewNop(),
+		host:                    host,
+		topicsCtrl:              topicsCtrl,
+		idx:                     idx,
+		persistentSubnets:       ownSubnets,
+		subscribedCommittees:    hashmap.New[string, committeeSubscriptionStatus](),
+		operatorPKHashToPKCache: hashmap.New[string, []byte](),
+	}
+}
+
+func subnetsFor(subnets ...uint64) commons.Subnets {
+	result := commons.ZeroSubnets
+	for _, subnet := range subnets {
+		result.Set(subnet)
+	}
+	return result
+}
+
+func newTestHost(t *testing.T) host.Host {
+	t.Helper()
+
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = h.Close()
+	})
+	return h
+}
+
+func connectHosts(t *testing.T, ctx context.Context, from host.Host, to host.Host) {
+	t.Helper()
+
+	require.NoError(t, from.Connect(ctx, peer.AddrInfo{ID: to.ID(), Addrs: to.Addrs()}))
+	require.Eventually(t, func() bool {
+		return len(from.Network().ConnsToPeer(to.ID())) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func newBenchmarkHost(b *testing.B) host.Host {
+	b.Helper()
+
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(b, err)
+	b.Cleanup(func() {
+		_ = h.Close()
+	})
+	return h
+}
+
+func connectHostsForBenchmark(b *testing.B, ctx context.Context, from host.Host, to host.Host) {
+	b.Helper()
+
+	require.NoError(b, from.Connect(ctx, peer.AddrInfo{ID: to.ID(), Addrs: to.Addrs()}))
+	require.Eventually(b, func() bool {
+		return len(from.Network().ConnsToPeer(to.ID())) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+}

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -7,16 +7,13 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
-	p2pnet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
-	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/network/topics"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
@@ -60,116 +57,11 @@ func (c *testTopicsController) Close() error {
 
 var _ topics.Controller = (*testTopicsController)(nil)
 
-type testPeerIndex struct {
-	subnets peers.SubnetsIndex
-}
-
-func newTestPeerIndex() *testPeerIndex {
-	return &testPeerIndex{
-		subnets: peers.NewSubnetsIndex(),
-	}
-}
-
-func (i *testPeerIndex) Connectedness(peer.ID) p2pnet.Connectedness {
-	return p2pnet.NotConnected
-}
-
-func (i *testPeerIndex) CanConnect(peer.ID) error {
-	return nil
-}
-
-func (i *testPeerIndex) AtLimit(p2pnet.Direction) bool {
-	return false
-}
-
-func (i *testPeerIndex) IsBad(peer.ID) bool {
-	return false
-}
-
-func (i *testPeerIndex) Score(peer.ID, ...*peers.NodeScore) error {
-	return nil
-}
-
-func (i *testPeerIndex) GetScore(peer.ID, ...string) ([]peers.NodeScore, error) {
-	return nil, nil
-}
-
-func (i *testPeerIndex) SelfSealed() ([]byte, error) {
-	return nil, nil
-}
-
-func (i *testPeerIndex) Self() *records.NodeInfo {
-	return nil
-}
-
-func (i *testPeerIndex) UpdateSelfRecord(func(*records.NodeInfo) *records.NodeInfo) {
-}
-
-func (i *testPeerIndex) SetNodeInfo(peer.ID, *records.NodeInfo) {
-}
-
-func (i *testPeerIndex) NodeInfo(peer.ID) *records.NodeInfo {
-	return nil
-}
-
-func (i *testPeerIndex) PeerInfo(peer.ID) *peers.PeerInfo {
-	return nil
-}
-
-func (i *testPeerIndex) AddPeerInfo(peer.ID, ma.Multiaddr, p2pnet.Direction) {
-}
-
-func (i *testPeerIndex) UpdatePeerInfo(peer.ID, func(*peers.PeerInfo)) {
-}
-
-func (i *testPeerIndex) State(peer.ID) peers.PeerState {
-	return peers.StateUnknown
-}
-
-func (i *testPeerIndex) SetState(peer.ID, peers.PeerState) {
-}
-
-func (i *testPeerIndex) UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool {
-	return i.subnets.UpdatePeerSubnets(id, subnets)
-}
-
-func (i *testPeerIndex) GetSubnetPeers(subnet int) []peer.ID {
-	return i.subnets.GetSubnetPeers(subnet)
-}
-
-func (i *testPeerIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
-	return i.subnets.GetPeerSubnets(id)
-}
-
-func (i *testPeerIndex) GetSubnetsStats() *peers.SubnetsStats {
-	return i.subnets.GetSubnetsStats()
-}
-
-func (i *testPeerIndex) SetScores(map[peer.ID]float64) {
-}
-
-func (i *testPeerIndex) GetGossipScore(peer.ID) (float64, bool) {
-	return 0, false
-}
-
-func (i *testPeerIndex) HasBadGossipScore(peer.ID) (bool, float64) {
-	return false, 0
-}
-
-func (i *testPeerIndex) Close() error {
-	return nil
-}
-
-var _ peers.Index = (*testPeerIndex)(nil)
-
 func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other1 := peer.ID("other-1")
 	other2 := peer.ID("other-2")
 	other3 := peer.ID("other-3")
-
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0, 1, 2, 3)))
 
 	network := newTrimTestNetwork(
 		nil,
@@ -182,19 +74,20 @@ func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 				"3": {candidate, other1, other2, other3},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1, 2, 3),
 	)
 
-	assert.Equal(t, 21.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		21.0, // dead + solo + duo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
-
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(1)))
 
 	network := newTrimTestNetwork(
 		nil,
@@ -204,19 +97,20 @@ func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 				"1": {candidate, other},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(1),
 	)
 
-	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		4.0, // solo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
-
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0)))
 
 	network := newTrimTestNetwork(
 		nil,
@@ -228,11 +122,15 @@ func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 				"999":          {candidate},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0),
 	)
 
-	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		4.0, // solo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
@@ -246,11 +144,6 @@ func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
 	connectHosts(t, ctx, localHost, mediumValuePeer)
 	connectHosts(t, ctx, localHost, lowValuePeer)
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(highValuePeer.ID(), subnetsFor(0)))
-	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer.ID(), subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(lowValuePeer.ID(), subnetsFor(3)))
-
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
@@ -262,7 +155,7 @@ func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
 			},
 			allPeers: []peer.ID{highValuePeer.ID(), mediumValuePeer.ID(), lowValuePeer.ID()},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
@@ -281,11 +174,6 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 	connectHosts(t, ctx, inboundPeer, localHost)
 	connectHosts(t, ctx, highValueInboundPeer, localHost)
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(outboundPeer.ID(), subnetsFor(3)))
-	require.True(t, idx.UpdatePeerSubnets(inboundPeer.ID(), subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(highValueInboundPeer.ID(), subnetsFor(0)))
-
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
@@ -297,7 +185,7 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 			},
 			allPeers: []peer.ID{outboundPeer.ID(), inboundPeer.ID(), highValueInboundPeer.ID()},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
@@ -310,11 +198,6 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	mediumValuePeer := peer.ID("medium-value")
 	lowValuePeer := peer.ID("low-value")
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(highValuePeer, subnetsFor(0)))
-	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer, subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(lowValuePeer, subnetsFor(3)))
-
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
@@ -325,14 +208,14 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 				"3": {lowValuePeer},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
 	scores := network.buildPeerTrimScores([]peer.ID{highValuePeer, mediumValuePeer, lowValuePeer})
 	assert.Equal(t, map[peer.ID]float64{
-		highValuePeer:   16,
-		mediumValuePeer: 4,
+		highValuePeer:   16 + 4, // dead + solo
+		mediumValuePeer: 4,      // solo
 		lowValuePeer:    0,
 	}, scores)
 }
@@ -354,14 +237,12 @@ func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	}
 
 	allPeers := make([]peer.ID, 0, peerCount)
-	idx := newTestPeerIndex()
 	for i := 0; i < peerCount; i++ {
 		remoteHost := newBenchmarkHost(b)
 		connectHostsForBenchmark(b, ctx, localHost, remoteHost)
 
 		peerID := remoteHost.ID()
 		subnet := uint64(i % topicCount)
-		require.True(b, idx.UpdatePeerSubnets(peerID, subnetsFor(subnet)))
 		topicsByName[commons.SubnetTopicID(subnet)] = append(topicsByName[commons.SubnetTopicID(subnet)], peerID)
 		allPeers = append(allPeers, peerID)
 	}
@@ -373,7 +254,7 @@ func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 			peersByTopic: topicsByName,
 			allPeers:     allPeers,
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1, 2, 3, 4, 5, 6, 7),
 	)
 

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -162,7 +162,7 @@ func (i *testPeerIndex) Close() error {
 
 var _ peers.Index = (*testPeerIndex)(nil)
 
-func TestPeerScore_CharacterizesDeadSoloDuoScoring(t *testing.T) {
+func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other1 := peer.ID("other-1")
 	other2 := peer.ID("other-2")
@@ -186,10 +186,10 @@ func TestPeerScore_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 		subnetsFor(0, 1, 2, 3),
 	)
 
-	assert.Equal(t, 21.0, network.peerScore(candidate))
+	assert.Equal(t, 21.0, singleTrimScore(network, candidate))
 }
 
-func TestPeerScore_ExcludesCandidateFromSubnetCounts(t *testing.T) {
+func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
 
@@ -208,10 +208,10 @@ func TestPeerScore_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 		subnetsFor(1),
 	)
 
-	assert.Equal(t, 4.0, network.peerScore(candidate))
+	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
 }
 
-func TestPeerScore_IgnoresInvalidTopics(t *testing.T) {
+func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
 
@@ -232,7 +232,7 @@ func TestPeerScore_IgnoresInvalidTopics(t *testing.T) {
 		subnetsFor(0),
 	)
 
-	assert.Equal(t, 4.0, network.peerScore(candidate))
+	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
 }
 
 func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
@@ -305,6 +305,38 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 	assert.Equal(t, map[peer.ID]struct{}{inboundPeer.ID(): {}}, trimmed)
 }
 
+func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
+	highValuePeer := peer.ID("high-value")
+	mediumValuePeer := peer.ID("medium-value")
+	lowValuePeer := peer.ID("low-value")
+
+	idx := newTestPeerIndex()
+	require.True(t, idx.UpdatePeerSubnets(highValuePeer, subnetsFor(0)))
+	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer, subnetsFor(1)))
+	require.True(t, idx.UpdatePeerSubnets(lowValuePeer, subnetsFor(3)))
+
+	network := newTrimTestNetwork(
+		nil,
+		&testTopicsController{
+			topics: []string{"0", "1", "3"},
+			peersByTopic: map[string][]peer.ID{
+				"0": {highValuePeer},
+				"1": {highValuePeer, mediumValuePeer},
+				"3": {lowValuePeer},
+			},
+		},
+		idx,
+		subnetsFor(0, 1),
+	)
+
+	scores := network.buildPeerTrimScores([]peer.ID{highValuePeer, mediumValuePeer, lowValuePeer})
+	assert.Equal(t, map[peer.ID]float64{
+		highValuePeer:   16,
+		mediumValuePeer: 4,
+		lowValuePeer:    0,
+	}, scores)
+}
+
 func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	ctx := context.Background()
 	localHost := newBenchmarkHost(b)
@@ -350,6 +382,10 @@ func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = network.choosePeersToTrim(trimCount, false)
 	}
+}
+
+func singleTrimScore(network *p2pNetwork, peerID peer.ID) float64 {
+	return network.buildPeerTrimScores([]peer.ID{peerID})[peerID]
 }
 
 func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.Index, ownSubnets commons.Subnets) *p2pNetwork {

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -337,6 +337,16 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	}, scores)
 }
 
+func TestSubnetPeersSubtract_ClampsUnderflow(t *testing.T) {
+	base := newSubnetPeers()
+	base[3] = 1
+
+	subtracted := newSubnetPeers()
+	subtracted[3] = 2
+
+	assert.Equal(t, uint16(0), base.Subtract(subtracted)[3])
+}
+
 func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	ctx := context.Background()
 	localHost := newBenchmarkHost(b)

--- a/network/peers/index.go
+++ b/network/peers/index.go
@@ -96,7 +96,8 @@ type SubnetsStats struct {
 }
 
 // SubnetsIndex stores information on subnets.
-// it keeps track of subnets but doesn't mind regards actual connections that we have.
+// It keeps track of subnets based on what peers advertise, but the actual subnets these peers have
+// might change by the time we directly connect with them.
 type SubnetsIndex interface {
 	// UpdatePeerSubnets updates the given peer's subnets
 	UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool


### PR DESCRIPTION
O(n^2) Peer Scoring During Trimming

Improve peer scoring performance from O(n^2) to O(n log(n)) by precomputing peer scores before sorting.