### PR TITLE
message/validation: refactor validation flow to per-message actors

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -47,23 +47,23 @@ func (mv *messageValidator) validateConsensusMessage(
 		return consensusMessage, err
 	}
 
-	if err := mv.verifyConsensusMessageSignatures(signedSSVMessage); err != nil {
-		return consensusMessage, err
-	}
+	if err := mv.withValidationActor(
+		ssvMessage.GetID(),
+		committeeInfo,
+		func(state *ValidatorState) error {
+			if err := mv.validateQBFTLogic(signedSSVMessage, consensusMessage, committeeInfo, receivedFrom, receivedAt, state); err != nil {
+				return err
+			}
 
-	if err := mv.withValidationLock(ssvMessage.GetID(), func() error {
-		state := mv.validatorState(ssvMessage.GetID(), committeeInfo)
-
-		if err := mv.validateQBFTLogic(signedSSVMessage, consensusMessage, committeeInfo, receivedFrom, receivedAt, state); err != nil {
-			return err
-		}
-
-		if err := mv.validateQBFTMessageByDutyLogic(signedSSVMessage, consensusMessage, committeeInfo, receivedAt, state); err != nil {
-			return err
-		}
-
-		return mv.updateConsensusState(signedSSVMessage, consensusMessage, committeeInfo, receivedFrom, state)
-	}); err != nil {
+			return mv.validateQBFTMessageByDutyLogic(signedSSVMessage, consensusMessage, committeeInfo, receivedAt, state)
+		},
+		func() error {
+			return mv.verifyConsensusMessageSignatures(signedSSVMessage)
+		},
+		func(state *ValidatorState) error {
+			return mv.updateConsensusState(signedSSVMessage, consensusMessage, committeeInfo, receivedFrom, state)
+		},
+	); err != nil {
 		return consensusMessage, err
 	}
 

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -43,19 +43,20 @@ func (mv *messageValidator) validatePartialSignatureMessage(
 		return partialSignatureMessages, err
 	}
 
-	if err := mv.verifyPartialSignatureMessageSignature(signedSSVMessage); err != nil {
-		return partialSignatureMessages, err
-	}
-
 	signer := signedSSVMessage.OperatorIDs[0]
-	if err := mv.withValidationLock(ssvMessage.GetID(), func() error {
-		state := mv.validatorState(ssvMessage.GetID(), committeeInfo)
-		if err := mv.validatePartialSigMessagesByDutyLogic(signedSSVMessage, partialSignatureMessages, committeeInfo, receivedFrom, receivedAt, state); err != nil {
-			return err
-		}
-
-		return mv.updatePartialSignatureState(partialSignatureMessages, receivedFrom, state, signer, committeeInfo)
-	}); err != nil {
+	if err := mv.withValidationActor(
+		ssvMessage.GetID(),
+		committeeInfo,
+		func(state *ValidatorState) error {
+			return mv.validatePartialSigMessagesByDutyLogic(signedSSVMessage, partialSignatureMessages, committeeInfo, receivedFrom, receivedAt, state)
+		},
+		func() error {
+			return mv.verifyPartialSignatureMessageSignature(signedSSVMessage)
+		},
+		func(state *ValidatorState) error {
+			return mv.updatePartialSignatureState(partialSignatureMessages, receivedFrom, state, signer, committeeInfo)
+		},
+	); err != nil {
 		return partialSignatureMessages, err
 	}
 

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -231,7 +231,6 @@ func (mv *messageValidator) committeeChecks(signedSSVMessage *spectypes.SignedSS
 func (mv *messageValidator) getValidationActor(key spectypes.MessageID) *validationActor {
 	actor, _, _ := mv.validationActorsInflight.Do(key, func() (*validationActor, error) {
 		if cached := mv.validationActors.Get(key); cached != nil {
-			mv.validationActors.Touch(key)
 			return cached.Value(), nil
 		}
 

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -56,15 +55,11 @@ type messageValidator struct {
 
 	signatureVerifier signatureverifier.SignatureVerifier // TODO: use spectypes.SignatureVerifier
 
-	// validationLockCache is a map of locks (SSV message ID -> lock) to ensure messages with
-	// the same ID apply any state modifications (during message validation - which is not
-	// stateless) in an isolated synchronized manner with respect to each other.
-	validationLockCache *ttlcache.Cache[spectypes.MessageID, *sync.Mutex]
-	// validationLocksInflight helps us prevent generating 2 different validation locks
-	// for messages that must lock on the same lock (messages with the same ID) when undergoing
-	// validation (that validation is not stateless - it often requires messageValidator to
-	// update some state).
-	validationLocksInflight singleflight.Group[spectypes.MessageID, *sync.Mutex]
+	// validationActors serialize mutable validation state per MessageID while allowing
+	// signature verification to run asynchronously outside the actor loop.
+	validationActors *ttlcache.Cache[spectypes.MessageID, *validationActor]
+	// validationActorsInflight prevents duplicate actor creation for the same MessageID.
+	validationActorsInflight singleflight.Group[spectypes.MessageID, *validationActor]
 	// states keeps track of signers(individual runners, of which every operator has multiple) per validator.
 	states *ttlcache.Cache[spectypes.MessageID, *ValidatorState]
 
@@ -83,13 +78,13 @@ func New(
 	opts ...Option,
 ) MessageValidator {
 	mv := &messageValidator{
-		logger:              zap.NewNop(),
-		netCfg:              netCfg,
-		validationLockCache: ttlcache.New[spectypes.MessageID, *sync.Mutex](),
-		validatorStore:      validatorStore,
-		operators:           operators,
-		dutyStore:           dutyStore,
-		signatureVerifier:   signatureVerifier,
+		logger:            zap.NewNop(),
+		netCfg:            netCfg,
+		validationActors:  ttlcache.New[spectypes.MessageID, *validationActor](),
+		validatorStore:    validatorStore,
+		operators:         operators,
+		dutyStore:         dutyStore,
+		signatureVerifier: signatureVerifier,
 	}
 
 	ttl := time.Duration(mv.maxStoredSlots()) * netCfg.SlotDuration // #nosec G115 -- amount of slots cannot exceed int64
@@ -101,8 +96,12 @@ func New(
 		opt(mv)
 	}
 
-	// Start automatic expired item deletion for validationLockCache.
-	go mv.validationLockCache.Start()
+	mv.validationActors.OnEviction(func(_ context.Context, _ ttlcache.EvictionReason, item *ttlcache.Item[spectypes.MessageID, *validationActor]) {
+		item.Value().stop()
+	})
+
+	// Start automatic expired item deletion for validationActors.
+	go mv.validationActors.Start()
 	// Start automatic expired item deletion for states.
 	go mv.states.Start()
 
@@ -229,36 +228,43 @@ func (mv *messageValidator) committeeChecks(signedSSVMessage *spectypes.SignedSS
 	return nil
 }
 
-func (mv *messageValidator) getValidationLock(key spectypes.MessageID) *sync.Mutex {
-	lock, _, _ := mv.validationLocksInflight.Do(key, func() (*sync.Mutex, error) {
-		cachedLock := mv.validationLockCache.Get(key)
-		if cachedLock != nil {
-			return cachedLock.Value(), nil
+func (mv *messageValidator) getValidationActor(key spectypes.MessageID) *validationActor {
+	actor, _, _ := mv.validationActorsInflight.Do(key, func() (*validationActor, error) {
+		if cached := mv.validationActors.Get(key); cached != nil {
+			mv.validationActors.Touch(key)
+			return cached.Value(), nil
 		}
 
-		lock := &sync.Mutex{}
-
-		// validationLockTTL specifies how much time a particular validation lock is meant to
-		// live. It must be large enough for validation lock to never expire while we still are
-		// expecting to process messages targeting that same validation lock. For a message
-		// that will get rejected due to being stale (even after acquiring some validation lock)
-		// it doesn't matter which exact lock will get acquired (because no state updates will
-		// be allowed to take place).
-		// 2 epoch duration is a safe TTL to use - message validation will reject processing
-		// for any message older than that.
-		mv.validationLockCache.Set(key, lock, 2*mv.netCfg.EpochDuration())
-
-		return lock, nil
+		actor := newValidationActor()
+		mv.validationActors.Set(key, actor, 2*mv.netCfg.EpochDuration())
+		go actor.run(mv, key)
+		return actor, nil
 	})
-	return lock
+	mv.validationActors.Touch(key)
+	return actor
 }
 
-func (mv *messageValidator) withValidationLock(key spectypes.MessageID, fn func() error) error {
-	validationMu := mv.getValidationLock(key)
-	validationMu.Lock()
-	defer validationMu.Unlock()
+func (mv *messageValidator) withValidationActor(
+	key spectypes.MessageID,
+	committeeInfo CommitteeInfo,
+	precheck func(*ValidatorState) error,
+	verify func() error,
+	commit func(*ValidatorState) error,
+) error {
+	req := &validationRequest{
+		committeeInfo: committeeInfo,
+		precheck:      precheck,
+		verify:        verify,
+		commit:        commit,
+		result:        make(chan error, 1),
+	}
 
-	return fn()
+	actor := mv.getValidationActor(key)
+	if !actor.submit(req) {
+		return errValidationActorClosed
+	}
+
+	return <-req.result
 }
 
 func (mv *messageValidator) getCommitteeAndValidatorIndices(msgID spectypes.MessageID) (CommitteeInfo, error) {

--- a/message/validation/validation_actor.go
+++ b/message/validation/validation_actor.go
@@ -94,6 +94,7 @@ func (a *validationActor) run(mv *messageValidator, key spectypes.MessageID) {
 			}
 
 		case <-a.stopCh:
+			a.drainPending()
 			return
 		}
 	}
@@ -103,5 +104,21 @@ func (a *validationActor) verifyAndResubmit(req *validationRequest) {
 	err := req.verify()
 	if !a.submit(&validationVerified{request: req, err: err}) {
 		req.respond(errValidationActorClosed)
+	}
+}
+
+func (a *validationActor) drainPending() {
+	for {
+		select {
+		case raw := <-a.inbox:
+			switch msg := raw.(type) {
+			case *validationRequest:
+				msg.respond(errValidationActorClosed)
+			case *validationVerified:
+				msg.request.respond(errValidationActorClosed)
+			}
+		default:
+			return
+		}
 	}
 }

--- a/message/validation/validation_actor.go
+++ b/message/validation/validation_actor.go
@@ -31,9 +31,11 @@ type validationVerified struct {
 }
 
 type validationActor struct {
-	inbox    chan any
-	stopCh   chan struct{}
-	stopOnce sync.Once
+	inbox       chan any
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	lifecycleMu sync.Mutex
+	stopped     bool
 }
 
 func newValidationActor() *validationActor {
@@ -45,23 +47,24 @@ func newValidationActor() *validationActor {
 
 func (a *validationActor) stop() {
 	a.stopOnce.Do(func() {
+		a.lifecycleMu.Lock()
+		defer a.lifecycleMu.Unlock()
+
+		a.stopped = true
 		close(a.stopCh)
 	})
 }
 
 func (a *validationActor) submit(msg any) bool {
-	select {
-	case <-a.stopCh:
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
+
+	if a.stopped {
 		return false
-	default:
 	}
 
-	select {
-	case a.inbox <- msg:
-		return true
-	case <-a.stopCh:
-		return false
-	}
+	a.inbox <- msg
+	return true
 }
 
 func (a *validationActor) run(mv *messageValidator, key spectypes.MessageID) {

--- a/message/validation/validation_actor.go
+++ b/message/validation/validation_actor.go
@@ -36,34 +36,49 @@ type validationActor struct {
 	stopOnce    sync.Once
 	lifecycleMu sync.Mutex
 	stopped     bool
+	active      int
+	drained     *sync.Cond
 }
 
 func newValidationActor() *validationActor {
-	return &validationActor{
+	actor := &validationActor{
 		inbox:  make(chan any, 64),
 		stopCh: make(chan struct{}),
 	}
+	actor.drained = sync.NewCond(&actor.lifecycleMu)
+	return actor
 }
 
 func (a *validationActor) stop() {
 	a.stopOnce.Do(func() {
 		a.lifecycleMu.Lock()
-		defer a.lifecycleMu.Unlock()
-
 		a.stopped = true
+		for a.active > 0 {
+			a.drained.Wait()
+		}
 		close(a.stopCh)
+		a.lifecycleMu.Unlock()
 	})
 }
 
 func (a *validationActor) submit(msg any) bool {
 	a.lifecycleMu.Lock()
-	defer a.lifecycleMu.Unlock()
-
 	if a.stopped {
+		a.lifecycleMu.Unlock()
 		return false
 	}
+	a.active++
+	a.lifecycleMu.Unlock()
 
 	a.inbox <- msg
+
+	a.lifecycleMu.Lock()
+	a.active--
+	if a.active == 0 {
+		a.drained.Broadcast()
+	}
+	a.lifecycleMu.Unlock()
+
 	return true
 }
 
@@ -105,6 +120,7 @@ func (a *validationActor) run(mv *messageValidator, key spectypes.MessageID) {
 
 func (a *validationActor) verifyAndResubmit(req *validationRequest) {
 	err := req.verify()
+	// Callers block on req.result, so a stopped actor must still produce a terminal response.
 	if !a.submit(&validationVerified{request: req, err: err}) {
 		req.respond(errValidationActorClosed)
 	}

--- a/message/validation/validation_actor.go
+++ b/message/validation/validation_actor.go
@@ -1,0 +1,107 @@
+package validation
+
+import (
+	"errors"
+	"sync"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+)
+
+var errValidationActorClosed = errors.New("validation actor closed")
+
+type validationRequest struct {
+	committeeInfo CommitteeInfo
+	precheck      func(*ValidatorState) error
+	verify        func() error
+	commit        func(*ValidatorState) error
+	result        chan error
+
+	respondOnce sync.Once
+}
+
+func (r *validationRequest) respond(err error) {
+	r.respondOnce.Do(func() {
+		r.result <- err
+	})
+}
+
+type validationVerified struct {
+	request *validationRequest
+	err     error
+}
+
+type validationActor struct {
+	inbox    chan any
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func newValidationActor() *validationActor {
+	return &validationActor{
+		inbox:  make(chan any, 64),
+		stopCh: make(chan struct{}),
+	}
+}
+
+func (a *validationActor) stop() {
+	a.stopOnce.Do(func() {
+		close(a.stopCh)
+	})
+}
+
+func (a *validationActor) submit(msg any) bool {
+	select {
+	case <-a.stopCh:
+		return false
+	default:
+	}
+
+	select {
+	case a.inbox <- msg:
+		return true
+	case <-a.stopCh:
+		return false
+	}
+}
+
+func (a *validationActor) run(mv *messageValidator, key spectypes.MessageID) {
+	for {
+		select {
+		case raw := <-a.inbox:
+			switch msg := raw.(type) {
+			case *validationRequest:
+				state := mv.validatorState(key, msg.committeeInfo)
+				if err := msg.precheck(state); err != nil {
+					msg.respond(err)
+					continue
+				}
+
+				go a.verifyAndResubmit(msg)
+
+			case *validationVerified:
+				if msg.err != nil {
+					msg.request.respond(msg.err)
+					continue
+				}
+
+				state := mv.validatorState(key, msg.request.committeeInfo)
+				if err := msg.request.precheck(state); err != nil {
+					msg.request.respond(err)
+					continue
+				}
+
+				msg.request.respond(msg.request.commit(state))
+			}
+
+		case <-a.stopCh:
+			return
+		}
+	}
+}
+
+func (a *validationActor) verifyAndResubmit(req *validationRequest) {
+	err := req.verify()
+	if !a.submit(&validationVerified{request: req, err: err}) {
+		req.respond(errValidationActorClosed)
+	}
+}

--- a/message/validation/validation_actor_test.go
+++ b/message/validation/validation_actor_test.go
@@ -142,10 +142,15 @@ func TestConsensusActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	env := newValidationActorTestEnv(t, verifier)
 
 	slot := env.netCfg.FirstSlotAtEpoch(1)
-	signedSSVMessage := generateSignedMessage(env.ks, env.committeeIdentifier, slot, func(message *specqbft.Message) {
-		message.MsgType = specqbft.CommitMsgType
-	})
-	signedSSVMessage.FullData = nil
+	newSignedMessage := func() *spectypes.SignedSSVMessage {
+		signedSSVMessage := generateSignedMessage(env.ks, env.committeeIdentifier, slot, func(message *specqbft.Message) {
+			message.MsgType = specqbft.CommitMsgType
+		})
+		signedSSVMessage.FullData = nil
+		return signedSSVMessage
+	}
+	signedSSVMessage1 := newSignedMessage()
+	signedSSVMessage2 := newSignedMessage()
 
 	topicID := commons.CommitteeTopicID(env.committeeID)[0]
 	peerID, err := libp2ptest.RandPeerID()
@@ -156,7 +161,7 @@ func TestConsensusActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	done2 := make(chan error, 1)
 
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage1, topicID, peerID, receivedAt)
 		done1 <- err
 	}()
 
@@ -167,7 +172,7 @@ func TestConsensusActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	}
 
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage2, topicID, peerID, receivedAt)
 		done2 <- err
 	}()
 
@@ -201,9 +206,13 @@ func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	env := newValidationActorTestEnv(t, verifier)
 
 	partialSignatureMessages := spectestingutils.PostConsensusAggregatorMsg(env.ks.Shares[1], 1, spec.DataVersionPhase0)
-	ssvMessage := spectestingutils.SSVMsgAggregator(nil, partialSignatureMessages)
-	ssvMessage.MsgID = env.committeeIdentifier
-	signedSSVMessage := spectestingutils.SignPartialSigSSVMessage(env.ks, ssvMessage)
+	newSignedMessage := func() *spectypes.SignedSSVMessage {
+		ssvMessage := spectestingutils.SSVMsgAggregator(nil, partialSignatureMessages)
+		ssvMessage.MsgID = env.committeeIdentifier
+		return spectestingutils.SignPartialSigSSVMessage(env.ks, ssvMessage)
+	}
+	signedSSVMessage1 := newSignedMessage()
+	signedSSVMessage2 := newSignedMessage()
 
 	topicID := commons.CommitteeTopicID(env.committeeID)[0]
 	peerID, err := libp2ptest.RandPeerID()
@@ -214,7 +223,7 @@ func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	done2 := make(chan error, 1)
 
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage1, topicID, peerID, receivedAt)
 		done1 <- err
 	}()
 
@@ -225,7 +234,7 @@ func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	}
 
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage2, topicID, peerID, receivedAt)
 		done2 <- err
 	}()
 

--- a/message/validation/validation_actor_test.go
+++ b/message/validation/validation_actor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"maps"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
 
@@ -28,11 +30,14 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-type observingSignatureVerifier struct {
-	called chan struct{}
+type blockingSignatureVerifier struct {
+	mu      sync.Mutex
+	started chan int
+	release chan struct{}
+	calls   int
 }
 
-type validationLockTestEnv struct {
+type validationActorTestEnv struct {
 	validator           *messageValidator
 	committeeID         spectypes.CommitteeID
 	committeeIdentifier spectypes.MessageID
@@ -40,16 +45,20 @@ type validationLockTestEnv struct {
 	ks                  *spectestingutils.TestKeySet
 }
 
-func (v *observingSignatureVerifier) VerifySignature(spectypes.OperatorID, *spectypes.SSVMessage, []byte) error {
-	select {
-	case v.called <- struct{}{}:
-	default:
-	}
+func (v *blockingSignatureVerifier) VerifySignature(spectypes.OperatorID, *spectypes.SSVMessage, []byte) error {
+	v.mu.Lock()
+	v.calls++
+	call := v.calls
+	v.mu.Unlock()
 
+	v.started <- call
+	<-v.release
 	return nil
 }
 
-func newValidationLockTestEnv(t *testing.T) validationLockTestEnv {
+func newValidationActorTestEnv(t *testing.T, verifier interface {
+	VerifySignature(spectypes.OperatorID, *spectypes.SSVMessage, []byte) error
+}) validationActorTestEnv {
 	ctrl := gomock.NewController(t)
 
 	logger := zaptest.NewLogger(t)
@@ -105,8 +114,6 @@ func newValidationLockTestEnv(t *testing.T) validationLockTestEnv {
 			AnyTimes()
 	}
 
-	verifier := &observingSignatureVerifier{called: make(chan struct{}, 1)}
-
 	validator := New(
 		netCfg,
 		validatorStore,
@@ -118,7 +125,7 @@ func newValidationLockTestEnv(t *testing.T) validationLockTestEnv {
 	encodedCommitteeID := append(bytes.Repeat([]byte{0}, 16), committeeID[:]...)
 	committeeIdentifier := spectypes.NewMsgID(netCfg.DomainType, encodedCommitteeID, spectypes.RoleCommittee)
 
-	return validationLockTestEnv{
+	return validationActorTestEnv{
 		validator:           validator,
 		committeeID:         committeeID,
 		committeeIdentifier: committeeIdentifier,
@@ -127,98 +134,118 @@ func newValidationLockTestEnv(t *testing.T) validationLockTestEnv {
 	}
 }
 
-func TestConsensusSignatureVerificationOutsideValidationLock(t *testing.T) {
-	env := newValidationLockTestEnv(t)
+func TestConsensusActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
+	verifier := &blockingSignatureVerifier{
+		started: make(chan int, 2),
+		release: make(chan struct{}, 2),
+	}
+	env := newValidationActorTestEnv(t, verifier)
 
 	slot := env.netCfg.FirstSlotAtEpoch(1)
-	signedSSVMessage := generateSignedMessage(env.ks, env.committeeIdentifier, slot)
+	signedSSVMessage := generateSignedMessage(env.ks, env.committeeIdentifier, slot, func(message *specqbft.Message) {
+		message.MsgType = specqbft.CommitMsgType
+	})
+	signedSSVMessage.FullData = nil
+
 	topicID := commons.CommitteeTopicID(env.committeeID)[0]
 	peerID, err := libp2ptest.RandPeerID()
 	require.NoError(t, err)
+	receivedAt := env.netCfg.SlotStartTime(slot)
 
-	validationMu := env.validator.getValidationLock(signedSSVMessage.SSVMessage.GetID())
-	validationMu.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			validationMu.Unlock()
-		}
-	}()
+	done1 := make(chan error, 1)
+	done2 := make(chan error, 1)
 
-	done := make(chan error, 1)
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, env.netCfg.SlotStartTime(slot))
-		done <- err
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		done1 <- err
 	}()
 
 	select {
-	case <-env.validator.signatureVerifier.(*observingSignatureVerifier).called:
+	case <-verifier.started:
 	case <-time.After(time.Second):
-		t.Fatal("signature verification did not start while the validation lock was held")
+		t.Fatal("first consensus signature verification did not start")
 	}
 
+	go func() {
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		done2 <- err
+	}()
+
 	select {
-	case err := <-done:
-		t.Fatalf("validation completed before the lock was released: %v", err)
-	default:
+	case <-verifier.started:
+	case <-time.After(time.Second):
+		t.Fatal("second consensus signature verification did not start while the first was still verifying")
 	}
 
-	validationMu.Unlock()
-	locked = false
+	verifier.release <- struct{}{}
+	verifier.release <- struct{}{}
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("validation did not complete after the lock was released")
+	err1 := <-done1
+	err2 := <-done2
+
+	require.True(t, (err1 == nil) != (err2 == nil), "expected exactly one consensus message to commit")
+
+	dupErr := ErrDuplicatedMessage
+	if err1 != nil {
+		require.ErrorIs(t, err1, dupErr)
+	} else {
+		require.ErrorIs(t, err2, dupErr)
 	}
 }
 
-func TestPartialSignatureVerificationOutsideValidationLock(t *testing.T) {
-	env := newValidationLockTestEnv(t)
+func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
+	verifier := &blockingSignatureVerifier{
+		started: make(chan int, 2),
+		release: make(chan struct{}, 2),
+	}
+	env := newValidationActorTestEnv(t, verifier)
 
-	slot := env.netCfg.FirstSlotAtEpoch(1)
-	ssvMessage := spectestingutils.SSVMsgAggregator(nil, spectestingutils.PostConsensusAggregatorMsg(env.ks.Shares[1], 1, spec.DataVersionPhase0))
+	partialSignatureMessages := spectestingutils.PostConsensusAggregatorMsg(env.ks.Shares[1], 1, spec.DataVersionPhase0)
+	ssvMessage := spectestingutils.SSVMsgAggregator(nil, partialSignatureMessages)
 	ssvMessage.MsgID = env.committeeIdentifier
 	signedSSVMessage := spectestingutils.SignPartialSigSSVMessage(env.ks, ssvMessage)
+
 	topicID := commons.CommitteeTopicID(env.committeeID)[0]
 	peerID, err := libp2ptest.RandPeerID()
 	require.NoError(t, err)
+	receivedAt := env.netCfg.SlotStartTime(partialSignatureMessages.Slot)
 
-	validationMu := env.validator.getValidationLock(signedSSVMessage.SSVMessage.GetID())
-	validationMu.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			validationMu.Unlock()
-		}
-	}()
+	done1 := make(chan error, 1)
+	done2 := make(chan error, 1)
 
-	done := make(chan error, 1)
 	go func() {
-		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, env.netCfg.SlotStartTime(slot))
-		done <- err
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		done1 <- err
 	}()
 
 	select {
-	case <-env.validator.signatureVerifier.(*observingSignatureVerifier).called:
+	case <-verifier.started:
 	case <-time.After(time.Second):
-		t.Fatal("partial signature verification did not start while the validation lock was held")
+		t.Fatal("first partial signature verification did not start")
 	}
 
+	go func() {
+		_, err := env.validator.handleSignedSSVMessage(signedSSVMessage, topicID, peerID, receivedAt)
+		done2 <- err
+	}()
+
 	select {
-	case err := <-done:
-		t.Fatalf("partial validation completed before the lock was released: %v", err)
-	default:
+	case <-verifier.started:
+	case <-time.After(time.Second):
+		t.Fatal("second partial signature verification did not start while the first was still verifying")
 	}
 
-	validationMu.Unlock()
-	locked = false
+	verifier.release <- struct{}{}
+	verifier.release <- struct{}{}
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("partial validation did not complete after the lock was released")
+	err1 := <-done1
+	err2 := <-done2
+
+	require.True(t, (err1 == nil) != (err2 == nil), "expected exactly one partial signature message to commit")
+
+	if err1 != nil {
+		require.ErrorIs(t, err1, ErrTooManyPartialSigMessage)
+	} else {
+		require.ErrorIs(t, err2, ErrTooManyPartialSigMessage)
 	}
 }

--- a/message/validation/validation_actor_test.go
+++ b/message/validation/validation_actor_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"context"
 	"maps"
 	"slices"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	libp2ptest "github.com/libp2p/go-libp2p/core/test"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -205,19 +207,19 @@ func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	}
 	env := newValidationActorTestEnv(t, verifier)
 
-	partialSignatureMessages := spectestingutils.PostConsensusAggregatorMsg(env.ks.Shares[1], 1, spec.DataVersionPhase0)
-	newSignedMessage := func() *spectypes.SignedSSVMessage {
+	newSignedMessage := func() (*spectypes.SignedSSVMessage, phase0.Slot) {
+		partialSignatureMessages := spectestingutils.PostConsensusAggregatorMsg(env.ks.Shares[1], 1, spec.DataVersionPhase0)
 		ssvMessage := spectestingutils.SSVMsgAggregator(nil, partialSignatureMessages)
 		ssvMessage.MsgID = env.committeeIdentifier
-		return spectestingutils.SignPartialSigSSVMessage(env.ks, ssvMessage)
+		return spectestingutils.SignPartialSigSSVMessage(env.ks, ssvMessage), partialSignatureMessages.Slot
 	}
-	signedSSVMessage1 := newSignedMessage()
-	signedSSVMessage2 := newSignedMessage()
+	signedSSVMessage1, slot := newSignedMessage()
+	signedSSVMessage2, _ := newSignedMessage()
 
 	topicID := commons.CommitteeTopicID(env.committeeID)[0]
 	peerID, err := libp2ptest.RandPeerID()
 	require.NoError(t, err)
-	receivedAt := env.netCfg.SlotStartTime(partialSignatureMessages.Slot)
+	receivedAt := env.netCfg.SlotStartTime(slot)
 
 	done1 := make(chan error, 1)
 	done2 := make(chan error, 1)
@@ -257,4 +259,18 @@ func TestPartialActorVerifiesSameKeyMessagesConcurrently(t *testing.T) {
 	} else {
 		require.ErrorIs(t, err2, ErrTooManyPartialSigMessage)
 	}
+}
+
+func TestValidationActorClosedIsIgnored(t *testing.T) {
+	verifier := &blockingSignatureVerifier{
+		started: make(chan int, 1),
+		release: make(chan struct{}, 1),
+	}
+	env := newValidationActorTestEnv(t, verifier)
+
+	peerID, err := libp2ptest.RandPeerID()
+	require.NoError(t, err)
+
+	result := env.validator.handleValidationError(context.Background(), peerID, nil, errValidationActorClosed)
+	require.Equal(t, pubsub.ValidationIgnore, result)
 }


### PR DESCRIPTION
**Summary**
Refactor the message validation pipeline to use per-`MessageID` actors instead of per-`MessageID` mutex locking.

This PR is a part of `F-ssv-164` and depends on [#2728](https://github.com/ssvlabs/ssv/pull/2728).

The goal is to explore a different concurrency model for validation on critical paths where multiple messages for the same validator/role arrive close together.

**Motivation**
The current lock-based validation flow has a hard tradeoff:
- keep all validation under one lock and serialize expensive signature verification
- or move signature verification outside the lock and accept more subtle lock-splitting behavior

This PR explores a third option:
- assign mutable validation state ownership to a per-`MessageID` actor
- run cheap stateful checks on that actor before signature verification
- run signature verification outside the actor
- re-enter the actor to recheck and commit state

This preserves cheap stale/duplicate filtering before signature verification while allowing signature verification to proceed concurrently.

**What Changed**
- Replaced per-`MessageID` mutex coordination with a per-`MessageID` actor/mailbox model
- Added a new actor implementation in `message/validation/validation_actor.go`
- Updated `message/validation/validation.go` to cache and manage actors instead of locks
- Routed consensus validation through the actor flow in `message/validation/consensus_validation.go`
- Routed partial-signature validation through the actor flow in `message/validation/partial_validation.go`
- Replaced lock-specific concurrency tests with actor-specific concurrency tests in `message/validation/validation_actor_test.go`

**Behavioral Model**
For a given `MessageID`, validation now follows this shape:
1. decode and semantic validation
2. actor-owned stateful precheck
3. signature verification outside the actor
4. actor-owned recheck and state commit

This means:
- mutable validation state is still serialized per `MessageID`
- duplicate/stale guards still happen before signature verification
- signature verification is no longer serialized with state ownership
