### PR TITLE
fix(eventparser): replace panic with error return in constructor

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -1088,7 +1088,10 @@ func syncContractEvents(
 		logger.Fatal("failed to set up event filterer", zap.Error(err))
 	}
 
-	eventParser := eventparser.New(eventFilterer)
+	eventParser, err := eventparser.New(eventFilterer)
+	if err != nil {
+		logger.Fatal("failed to create event parser", zap.Error(err))
+	}
 
 	eventHandler, err := eventhandler.New(
 		nodeStorage,

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/herumi/bls-eth-go-binary/bls"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
@@ -182,7 +183,8 @@ func setupEventHandler(
 	if useMockCtrl {
 		tExecutor := mocks.NewMockTaskExecutor(ctrl)
 
-		parser := eventparser.New(contractFilterer)
+		parser, err := eventparser.New(contractFilterer)
+		require.NoError(t, err)
 
 		eh, err := eventhandler.New(
 			nodeStorage,
@@ -213,7 +215,8 @@ func setupEventHandler(
 		OperatorDataStore: operatorDataStore,
 	}, exporter.Options{})
 
-	parser := eventparser.New(contractFilterer)
+	parser, err := eventparser.New(contractFilterer)
+	require.NoError(t, err)
 
 	eh, err := eventhandler.New(
 		nodeStorage,

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -1384,7 +1384,8 @@ func setupEventHandler(
 		contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 		require.NoError(t, err)
 
-		parser := eventparser.New(contractFilterer)
+		parser, err := eventparser.New(contractFilterer)
+		require.NoError(t, err)
 
 		eh, err := New(
 			nodeStorage,
@@ -1419,7 +1420,8 @@ func setupEventHandler(
 	contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 	require.NoError(t, err)
 
-	parser := eventparser.New(contractFilterer)
+	parser, err := eventparser.New(contractFilterer)
+	require.NoError(t, err)
 
 	eh, err := New(
 		nodeStorage,

--- a/eth/eventparser/event_parser.go
+++ b/eth/eventparser/event_parser.go
@@ -38,22 +38,23 @@ type eventByIDGetter interface {
 	EventByID(topic ethcommon.Hash) (*ethabi.Event, error)
 }
 
-func New(eventFilterer eventFilterer) *EventParser {
+// New creates an EventParser with the SSV contract and operator public key ABIs.
+func New(eventFilterer eventFilterer) (*EventParser, error) {
 	contractABI, err := contract.ContractMetaData.GetAbi()
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("parse contract ABI: %w", err)
 	}
 
 	operatorPublicKeyABI, err := contract.OperatorPublicKeyMetaData.GetAbi()
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("parse operator public key ABI: %w", err)
 	}
 
 	return &EventParser{
 		eventFilterer:        eventFilterer,
 		eventByIDGetter:      contractABI,
 		operatorPublicKeyABI: operatorPublicKeyABI,
-	}
+	}, nil
 }
 
 func (e *EventParser) ParseOperatorAdded(log ethtypes.Log) (*contract.ContractOperatorAdded, error) {

--- a/eth/eventparser/event_parser_test.go
+++ b/eth/eventparser/event_parser_test.go
@@ -18,7 +18,8 @@ func TestEventParser(t *testing.T) {
 	contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 	require.NoError(t, err)
 
-	parser := eventparser.New(contractFilterer)
+	parser, err := eventparser.New(contractFilterer)
+	require.NoError(t, err)
 
 	t.Run("OperatorAdded", func(t *testing.T) {
 		const event = `{

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -214,7 +214,8 @@ func setupEventHandler(
 	contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 	require.NoError(t, err)
 
-	parser := eventparser.New(contractFilterer)
+	parser, err := eventparser.New(contractFilterer)
+	require.NoError(t, err)
 
 	dgHandler := doppelganger.NoOpHandler{}
 


### PR DESCRIPTION
## Summary
- Change `eventparser.New()` from panicking on ABI parse failure to returning `(*EventParser, error)`
- Replace both `panic(err)` calls with `fmt.Errorf` error returns
- Update production caller (`cli/operator/node.go`) and all 6 test callers

## Finding
F-ssv-050 — Panics in `EventParser.New` constructor

## Test
All `eventparser` tests pass. Build and lint clean. ABIs are hardcoded so the error path is unreachable in practice, but library code should return errors, not panic — callers decide how to handle failure.
