### PR TITLE
fix(topics): replace error-swallowing Get with read-only Lookup

### DIFF
--- a/network/topics/container.go
+++ b/network/topics/container.go
@@ -33,9 +33,11 @@ func newTopicsContainer(ps *pubsub.PubSub, onTopicJoined onTopicJoined) *topicsC
 	}
 }
 
-func (tc *topicsContainer) Get(name string) *pubsub.Topic {
-	topic, _ := tc.Join(name)
-	return topic
+// Lookup returns a cached topic by name, or nil if not found.
+func (tc *topicsContainer) Lookup(name string) *pubsub.Topic {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+	return tc.topics[name]
 }
 
 func (tc *topicsContainer) Leave(name string) error {

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -115,9 +115,9 @@ func (ctrl *topicsCtrl) UpdateScoreParams() error {
 	var errs error
 	topics := ctrl.ps.GetTopics()
 	for _, topicName := range topics {
-		topic := ctrl.container.Get(topicName)
+		topic := ctrl.container.Lookup(topicName)
 		if topic == nil {
-			errs = errors.Join(errs, fmt.Errorf("topic %s is not ready; ", topicName))
+			errs = errors.Join(errs, fmt.Errorf("topic %s not found in cache", topicName))
 			continue
 		}
 		p := ctrl.scoreParamsFactory(topicName)
@@ -149,7 +149,7 @@ func (ctrl *topicsCtrl) Peers(name string) ([]peer.ID, error) {
 		return ctrl.ps.ListPeers(""), nil
 	}
 	name = commons.GetTopicFullName(name)
-	topic := ctrl.container.Get(name)
+	topic := ctrl.container.Lookup(name)
 	if topic == nil {
 		return nil, nil
 	}

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -16,11 +16,6 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 )
 
-var (
-	// ErrTopicNotReady happens when trying to access a topic which is not ready yet
-	ErrTopicNotReady = errors.New("topic is not ready")
-)
-
 // Controller is an interface for managing pubsub topics
 type Controller interface {
 	// Subscribe subscribes to the given topic
@@ -122,11 +117,11 @@ func (ctrl *topicsCtrl) UpdateScoreParams() error {
 		}
 		p := ctrl.scoreParamsFactory(topicName)
 		if p == nil {
-			errs = errors.Join(errs, fmt.Errorf("score params for topic %s is nil; ", topicName))
+			errs = errors.Join(errs, fmt.Errorf("score params for topic %s is nil", topicName))
 			continue
 		}
 		if err := topic.SetScoreParams(p); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("could not set score params for topic %s: %w; ", topicName, err))
+			errs = errors.Join(errs, fmt.Errorf("set score params for topic %s: %w", topicName, err))
 			continue
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove `Get()` which silently discarded `Join()` errors (`topic, _ := tc.Join(name)`)
- Replace with read-only `Lookup()` that reads from the topic cache without calling `Join`
- `Get` called `Join` internally, which has a create side effect — inappropriate for read-only callers like `Peers` and `UpdateScoreParams`. During topic leave/rejoin, `Join` can race with libp2p's async close and fail with "topic already exists"
- `Lookup` avoids this entirely: read-only cache access with `RLock`, no side effects

## Finding
F-ssv-051 — Swallowed error in topic container `Get`

## Test
Build clean. Lint clean. `Peers` returns `nil, nil` on cache miss — same behavior as before, no caller changes needed.
