### PR TITLE
fix(ttl): add context support to prevent goroutine leak

### DIFF
--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -122,8 +122,8 @@ func TestCheckPeer(t *testing.T) {
 		subnetsIdx:          subnetIndex,
 		ssvConfig:           checkPeerTestSSVConfig,
 		subnets:             mySubnets,
-		discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](time.Hour, time.Hour),
-		trimmedRecently:     ttl.New[peer.ID, struct{}](time.Hour, time.Hour),
+		discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](ctx, time.Hour, time.Hour),
+		trimmedRecently:     ttl.New[peer.ID, struct{}](ctx, time.Hour, time.Hour),
 	}
 
 	for _, test := range tests {

--- a/network/discovery/util_test.go
+++ b/network/discovery/util_test.go
@@ -70,8 +70,8 @@ func testingDiscoveryOptions(t *testing.T, ssvConfig *networkconfig.SSV) *Option
 		ConnIndex:           connectionIndex,
 		SubnetsIdx:          subnetsIndex,
 		SSVConfig:           ssvConfig,
-		DiscoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](time.Hour, time.Hour),
-		TrimmedRecently:     ttl.New[peer.ID, struct{}](time.Hour, time.Hour),
+		DiscoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](t.Context(), time.Hour, time.Hour),
+		TrimmedRecently:     ttl.New[peer.ID, struct{}](t.Context(), time.Hour, time.Hour),
 	}
 }
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -142,8 +142,8 @@ func New(
 		operatorPKHashToPKCache: hashmap.New[string, []byte](),
 		operatorSigner:          cfg.OperatorSigner,
 		operatorDataStore:       cfg.OperatorDataStore,
-		discoveredPeersPool:     ttl.New[peer.ID, discovery.DiscoveredPeer](30*time.Minute, 3*time.Minute),
-		trimmedRecently:         ttl.New[peer.ID, struct{}](30*time.Minute, 3*time.Minute),
+		discoveredPeersPool:     ttl.New[peer.ID, discovery.DiscoveredPeer](ctx, 30*time.Minute, 3*time.Minute),
+		trimmedRecently:         ttl.New[peer.ID, struct{}](ctx, 30*time.Minute, 3*time.Minute),
 	}
 	if err := n.parseTrustedPeers(); err != nil {
 		return nil, err

--- a/utils/ttl/map.go
+++ b/utils/ttl/map.go
@@ -33,7 +33,6 @@ func New[Key comparable, Value any](ctx context.Context, lifespan, cleanupInterv
 			case <-ticker.C:
 				m.idxLastUpdatedAt.Range(func(key Key, t time.Time) bool {
 					if time.Since(t) > lifespan {
-						m.idxLastUpdatedAt.Delete(key)
 						m.Delete(key)
 					}
 					return true

--- a/utils/ttl/map.go
+++ b/utils/ttl/map.go
@@ -23,14 +23,11 @@ func New[Key comparable, Value any](ctx context.Context, lifespan, cleanupInterv
 		idxLastUpdatedAt: hashmap.Map[Key, time.Time]{},
 	}
 	go func() {
-		ticker := time.NewTicker(cleanupInterval)
-		defer ticker.Stop()
-
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
+			case <-time.After(cleanupInterval):
 				m.idxLastUpdatedAt.Range(func(key Key, t time.Time) bool {
 					if time.Since(t) > lifespan {
 						m.Delete(key)

--- a/utils/ttl/map.go
+++ b/utils/ttl/map.go
@@ -1,36 +1,44 @@
 package ttl
 
 import (
+	"context"
 	"time"
 
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
-// Map implements a thread-safe map with a sync.Map under the hood.
+// Map implements a thread-safe map with automatic TTL-based expiry.
 type Map[Key comparable, Value any] struct {
 	*hashmap.Map[Key, Value]
 	idxLastUpdatedAt hashmap.Map[Key, time.Time]
 }
 
-func New[Key comparable, Value any](lifespan, cleanupInterval time.Duration) *Map[Key, Value] {
+// New creates a TTL map that automatically removes entries older than lifespan.
+// The cleanup goroutine runs every cleanupInterval and exits when ctx is canceled.
+// After ctx is canceled, the map remains readable but should not be used for new writes —
+// cleanup is permanently stopped and timestamp metadata from new writes will not be reclaimed.
+func New[Key comparable, Value any](ctx context.Context, lifespan, cleanupInterval time.Duration) *Map[Key, Value] {
 	m := &Map[Key, Value]{
 		Map:              hashmap.New[Key, Value](),
 		idxLastUpdatedAt: hashmap.Map[Key, time.Time]{},
 	}
 	go func() {
-		// TODO: use time.After when Go is updated to 1.23
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 
-		// TODO - consider terminating with ctx.Done() to make this ttl map garbage-collectable
-		for range ticker.C {
-			m.idxLastUpdatedAt.Range(func(key Key, t time.Time) bool {
-				if time.Since(t) > lifespan {
-					m.idxLastUpdatedAt.Delete(key)
-					m.Delete(key)
-				}
-				return true
-			})
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.idxLastUpdatedAt.Range(func(key Key, t time.Time) bool {
+					if time.Since(t) > lifespan {
+						m.idxLastUpdatedAt.Delete(key)
+						m.Delete(key)
+					}
+					return true
+				})
+			}
 		}
 	}()
 	return m
@@ -39,7 +47,6 @@ func New[Key comparable, Value any](lifespan, cleanupInterval time.Duration) *Ma
 func (m *Map[Key, Value]) GetOrSet(key Key, value Value) (Value, bool) {
 	result, loaded := m.Map.GetOrSet(key, value)
 	if !loaded {
-		// gotta update timestamp sine we've just set value for this key
 		m.idxLastUpdatedAt.Set(key, time.Now())
 	}
 	return result, loaded
@@ -48,10 +55,19 @@ func (m *Map[Key, Value]) GetOrSet(key Key, value Value) (Value, bool) {
 func (m *Map[Key, Value]) CompareAndSwap(key Key, oldValue, newValue Value) (swapped bool) {
 	swapped = m.Map.CompareAndSwap(key, oldValue, newValue)
 	if swapped {
-		// gotta update timestamp sine we've just set value for this key
 		m.idxLastUpdatedAt.Set(key, time.Now())
 	}
 	return swapped
+}
+
+func (m *Map[Key, Value]) Delete(key Key) bool {
+	m.idxLastUpdatedAt.Delete(key)
+	return m.Map.Delete(key)
+}
+
+func (m *Map[Key, Value]) GetAndDelete(key Key) (Value, bool) {
+	m.idxLastUpdatedAt.Delete(key)
+	return m.Map.GetAndDelete(key)
 }
 
 func (m *Map[Key, Value]) Set(key Key, value Value) {

--- a/utils/ttl/map_test.go
+++ b/utils/ttl/map_test.go
@@ -593,11 +593,17 @@ func TestCleanupStopsOnCancel(t *testing.T) {
 
 	// Cancel and verify no panic — cleanup goroutine should exit cleanly.
 	cancel()
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-t.Context().Done():
+	}
 
 	// After cancel, new entries should NOT be cleaned up (goroutine exited).
 	m.Set(4, "d")
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case <-t.Context().Done():
+	}
 	_, ok := m.Get(4)
 	assert.True(t, ok, "entry should persist after context is canceled — cleanup stopped")
 }

--- a/utils/ttl/map_test.go
+++ b/utils/ttl/map_test.go
@@ -594,14 +594,14 @@ func TestCleanupStopsOnCancel(t *testing.T) {
 	// Cancel and verify no panic — cleanup goroutine should exit cleanly.
 	cancel()
 	select {
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(400 * time.Millisecond):
 	case <-t.Context().Done():
 	}
 
 	// After cancel, new entries should NOT be cleaned up (goroutine exited).
 	m.Set(4, "d")
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(400 * time.Millisecond):
 	case <-t.Context().Done():
 	}
 	_, ok := m.Get(4)

--- a/utils/ttl/map_test.go
+++ b/utils/ttl/map_test.go
@@ -1,6 +1,7 @@
 package ttl
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math/rand"
@@ -20,14 +21,14 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	m := New[uintptr, uintptr](1*time.Hour, 1*time.Hour)
+	m := New[uintptr, uintptr](t.Context(), 1*time.Hour, 1*time.Hour)
 	assert.Equal(t, 0, m.SlowLen())
 }
 
 func TestSetString(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 	elephant := "elephant"
 	monkey := "monkey"
 
@@ -53,7 +54,7 @@ func TestSetString(t *testing.T) {
 func TestSetUint8(t *testing.T) {
 	t.Parallel()
 
-	m := New[uint8, int](1*time.Hour, 1*time.Hour)
+	m := New[uint8, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set(1, 128) // insert
 	value, ok := m.Get(1)
@@ -70,7 +71,7 @@ func TestSetUint8(t *testing.T) {
 func TestSetInt16(t *testing.T) {
 	t.Parallel()
 
-	m := New[int16, int](1*time.Hour, 1*time.Hour)
+	m := New[int16, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set(1, 128) // insert
 	value, ok := m.Get(1)
@@ -87,7 +88,7 @@ func TestSetInt16(t *testing.T) {
 func TestSetFloat32(t *testing.T) {
 	t.Parallel()
 
-	m := New[float32, int](1*time.Hour, 1*time.Hour)
+	m := New[float32, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set(1.1, 128) // insert
 	value, ok := m.Get(1.1)
@@ -104,7 +105,7 @@ func TestSetFloat32(t *testing.T) {
 func TestSetFloat64(t *testing.T) {
 	t.Parallel()
 
-	m := New[float64, int](1*time.Hour, 1*time.Hour)
+	m := New[float64, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set(1.1, 128) // insert
 	value, ok := m.Get(1.1)
@@ -121,7 +122,7 @@ func TestSetFloat64(t *testing.T) {
 func TestSetInt64(t *testing.T) {
 	t.Parallel()
 
-	m := New[int64, int](1*time.Hour, 1*time.Hour)
+	m := New[int64, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set(1, 128) // insert
 	value, ok := m.Get(1)
@@ -138,7 +139,7 @@ func TestSetInt64(t *testing.T) {
 func TestByteArray(t *testing.T) {
 	t.Parallel()
 
-	m := New[[4]byte, int](1*time.Hour, 1*time.Hour)
+	m := New[[4]byte, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	m.Set([4]byte{1, 2, 3, 4}, 128) // insert
 	value, ok := m.Get([4]byte{1, 2, 3, 4})
@@ -155,7 +156,7 @@ func TestByteArray(t *testing.T) {
 func TestGetNonExistingItem(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 	value, ok := m.Get(1)
 	assert.False(t, ok)
 	assert.Equal(t, "", value)
@@ -164,7 +165,7 @@ func TestGetNonExistingItem(t *testing.T) {
 func TestStringer(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	// Test with zero items
 	assert.Equal(t, "[]", m.String())
@@ -183,7 +184,7 @@ func TestStringer(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 	elephant := "elephant"
 	monkey := "monkey"
 
@@ -211,7 +212,7 @@ func TestDelete(t *testing.T) {
 func TestGetAndDelete(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 	value, ok := m.GetAndDelete(1)
 	assert.False(t, ok)
 	assert.Equal(t, "", value)
@@ -229,7 +230,7 @@ func TestGetAndDelete(t *testing.T) {
 func TestRange(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	items := map[int]string{}
 	m.Range(func(key int, value string) bool {
@@ -269,7 +270,7 @@ func TestRange(t *testing.T) {
 func TestHashMap_parallel(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, int](1*time.Hour, 1*time.Hour)
+	m := New[int, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	maxCount := 10
 	dur := 2 * time.Second
@@ -347,7 +348,7 @@ func TestHashMap_parallel(t *testing.T) {
 func TestHashMap_SetConcurrent(t *testing.T) {
 	t.Parallel()
 
-	m := New[string, int](1*time.Hour, 1*time.Hour)
+	m := New[string, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
@@ -374,7 +375,7 @@ func TestConcurrentInsertDelete(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 200; i++ {
-		l := New[int, int](1*time.Hour, 1*time.Hour)
+		l := New[int, int](t.Context(), 1*time.Hour, 1*time.Hour)
 		l.Set(111, 111)
 		l.Set(222, 222)
 		l.Set(333, 333)
@@ -402,7 +403,7 @@ func TestConcurrentInsertDelete(t *testing.T) {
 func TestGetOrSet(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	value, ok := m.GetOrSet(1, "1")
 	assert.False(t, ok)
@@ -416,7 +417,7 @@ func TestGetOrSet(t *testing.T) {
 func TestCompareAndSwap(t *testing.T) {
 	t.Parallel()
 
-	m := New[int, string](1*time.Hour, 1*time.Hour)
+	m := New[int, string](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	ok := m.CompareAndSwap(1, "", "replacing zero value doesn't count as swap, and doesn't even succeed")
 	assert.False(t, ok)
@@ -435,7 +436,7 @@ func TestCompareAndSwap(t *testing.T) {
 func TestGetOrInsertHangIssue67(t *testing.T) {
 	t.Parallel()
 
-	m := New[string, int](1*time.Hour, 1*time.Hour)
+	m := New[string, int](t.Context(), 1*time.Hour, 1*time.Hour)
 
 	var wg sync.WaitGroup
 	key := "key"
@@ -488,7 +489,7 @@ func TestIssue1682(t *testing.T) {
 		go func() {
 			defer wwg.Done()
 
-			m := New[string, validatorStatus](1*time.Hour, 1*time.Hour)
+			m := New[string, validatorStatus](t.Context(), 1*time.Hour, 1*time.Hour)
 			var wg sync.WaitGroup
 			for _, cmtID := range cmtIDs {
 				n := 50 + randSeed().Intn(200)
@@ -548,6 +549,57 @@ func TestIssue1682(t *testing.T) {
 	}
 	wwg.Wait()
 	require.Empty(t, errs)
+}
+
+func TestDeleteCleansTimestampIndex(t *testing.T) {
+	t.Parallel()
+
+	m := New[int, string](t.Context(), time.Hour, time.Hour)
+	m.Set(1, "a")
+	m.Set(2, "b")
+
+	// Delete should clean both the data and the timestamp index.
+	m.Delete(1)
+	assert.Equal(t, 1, m.SlowLen())
+	_, hasTimestamp := m.idxLastUpdatedAt.Get(1)
+	assert.False(t, hasTimestamp, "timestamp should be cleaned on Delete")
+
+	// GetAndDelete should also clean the timestamp index.
+	val, ok := m.GetAndDelete(2)
+	assert.True(t, ok)
+	assert.Equal(t, "b", val)
+	_, hasTimestamp = m.idxLastUpdatedAt.Get(2)
+	assert.False(t, hasTimestamp, "timestamp should be cleaned on GetAndDelete")
+}
+
+func TestCleanupStopsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	m := New[int, string](ctx, 50*time.Millisecond, 10*time.Millisecond)
+	m.Set(1, "a")
+	m.Set(2, "b")
+
+	// Verify cleanup is running — entries should expire.
+	require.Eventually(t, func() bool {
+		return m.SlowLen() == 0
+	}, time.Second, 10*time.Millisecond, "entries should be cleaned up")
+
+	// Add new entries to verify cleanup still works.
+	m.Set(3, "c")
+	require.Eventually(t, func() bool {
+		return m.SlowLen() == 0
+	}, time.Second, 10*time.Millisecond, "new entries should also be cleaned up")
+
+	// Cancel and verify no panic — cleanup goroutine should exit cleanly.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	// After cancel, new entries should NOT be cleaned up (goroutine exited).
+	m.Set(4, "d")
+	time.Sleep(100 * time.Millisecond)
+	_, ok := m.Get(4)
+	assert.True(t, ok, "entry should persist after context is canceled — cleanup stopped")
 }
 
 func randSeed() *rand.Rand {


### PR DESCRIPTION
## Summary
- Add `context.Context` to `ttl.New()` — cleanup goroutine exits when context is canceled
- Override `Delete` and `GetAndDelete` to also clean timestamp index — fixes pre-existing metadata leak
- Resolve both TODOs in the code (`ctx.Done()` support and Go version comment)
- Update all callers (2 production, 4 test) to pass context
- Add `TestCleanupStopsOnCancel` and `TestDeleteCleansTimestampIndex`

## Finding
F-ssv-036 — TTL Map goroutine leak, no cancellation mechanism

## Test
All `utils/ttl` tests pass. Two new tests: cancellation behavior and timestamp index cleanup.
Lint clean (`golangci-lint`).
