### PR TITLE
p2p: use exact peer-subnets (vs advertized)

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -658,8 +658,7 @@ func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 
 			}
 		}
 
-		advertisedSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, advertisedSubnets)
+		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
 	}
 	return scores
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ssvlabs/ssv/pull/2727#discussion_r2981402627

I think it's better if we use the actual data from the peer-controller (`p2pNetwork.topicsCtrl`) rather than `p2pNetwork.idx` to fetch the up-to-date subnets a connected-to-us peer supports - it should provide more of an up-to-date data since the index keeps track of "what's been advertised by peers at some point in the past" (rather than what subnets they actually participate in), and our algo doesn't have to rely on an external structure of some index).

Resolves `F-ssv-264 P2`