### PR TITLE
protocol/v2/qbft/instance: add missing unit tests

### DIFF
--- a/protocol/v2/qbft/instance/commit_test.go
+++ b/protocol/v2/qbft/instance/commit_test.go
@@ -1,0 +1,157 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestAggregateCommitMsgsSortsOperatorIDsWithMatchingSignatures(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	msgs := []*specqbft.ProcessingMessage{
+		env.commit(1, 3, root),
+		env.commit(1, 1, root),
+		env.commit(1, 2, root),
+	}
+
+	aggregated, err := aggregateCommitMsgs(msgs, fullData)
+	require.NoError(t, err)
+
+	require.Equal(t, []spectypes.OperatorID{1, 2, 3}, aggregated.OperatorIDs)
+	require.Equal(t, fullData, aggregated.FullData)
+	require.NoError(t, spectypes.Verify(aggregated, env.inst.State.CommitteeMember.Committee))
+}
+
+func TestAggregateCommitMsgsRejectsZeroMessages(t *testing.T) {
+	aggregated, err := aggregateCommitMsgs(nil, []byte("commit-value"))
+	require.Nil(t, aggregated)
+	require.ErrorContains(t, err, "can't aggregate zero commit msgs")
+}
+
+func TestUponCommitReturnsDecidedOnQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	env.setLeader(1)
+
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+
+	env.addMessages(
+		env.inst.State.CommitContainer,
+		env.commit(1, 1, root),
+		env.commit(1, 2, root),
+	)
+
+	decided, decidedValue, aggregated, err := env.inst.UponCommit(
+		context.Background(),
+		zap.NewNop(),
+		env.commit(1, 3, root),
+	)
+	require.NoError(t, err)
+	require.True(t, decided)
+	require.Equal(t, fullData, decidedValue)
+	require.NotNil(t, aggregated)
+	require.NoError(t, spectypes.Verify(aggregated, env.inst.State.CommitteeMember.Committee))
+}
+
+func TestUponCommitNoQuorumOrDuplicateReturnsNoDecision(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	env.setLeader(1)
+
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	msg := env.commit(1, 1, root)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+
+	decided, decidedValue, aggregated, err := env.inst.UponCommit(context.Background(), zap.NewNop(), msg)
+	require.NoError(t, err)
+	require.False(t, decided)
+	require.Nil(t, decidedValue)
+	require.Nil(t, aggregated)
+
+	decided, decidedValue, aggregated, err = env.inst.UponCommit(context.Background(), zap.NewNop(), msg)
+	require.NoError(t, err)
+	require.False(t, decided)
+	require.Nil(t, decidedValue)
+	require.Nil(t, aggregated)
+}
+
+func TestBaseCommitValidation(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	root := env.hash([]byte("commit-value"))
+
+	t.Run("wrong type", func(t *testing.T) {
+		err := baseCommitValidationIgnoreSignature(env.prepare(1, 1, root), env.inst.State.Height, env.inst.State.CommitteeMember.Committee)
+		require.ErrorContains(t, err, "commit msg type is wrong")
+	})
+
+	t.Run("wrong height", func(t *testing.T) {
+		msg := env.processingMessage(&specqbft.Message{
+			MsgType:    specqbft.CommitMsgType,
+			Height:     env.inst.State.Height + 1,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 1, nil)
+		err := baseCommitValidationIgnoreSignature(msg, env.inst.State.Height, env.inst.State.CommitteeMember.Committee)
+		require.ErrorContains(t, err, ErrWrongMsgHeight.Error())
+	})
+
+	t.Run("signer not in committee", func(t *testing.T) {
+		msg := env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.CommitMsgType,
+			Height:     env.inst.State.Height,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 99, env.keys.OperatorKeys[2], nil)
+		err := baseCommitValidationIgnoreSignature(msg, env.inst.State.Height, env.inst.State.CommitteeMember.Committee)
+		require.ErrorContains(t, err, "signer not in committee")
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		msg := env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.CommitMsgType,
+			Height:     env.inst.State.Height,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 1, env.keys.OperatorKeys[2], nil)
+		err := BaseCommitValidationVerifySignature(msg, env.inst.State.Height, env.inst.State.CommitteeMember.Committee)
+		require.ErrorContains(t, err, "msg signature invalid")
+	})
+}
+
+func TestValidateCommit(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	env.setLeader(1)
+
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	env.inst.State.Round = 2
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(2, 1, fullData, root, nil, nil)
+
+	t.Run("wrong round is retryable", func(t *testing.T) {
+		err := env.inst.validateCommit(env.commit(1, 1, root))
+		require.Error(t, err)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("mismatched root is rejected", func(t *testing.T) {
+		err := env.inst.validateCommit(env.commit(2, 1, [32]byte{6}))
+		require.ErrorContains(t, err, "proposed data mismatch")
+	})
+
+	t.Run("multiple signers are rejected", func(t *testing.T) {
+		msg := env.aggregateMessages(env.commit(2, 1, root), env.commit(2, 2, root))
+		err := env.inst.validateCommit(msg)
+		require.ErrorContains(t, err, "msg allows 1 signer")
+	})
+}

--- a/protocol/v2/qbft/instance/prepare_test.go
+++ b/protocol/v2/qbft/instance/prepare_test.go
@@ -1,0 +1,199 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestUponPrepareBroadcastsCommitOnNewQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+
+	env.addMessages(
+		env.inst.State.PrepareContainer,
+		env.prepare(1, 1, root),
+		env.prepare(1, 3, root),
+	)
+
+	err := env.inst.uponPrepare(context.Background(), zap.NewNop(), env.prepare(1, 4, root))
+	require.NoError(t, err)
+
+	require.Equal(t, fullData, env.inst.State.LastPreparedValue)
+	require.Equal(t, specqbft.Round(1), env.inst.State.LastPreparedRound)
+
+	commit := env.broadcastedProcessingMessage(0)
+	require.Equal(t, specqbft.CommitMsgType, commit.QBFTMessage.MsgType)
+	require.Equal(t, specqbft.Round(1), commit.QBFTMessage.Round)
+	require.Equal(t, root, commit.QBFTMessage.Root)
+	require.Equal(t, []spectypes.OperatorID{2}, commit.SignedMessage.OperatorIDs)
+}
+
+func TestUponPrepareReturnsEarlyWhenQuorumAlreadyReached(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+	env.inst.State.LastPreparedValue = []byte("existing")
+	env.inst.State.LastPreparedRound = 9
+
+	env.addMessages(
+		env.inst.State.PrepareContainer,
+		env.prepare(1, 1, root),
+		env.prepare(1, 3, root),
+		env.prepare(1, 4, root),
+	)
+
+	err := env.inst.uponPrepare(context.Background(), zap.NewNop(), env.prepare(1, 2, root))
+	require.NoError(t, err)
+
+	require.Equal(t, []byte("existing"), env.inst.State.LastPreparedValue)
+	require.Equal(t, specqbft.Round(9), env.inst.State.LastPreparedRound)
+	require.Empty(t, env.network.BroadcastedMsgs)
+}
+
+func TestUponPrepareWithoutQuorumDoesNotBroadcast(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+	env.addMessages(env.inst.State.PrepareContainer, env.prepare(1, 1, root))
+
+	err := env.inst.uponPrepare(context.Background(), zap.NewNop(), env.prepare(1, 3, root))
+	require.NoError(t, err)
+
+	require.Nil(t, env.inst.State.LastPreparedValue)
+	require.Equal(t, specqbft.NoRound, env.inst.State.LastPreparedRound)
+	require.Empty(t, env.network.BroadcastedMsgs)
+}
+
+func TestGetRoundChangeJustificationFiltersMatchingPrepares(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+	env.inst.State.LastPreparedValue = fullData
+	env.inst.State.LastPreparedRound = 1
+
+	env.addMessages(
+		env.inst.State.PrepareContainer,
+		env.prepare(1, 1, root),
+		env.prepare(1, 2, root),
+		env.prepare(1, 3, root),
+		env.prepare(1, 4, [32]byte{7}),
+	)
+
+	justification, err := env.inst.getRoundChangeJustification()
+	require.NoError(t, err)
+	require.Len(t, justification, 3)
+	for _, msg := range justification {
+		require.Equal(t, root, msg.QBFTMessage.Root)
+	}
+}
+
+func TestGetRoundChangeJustificationReturnsNilWhenNoPreparedValueOrNoQuorum(t *testing.T) {
+	t.Run("no prepared value", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 2)
+		justification, err := env.inst.getRoundChangeJustification()
+		require.NoError(t, err)
+		require.Nil(t, justification)
+	})
+
+	t.Run("filtered prepares do not reach quorum", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 2)
+		fullData := []byte("proposal-value")
+		root := env.hash(fullData)
+		env.inst.State.LastPreparedValue = fullData
+		env.inst.State.LastPreparedRound = 1
+		env.addMessages(
+			env.inst.State.PrepareContainer,
+			env.prepare(1, 1, root),
+			env.prepare(1, 2, [32]byte{5}),
+			env.prepare(1, 3, [32]byte{6}),
+		)
+
+		justification, err := env.inst.getRoundChangeJustification()
+		require.NoError(t, err)
+		require.Nil(t, justification)
+	})
+}
+
+func TestValidSignedPrepareForHeightRoundAndRootIgnoreSignature(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	root := env.hash([]byte("proposal-value"))
+
+	t.Run("wrong type is rejected", func(t *testing.T) {
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(env.commit(1, 1, root), 1, root)
+		require.ErrorContains(t, err, "prepare msg type is wrong")
+	})
+
+	t.Run("wrong height is rejected", func(t *testing.T) {
+		msg := env.processingMessage(&specqbft.Message{
+			MsgType:    specqbft.PrepareMsgType,
+			Height:     env.inst.State.Height + 1,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 1, nil)
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(msg, 1, root)
+		require.ErrorContains(t, err, ErrWrongMsgHeight.Error())
+	})
+
+	t.Run("wrong round is retryable", func(t *testing.T) {
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(env.prepare(2, 1, root), 1, root)
+		require.Error(t, err)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("wrong root is rejected", func(t *testing.T) {
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(env.prepare(1, 1, [32]byte{8}), 1, root)
+		require.ErrorContains(t, err, "proposed data mismatch")
+	})
+
+	t.Run("multiple signers are rejected", func(t *testing.T) {
+		msg := env.aggregateMessages(env.prepare(1, 1, root), env.prepare(1, 2, root))
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(msg, 1, root)
+		require.ErrorContains(t, err, "signer not in committee")
+	})
+
+	t.Run("signer not in committee is rejected", func(t *testing.T) {
+		msg := env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.PrepareMsgType,
+			Height:     env.inst.State.Height,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 99, env.keys.OperatorKeys[2], nil)
+		err := env.inst.validSignedPrepareForHeightRoundAndRootIgnoreSignature(msg, 1, root)
+		require.ErrorContains(t, err, "signer not in committee")
+	})
+}
+
+func TestValidSignedPrepareForHeightRoundAndRootVerifySignatureRejectsInvalidSignature(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	root := env.hash([]byte("proposal-value"))
+
+	msg := env.processingMessageWithKey(&specqbft.Message{
+		MsgType:    specqbft.PrepareMsgType,
+		Height:     env.inst.State.Height,
+		Round:      1,
+		Identifier: env.inst.State.ID,
+		Root:       root,
+	}, 1, env.keys.OperatorKeys[2], nil)
+
+	err := env.inst.validSignedPrepareForHeightRoundAndRootVerifySignature(msg, 1, root)
+	require.ErrorContains(t, err, "msg signature invalid")
+}

--- a/protocol/v2/qbft/instance/process_msg_test.go
+++ b/protocol/v2/qbft/instance/process_msg_test.go
@@ -26,6 +26,7 @@ func TestBaseMsgValidationPastRoundDecidedCommitBypassesPastRoundGuard(t *testin
 	err := env.inst.BaseMsgValidation(msg)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "msg allows 1 signer")
+	require.NotContains(t, err.Error(), "past round")
 }
 
 func TestBaseMsgValidationPastRoundNonDecidedRejected(t *testing.T) {

--- a/protocol/v2/qbft/instance/process_msg_test.go
+++ b/protocol/v2/qbft/instance/process_msg_test.go
@@ -88,6 +88,8 @@ func TestProcessMsgConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// Intentionally reuse the same message pointer to exercise dedup/idempotent
+			// processing while ProcessMsg serializes handler execution through processMsgF.
 			_, _, _, err := env.inst.ProcessMsg(context.Background(), zap.NewNop(), msg)
 			errs <- err
 		}()

--- a/protocol/v2/qbft/instance/process_msg_test.go
+++ b/protocol/v2/qbft/instance/process_msg_test.go
@@ -1,0 +1,110 @@
+package instance
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestBaseMsgValidationPastRoundDecidedCommitBypassesPastRoundGuard(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	env.inst.State.Round = 2
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(2, 1, fullData, root, nil, nil)
+
+	msg := env.aggregateMessages(
+		env.commit(1, 1, root),
+		env.commit(1, 2, root),
+		env.commit(1, 3, root),
+	)
+
+	err := env.inst.BaseMsgValidation(msg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "msg allows 1 signer")
+}
+
+func TestBaseMsgValidationPastRoundNonDecidedRejected(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	root := env.hash([]byte("proposal-value"))
+	env.inst.State.Round = 2
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(2, 1, []byte("proposal-value"), root, nil, nil)
+
+	err := env.inst.BaseMsgValidation(env.prepare(1, 1, root))
+	require.ErrorContains(t, err, "past round")
+
+	err = env.inst.BaseMsgValidation(env.commit(1, 1, root))
+	require.ErrorContains(t, err, "past round")
+}
+
+func TestProcessMsgDispatchCommitUpdatesDecision(t *testing.T) {
+	env := newInstanceTestEnv(t, 4)
+	env.setLeader(1)
+
+	fullData := []byte("commit-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+	env.addMessages(
+		env.inst.State.CommitContainer,
+		env.commit(1, 1, root),
+		env.commit(1, 2, root),
+	)
+
+	decided, decidedValue, aggregated, err := env.inst.ProcessMsg(
+		context.Background(),
+		zap.NewNop(),
+		env.commit(1, 3, root),
+	)
+	require.NoError(t, err)
+	require.True(t, decided)
+	require.Equal(t, fullData, decidedValue)
+	require.NotNil(t, aggregated)
+	require.True(t, env.inst.State.Decided)
+	require.Equal(t, fullData, env.inst.State.DecidedValue)
+}
+
+func TestProcessMsgConcurrentAccess(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+	env.addMessages(
+		env.inst.State.PrepareContainer,
+		env.prepare(1, 1, root),
+		env.prepare(1, 3, root),
+	)
+	msg := env.prepare(1, 4, root)
+
+	const workers = 8
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _, err := env.inst.ProcessMsg(context.Background(), zap.NewNop(), msg)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, specqbft.Round(1), env.inst.State.Round)
+	require.Equal(t, fullData, env.inst.State.LastPreparedValue)
+	require.Equal(t, specqbft.Round(1), env.inst.State.LastPreparedRound)
+	require.Len(t, env.network.BroadcastedMsgs, 1)
+
+	broadcasted, err := specqbft.NewProcessingMessage(env.network.BroadcastedMsgs[0])
+	require.NoError(t, err)
+	require.Equal(t, specqbft.CommitMsgType, broadcasted.QBFTMessage.MsgType)
+}

--- a/protocol/v2/qbft/instance/proposal_test.go
+++ b/protocol/v2/qbft/instance/proposal_test.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"context"
 	"testing"
 
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -17,7 +16,7 @@ func TestUponProposalFutureRoundBumpsAndBroadcastsPrepare(t *testing.T) {
 	fullData := []byte("proposal-value")
 	proposal := env.proposal(2, 1, fullData, env.hash(fullData), nil, nil)
 
-	err := env.inst.uponProposal(context.Background(), zap.NewNop(), proposal)
+	err := env.inst.uponProposal(t.Context(), zap.NewNop(), proposal)
 	require.NoError(t, err)
 
 	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
@@ -39,8 +38,8 @@ func TestUponProposalDuplicateIgnored(t *testing.T) {
 	fullData := []byte("proposal-value")
 	proposal := env.proposal(1, 1, fullData, env.hash(fullData), nil, nil)
 
-	require.NoError(t, env.inst.uponProposal(context.Background(), zap.NewNop(), proposal))
-	require.NoError(t, env.inst.uponProposal(context.Background(), zap.NewNop(), proposal))
+	require.NoError(t, env.inst.uponProposal(t.Context(), zap.NewNop(), proposal))
+	require.NoError(t, env.inst.uponProposal(t.Context(), zap.NewNop(), proposal))
 
 	require.Len(t, env.network.BroadcastedMsgs, 1)
 }

--- a/protocol/v2/qbft/instance/proposal_test.go
+++ b/protocol/v2/qbft/instance/proposal_test.go
@@ -1,0 +1,193 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestUponProposalFutureRoundBumpsAndBroadcastsPrepare(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	proposal := env.proposal(2, 1, fullData, env.hash(fullData), nil, nil)
+
+	err := env.inst.uponProposal(context.Background(), zap.NewNop(), proposal)
+	require.NoError(t, err)
+
+	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
+	require.Same(t, proposal, env.inst.State.ProposalAcceptedForCurrentRound)
+	require.Equal(t, 1, env.timer.State.Timeouts)
+	require.Equal(t, specqbft.Round(2), env.timer.State.Round)
+
+	prepare := env.broadcastedProcessingMessage(0)
+	require.Equal(t, specqbft.PrepareMsgType, prepare.QBFTMessage.MsgType)
+	require.Equal(t, specqbft.Round(2), prepare.QBFTMessage.Round)
+	require.Equal(t, env.hash(fullData), prepare.QBFTMessage.Root)
+	require.Equal(t, []spectypes.OperatorID{2}, prepare.SignedMessage.OperatorIDs)
+}
+
+func TestUponProposalDuplicateIgnored(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	proposal := env.proposal(1, 1, fullData, env.hash(fullData), nil, nil)
+
+	require.NoError(t, env.inst.uponProposal(context.Background(), zap.NewNop(), proposal))
+	require.NoError(t, env.inst.uponProposal(context.Background(), zap.NewNop(), proposal))
+
+	require.Len(t, env.network.BroadcastedMsgs, 1)
+}
+
+func TestIsValidProposalRejectsWrongLeader(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	proposal := env.proposal(1, 2, fullData, env.hash(fullData), nil, nil)
+
+	err := env.inst.isValidProposal(proposal)
+	require.ErrorContains(t, err, "proposal leader invalid")
+}
+
+func TestIsValidProposalValidationBranches(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+	fullData := []byte("proposal-value")
+	root := env.hash(fullData)
+
+	t.Run("wrong type", func(t *testing.T) {
+		err := env.inst.isValidProposal(env.prepare(1, 1, root))
+		require.ErrorContains(t, err, "msg type is not proposal")
+	})
+
+	t.Run("wrong height", func(t *testing.T) {
+		msg := env.processingMessage(&specqbft.Message{
+			MsgType:    specqbft.ProposalMsgType,
+			Height:     env.inst.State.Height + 1,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 1, fullData)
+		err := env.inst.isValidProposal(msg)
+		require.ErrorContains(t, err, ErrWrongMsgHeight.Error())
+	})
+
+	t.Run("multiple signers", func(t *testing.T) {
+		msg := env.aggregateMessages(
+			env.proposal(1, 1, fullData, root, nil, nil),
+			env.proposal(1, 2, fullData, root, nil, nil),
+		)
+		err := env.inst.isValidProposal(msg)
+		require.ErrorContains(t, err, "msg allows 1 signer")
+	})
+
+	t.Run("signer not in committee", func(t *testing.T) {
+		msg := env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.ProposalMsgType,
+			Height:     env.inst.State.Height,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 99, env.keys.OperatorKeys[2], fullData)
+		err := env.inst.isValidProposal(msg)
+		require.ErrorContains(t, err, "signer not in committee")
+	})
+
+	t.Run("current state rejects second proposal for same round", func(t *testing.T) {
+		env.inst.State.Round = 1
+		env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, fullData, root, nil, nil)
+		err := env.inst.isValidProposal(env.proposal(1, 1, fullData, root, nil, nil))
+		require.ErrorContains(t, err, "proposal is not valid with current state")
+	})
+}
+
+func TestIsValidProposalRejectsRootMismatch(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	fullData := []byte("proposal-value")
+	proposal := env.proposal(1, 1, fullData, [32]byte{9, 9, 9}, nil, nil)
+
+	err := env.inst.isValidProposal(proposal)
+	require.ErrorContains(t, err, "H(data) != root")
+}
+
+func TestIsValidProposalRejectsInvalidValue(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+
+	err := env.inst.isValidProposal(env.proposal(1, 1, []byte("invalid-value"), env.hash([]byte("invalid-value")), nil, nil))
+	require.ErrorContains(t, err, "proposal fullData invalid")
+}
+
+func TestIsProposalJustificationRequiresRoundChangeQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("proposal-value")
+	roundChanges := []*specqbft.ProcessingMessage{
+		env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+	}
+
+	err := env.inst.isProposalJustification(roundChanges, nil, 2, fullData)
+	require.ErrorContains(t, err, "change round has no quorum")
+}
+
+func TestIsProposalJustificationRejectsPreparedRoundChangeValueMismatch(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	preparedValue := []byte("prepared-value")
+	roundChanges, prepares := env.preparedRoundChangeSet(2, 1, preparedValue, []spectypes.OperatorID{1, 2, 3}, []spectypes.OperatorID{1, 2, 3})
+
+	err := env.inst.isProposalJustification(roundChanges, prepares, 2, []byte("different-value"))
+	require.ErrorContains(t, err, "change round msg not valid")
+}
+
+func TestIsProposalJustificationRequiresPrepareQuorumForPreparedRoundChange(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("prepared-value")
+	roundChanges, prepares := env.preparedRoundChangeSet(2, 1, fullData, []spectypes.OperatorID{1, 2, 3}, []spectypes.OperatorID{1, 2, 3})
+
+	err := env.inst.isProposalJustification(roundChanges, prepares[:2], 2, fullData)
+	require.ErrorContains(t, err, "prepares has no quorum")
+}
+
+func TestIsProposalJustificationRejectsInvalidPrepareJustification(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("prepared-value")
+	root := env.hash(fullData)
+	roundChanges, _ := env.preparedRoundChangeSet(2, 1, fullData, []spectypes.OperatorID{1, 2, 3}, []spectypes.OperatorID{1, 2, 3})
+	prepares := []*specqbft.ProcessingMessage{
+		env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.PrepareMsgType,
+			Height:     env.inst.State.Height,
+			Round:      1,
+			Identifier: env.inst.State.ID,
+			Root:       root,
+		}, 1, env.keys.OperatorKeys[2], nil),
+		env.prepare(1, 2, root),
+		env.prepare(1, 3, root),
+	}
+
+	err := env.inst.isProposalJustification(roundChanges, prepares, 2, fullData)
+	require.ErrorContains(t, err, "signed prepare not valid")
+}
+
+func TestIsProposalJustificationAcceptsPreparedQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("prepared-value")
+	roundChanges, prepares := env.preparedRoundChangeSet(2, 1, fullData, []spectypes.OperatorID{1, 2, 3}, []spectypes.OperatorID{1, 2, 3})
+
+	err := env.inst.isProposalJustification(roundChanges, prepares, 2, fullData)
+	require.NoError(t, err)
+}

--- a/protocol/v2/qbft/instance/round_change_test.go
+++ b/protocol/v2/qbft/instance/round_change_test.go
@@ -168,15 +168,17 @@ func TestUponRoundChangeWithPartialQuorumBumpsRoundAndBroadcastsRoundChange(t *t
 	require.Equal(t, []spectypes.OperatorID{2}, msg.SignedMessage.OperatorIDs)
 }
 
-func TestUponRoundChangeReturnsEarlyOnDuplicateOrExistingQuorum(t *testing.T) {
+func TestUponRoundChangeReturnsEarlyOnDuplicate(t *testing.T) {
 	env := newInstanceTestEnv(t, 2)
 	msg := env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil)
 	env.addMessages(env.inst.State.RoundChangeContainer, msg)
 
 	require.NoError(t, env.inst.uponRoundChange(context.Background(), zap.NewNop(), msg))
 	require.Empty(t, env.network.BroadcastedMsgs)
+}
 
-	env = newInstanceTestEnv(t, 2)
+func TestUponRoundChangeReturnsEarlyWhenQuorumAlreadyExists(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
 	env.addMessages(
 		env.inst.State.RoundChangeContainer,
 		env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),

--- a/protocol/v2/qbft/instance/round_change_test.go
+++ b/protocol/v2/qbft/instance/round_change_test.go
@@ -1,0 +1,378 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestHasReceivedPartialQuorumIgnoresCurrentAndPastRounds(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.inst.State.Round = 2
+
+	env.addMessages(
+		env.inst.State.RoundChangeContainer,
+		env.roundChange(1, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(3, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(3, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+
+	partialQuorum, msgs := env.inst.hasReceivedPartialQuorum()
+	require.True(t, partialQuorum)
+	require.Len(t, msgs, 2)
+	for _, msg := range msgs {
+		require.Greater(t, msg.QBFTMessage.Round, specqbft.Round(2))
+	}
+}
+
+func TestHasReceivedPartialQuorumRequiresPartialThreshold(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.inst.State.Round = 2
+	env.addMessages(env.inst.State.RoundChangeContainer, env.roundChange(3, 3, specqbft.NoRound, [32]byte{}, nil, nil))
+
+	partialQuorum, msgs := env.inst.hasReceivedPartialQuorum()
+	require.False(t, partialQuorum)
+	require.Len(t, msgs, 1)
+}
+
+func TestHighestPreparedReturnsRoundChangeWithHighestPreparedRound(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("prepared-value")
+	root := env.hash(fullData)
+	highest, err := highestPrepared([]*specqbft.ProcessingMessage{
+		env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 2, 1, root, fullData, []*specqbft.ProcessingMessage{
+			env.prepare(1, 1, root),
+			env.prepare(1, 2, root),
+			env.prepare(1, 3, root),
+		}),
+		env.roundChange(2, 3, 2, root, fullData, []*specqbft.ProcessingMessage{
+			env.prepare(2, 1, root),
+			env.prepare(2, 2, root),
+			env.prepare(2, 3, root),
+		}),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, highest)
+	require.Equal(t, specqbft.Round(2), highest.QBFTMessage.DataRound)
+	require.Equal(t, []spectypes.OperatorID{3}, highest.SignedMessage.OperatorIDs)
+}
+
+func TestHasReceivedProposalJustificationForLeadingRound(t *testing.T) {
+	t.Run("returns nil without quorum", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 1)
+		env.setLeader(1)
+		msg := env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil)
+		env.addMessages(env.inst.State.RoundChangeContainer, msg)
+
+		got, value, err := env.inst.hasReceivedProposalJustificationForLeadingRound(msg)
+		require.NoError(t, err)
+		require.Nil(t, got)
+		require.Nil(t, value)
+	})
+
+	t.Run("returns highest prepared value for leader", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 1)
+		env.setLeader(1)
+		env.inst.State.Round = 2
+		env.inst.StartValue = []byte("start-value")
+
+		value := []byte("prepared-b")
+		root := env.hash(value)
+
+		rc1 := env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil)
+		rc2 := env.roundChange(2, 3, 1, root, value, []*specqbft.ProcessingMessage{
+			env.prepare(1, 1, root),
+			env.prepare(1, 2, root),
+			env.prepare(1, 3, root),
+		})
+		rc3 := env.roundChange(2, 4, 2, root, value, []*specqbft.ProcessingMessage{
+			env.prepare(2, 1, root),
+			env.prepare(2, 2, root),
+			env.prepare(2, 4, root),
+		})
+		env.addMessages(env.inst.State.RoundChangeContainer, rc1, rc2, rc3)
+
+		got, value, err := env.inst.hasReceivedProposalJustificationForLeadingRound(rc1)
+		require.NoError(t, err)
+		require.Same(t, rc3, got)
+		require.Equal(t, []byte("prepared-b"), value)
+	})
+}
+
+func TestIsProposalJustificationForLeadingRound(t *testing.T) {
+	env := newInstanceTestEnv(t, 1)
+	env.setLeader(1)
+	env.inst.State.Round = 2
+	value := []byte("proposal-value")
+	roundChanges := []*specqbft.ProcessingMessage{
+		env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+	}
+	roundChangeMsg := roundChanges[0]
+
+	t.Run("not proposer", func(t *testing.T) {
+		nonLeaderEnv := newInstanceTestEnv(t, 2)
+		nonLeaderEnv.setLeader(1)
+		nonLeaderEnv.inst.State.Round = 2
+		err := nonLeaderEnv.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 2)
+		require.ErrorContains(t, err, "not proposer")
+	})
+
+	t.Run("proposal round mismatch", func(t *testing.T) {
+		env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(2, 1, value, env.hash(value), nil, nil)
+		err := env.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 2)
+		require.ErrorContains(t, err, "proposal round mismatch")
+	})
+
+	t.Run("accepts future round proposal", func(t *testing.T) {
+		env.inst.State.ProposalAcceptedForCurrentRound = nil
+		err := env.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 3)
+		require.NoError(t, err)
+	})
+}
+
+func TestUponRoundChangeWithPartialQuorumBumpsRoundAndBroadcastsRoundChange(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.setLeader(1)
+	env.inst.State.Round = 1
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, []byte("old-value"), env.hash([]byte("old-value")), nil, nil)
+
+	env.addMessages(
+		env.inst.State.RoundChangeContainer,
+		env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+
+	err := env.inst.uponRoundChange(
+		context.Background(),
+		zap.NewNop(),
+		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
+	require.Nil(t, env.inst.State.ProposalAcceptedForCurrentRound)
+	require.Equal(t, 1, env.timer.State.Timeouts)
+	require.Equal(t, specqbft.Round(2), env.timer.State.Round)
+
+	msg := env.broadcastedProcessingMessage(0)
+	require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
+	require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)
+	require.Equal(t, []spectypes.OperatorID{2}, msg.SignedMessage.OperatorIDs)
+}
+
+func TestUponRoundChangeReturnsEarlyOnDuplicateOrExistingQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	msg := env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil)
+	env.addMessages(env.inst.State.RoundChangeContainer, msg)
+
+	require.NoError(t, env.inst.uponRoundChange(context.Background(), zap.NewNop(), msg))
+	require.Empty(t, env.network.BroadcastedMsgs)
+
+	env = newInstanceTestEnv(t, 2)
+	env.addMessages(
+		env.inst.State.RoundChangeContainer,
+		env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+	err := env.inst.uponRoundChange(context.Background(), zap.NewNop(), env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil))
+	require.NoError(t, err)
+	require.Empty(t, env.network.BroadcastedMsgs)
+}
+
+func TestUponRoundChangeAsLeaderBroadcastsProposalOnJustifiedQuorum(t *testing.T) {
+	env := newInstanceTestEnv(t, 1)
+	env.setLeader(1)
+	env.inst.State.Round = 2
+	env.inst.StartValue = []byte("start-value")
+
+	env.addMessages(
+		env.inst.State.RoundChangeContainer,
+		env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+
+	err := env.inst.uponRoundChange(
+		context.Background(),
+		zap.NewNop(),
+		env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+	)
+	require.NoError(t, err)
+
+	msg := env.broadcastedProcessingMessage(0)
+	require.Equal(t, specqbft.ProposalMsgType, msg.QBFTMessage.MsgType)
+	require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)
+	require.Equal(t, env.hash(env.inst.StartValue), msg.QBFTMessage.Root)
+}
+
+func TestValidRoundChangeForDataIgnoreSignatureValidationBranches(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	fullData := []byte("prepared-value")
+	root := env.hash(fullData)
+
+	t.Run("wrong type", func(t *testing.T) {
+		err := env.inst.validRoundChangeForDataIgnoreSignature(env.prepare(2, 1, root), 2, fullData)
+		require.ErrorContains(t, err, "round change msg type is wrong")
+	})
+
+	t.Run("wrong height", func(t *testing.T) {
+		msg := env.processingMessage(&specqbft.Message{
+			MsgType:    specqbft.RoundChangeMsgType,
+			Height:     env.inst.State.Height + 1,
+			Round:      2,
+			Identifier: env.inst.State.ID,
+		}, 1, nil)
+		err := env.inst.validRoundChangeForDataIgnoreSignature(msg, 2, fullData)
+		require.ErrorContains(t, err, ErrWrongMsgHeight.Error())
+	})
+
+	t.Run("wrong round is retryable", func(t *testing.T) {
+		err := env.inst.validRoundChangeForDataIgnoreSignature(env.roundChange(3, 1, specqbft.NoRound, [32]byte{}, nil, nil), 2, fullData)
+		require.Error(t, err)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("multiple signers", func(t *testing.T) {
+		msg := env.aggregateMessages(
+			env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil),
+			env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+		)
+		err := env.inst.validRoundChangeForDataIgnoreSignature(msg, 2, fullData)
+		require.ErrorContains(t, err, "msg allows 1 signer")
+	})
+
+	t.Run("signer not in committee", func(t *testing.T) {
+		msg := env.processingMessageWithKey(&specqbft.Message{
+			MsgType:    specqbft.RoundChangeMsgType,
+			Height:     env.inst.State.Height,
+			Round:      2,
+			Identifier: env.inst.State.ID,
+		}, 99, env.keys.OperatorKeys[2], nil)
+		err := env.inst.validRoundChangeForDataIgnoreSignature(msg, 2, fullData)
+		require.ErrorContains(t, err, "signer not in committee")
+	})
+
+	t.Run("prepared full data root mismatch", func(t *testing.T) {
+		msg := env.roundChange(2, 1, 1, [32]byte{9}, fullData, []*specqbft.ProcessingMessage{
+			env.prepare(1, 1, [32]byte{9}),
+			env.prepare(1, 2, [32]byte{9}),
+			env.prepare(1, 3, [32]byte{9}),
+		})
+		err := env.inst.validRoundChangeForDataIgnoreSignature(msg, 2, fullData)
+		require.ErrorContains(t, err, "H(data) != root")
+	})
+
+	t.Run("invalid prepare signature", func(t *testing.T) {
+		msg := env.roundChange(2, 1, 1, root, fullData, []*specqbft.ProcessingMessage{
+			env.processingMessageWithKey(&specqbft.Message{
+				MsgType:    specqbft.PrepareMsgType,
+				Height:     env.inst.State.Height,
+				Round:      1,
+				Identifier: env.inst.State.ID,
+				Root:       root,
+			}, 1, env.keys.OperatorKeys[2], nil),
+			env.prepare(1, 2, root),
+			env.prepare(1, 3, root),
+		})
+		err := env.inst.validRoundChangeForDataIgnoreSignature(msg, 2, fullData)
+		require.ErrorContains(t, err, "round change justification invalid")
+	})
+}
+
+func TestValidRoundChangeForDataIgnoreSignatureRejectsInvalidPreparedJustification(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	fullData := []byte("prepared-value")
+	root := env.hash(fullData)
+
+	err := env.inst.validRoundChangeForDataIgnoreSignature(
+		env.roundChange(2, 1, 1, root, fullData, []*specqbft.ProcessingMessage{
+			env.prepare(1, 1, root),
+			env.prepare(1, 2, root),
+		}),
+		2,
+		fullData,
+	)
+	require.ErrorContains(t, err, "no justifications quorum")
+
+	err = env.inst.validRoundChangeForDataIgnoreSignature(
+		env.roundChange(2, 1, 3, root, fullData, []*specqbft.ProcessingMessage{
+			env.prepare(3, 1, root),
+			env.prepare(3, 2, root),
+			env.prepare(3, 3, root),
+		}),
+		2,
+		fullData,
+	)
+	require.ErrorContains(t, err, "prepared round > round")
+}
+
+func TestValidRoundChangeForDataVerifySignatureRejectsInvalidSignature(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+
+	msg := env.processingMessageWithKey(&specqbft.Message{
+		MsgType:    specqbft.RoundChangeMsgType,
+		Height:     env.inst.State.Height,
+		Round:      2,
+		Identifier: env.inst.State.ID,
+	}, 1, env.keys.OperatorKeys[2], nil)
+
+	err := env.inst.validRoundChangeForDataVerifySignature(msg, 2, nil)
+	require.ErrorContains(t, err, "msg signature invalid")
+}
+
+func TestGetRoundChangeDataAndCreateRoundChange(t *testing.T) {
+	t.Run("returns empty data without prepared state", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 2)
+		round, root, fullData, justifications, err := env.inst.getRoundChangeData()
+		require.NoError(t, err)
+		require.Equal(t, specqbft.NoRound, round)
+		require.Equal(t, [32]byte{}, root)
+		require.Nil(t, fullData)
+		require.Nil(t, justifications)
+	})
+
+	t.Run("includes prepared round root value and justifications", func(t *testing.T) {
+		env := newInstanceTestEnv(t, 2)
+		fullData := []byte("prepared-value")
+		root := env.hash(fullData)
+		env.inst.State.LastPreparedRound = 1
+		env.inst.State.LastPreparedValue = fullData
+		env.addMessages(
+			env.inst.State.PrepareContainer,
+			env.prepare(1, 1, root),
+			env.prepare(1, 2, root),
+			env.prepare(1, 3, root),
+		)
+
+		round, gotRoot, gotValue, justifications, err := env.inst.getRoundChangeData()
+		require.NoError(t, err)
+		require.Equal(t, specqbft.Round(1), round)
+		require.Equal(t, root, gotRoot)
+		require.Equal(t, fullData, gotValue)
+		require.Len(t, justifications, 3)
+
+		signed, err := env.inst.CreateRoundChange(2)
+		require.NoError(t, err)
+
+		msg, err := specqbft.NewProcessingMessage(signed)
+		require.NoError(t, err)
+		require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
+		require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)
+		require.Equal(t, specqbft.Round(1), msg.QBFTMessage.DataRound)
+		require.Equal(t, root, msg.QBFTMessage.Root)
+		require.Equal(t, fullData, msg.SignedMessage.FullData)
+
+		prepareJustifications, err := msg.QBFTMessage.GetRoundChangeJustifications()
+		require.NoError(t, err)
+		require.Len(t, prepareJustifications, 3)
+	})
+}

--- a/protocol/v2/qbft/instance/round_change_test.go
+++ b/protocol/v2/qbft/instance/round_change_test.go
@@ -107,32 +107,39 @@ func TestHasReceivedProposalJustificationForLeadingRound(t *testing.T) {
 }
 
 func TestIsProposalJustificationForLeadingRound(t *testing.T) {
-	env := newInstanceTestEnv(t, 1)
-	env.setLeader(1)
-	env.inst.State.Round = 2
-	value := []byte("proposal-value")
-	roundChanges := []*specqbft.ProcessingMessage{
-		env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
-		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
-		env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+	newLeadingRoundEnv := func(t *testing.T) (*instanceTestEnv, []byte, []*specqbft.ProcessingMessage, *specqbft.ProcessingMessage) {
+		t.Helper()
+
+		env := newInstanceTestEnv(t, 1)
+		env.setLeader(1)
+		env.inst.State.Round = 2
+		value := []byte("proposal-value")
+		roundChanges := []*specqbft.ProcessingMessage{
+			env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil),
+			env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
+			env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
+		}
+		return env, value, roundChanges, roundChanges[0]
 	}
-	roundChangeMsg := roundChanges[0]
 
 	t.Run("not proposer", func(t *testing.T) {
 		nonLeaderEnv := newInstanceTestEnv(t, 2)
 		nonLeaderEnv.setLeader(1)
 		nonLeaderEnv.inst.State.Round = 2
+		_, value, roundChanges, roundChangeMsg := newLeadingRoundEnv(t)
 		err := nonLeaderEnv.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 2)
 		require.ErrorContains(t, err, "not proposer")
 	})
 
 	t.Run("proposal round mismatch", func(t *testing.T) {
+		env, value, roundChanges, roundChangeMsg := newLeadingRoundEnv(t)
 		env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(2, 1, value, env.hash(value), nil, nil)
 		err := env.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 2)
 		require.ErrorContains(t, err, "proposal round mismatch")
 	})
 
 	t.Run("accepts future round proposal", func(t *testing.T) {
+		env, value, roundChanges, roundChangeMsg := newLeadingRoundEnv(t)
 		env.inst.State.ProposalAcceptedForCurrentRound = nil
 		err := env.inst.isProposalJustificationForLeadingRound(roundChangeMsg, roundChanges, nil, value, 3)
 		require.NoError(t, err)
@@ -165,6 +172,7 @@ func TestUponRoundChangeWithPartialQuorumBumpsRoundAndBroadcastsRoundChange(t *t
 	msg := env.broadcastedProcessingMessage(0)
 	require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
 	require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)
+	require.Equal(t, specqbft.NoRound, msg.QBFTMessage.DataRound)
 	require.Equal(t, []spectypes.OperatorID{2}, msg.SignedMessage.OperatorIDs)
 }
 
@@ -173,8 +181,10 @@ func TestUponRoundChangeReturnsEarlyOnDuplicate(t *testing.T) {
 	msg := env.roundChange(2, 1, specqbft.NoRound, [32]byte{}, nil, nil)
 	env.addMessages(env.inst.State.RoundChangeContainer, msg)
 
+	currentRound := env.inst.State.Round
 	require.NoError(t, env.inst.uponRoundChange(context.Background(), zap.NewNop(), msg))
 	require.Empty(t, env.network.BroadcastedMsgs)
+	require.Equal(t, currentRound, env.inst.State.Round)
 }
 
 func TestUponRoundChangeReturnsEarlyWhenQuorumAlreadyExists(t *testing.T) {
@@ -185,9 +195,11 @@ func TestUponRoundChangeReturnsEarlyWhenQuorumAlreadyExists(t *testing.T) {
 		env.roundChange(2, 3, specqbft.NoRound, [32]byte{}, nil, nil),
 		env.roundChange(2, 4, specqbft.NoRound, [32]byte{}, nil, nil),
 	)
+	currentRound := env.inst.State.Round
 	err := env.inst.uponRoundChange(context.Background(), zap.NewNop(), env.roundChange(2, 2, specqbft.NoRound, [32]byte{}, nil, nil))
 	require.NoError(t, err)
 	require.Empty(t, env.network.BroadcastedMsgs)
+	require.Equal(t, currentRound, env.inst.State.Round)
 }
 
 func TestUponRoundChangeAsLeaderBroadcastsProposalOnJustifiedQuorum(t *testing.T) {

--- a/protocol/v2/qbft/instance/test_helpers_test.go
+++ b/protocol/v2/qbft/instance/test_helpers_test.go
@@ -52,6 +52,8 @@ func (testValueChecker) CheckValue(data []byte) error {
 
 func newInstanceTestEnv(t *testing.T, operatorID spectypes.OperatorID) *instanceTestEnv {
 	t.Helper()
+	require.GreaterOrEqual(t, int(operatorID), 1, "operatorID must be in Testing4SharesSet range [1,4]")
+	require.LessOrEqual(t, int(operatorID), 4, "operatorID must be in Testing4SharesSet range [1,4]")
 
 	keys := spectestingutils.Testing4SharesSet()
 	committeeMember := spectestingutils.TestingCommitteeMember(keys)

--- a/protocol/v2/qbft/instance/test_helpers_test.go
+++ b/protocol/v2/qbft/instance/test_helpers_test.go
@@ -25,6 +25,19 @@ type instanceTestEnv struct {
 	timer   *roundtimer.TestQBFTTimer
 }
 
+type spyNetwork struct {
+	broadcasted []*spectypes.SignedSSVMessage
+	onBroadcast func(*spectypes.SignedSSVMessage) error
+}
+
+func (n *spyNetwork) Broadcast(msgID spectypes.MessageID, message *spectypes.SignedSSVMessage) error {
+	n.broadcasted = append(n.broadcasted, message)
+	if n.onBroadcast != nil {
+		return n.onBroadcast(message)
+	}
+	return nil
+}
+
 type testValueChecker struct{}
 
 func (testValueChecker) CheckValue(data []byte) error {
@@ -90,6 +103,10 @@ func (e *instanceTestEnv) setLeader(operatorID spectypes.OperatorID) {
 	e.config.ProposerF = func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
 		return operatorID
 	}
+}
+
+func (e *instanceTestEnv) setNetwork(network specqbft.Network) {
+	e.config.Network = network
 }
 
 func (e *instanceTestEnv) hash(fullData []byte) [32]byte {

--- a/protocol/v2/qbft/instance/test_helpers_test.go
+++ b/protocol/v2/qbft/instance/test_helpers_test.go
@@ -25,12 +25,12 @@ type instanceTestEnv struct {
 	timer   *roundtimer.TestQBFTTimer
 }
 
-type spyNetwork struct {
+type recordingNetwork struct {
 	broadcasted []*spectypes.SignedSSVMessage
 	onBroadcast func(*spectypes.SignedSSVMessage) error
 }
 
-func (n *spyNetwork) Broadcast(msgID spectypes.MessageID, message *spectypes.SignedSSVMessage) error {
+func (n *recordingNetwork) Broadcast(msgID spectypes.MessageID, message *spectypes.SignedSSVMessage) error {
 	n.broadcasted = append(n.broadcasted, message)
 	if n.onBroadcast != nil {
 		return n.onBroadcast(message)

--- a/protocol/v2/qbft/instance/test_helpers_test.go
+++ b/protocol/v2/qbft/instance/test_helpers_test.go
@@ -1,0 +1,274 @@
+package instance
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	qbftconfig "github.com/ssvlabs/ssv/protocol/v2/qbft"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
+	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+)
+
+type instanceTestEnv struct {
+	t       *testing.T
+	keys    *spectestingutils.TestKeySet
+	config  *qbftconfig.Config
+	inst    *Instance
+	network *spectestingutils.TestingNetwork
+	timer   *roundtimer.TestQBFTTimer
+}
+
+type testValueChecker struct{}
+
+func (testValueChecker) CheckValue(data []byte) error {
+	if len(data) == 0 {
+		return spectypes.NewError(spectypes.QBFTValueInvalidErrorCode, "invalid value")
+	}
+	if bytes.Equal(data, []byte("invalid-value")) {
+		return spectypes.NewError(spectypes.QBFTValueInvalidErrorCode, "invalid value")
+	}
+	return nil
+}
+
+func newInstanceTestEnv(t *testing.T, operatorID spectypes.OperatorID) *instanceTestEnv {
+	t.Helper()
+
+	keys := spectestingutils.Testing4SharesSet()
+	committeeMember := spectestingutils.TestingCommitteeMember(keys)
+	committeeMember.OperatorID = operatorID
+
+	pubKey, err := spectypes.GetPublicKeyPem(keys.OperatorKeys[operatorID])
+	require.NoError(t, err)
+	committeeMember.SSVOperatorPubKey = pubKey
+
+	config := &qbftconfig.Config{
+		BeaconSigner: ekm.NewTestingKeyManagerAdapter(spectestingutils.NewTestingKeyManager()),
+		Domain:       spectestingutils.TestingSSVDomainType,
+		ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+			return 1
+		},
+		Network:     spectestingutils.NewTestingNetwork(operatorID, keys.OperatorKeys[operatorID]),
+		Timer:       roundtimer.NewTestingTimer(),
+		CutOffRound: spectestingutils.TestingCutOffRound,
+	}
+
+	inst := NewInstance(
+		zap.NewNop(),
+		config,
+		committeeMember,
+		spectestingutils.TestingIdentifier,
+		specqbft.FirstHeight,
+		spectestingutils.NewOperatorSigner(keys, operatorID),
+	)
+	inst.StartValue = []byte("start-value")
+	inst.ValueChecker = testValueChecker{}
+
+	timer, ok := config.GetTimer().(*roundtimer.TestQBFTTimer)
+	require.True(t, ok)
+
+	network, ok := config.GetNetwork().(*spectestingutils.TestingNetwork)
+	require.True(t, ok)
+
+	return &instanceTestEnv{
+		t:       t,
+		keys:    keys,
+		config:  config,
+		inst:    inst,
+		network: network,
+		timer:   timer,
+	}
+}
+
+func (e *instanceTestEnv) setLeader(operatorID spectypes.OperatorID) {
+	e.config.ProposerF = func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+		return operatorID
+	}
+}
+
+func (e *instanceTestEnv) hash(fullData []byte) [32]byte {
+	e.t.Helper()
+
+	root, err := specqbft.HashDataRoot(fullData)
+	require.NoError(e.t, err)
+	return root
+}
+
+func (e *instanceTestEnv) marshalJustifications(msgs []*specqbft.ProcessingMessage) [][]byte {
+	e.t.Helper()
+
+	signedMessages := make([]*spectypes.SignedSSVMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		signedMessages = append(signedMessages, msg.SignedMessage)
+	}
+
+	justifications, err := specqbft.MarshalJustifications(signedMessages)
+	require.NoError(e.t, err)
+	return justifications
+}
+
+func (e *instanceTestEnv) processingMessage(msg *specqbft.Message, signerID spectypes.OperatorID, fullData []byte) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	signed := spectestingutils.SignQBFTMsg(e.keys.OperatorKeys[signerID], signerID, msg)
+	signed.FullData = fullData
+
+	procMsg, err := specqbft.NewProcessingMessage(signed)
+	require.NoError(e.t, err)
+	return procMsg
+}
+
+func (e *instanceTestEnv) processingMessageWithKey(
+	msg *specqbft.Message,
+	signerID spectypes.OperatorID,
+	signerKey *rsa.PrivateKey,
+	fullData []byte,
+) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	signed := spectestingutils.SignQBFTMsg(signerKey, signerID, msg)
+	signed.FullData = fullData
+
+	procMsg, err := specqbft.NewProcessingMessage(signed)
+	require.NoError(e.t, err)
+	return procMsg
+}
+
+func (e *instanceTestEnv) proposal(
+	round specqbft.Round,
+	signerID spectypes.OperatorID,
+	fullData []byte,
+	root [32]byte,
+	roundChanges []*specqbft.ProcessingMessage,
+	prepares []*specqbft.ProcessingMessage,
+) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	return e.processingMessage(&specqbft.Message{
+		MsgType:                  specqbft.ProposalMsgType,
+		Height:                   e.inst.State.Height,
+		Round:                    round,
+		Identifier:               e.inst.State.ID,
+		Root:                     root,
+		RoundChangeJustification: e.marshalJustifications(roundChanges),
+		PrepareJustification:     e.marshalJustifications(prepares),
+	}, signerID, fullData)
+}
+
+func (e *instanceTestEnv) prepare(
+	round specqbft.Round,
+	signerID spectypes.OperatorID,
+	root [32]byte,
+) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	return e.processingMessage(&specqbft.Message{
+		MsgType:    specqbft.PrepareMsgType,
+		Height:     e.inst.State.Height,
+		Round:      round,
+		Identifier: e.inst.State.ID,
+		Root:       root,
+	}, signerID, nil)
+}
+
+func (e *instanceTestEnv) commit(
+	round specqbft.Round,
+	signerID spectypes.OperatorID,
+	root [32]byte,
+) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	return e.processingMessage(&specqbft.Message{
+		MsgType:    specqbft.CommitMsgType,
+		Height:     e.inst.State.Height,
+		Round:      round,
+		Identifier: e.inst.State.ID,
+		Root:       root,
+	}, signerID, nil)
+}
+
+func (e *instanceTestEnv) roundChange(
+	round specqbft.Round,
+	signerID spectypes.OperatorID,
+	dataRound specqbft.Round,
+	root [32]byte,
+	fullData []byte,
+	prepares []*specqbft.ProcessingMessage,
+) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	return e.processingMessage(&specqbft.Message{
+		MsgType:                  specqbft.RoundChangeMsgType,
+		Height:                   e.inst.State.Height,
+		Round:                    round,
+		Identifier:               e.inst.State.ID,
+		Root:                     root,
+		DataRound:                dataRound,
+		RoundChangeJustification: e.marshalJustifications(prepares),
+	}, signerID, fullData)
+}
+
+func (e *instanceTestEnv) addMessages(container *specqbft.MsgContainer, msgs ...*specqbft.ProcessingMessage) {
+	e.t.Helper()
+
+	for _, msg := range msgs {
+		added, err := container.AddFirstMsgForSignerAndRound(msg)
+		require.NoError(e.t, err)
+		require.True(e.t, added)
+	}
+}
+
+func (e *instanceTestEnv) broadcastedProcessingMessage(index int) *specqbft.ProcessingMessage {
+	e.t.Helper()
+
+	require.Len(e.t, e.network.BroadcastedMsgs, index+1)
+
+	msg, err := specqbft.NewProcessingMessage(e.network.BroadcastedMsgs[index])
+	require.NoError(e.t, err)
+	return msg
+}
+
+func (e *instanceTestEnv) aggregateMessages(msgs ...*specqbft.ProcessingMessage) *specqbft.ProcessingMessage {
+	e.t.Helper()
+	require.NotEmpty(e.t, msgs)
+
+	ret := msgs[0].SignedMessage.DeepCopy()
+	for _, msg := range msgs[1:] {
+		require.NoError(e.t, ret.Aggregate(msg.SignedMessage))
+	}
+
+	procMsg, err := specqbft.NewProcessingMessage(ret)
+	require.NoError(e.t, err)
+	procMsg.SignedMessage.FullData = msgs[0].SignedMessage.FullData
+	return procMsg
+}
+
+func (e *instanceTestEnv) preparedRoundChangeSet(
+	round specqbft.Round,
+	preparedRound specqbft.Round,
+	fullData []byte,
+	prepareSigners []spectypes.OperatorID,
+	roundChangeSigners []spectypes.OperatorID,
+) ([]*specqbft.ProcessingMessage, []*specqbft.ProcessingMessage) {
+	e.t.Helper()
+
+	root := e.hash(fullData)
+
+	prepares := make([]*specqbft.ProcessingMessage, 0, len(prepareSigners))
+	for _, signerID := range prepareSigners {
+		prepares = append(prepares, e.prepare(preparedRound, signerID, root))
+	}
+
+	roundChanges := make([]*specqbft.ProcessingMessage, 0, len(roundChangeSigners))
+	for _, signerID := range roundChangeSigners {
+		roundChanges = append(roundChanges, e.roundChange(round, signerID, preparedRound, root, fullData, prepares))
+	}
+
+	return roundChanges, prepares
+}

--- a/protocol/v2/qbft/instance/timeout_test.go
+++ b/protocol/v2/qbft/instance/timeout_test.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"context"
 	"testing"
 
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -34,7 +33,7 @@ func TestUponRoundTimeoutBumpsRoundAfterBroadcast(t *testing.T) {
 	}
 	env.setNetwork(network)
 
-	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
 	require.NoError(t, err)
 
 	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
@@ -56,14 +55,19 @@ func TestUponRoundTimeoutForceStoppedInstance(t *testing.T) {
 	env := newInstanceTestEnv(t, 2)
 	env.inst.ForceStop()
 
-	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
 	require.ErrorContains(t, err, "instance stopped processing timeouts")
 }
 
-func TestUponRoundTimeoutAtCutOffRound(t *testing.T) {
+func TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound(t *testing.T) {
 	env := newInstanceTestEnv(t, 2)
-	env.config.CutOffRound = env.inst.State.Round
+	env.inst.StartValue = []byte("start-value")
+	env.config.CutOffRound = env.inst.State.Round + 1
 
-	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
+	require.NoError(t, err)
+	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
+
+	err = env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
 	require.ErrorContains(t, err, "instance stopped processing timeouts")
 }

--- a/protocol/v2/qbft/instance/timeout_test.go
+++ b/protocol/v2/qbft/instance/timeout_test.go
@@ -1,0 +1,69 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestUponRoundTimeoutBumpsRoundAfterBroadcast(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.inst.State.Round = 1
+	env.inst.State.ProposalAcceptedForCurrentRound = env.proposal(1, 1, []byte("proposal-value"), env.hash([]byte("proposal-value")), nil, nil)
+	env.inst.State.LastPreparedRound = 1
+	env.inst.State.LastPreparedValue = []byte("prepared-value")
+
+	root := env.hash(env.inst.State.LastPreparedValue)
+	env.addMessages(
+		env.inst.State.PrepareContainer,
+		env.prepare(1, 1, root),
+		env.prepare(1, 2, root),
+		env.prepare(1, 3, root),
+	)
+
+	spy := &spyNetwork{
+		onBroadcast: func(message *spectypes.SignedSSVMessage) error {
+			require.Equal(t, specqbft.Round(1), env.inst.State.Round)
+			require.NotNil(t, env.inst.State.ProposalAcceptedForCurrentRound)
+			return nil
+		},
+	}
+	env.setNetwork(spy)
+
+	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	require.NoError(t, err)
+
+	require.Equal(t, specqbft.Round(2), env.inst.State.Round)
+	require.Nil(t, env.inst.State.ProposalAcceptedForCurrentRound)
+	require.Equal(t, 1, env.timer.State.Timeouts)
+	require.Equal(t, specqbft.Round(2), env.timer.State.Round)
+	require.Len(t, spy.broadcasted, 1)
+
+	msg, err := specqbft.NewProcessingMessage(spy.broadcasted[0])
+	require.NoError(t, err)
+	require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
+	require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)
+	require.Equal(t, specqbft.Round(1), msg.QBFTMessage.DataRound)
+	require.Equal(t, root, msg.QBFTMessage.Root)
+	require.Equal(t, env.inst.State.LastPreparedValue, msg.SignedMessage.FullData)
+}
+
+func TestUponRoundTimeoutForceStoppedInstance(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.inst.ForceStop()
+
+	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	require.ErrorContains(t, err, "instance stopped processing timeouts")
+}
+
+func TestUponRoundTimeoutAtCutOffRound(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.config.CutOffRound = env.inst.State.Round
+
+	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
+	require.ErrorContains(t, err, "instance stopped processing timeouts")
+}

--- a/protocol/v2/qbft/instance/timeout_test.go
+++ b/protocol/v2/qbft/instance/timeout_test.go
@@ -25,14 +25,14 @@ func TestUponRoundTimeoutBumpsRoundAfterBroadcast(t *testing.T) {
 		env.prepare(1, 3, root),
 	)
 
-	spy := &spyNetwork{
+	network := &recordingNetwork{
 		onBroadcast: func(message *spectypes.SignedSSVMessage) error {
 			require.Equal(t, specqbft.Round(1), env.inst.State.Round)
 			require.NotNil(t, env.inst.State.ProposalAcceptedForCurrentRound)
 			return nil
 		},
 	}
-	env.setNetwork(spy)
+	env.setNetwork(network)
 
 	err := env.inst.UponRoundTimeout(context.Background(), zap.NewNop())
 	require.NoError(t, err)
@@ -41,9 +41,9 @@ func TestUponRoundTimeoutBumpsRoundAfterBroadcast(t *testing.T) {
 	require.Nil(t, env.inst.State.ProposalAcceptedForCurrentRound)
 	require.Equal(t, 1, env.timer.State.Timeouts)
 	require.Equal(t, specqbft.Round(2), env.timer.State.Round)
-	require.Len(t, spy.broadcasted, 1)
+	require.Len(t, network.broadcasted, 1)
 
-	msg, err := specqbft.NewProcessingMessage(spy.broadcasted[0])
+	msg, err := specqbft.NewProcessingMessage(network.broadcasted[0])
 	require.NoError(t, err)
 	require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
 	require.Equal(t, specqbft.Round(2), msg.QBFTMessage.Round)


### PR DESCRIPTION
## Summary

Adds missing unit test coverage for QBFT instance logic in `protocol/v2/qbft/instance`.

Covers:
- `T-ssv-001` Proposal processing
- `T-ssv-002` Prepare processing
- `T-ssv-003` Commit processing
- `T-ssv-004` Round change processing
- `T-ssv-005` Timeout handling
- `T-ssv-006` `ProcessMsg` dispatch and `BaseMsgValidation`

## What’s Included

Added focused test files for:
- proposal handling and justification validation
- prepare quorum/validation paths
- commit quorum, aggregation, and validation paths
- round change orchestration and validation paths
- timeout handling, including deferred round bump behavior
- `ProcessMsg` dispatch, past-round handling, and concurrent access behavior

Also added shared test helpers for building signed QBFT messages and asserting timer/network behavior.

## Key Behaviors Covered

- future-round proposal bump and prepare broadcast
- wrong leader, wrong height, signer, root, and justification rejection
- prepare quorum transition, early return when quorum already existed, and round-change justification extraction
- commit quorum detection and `aggregateCommitMsgs` operator/signature ordering
- partial quorum round change flow, justified leader proposal flow, `highestPrepared`, `CreateRoundChange`, and round-change validation branches
- timeout behavior where `CreateRoundChange` runs against old round state and the round bump happens after broadcast
- `BaseMsgValidation` past-round behavior and `ProcessMsg` state update/dispatch behavior

## Notes

- The exact `newRound <= prevRound` guard in `round_change.go` appears structurally unreachable through normal inputs because `hasReceivedPartialQuorum()` only returns rounds strictly greater than the current instance round. The surrounding partial-quorum behavior is covered.
- For `T-ssv-006`, the code currently bypasses the generic past-round rejection for quorum commit messages, but still applies commit-specific validation afterward. The tests reflect the implemented behavior.