### PR TITLE
fix(streams): preserve write error and handle short writes in WriteWithTimeout

### DIFF
--- a/network/streams/stream.go
+++ b/network/streams/stream.go
@@ -1,11 +1,11 @@
 package streams
 
 import (
+	"fmt"
 	"io"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core"
-	"github.com/pkg/errors"
 )
 
 // Stream represents a stream in the system
@@ -36,22 +36,24 @@ func NewStream(s core.Stream) Stream {
 // ReadWithTimeout reads with timeout
 func (ts *streamWrapper) ReadWithTimeout(timeout time.Duration) ([]byte, error) {
 	if err := ts.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		return nil, errors.Wrap(err, "could not set read deadline")
+		return nil, fmt.Errorf("set read deadline: %w", err)
 	}
 	return io.ReadAll(ts.Stream)
 }
 
-// WriteWithTimeout reads next message with timeout
+// WriteWithTimeout writes data to stream with timeout
 func (ts *streamWrapper) WriteWithTimeout(data []byte, timeout time.Duration) error {
 	if err := ts.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
-		return errors.Wrap(err, "could not set write deadline")
+		return fmt.Errorf("set write deadline: %w", err)
 	}
 
 	n := len(data)
 	bytesWritten, err := ts.Write(data)
-	if bytesWritten != n {
-		return errors.Errorf("written bytes (%d) to sync stream doesnt match input data (%d)", bytesWritten, n)
+	if err != nil {
+		return fmt.Errorf("write stream: %w", err)
 	}
-
-	return err
+	if bytesWritten != n {
+		return fmt.Errorf("wrote %d of %d bytes: %w", bytesWritten, n, io.ErrShortWrite)
+	}
+	return nil
 }

--- a/network/streams/stream_test.go
+++ b/network/streams/stream_test.go
@@ -2,6 +2,8 @@ package streams
 
 import (
 	"context"
+	"errors"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +15,27 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 )
+
+type stubStream struct {
+	core.Stream
+
+	writeFn            func([]byte) (int, error)
+	setWriteDeadlineFn func(time.Time) error
+}
+
+func (s *stubStream) Write(p []byte) (int, error) {
+	if s.writeFn != nil {
+		return s.writeFn(p)
+	}
+	return len(p), nil
+}
+
+func (s *stubStream) SetWriteDeadline(t time.Time) error {
+	if s.setWriteDeadlineFn != nil {
+		return s.setWriteDeadlineFn(t)
+	}
+	return nil
+}
 
 func TestStream(t *testing.T) {
 	hosts := testHosts(t, 3)
@@ -64,6 +87,52 @@ func TestStream(t *testing.T) {
 	})
 
 	wg.Wait()
+}
+
+func TestWriteWithTimeout_ErrorPaths(t *testing.T) {
+	t.Run("write error preserves root cause", func(t *testing.T) {
+		rootErr := errors.New("boom")
+		s := NewStream(&stubStream{
+			writeFn: func(p []byte) (int, error) {
+				return len(p) - 1, rootErr
+			},
+		})
+
+		err := s.WriteWithTimeout([]byte("abc"), time.Second)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, rootErr)
+		require.ErrorContains(t, err, "write stream")
+	})
+
+	t.Run("short write without error returns ErrShortWrite", func(t *testing.T) {
+		s := NewStream(&stubStream{
+			writeFn: func(p []byte) (int, error) {
+				return len(p) - 1, nil
+			},
+		})
+
+		err := s.WriteWithTimeout([]byte("abc"), time.Second)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, io.ErrShortWrite)
+		require.ErrorContains(t, err, "wrote 2 of 3 bytes")
+	})
+
+	t.Run("set write deadline error is wrapped", func(t *testing.T) {
+		deadlineErr := errors.New("deadline failed")
+		s := NewStream(&stubStream{
+			setWriteDeadlineFn: func(t time.Time) error {
+				return deadlineErr
+			},
+		})
+
+		err := s.WriteWithTimeout([]byte("abc"), time.Second)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, deadlineErr)
+		require.ErrorContains(t, err, "set write deadline")
+	})
 }
 
 func testHosts(t *testing.T, n int) []host.Host {


### PR DESCRIPTION
## Summary
- Preserve the original `Write` error on failure instead of discarding it with a generic "bytes don't match" message
- Add defensive `io.ErrShortWrite` fallback for contract-violating short writes with nil error
- Migrate `pkg/errors` to `fmt.Errorf` with `%w`
- Fix doc comment ("reads" → "writes")
- Add regression tests for all three error paths

## Finding
F-ssv-052 — `WriteWithTimeout` discards original write error on short write

## Test
New `TestWriteWithTimeout_ErrorPaths` covers: write error preserves root cause, short write returns `io.ErrShortWrite`, deadline failure is wrapped. All stream tests pass. Lint clean.
