### PR TITLE
cli/operator: add configurable SSV API address warning

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -115,6 +117,7 @@ type config struct {
 	NetworkPrivateKey            string                  `yaml:"NetworkPrivateKey" env:"NETWORK_PRIVATE_KEY" env-description:"Private key for P2P network identity"`
 	WsAPIPort                    int                     `yaml:"WebSocketAPIPort" env:"WS_API_PORT" env-description:"Port for WebSocket API server"`
 	WithPing                     bool                    `yaml:"WithPing" env:"WITH_PING" env-description:"Enable WebSocket ping messages"`
+	SSVAPIAddress                string                  `yaml:"SSVAPIAddress" env:"SSV_API_ADDRESS" env-description:"Listen address for SSV API server. Leave empty to listen on all interfaces; use 127.0.0.1 to keep it local-only"`
 	SSVAPIPort                   int                     `yaml:"SSVAPIPort" env:"SSV_API_PORT" env-description:"Port for SSV API server"`
 	LocalEventsPath              string                  `yaml:"LocalEventsPath" env:"EVENTS_PATH" env-description:"Path to local events file"`
 	EnableDoppelgangerProtection bool                    `yaml:"EnableDoppelgangerProtection" env:"ENABLE_DOPPELGANGER_PROTECTION" env-description:"Enable doppelganger protection for validators"`
@@ -655,9 +658,16 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		if cfg.SSVAPIPort > 0 {
+			if cfg.SSVAPIAddress == "" {
+				logger.Warn("SSV API address not configured; listening on all interfaces",
+					zap.Int("port", cfg.SSVAPIPort),
+					zap.String("config_key", "SSVAPIAddress"),
+					zap.String("recommended_address", "127.0.0.1"),
+				)
+			}
 			apiServer := apiserver.New(
 				logger,
-				fmt.Sprintf(":%d", cfg.SSVAPIPort),
+				net.JoinHostPort(cfg.SSVAPIAddress, strconv.Itoa(cfg.SSVAPIPort)),
 				hnode.NewNode(
 					// TODO: replace with narrower interface! (instead of accessing the entire PeersIndex)
 					[]string{fmt.Sprintf("tcp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.TCPPort), fmt.Sprintf("udp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.UDPPort)},

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -658,13 +658,7 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		if cfg.SSVAPIPort > 0 {
-			if cfg.SSVAPIAddress == "" {
-				logger.Warn("SSV API address not configured; listening on all interfaces",
-					zap.Int("port", cfg.SSVAPIPort),
-					zap.String("config_key", "SSVAPIAddress"),
-					zap.String("recommended_address", "127.0.0.1"),
-				)
-			}
+			warnIfSSVAPIAddressUnset(logger, cfg.SSVAPIAddress, cfg.SSVAPIPort)
 			apiServer := apiserver.New(
 				logger,
 				net.JoinHostPort(cfg.SSVAPIAddress, strconv.Itoa(cfg.SSVAPIPort)),
@@ -696,6 +690,18 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("failed to start SSV node", zap.Error(err))
 		}
 	},
+}
+
+func warnIfSSVAPIAddressUnset(logger *zap.Logger, address string, port int) {
+	if address != "" {
+		return
+	}
+
+	logger.Warn("SSV API address not configured; listening on all interfaces",
+		zap.Int("port", port),
+		zap.String("config_key", "SSVAPIAddress"),
+		zap.String("recommended_address", "127.0.0.1"),
+	)
 }
 
 func ensureNoMissingKeys(

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -14,6 +16,70 @@ import (
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
+
+func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("warns when address is empty", func(t *testing.T) {
+		core, recorded := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+
+		warnIfSSVAPIAddressUnset(logger, "", 16000)
+
+		logs := recorded.All()
+		require.Len(t, logs, 1)
+		require.Equal(t, zapcore.WarnLevel, logs[0].Level)
+		require.Equal(t, "SSV API address not configured; listening on all interfaces", logs[0].Message)
+		require.EqualValues(t, 16000, logs[0].ContextMap()["port"])
+		require.Equal(t, "SSVAPIAddress", logs[0].ContextMap()["config_key"])
+		require.Equal(t, "127.0.0.1", logs[0].ContextMap()["recommended_address"])
+	})
+
+	t.Run("does not warn when address is set", func(t *testing.T) {
+		core, recorded := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+
+		warnIfSSVAPIAddressUnset(logger, "127.0.0.1", 16000)
+
+		require.Len(t, recorded.All(), 0)
+	})
+}
+
+func Test_ssvAPIListenAddress(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		address string
+		port    int
+		want    string
+	}{
+		{
+			name: "empty address listens on all interfaces",
+			port: 16000,
+			want: ":16000",
+		},
+		{
+			name:    "ipv4 loopback",
+			address: "127.0.0.1",
+			port:    16000,
+			want:    "127.0.0.1:16000",
+		},
+		{
+			name:    "ipv6 loopback",
+			address: "::1",
+			port:    16000,
+			want:    "[::1]:16000",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := net.JoinHostPort(tc.address, strconv.Itoa(tc.port))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
 
 func Test_verifyConfig(t *testing.T) {
 	logger := zap.New(zapcore.NewNopCore(), zap.WithFatalHook(zapcore.WriteThenPanic))

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -54,7 +54,7 @@ MetricsAPIPort: 15000
 EnableTraces: false
 
 # These settings enable the SSV API at the specified address+port. Refer to the documentation at https://bloxapp.github.io/ssv/
-# Prefer 127.0.0.1 address and use 0.0.0.0 only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
-# SSVAPIAddress defaults to 0.0.0.0 if not specified (for backward compatibility).
+# Prefer 127.0.0.1 and listen on all interfaces only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
+# If SSVAPIAddress is omitted, the API listens on all interfaces (for backward compatibility).
 # SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -53,8 +53,8 @@ MetricsAPIPort: 15000
 # This enables Open Telemetry traces
 EnableTraces: false
 
-# This enables the SSV API at the specified port. Refer to the documentation at https://bloxapp.github.io/ssv/
-# Bind it to 127.0.0.1 by default and expose 0.0.0.0 only when remote access is intentional and protected by network controls.
-# It's recommended to keep this port private to prevent potential resource-intensive attacks.
+# These settings enable the SSV API at the specified address+port. Refer to the documentation at https://bloxapp.github.io/ssv/
+# Prefer 127.0.0.1 address and use 0.0.0.0 only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
+# SSVAPIAddress defaults to 0.0.0.0 if not specified (for backward compatibility).
 # SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -54,5 +54,7 @@ MetricsAPIPort: 15000
 EnableTraces: false
 
 # This enables the SSV API at the specified port. Refer to the documentation at https://bloxapp.github.io/ssv/
+# Bind it to 127.0.0.1 by default and expose 0.0.0.0 only when remote access is intentional and protected by network controls.
 # It's recommended to keep this port private to prevent potential resource-intensive attacks.
+# SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/config/config.exporter.example.yaml
+++ b/config/config.exporter.example.yaml
@@ -38,8 +38,8 @@ WebSocketAPIPort: 16000
 # This enables Open Telemetry traces
 EnableTraces: false
 
-# This enables the SSV API at the specified port. Refer to the documentation at https://bloxapp.github.io/ssv/
-# Bind it to 127.0.0.1 by default and expose 0.0.0.0 only when remote access is intentional and protected by network controls.
-# It's recommended to keep this port private to prevent potential resource-intensive attacks.
+# These settings enable the SSV API at the specified address+port. Refer to the documentation at https://bloxapp.github.io/ssv/
+# Prefer 127.0.0.1 address and use 0.0.0.0 only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
+# SSVAPIAddress defaults to 0.0.0.0 if not specified (for backward compatibility).
 # SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/config/config.exporter.example.yaml
+++ b/config/config.exporter.example.yaml
@@ -39,7 +39,7 @@ WebSocketAPIPort: 16000
 EnableTraces: false
 
 # These settings enable the SSV API at the specified address+port. Refer to the documentation at https://bloxapp.github.io/ssv/
-# Prefer 127.0.0.1 address and use 0.0.0.0 only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
-# SSVAPIAddress defaults to 0.0.0.0 if not specified (for backward compatibility).
+# Prefer 127.0.0.1 and listen on all interfaces only when remote access is intentional and protected by network controls (to prevent potential resource-intensive attacks).
+# If SSVAPIAddress is omitted, the API listens on all interfaces (for backward compatibility).
 # SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/config/config.exporter.example.yaml
+++ b/config/config.exporter.example.yaml
@@ -39,5 +39,7 @@ WebSocketAPIPort: 16000
 EnableTraces: false
 
 # This enables the SSV API at the specified port. Refer to the documentation at https://bloxapp.github.io/ssv/
+# Bind it to 127.0.0.1 by default and expose 0.0.0.0 only when remote access is intentional and protected by network controls.
 # It's recommended to keep this port private to prevent potential resource-intensive attacks.
+# SSVAPIAddress: 127.0.0.1
 # SSVAPIPort: 16000

--- a/docs/release-notes_exporter_v2.0.0-rc.1.md
+++ b/docs/release-notes_exporter_v2.0.0-rc.1.md
@@ -71,6 +71,7 @@ exporter:
   Enabled: true
   Mode: archive
 
+SSVAPIAddress: 127.0.0.1
 SSVAPIPort: 16000        # enables HTTP API, optional 
 WebSocketAPIPort: 16001  # enables WS API, optional
 WithPing: true
@@ -103,6 +104,7 @@ exporter:
   Mode: standard
   RetainSlots: 50400     # v1-compatible way to control memory use
 
+SSVAPIAddress: 127.0.0.1
 SSVAPIPort: 16000        # enables HTTP API, optional 
 WebSocketAPIPort: 16001  # enables WS API, optional
 WithPing: true
@@ -113,6 +115,8 @@ WithPing: true
 ## HTTP API overview (updated)
 
 Please refer to the new [OpenApi spec](https://github.com/ssvlabs/ssv/tree/stage/docs/api) (`docs/api/ssvnode.openapi.yaml|json`) for details. Below is a high-level overview of the new HTTP API endpoints.
+
+For operator deployments, prefer binding the HTTP API to `127.0.0.1` and only expose `0.0.0.0` when remote access is intentional and protected by network controls such as a private network, firewall, or reverse proxy.
 
 For each endpoint, the same filters can be sent via GET (query parameters) or POST (JSON body).
 


### PR DESCRIPTION
## Summary

Adds a configurable listen address for the SSV HTTP API.

Until now, enabling `SSVAPIPort` always started the API on `:<port>`, which listens on all interfaces. This change adds `SSVAPIAddress` so operators can explicitly bind the API to `127.0.0.1` or another address without changing the port behavior.

To avoid breaking existing deployments, the default remains unchanged:
- if `SSVAPIAddress` is unset, the API still listens on all interfaces
- when that happens, the node now logs a warning recommending `127.0.0.1`

## Changes

- Added `SSVAPIAddress` config/env support in `cli/operator`
- Wired API server startup to use `SSVAPIAddress + SSVAPIPort`
- Added a warning when the API is enabled and `SSVAPIAddress` is not set
- Updated example configs and exporter release notes to recommend `SSVAPIAddress: 127.0.0.1`

## Compatibility

This is intentionally non-breaking.
Existing setups that only configure `SSVAPIPort` continue to behave the same way.
