### PR TITLE
Peer scoring algorithm (iurii suggestions)

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -631,7 +631,11 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 		subnetPeersExcluding := totalSubnetPeers
 		for subnet := range totalSubnetPeers {
 			if pSubnets.IsSet(uint64(subnet)) { //nolint: gosec
-				subnetPeersExcluding[subnet] -= 1
+				// This subtraction here should never result into an underflow in practice (by construction),
+				// clamp to zero just in case that invariant is ever broken by a future change.
+				if subnetPeersExcluding[subnet] >= 1 {
+					subnetPeersExcluding[subnet] -= 1
+				}
 			}
 		}
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -381,7 +381,7 @@ func (n *p2pNetwork) peersTrimming() func() {
 }
 
 // choosePeersToTrim returns a map of peers that are least-valuable to us based on how much
-// (dead/solo/duo) they contribute to us (as defined by peerScore func).
+// (dead/solo/duo) they contribute to us.
 func (n *p2pNetwork) choosePeersToTrim(trimCnt int, trimInboundOnly bool) map[peer.ID]struct{} {
 	myPeers, err := n.topicsCtrl.Peers("")
 	if err != nil {
@@ -654,7 +654,7 @@ func (n *p2pNetwork) topicSubnet(topic string) (uint64, bool) {
 	return uint64(subnet), true
 }
 
-// SubnetPeers contains the number of peers we are connected to for each subnet.
+// SubnetPeers maps subnets to the number of peers connected to each of those subnets.
 type SubnetPeers [commons.SubnetsCount]uint16
 
 func newSubnetPeers() SubnetPeers {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -594,16 +594,22 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 // buildPeerTrimScores snapshots topic membership once and computes trim scores
 // for the given peers.
 //
-// ownSubnets is our local subscription bitset: which subnets this node cares
-// about when evaluating a peer's usefulness.
+// The peer-scores are calculated based on:
+//   - ownSubnets is the desired set of subnets we want to be connected to
+//   - totalSubnetPeers is our own currently connected peer count per subnet across all
+//     peers in our topic mesh
+//   - peerSubnets tracks all the subnets each of our peers is connected to
 //
-// totalSubnetPeers is the current connected peer count per subnet across all
-// peers in our topic mesh. For each candidate peer we subtract only that peer's
-// own contribution from this total before scoring it.
+// Algo:
+//   - calculate (take snapshot of) ownSubnets, totalSubnetPeers, peerSubnets
+//   - for each candidate peer we need to score:
+//   - calculate subnetPeersExcluding (currently connected subnets IF that candidate peer is excluded/disconnected)
+//   - use SubnetPeers.Score to calculate the final peer-score for each peer (based on: subnetPeersExcluding, desired
+//     set of subnets, subnets this peer is connected to)
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
 	ownSubnets := n.SubscribedSubnets()
 	totalSubnetPeers := newSubnetPeers()
-	peerSubnetPeers := make(map[peer.ID]SubnetPeers)
+	peerSubnets := make(map[peer.ID]commons.Subnets)
 
 	for topic, peers := range n.PeersByTopic() {
 		subnet, ok := n.topicSubnet(topic)
@@ -613,35 +619,29 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 
 		totalSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
 		for _, peerID := range peers {
-			peerContribution := peerSubnetPeers[peerID]
-			peerContribution[subnet]++
-			peerSubnetPeers[peerID] = peerContribution
+			peerContribution := peerSubnets[peerID]
+			peerContribution.Set(subnet)
+			peerSubnets[peerID] = peerContribution
 		}
 	}
 
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
-		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
+		pSubnets := peerSubnets[peerID]
 		subnetPeersExcluding := totalSubnetPeers
-		for subnet := range subnetPeersExcluding {
-			peerContribution := peerSubnetPeers[peerID][subnet]
-			if peerContribution > subnetPeersExcluding[subnet] {
-				// peerSubnetPeers is built from the same topic membership snapshot as
-				// totalSubnetPeers, so underflow should be impossible. Clamp to zero if
-				// that invariant is ever broken by a future change.
-				subnetPeersExcluding[subnet] = 0
-				continue
+		for subnet := range totalSubnetPeers {
+			if pSubnets.IsSet(uint64(subnet)) { //nolint: gosec
+				subnetPeersExcluding[subnet] -= 1
 			}
-			subnetPeersExcluding[subnet] -= peerContribution
 		}
 
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, peerSubnets)
+		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
 	}
 	return scores
 }
 
 // topicSubnet parses a topic name into a subnet index and logs malformed topics.
-func (n *p2pNetwork) topicSubnet(topic string) (int, bool) {
+func (n *p2pNetwork) topicSubnet(topic string) (uint64, bool) {
 	subnet, err := strconv.ParseInt(commons.GetTopicBaseName(topic), 10, 64)
 	if err != nil {
 		n.logger.Error("failed to parse topic", zap.String("topic", topic), zap.Error(err))
@@ -651,7 +651,7 @@ func (n *p2pNetwork) topicSubnet(topic string) (int, bool) {
 		n.logger.Error("invalid topic", zap.String("topic", topic), zap.Int("subnet", int(subnet)))
 		return 0, false
 	}
-	return int(subnet), true
+	return uint64(subnet), true
 }
 
 // SubnetPeers contains the number of peers we are connected to for each subnet.

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -596,19 +596,19 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 //
 // The peer-scores are calculated based on:
 //   - ownSubnets is the desired set of subnets we want to be connected to
-//   - totalSubnetPeers is our own currently connected peer count per subnet across all
+//   - ownSubnetPeers is our own currently connected peer count per subnet across all
 //     peers in our topic mesh
 //   - peerSubnets tracks all the subnets each of our peers is connected to
 //
 // Algo:
-//   - calculate (take snapshot of) ownSubnets, totalSubnetPeers, peerSubnets
+//   - calculate (take snapshot of) ownSubnets, ownSubnetPeers, peerSubnets
 //   - for each candidate peer we need to score:
 //   - calculate subnetPeersExcluding (currently connected subnets IF that candidate peer is excluded/disconnected)
 //   - use SubnetPeers.Score to calculate the final peer-score for each peer (based on: subnetPeersExcluding, desired
 //     set of subnets, subnets this peer is connected to)
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
 	ownSubnets := n.SubscribedSubnets()
-	totalSubnetPeers := newSubnetPeers()
+	ownSubnetPeers := newSubnetPeers()
 	peerSubnets := make(map[peer.ID]commons.Subnets)
 
 	for topic, peers := range n.PeersByTopic() {
@@ -617,7 +617,7 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 			continue
 		}
 
-		totalSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
+		ownSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
 		for _, peerID := range peers {
 			peerContribution := peerSubnets[peerID]
 			peerContribution.Set(subnet)
@@ -628,8 +628,8 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
 		pSubnets := peerSubnets[peerID]
-		subnetPeersExcluding := totalSubnetPeers
-		for subnet := range totalSubnetPeers {
+		subnetPeersExcluding := ownSubnetPeers
+		for subnet := range ownSubnetPeers {
 			if pSubnets.IsSet(uint64(subnet)) { //nolint: gosec
 				// This subtraction here should never result into an underflow in practice (by construction),
 				// clamp to zero just in case that invariant is ever broken by a future change.

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -7,16 +7,13 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
-	p2pnet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
-	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/network/topics"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
@@ -59,108 +56,6 @@ func (c *testTopicsController) Close() error {
 }
 
 var _ topics.Controller = (*testTopicsController)(nil)
-
-type testPeerIndex struct {
-	subnets peers.SubnetsIndex
-}
-
-func newTestPeerIndex() *testPeerIndex {
-	return &testPeerIndex{
-		subnets: peers.NewSubnetsIndex(),
-	}
-}
-
-func (i *testPeerIndex) Connectedness(peer.ID) p2pnet.Connectedness {
-	return p2pnet.NotConnected
-}
-
-func (i *testPeerIndex) CanConnect(peer.ID) error {
-	return nil
-}
-
-func (i *testPeerIndex) AtLimit(p2pnet.Direction) bool {
-	return false
-}
-
-func (i *testPeerIndex) IsBad(peer.ID) bool {
-	return false
-}
-
-func (i *testPeerIndex) Score(peer.ID, ...*peers.NodeScore) error {
-	return nil
-}
-
-func (i *testPeerIndex) GetScore(peer.ID, ...string) ([]peers.NodeScore, error) {
-	return nil, nil
-}
-
-func (i *testPeerIndex) SelfSealed() ([]byte, error) {
-	return nil, nil
-}
-
-func (i *testPeerIndex) Self() *records.NodeInfo {
-	return nil
-}
-
-func (i *testPeerIndex) UpdateSelfRecord(func(*records.NodeInfo) *records.NodeInfo) {
-}
-
-func (i *testPeerIndex) SetNodeInfo(peer.ID, *records.NodeInfo) {
-}
-
-func (i *testPeerIndex) NodeInfo(peer.ID) *records.NodeInfo {
-	return nil
-}
-
-func (i *testPeerIndex) PeerInfo(peer.ID) *peers.PeerInfo {
-	return nil
-}
-
-func (i *testPeerIndex) AddPeerInfo(peer.ID, ma.Multiaddr, p2pnet.Direction) {
-}
-
-func (i *testPeerIndex) UpdatePeerInfo(peer.ID, func(*peers.PeerInfo)) {
-}
-
-func (i *testPeerIndex) State(peer.ID) peers.PeerState {
-	return peers.StateUnknown
-}
-
-func (i *testPeerIndex) SetState(peer.ID, peers.PeerState) {
-}
-
-func (i *testPeerIndex) UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool {
-	return i.subnets.UpdatePeerSubnets(id, subnets)
-}
-
-func (i *testPeerIndex) GetSubnetPeers(subnet int) []peer.ID {
-	return i.subnets.GetSubnetPeers(subnet)
-}
-
-func (i *testPeerIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
-	return i.subnets.GetPeerSubnets(id)
-}
-
-func (i *testPeerIndex) GetSubnetsStats() *peers.SubnetsStats {
-	return i.subnets.GetSubnetsStats()
-}
-
-func (i *testPeerIndex) SetScores(map[peer.ID]float64) {
-}
-
-func (i *testPeerIndex) GetGossipScore(peer.ID) (float64, bool) {
-	return 0, false
-}
-
-func (i *testPeerIndex) HasBadGossipScore(peer.ID) (bool, float64) {
-	return false, 0
-}
-
-func (i *testPeerIndex) Close() error {
-	return nil
-}
-
-var _ peers.Index = (*testPeerIndex)(nil)
 
 func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 	candidate := peer.ID("candidate")
@@ -249,11 +144,6 @@ func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
 	connectHosts(t, ctx, localHost, mediumValuePeer)
 	connectHosts(t, ctx, localHost, lowValuePeer)
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(highValuePeer.ID(), subnetsFor(0)))
-	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer.ID(), subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(lowValuePeer.ID(), subnetsFor(3)))
-
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
@@ -265,7 +155,7 @@ func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
 			},
 			allPeers: []peer.ID{highValuePeer.ID(), mediumValuePeer.ID(), lowValuePeer.ID()},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
@@ -284,11 +174,6 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 	connectHosts(t, ctx, inboundPeer, localHost)
 	connectHosts(t, ctx, highValueInboundPeer, localHost)
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(outboundPeer.ID(), subnetsFor(3)))
-	require.True(t, idx.UpdatePeerSubnets(inboundPeer.ID(), subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(highValueInboundPeer.ID(), subnetsFor(0)))
-
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
@@ -300,7 +185,7 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 			},
 			allPeers: []peer.ID{outboundPeer.ID(), inboundPeer.ID(), highValueInboundPeer.ID()},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
@@ -352,14 +237,12 @@ func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	}
 
 	allPeers := make([]peer.ID, 0, peerCount)
-	idx := newTestPeerIndex()
 	for i := 0; i < peerCount; i++ {
 		remoteHost := newBenchmarkHost(b)
 		connectHostsForBenchmark(b, ctx, localHost, remoteHost)
 
 		peerID := remoteHost.ID()
 		subnet := uint64(i % topicCount)
-		require.True(b, idx.UpdatePeerSubnets(peerID, subnetsFor(subnet)))
 		topicsByName[commons.SubnetTopicID(subnet)] = append(topicsByName[commons.SubnetTopicID(subnet)], peerID)
 		allPeers = append(allPeers, peerID)
 	}
@@ -371,7 +254,7 @@ func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 			peersByTopic: topicsByName,
 			allPeers:     allPeers,
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1, 2, 3, 4, 5, 6, 7),
 	)
 

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -168,9 +168,6 @@ func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 	other2 := peer.ID("other-2")
 	other3 := peer.ID("other-3")
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0, 1, 2, 3)))
-
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
@@ -182,19 +179,20 @@ func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 				"3": {candidate, other1, other2, other3},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1, 2, 3),
 	)
 
-	assert.Equal(t, 21.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		21.0, // dead + solo + duo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
-
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(1)))
 
 	network := newTrimTestNetwork(
 		nil,
@@ -204,19 +202,20 @@ func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 				"1": {candidate, other},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(1),
 	)
 
-	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		4.0, // duo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 	candidate := peer.ID("candidate")
 	other := peer.ID("other")
-
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(candidate, subnetsFor(0)))
 
 	network := newTrimTestNetwork(
 		nil,
@@ -228,11 +227,15 @@ func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 				"999":          {candidate},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0),
 	)
 
-	assert.Equal(t, 4.0, singleTrimScore(network, candidate))
+	assert.Equal(
+		t,
+		4.0, // duo
+		singleTrimScore(network, candidate),
+	)
 }
 
 func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
@@ -310,11 +313,6 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	mediumValuePeer := peer.ID("medium-value")
 	lowValuePeer := peer.ID("low-value")
 
-	idx := newTestPeerIndex()
-	require.True(t, idx.UpdatePeerSubnets(highValuePeer, subnetsFor(0)))
-	require.True(t, idx.UpdatePeerSubnets(mediumValuePeer, subnetsFor(1)))
-	require.True(t, idx.UpdatePeerSubnets(lowValuePeer, subnetsFor(3)))
-
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
@@ -325,14 +323,14 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 				"3": {lowValuePeer},
 			},
 		},
-		idx,
+		nil,
 		subnetsFor(0, 1),
 	)
 
 	scores := network.buildPeerTrimScores([]peer.ID{highValuePeer, mediumValuePeer, lowValuePeer})
 	assert.Equal(t, map[peer.ID]float64{
-		highValuePeer:   16,
-		mediumValuePeer: 4,
+		highValuePeer:   16 + 4, // dead + solo
+		mediumValuePeer: 4,      // solo
 		lowValuePeer:    0,
 	}, scores)
 }

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -208,7 +208,7 @@ func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 
 	assert.Equal(
 		t,
-		4.0, // duo
+		4.0, // solo
 		singleTrimScore(network, candidate),
 	)
 }
@@ -233,7 +233,7 @@ func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 
 	assert.Equal(
 		t,
-		4.0, // duo
+		4.0, // solo
 		singleTrimScore(network, candidate),
 	)
 }

--- a/network/peers/index.go
+++ b/network/peers/index.go
@@ -96,7 +96,8 @@ type SubnetsStats struct {
 }
 
 // SubnetsIndex stores information on subnets.
-// it keeps track of subnets but doesn't mind regards actual connections that we have.
+// It keeps track of subnets based on what peers advertise, but the actual subnets these peers have
+// might change by the time we directly connect with them.
 type SubnetsIndex interface {
 	// UpdatePeerSubnets updates the given peer's subnets
 	UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool


### PR DESCRIPTION
Simplifies https://github.com/ssvlabs/ssv/pull/2727 with the 2 main things being improved upon:

1) `SubnetPeers` will work, but `commons.Subnets` captures the intent better:
```
-	peerSubnetPeers := make(map[peer.ID]SubnetPeers)
+	peerSubnets := make(map[peer.ID]commons.Subnets)
```

2) I think it's better if we use the actual data from the peer-controller (`p2pNetwork.topicsCtrl`) rather than `p2pNetwork.idx` to fetch the up-to-date subnets a connected-to-us peer supports (I think it should provide more of an up-to-date data since the index keeps track of "what's being advertised by peers at some point in the past" (rather than what subnets they actually participate in), and our algo doesn't have to rely on an external structure of some index) ... Updated the affected tests accordingly.