### PR TITLE
network/peers: add connection management tests

### DIFF
--- a/network/peers/conn_manager_test.go
+++ b/network/peers/conn_manager_test.go
@@ -2,6 +2,7 @@ package peers
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -15,10 +16,13 @@ import (
 	"github.com/ssvlabs/ssv/network/commons"
 )
 
+var errTestClosePeer = errors.New("test close peer error")
+
 type testNetwork struct {
-	mu          sync.Mutex
-	peers       []peer.ID
-	closedPeers []peer.ID
+	mu            sync.Mutex
+	peers         []peer.ID
+	closedPeers   []peer.ID
+	closePeerErrs map[peer.ID]error
 }
 
 func (n *testNetwork) Peerstore() peerstore.Peerstore { return nil }
@@ -31,6 +35,9 @@ func (n *testNetwork) ClosePeer(id peer.ID) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
+	if err := n.closePeerErrs[id]; err != nil {
+		return err
+	}
 	n.closedPeers = append(n.closedPeers, id)
 	return nil
 }
@@ -184,4 +191,35 @@ func TestConnManagerDisconnectFromIrrelevantPeersDisconnectsPeersWithUnknownSubn
 
 	require.Equal(t, 2, disconnected)
 	require.Equal(t, []peer.ID{unknownPeer, irrelevantPeer}, net.ClosedPeers())
+}
+
+func TestConnManagerDisconnectFromIrrelevantPeersDoesNotCountCloseErrorsAgainstQuota(t *testing.T) {
+	p1 := peer.ID("peer-1")
+	p2 := peer.ID("peer-2")
+	p3 := peer.ID("peer-3")
+
+	mySubnets := commons.ZeroSubnets
+	mySubnets.Set(1)
+	irrelevantSubnets := commons.ZeroSubnets
+	irrelevantSubnets.Set(2)
+
+	subnetsIdx := NewSubnetsIndex()
+	subnetsIdx.UpdatePeerSubnets(p1, irrelevantSubnets)
+	subnetsIdx.UpdatePeerSubnets(p2, irrelevantSubnets)
+	subnetsIdx.UpdatePeerSubnets(p3, irrelevantSubnets)
+
+	manager := connManager{
+		logger:     zap.NewNop(),
+		subnetsIdx: subnetsIdx,
+	}
+	net := &testNetwork{
+		closePeerErrs: map[peer.ID]error{
+			p1: errTestClosePeer,
+		},
+	}
+
+	disconnected := manager.DisconnectFromIrrelevantPeers(2, net, []peer.ID{p1, p2, p3}, mySubnets)
+
+	require.Equal(t, 2, disconnected)
+	require.Equal(t, []peer.ID{p2, p3}, net.ClosedPeers())
 }

--- a/network/peers/conn_manager_test.go
+++ b/network/peers/conn_manager_test.go
@@ -1,0 +1,187 @@
+package peers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/network/commons"
+)
+
+type testNetwork struct {
+	mu          sync.Mutex
+	peers       []peer.ID
+	closedPeers []peer.ID
+}
+
+func (n *testNetwork) Peerstore() peerstore.Peerstore { return nil }
+
+func (n *testNetwork) LocalPeer() peer.ID { return "local" }
+
+func (n *testNetwork) DialPeer(context.Context, peer.ID) (libp2pnetwork.Conn, error) { return nil, nil }
+
+func (n *testNetwork) ClosePeer(id peer.ID) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.closedPeers = append(n.closedPeers, id)
+	return nil
+}
+
+func (n *testNetwork) Connectedness(peer.ID) libp2pnetwork.Connectedness {
+	return libp2pnetwork.NotConnected
+}
+
+func (n *testNetwork) Peers() []peer.ID {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	peers := make([]peer.ID, len(n.peers))
+	copy(peers, n.peers)
+	return peers
+}
+
+func (n *testNetwork) Conns() []libp2pnetwork.Conn { return nil }
+
+func (n *testNetwork) ConnsToPeer(peer.ID) []libp2pnetwork.Conn { return nil }
+
+func (n *testNetwork) Notify(libp2pnetwork.Notifiee) {}
+
+func (n *testNetwork) StopNotify(libp2pnetwork.Notifiee) {}
+
+func (n *testNetwork) CanDial(peer.ID, ma.Multiaddr) bool { return true }
+
+func (n *testNetwork) Close() error { return nil }
+
+func (n *testNetwork) SetStreamHandler(libp2pnetwork.StreamHandler) {}
+
+func (n *testNetwork) NewStream(context.Context, peer.ID) (libp2pnetwork.Stream, error) {
+	return nil, nil
+}
+
+func (n *testNetwork) Listen(...ma.Multiaddr) error { return nil }
+
+func (n *testNetwork) ListenAddresses() []ma.Multiaddr { return nil }
+
+func (n *testNetwork) InterfaceListenAddresses() ([]ma.Multiaddr, error) { return nil, nil }
+
+func (n *testNetwork) ResourceManager() libp2pnetwork.ResourceManager { return nil }
+
+func (n *testNetwork) ClosedPeers() []peer.ID {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	closedPeers := make([]peer.ID, len(n.closedPeers))
+	copy(closedPeers, n.closedPeers)
+	return closedPeers
+}
+
+type testGossipScoreIndex struct {
+	badPeers map[peer.ID]float64
+}
+
+func (i *testGossipScoreIndex) SetScores(map[peer.ID]float64) {}
+
+func (i *testGossipScoreIndex) GetGossipScore(peerID peer.ID) (float64, bool) {
+	score, ok := i.badPeers[peerID]
+	return score, ok
+}
+
+func (i *testGossipScoreIndex) HasBadGossipScore(peerID peer.ID) (bool, float64) {
+	score, ok := i.badPeers[peerID]
+	return ok, score
+}
+
+func TestConnManagerTrimPeers(t *testing.T) {
+	p1 := peer.ID("peer-1")
+	p2 := peer.ID("peer-2")
+	p3 := peer.ID("peer-3")
+	net := &testNetwork{peers: []peer.ID{p1, p2, p3}}
+
+	manager := connManager{
+		logger: zap.NewNop(),
+	}
+
+	manager.TrimPeers(t.Context(), net, map[peer.ID]struct{}{
+		p1: {},
+		p3: {},
+	})
+
+	require.ElementsMatch(t, []peer.ID{p1, p3}, net.ClosedPeers())
+}
+
+func TestConnManagerDisconnectFromBadPeers(t *testing.T) {
+	p1 := peer.ID("peer-1")
+	p2 := peer.ID("peer-2")
+	p3 := peer.ID("peer-3")
+	net := &testNetwork{}
+
+	manager := connManager{
+		logger:           zap.NewNop(),
+		gossipScoreIndex: &testGossipScoreIndex{badPeers: map[peer.ID]float64{p1: -101, p3: -202}},
+	}
+
+	disconnected := manager.DisconnectFromBadPeers(net, []peer.ID{p1, p2, p3})
+
+	require.Equal(t, 2, disconnected)
+	require.ElementsMatch(t, []peer.ID{p1, p3}, net.ClosedPeers())
+}
+
+func TestConnManagerDisconnectFromIrrelevantPeersRespectsQuota(t *testing.T) {
+	p1 := peer.ID("peer-1")
+	p2 := peer.ID("peer-2")
+	p3 := peer.ID("peer-3")
+
+	subnetsIdx := NewSubnetsIndex()
+	sharedSubnets := commons.ZeroSubnets
+	sharedSubnets.Set(1)
+	irrelevantSubnetsA := commons.ZeroSubnets
+	irrelevantSubnetsA.Set(2)
+	irrelevantSubnetsB := commons.ZeroSubnets
+	irrelevantSubnetsB.Set(3)
+
+	subnetsIdx.UpdatePeerSubnets(p1, sharedSubnets)
+	subnetsIdx.UpdatePeerSubnets(p2, irrelevantSubnetsA)
+	subnetsIdx.UpdatePeerSubnets(p3, irrelevantSubnetsB)
+
+	manager := connManager{
+		logger:     zap.NewNop(),
+		subnetsIdx: subnetsIdx,
+	}
+	net := &testNetwork{}
+
+	disconnected := manager.DisconnectFromIrrelevantPeers(1, net, []peer.ID{p1, p2, p3}, sharedSubnets)
+
+	require.Equal(t, 1, disconnected)
+	require.Equal(t, []peer.ID{p2}, net.ClosedPeers())
+}
+
+func TestConnManagerDisconnectFromIrrelevantPeersDisconnectsPeersWithUnknownSubnets(t *testing.T) {
+	unknownPeer := peer.ID("peer-unknown")
+	irrelevantPeer := peer.ID("peer-irrelevant")
+
+	subnetsIdx := NewSubnetsIndex()
+	mySubnets := commons.ZeroSubnets
+	mySubnets.Set(1)
+	irrelevantSubnets := commons.ZeroSubnets
+	irrelevantSubnets.Set(2)
+	subnetsIdx.UpdatePeerSubnets(irrelevantPeer, irrelevantSubnets)
+
+	manager := connManager{
+		logger:     zap.NewNop(),
+		subnetsIdx: subnetsIdx,
+	}
+	net := &testNetwork{}
+
+	disconnected := manager.DisconnectFromIrrelevantPeers(2, net, []peer.ID{unknownPeer, irrelevantPeer}, mySubnets)
+
+	require.Equal(t, 2, disconnected)
+	require.Equal(t, []peer.ID{unknownPeer, irrelevantPeer}, net.ClosedPeers())
+}

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -1,0 +1,98 @@
+package connections
+
+import (
+	"testing"
+	"time"
+
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	leakybucket "github.com/prysmaticlabs/prysm/v4/container/leaky-bucket"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/utils/ttl"
+)
+
+func TestConnGaterInterceptAddrDial(t *testing.T) {
+	gater := &connGater{
+		logger:          zap.NewNop(),
+		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+	}
+
+	require.False(t, gater.InterceptAddrDial("bad-peer", mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
+	require.True(t, gater.InterceptAddrDial("good-peer", mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
+}
+
+func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
+	t.Run("disabled bypasses limits", func(t *testing.T) {
+		gater := &connGater{
+			logger:          zap.NewNop(),
+			disable:         true,
+			atMaxPeersLimit: func() bool { return true },
+			atInboundLimit:  func() bool { return true },
+			trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+		}
+
+		require.True(t, gater.InterceptAccept(&testConn{remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13000")}))
+	})
+
+	t.Run("rejects at inbound limit", func(t *testing.T) {
+		gater := &connGater{
+			logger:          zap.NewNop(),
+			atMaxPeersLimit: func() bool { return false },
+			atInboundLimit:  func() bool { return true },
+			trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+		}
+
+		require.False(t, gater.InterceptAccept(&testConn{remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13000")}))
+	})
+
+	t.Run("rejects at max peers limit after a valid dial", func(t *testing.T) {
+		gater := &connGater{
+			logger:          zap.NewNop(),
+			atMaxPeersLimit: func() bool { return true },
+			atInboundLimit:  func() bool { return false },
+			ipLimiter:       leakybucket.NewCollector(ipLimitRate, ipLimitBurst, ipLimitPeriod, true),
+			trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+		}
+
+		require.False(t, gater.InterceptAccept(&testConn{remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13000")}))
+	})
+}
+
+func TestConnGaterInterceptAcceptRateLimitsByIP(t *testing.T) {
+	gater := &connGater{
+		logger:          zap.NewNop(),
+		atMaxPeersLimit: func() bool { return false },
+		atInboundLimit:  func() bool { return false },
+		ipLimiter:       leakybucket.NewCollector(ipLimitRate, ipLimitBurst, ipLimitPeriod, true),
+		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+	}
+
+	sameIPConn := &testConn{remoteMultiaddr: mustMultiaddr("/ip4/192.0.2.1/tcp/13000")}
+	for range ipLimitBurst {
+		require.True(t, gater.InterceptAccept(sameIPConn))
+	}
+	require.False(t, gater.InterceptAccept(sameIPConn))
+
+	otherIPConn := &testConn{remoteMultiaddr: mustMultiaddr("/ip4/192.0.2.2/tcp/13000")}
+	require.True(t, gater.InterceptAccept(otherIPConn))
+
+	require.False(t, gater.InterceptAccept(&testConn{remoteMultiaddr: mustMultiaddr("/dns4/example.com/tcp/13000")}))
+}
+
+func TestConnGaterInterceptSecured(t *testing.T) {
+	trimmedRecently := ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute)
+	trimmedRecently.Set("trimmed-peer", struct{}{})
+
+	gater := &connGater{
+		logger:          zap.NewNop(),
+		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		trimmedRecently: trimmedRecently,
+	}
+
+	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "trimmed-peer", nil))
+	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "bad-peer", nil))
+	require.True(t, gater.InterceptSecured(libp2pnetwork.DirOutbound, "good-peer", nil))
+}

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -78,6 +78,16 @@ func TestConnGaterInterceptAcceptRateLimitsByIP(t *testing.T) {
 
 	otherIPConn := &testConn{remoteMultiaddr: mustMultiaddr("/ip4/192.0.2.2/tcp/13000")}
 	require.True(t, gater.InterceptAccept(otherIPConn))
+}
+
+func TestConnGaterInterceptAcceptRejectsDNSAddresses(t *testing.T) {
+	gater := &connGater{
+		logger:          zap.NewNop(),
+		atMaxPeersLimit: func() bool { return false },
+		atInboundLimit:  func() bool { return false },
+		ipLimiter:       leakybucket.NewCollector(ipLimitRate, ipLimitBurst, ipLimitPeriod, true),
+		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+	}
 
 	require.False(t, gater.InterceptAccept(&testConn{remoteMultiaddr: mustMultiaddr("/dns4/example.com/tcp/13000")}))
 }

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -24,6 +24,12 @@ func TestConnGaterInterceptAddrDial(t *testing.T) {
 	require.True(t, gater.InterceptAddrDial("good-peer", mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
 }
 
+func TestConnGaterInterceptPeerDial(t *testing.T) {
+	gater := &connGater{}
+
+	require.True(t, gater.InterceptPeerDial("peer"))
+}
+
 func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
 	t.Run("disabled bypasses limits", func(t *testing.T) {
 		gater := &connGater{
@@ -105,4 +111,12 @@ func TestConnGaterInterceptSecured(t *testing.T) {
 	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "trimmed-peer", nil))
 	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "bad-peer", nil))
 	require.True(t, gater.InterceptSecured(libp2pnetwork.DirOutbound, "good-peer", nil))
+}
+
+func TestConnGaterInterceptUpgraded(t *testing.T) {
+	gater := &connGater{}
+
+	allowed, reason := gater.InterceptUpgraded(&testConn{})
+	require.True(t, allowed)
+	require.Zero(t, reason)
 }

--- a/network/peers/connections/conn_handler_test.go
+++ b/network/peers/connections/conn_handler_test.go
@@ -80,8 +80,12 @@ func TestConnHandlerHandleDeduplicatesConcurrentOutboundHandshakes(t *testing.T)
 	<-handshaker.started
 	notify.ConnectedF(net, conn)
 
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, 1, handshaker.CallCount())
+	// ConnectedF handles connections on background goroutines. Once the first
+	// handshake has started and is blocked, the second attempt should be ignored
+	// and must not start another handshake during this scheduling window.
+	require.Never(t, func() bool {
+		return handshaker.CallCount() > 1
+	}, 250*time.Millisecond, 10*time.Millisecond)
 
 	close(handshaker.release)
 

--- a/network/peers/connections/conn_handler_test.go
+++ b/network/peers/connections/conn_handler_test.go
@@ -21,6 +21,7 @@ func TestConnHandlerHandleOutboundConnection(t *testing.T) {
 	peerInfos := peers.NewPeerInfoIndex()
 	discoveredPeers := ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute)
 	discoveredPeers.Set(pid, discovery.DiscoveredPeer{})
+	connIdx := &mock.MockConnectionIndex{}
 
 	handshaker := &testHandshaker{}
 	handler := NewConnHandler(
@@ -29,7 +30,7 @@ func TestConnHandlerHandleOutboundConnection(t *testing.T) {
 		handshaker,
 		func() commons.Subnets { return commons.ZeroSubnets },
 		peers.NewSubnetsIndex(),
-		&mock.MockConnectionIndex{},
+		connIdx,
 		peerInfos,
 		discoveredPeers,
 	)
@@ -47,7 +48,75 @@ func TestConnHandlerHandleOutboundConnection(t *testing.T) {
 		return peerInfos.State(pid) == peers.StateConnected
 	}, 3*time.Second, 10*time.Millisecond)
 	require.Equal(t, 1, handshaker.CallCount())
-	require.False(t, discoveredPeers.Has(pid))
+	require.Eventually(t, func() bool {
+		return !discoveredPeers.Has(pid)
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestConnHandlerHandleOutboundConnectionHandshakeFailureDisconnects(t *testing.T) {
+	pid := peer.ID("peer-outbound-fail")
+	peerInfos := peers.NewPeerInfoIndex()
+	handshaker := &testHandshaker{err: errTestHandshake}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13010"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	require.Eventually(t, func() bool {
+		return len(net.ClosedPeers()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, []peer.ID{pid}, net.ClosedPeers())
+	require.Never(t, func() bool {
+		return peerInfos.State(pid) == peers.StateConnected
+	}, 250*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestConnHandlerHandleOutboundConnectionRejectsAtLimit(t *testing.T) {
+	pid := peer.ID("peer-outbound-at-limit")
+	peerInfos := peers.NewPeerInfoIndex()
+	handshaker := &testHandshaker{}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{LimitValue: true},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13011"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	require.Eventually(t, func() bool {
+		return len(net.ClosedPeers()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, []peer.ID{pid}, net.ClosedPeers())
+	require.Never(t, func() bool {
+		return peerInfos.State(pid) == peers.StateConnected
+	}, 250*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestConnHandlerHandleDeduplicatesConcurrentOutboundHandshakes(t *testing.T) {
@@ -98,6 +167,7 @@ func TestConnHandlerHandleInboundConnectionWaitsForHandshake(t *testing.T) {
 	pid := peer.ID("peer-inbound")
 	peerInfos := peers.NewPeerInfoIndex()
 	subnetsIndex := peers.NewSubnetsIndex()
+	handshaker := &testHandshaker{}
 	mySubnets := commons.ZeroSubnets
 	mySubnets.Set(1)
 	peerSubnets := commons.ZeroSubnets
@@ -107,7 +177,7 @@ func TestConnHandlerHandleInboundConnectionWaitsForHandshake(t *testing.T) {
 	handler := NewConnHandler(
 		t.Context(),
 		zap.NewNop(),
-		&testHandshaker{},
+		handshaker,
 		func() commons.Subnets { return mySubnets },
 		subnetsIndex,
 		&mock.MockConnectionIndex{},
@@ -123,18 +193,24 @@ func TestConnHandlerHandleInboundConnectionWaitsForHandshake(t *testing.T) {
 		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirInbound}},
 	}
 
-	handler.Handle().ConnectedF(net, conn)
+	bundle := handler.Handle()
+	bundle.ConnectedF(net, conn)
 
-	time.AfterFunc(100*time.Millisecond, func() {
-		peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
-			info.LastHandshake = time.Now()
-			info.LastHandshakeError = nil
-		})
+	require.Eventually(t, func() bool {
+		return peerInfos.State(pid) == peers.StateDisconnected
+	}, 3*time.Second, 10*time.Millisecond)
+	require.NotEqual(t, peers.StateConnected, peerInfos.State(pid))
+	require.Equal(t, 0, handshaker.CallCount(), "inbound path must not initiate handshake")
+
+	peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
+		info.LastHandshake = time.Now().Add(time.Hour)
+		info.LastHandshakeError = nil
 	})
 
 	require.Eventually(t, func() bool {
 		return peerInfos.State(pid) == peers.StateConnected
 	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, 0, handshaker.CallCount(), "inbound path must not initiate handshake")
 	require.Empty(t, net.ClosedPeers())
 }
 
@@ -142,6 +218,7 @@ func TestConnHandlerHandleInboundConnectionRejectsPeerWithoutSharedSubnets(t *te
 	pid := peer.ID("peer-inbound-no-shared")
 	peerInfos := peers.NewPeerInfoIndex()
 	subnetsIndex := peers.NewSubnetsIndex()
+	handshaker := &testHandshaker{}
 	mySubnets := commons.ZeroSubnets
 	mySubnets.Set(1)
 	peerSubnets := commons.ZeroSubnets
@@ -151,7 +228,7 @@ func TestConnHandlerHandleInboundConnectionRejectsPeerWithoutSharedSubnets(t *te
 	handler := NewConnHandler(
 		t.Context(),
 		zap.NewNop(),
-		&testHandshaker{},
+		handshaker,
 		func() commons.Subnets { return mySubnets },
 		subnetsIndex,
 		&mock.MockConnectionIndex{},
@@ -167,19 +244,25 @@ func TestConnHandlerHandleInboundConnectionRejectsPeerWithoutSharedSubnets(t *te
 		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirInbound}},
 	}
 
-	handler.Handle().ConnectedF(net, conn)
+	bundle := handler.Handle()
+	bundle.ConnectedF(net, conn)
 
-	time.AfterFunc(100*time.Millisecond, func() {
-		peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
-			info.LastHandshake = time.Now()
-			info.LastHandshakeError = nil
-		})
+	require.Eventually(t, func() bool {
+		return peerInfos.State(pid) == peers.StateDisconnected
+	}, 3*time.Second, 10*time.Millisecond)
+	require.NotEqual(t, peers.StateConnected, peerInfos.State(pid))
+	require.Equal(t, 0, handshaker.CallCount(), "inbound path must not initiate handshake")
+
+	peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
+		info.LastHandshake = time.Now().Add(time.Hour)
+		info.LastHandshakeError = nil
 	})
 
 	require.Eventually(t, func() bool {
 		return len(net.ClosedPeers()) == 1
 	}, 3*time.Second, 10*time.Millisecond)
 	require.Equal(t, []peer.ID{pid}, net.ClosedPeers())
+	require.Equal(t, 0, handshaker.CallCount(), "inbound path must not initiate handshake")
 	require.Equal(t, peers.StateDisconnected, peerInfos.State(pid))
 }
 
@@ -198,6 +281,7 @@ func TestConnHandlerDisconnectedF(t *testing.T) {
 		peerInfos,
 		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
 	)
+	bundle := handler.Handle()
 
 	net := newTestNetwork()
 	conn := &testConn{
@@ -207,12 +291,76 @@ func TestConnHandlerDisconnectedF(t *testing.T) {
 	}
 
 	net.connectedness[pid] = libp2pnetwork.Connected
-	handler.Handle().DisconnectedF(net, conn)
+	bundle.DisconnectedF(net, conn)
 	require.Equal(t, peers.StateConnected, peerInfos.State(pid))
 
 	net.connectedness[pid] = libp2pnetwork.NotConnected
-	handler.Handle().DisconnectedF(net, conn)
+	bundle.DisconnectedF(net, conn)
 	require.Equal(t, peers.StateDisconnected, peerInfos.State(pid))
+}
+
+func TestConnHandlerHandleIgnoresAlreadyConnectedPeer(t *testing.T) {
+	pid := peer.ID("peer-already-connected")
+	peerInfos := peers.NewPeerInfoIndex()
+	peerInfos.SetState(pid, peers.StateConnected)
+	handshaker := &testHandshaker{}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13012"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	require.Never(t, func() bool {
+		return handshaker.CallCount() > 0
+	}, 250*time.Millisecond, 10*time.Millisecond)
+	require.Empty(t, net.ClosedPeers())
+	require.Equal(t, peers.StateConnected, peerInfos.State(pid))
+}
+
+func TestConnHandlerHandleIgnoresAlreadyConnectingPeer(t *testing.T) {
+	pid := peer.ID("peer-already-connecting")
+	peerInfos := peers.NewPeerInfoIndex()
+	peerInfos.SetState(pid, peers.StateConnecting)
+	handshaker := &testHandshaker{}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13013"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	require.Never(t, func() bool {
+		return handshaker.CallCount() > 0
+	}, 250*time.Millisecond, 10*time.Millisecond)
+	require.Empty(t, net.ClosedPeers())
+	require.Equal(t, peers.StateConnecting, peerInfos.State(pid))
 }
 
 func TestConnHandlerSharesEnoughSubnets(t *testing.T) {

--- a/network/peers/connections/conn_handler_test.go
+++ b/network/peers/connections/conn_handler_test.go
@@ -1,0 +1,239 @@
+package connections
+
+import (
+	"testing"
+	"time"
+
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/network/discovery"
+	"github.com/ssvlabs/ssv/network/peers"
+	"github.com/ssvlabs/ssv/network/peers/connections/mock"
+	"github.com/ssvlabs/ssv/utils/ttl"
+)
+
+func TestConnHandlerHandleOutboundConnection(t *testing.T) {
+	pid := peer.ID("peer-outbound")
+	peerInfos := peers.NewPeerInfoIndex()
+	discoveredPeers := ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute)
+	discoveredPeers.Set(pid, discovery.DiscoveredPeer{})
+
+	handshaker := &testHandshaker{}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		discoveredPeers,
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13000"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	require.Eventually(t, func() bool {
+		return peerInfos.State(pid) == peers.StateConnected
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, 1, handshaker.CallCount())
+	require.False(t, discoveredPeers.Has(pid))
+}
+
+func TestConnHandlerHandleDeduplicatesConcurrentOutboundHandshakes(t *testing.T) {
+	pid := peer.ID("peer-dedup")
+	peerInfos := peers.NewPeerInfoIndex()
+	handshaker := &testHandshaker{
+		started: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		handshaker,
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13000"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirOutbound}},
+	}
+
+	notify := handler.Handle()
+	notify.ConnectedF(net, conn)
+	<-handshaker.started
+	notify.ConnectedF(net, conn)
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, handshaker.CallCount())
+
+	close(handshaker.release)
+
+	require.Eventually(t, func() bool {
+		return peerInfos.State(pid) == peers.StateConnected
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestConnHandlerHandleInboundConnectionWaitsForHandshake(t *testing.T) {
+	pid := peer.ID("peer-inbound")
+	peerInfos := peers.NewPeerInfoIndex()
+	subnetsIndex := peers.NewSubnetsIndex()
+	mySubnets := commons.ZeroSubnets
+	mySubnets.Set(1)
+	peerSubnets := commons.ZeroSubnets
+	peerSubnets.Set(1)
+	subnetsIndex.UpdatePeerSubnets(pid, peerSubnets)
+
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		&testHandshaker{},
+		func() commons.Subnets { return mySubnets },
+		subnetsIndex,
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	net.connectedness[pid] = libp2pnetwork.Connected
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13001"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirInbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	time.AfterFunc(100*time.Millisecond, func() {
+		peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
+			info.LastHandshake = time.Now()
+			info.LastHandshakeError = nil
+		})
+	})
+
+	require.Eventually(t, func() bool {
+		return peerInfos.State(pid) == peers.StateConnected
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Empty(t, net.ClosedPeers())
+}
+
+func TestConnHandlerHandleInboundConnectionRejectsPeerWithoutSharedSubnets(t *testing.T) {
+	pid := peer.ID("peer-inbound-no-shared")
+	peerInfos := peers.NewPeerInfoIndex()
+	subnetsIndex := peers.NewSubnetsIndex()
+	mySubnets := commons.ZeroSubnets
+	mySubnets.Set(1)
+	peerSubnets := commons.ZeroSubnets
+	peerSubnets.Set(2)
+	subnetsIndex.UpdatePeerSubnets(pid, peerSubnets)
+
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		&testHandshaker{},
+		func() commons.Subnets { return mySubnets },
+		subnetsIndex,
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	net.connectedness[pid] = libp2pnetwork.Connected
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13002"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirInbound}},
+	}
+
+	handler.Handle().ConnectedF(net, conn)
+
+	time.AfterFunc(100*time.Millisecond, func() {
+		peerInfos.UpdatePeerInfo(pid, func(info *peers.PeerInfo) {
+			info.LastHandshake = time.Now()
+			info.LastHandshakeError = nil
+		})
+	})
+
+	require.Eventually(t, func() bool {
+		return len(net.ClosedPeers()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, []peer.ID{pid}, net.ClosedPeers())
+	require.Equal(t, peers.StateDisconnected, peerInfos.State(pid))
+}
+
+func TestConnHandlerDisconnectedF(t *testing.T) {
+	pid := peer.ID("peer-disconnected")
+	peerInfos := peers.NewPeerInfoIndex()
+	peerInfos.SetState(pid, peers.StateConnected)
+
+	handler := NewConnHandler(
+		t.Context(),
+		zap.NewNop(),
+		&testHandshaker{},
+		func() commons.Subnets { return commons.ZeroSubnets },
+		peers.NewSubnetsIndex(),
+		&mock.MockConnectionIndex{},
+		peerInfos,
+		ttl.New[peer.ID, discovery.DiscoveredPeer](t.Context(), time.Minute, time.Minute),
+	)
+
+	net := newTestNetwork()
+	conn := &testConn{
+		remotePeer:      pid,
+		remoteMultiaddr: mustMultiaddr("/ip4/127.0.0.1/tcp/13003"),
+		stats:           libp2pnetwork.ConnStats{Stats: libp2pnetwork.Stats{Direction: libp2pnetwork.DirInbound}},
+	}
+
+	net.connectedness[pid] = libp2pnetwork.Connected
+	handler.Handle().DisconnectedF(net, conn)
+	require.Equal(t, peers.StateConnected, peerInfos.State(pid))
+
+	net.connectedness[pid] = libp2pnetwork.NotConnected
+	handler.Handle().DisconnectedF(net, conn)
+	require.Equal(t, peers.StateDisconnected, peerInfos.State(pid))
+}
+
+func TestConnHandlerSharesEnoughSubnets(t *testing.T) {
+	pid := peer.ID("peer-subnets")
+	subnetsIndex := peers.NewSubnetsIndex()
+	handler := &connHandler{
+		logger:          zap.NewNop(),
+		subnetsProvider: func() commons.Subnets { return commons.ZeroSubnets },
+		subnetsIndex:    subnetsIndex,
+	}
+	conn := &testConn{remotePeer: pid}
+
+	require.False(t, handler.sharesEnoughSubnets(conn))
+
+	peerSubnets := commons.ZeroSubnets
+	peerSubnets.Set(2)
+	subnetsIndex.UpdatePeerSubnets(pid, peerSubnets)
+	require.True(t, handler.sharesEnoughSubnets(conn))
+
+	mySubnets := commons.ZeroSubnets
+	mySubnets.Set(3)
+	handler.subnetsProvider = func() commons.Subnets { return mySubnets }
+	require.False(t, handler.sharesEnoughSubnets(conn))
+
+	mySubnets.Set(2)
+	handler.subnetsProvider = func() commons.Subnets { return mySubnets }
+	require.True(t, handler.sharesEnoughSubnets(conn))
+}

--- a/network/peers/connections/helpers_test.go
+++ b/network/peers/connections/helpers_test.go
@@ -2,6 +2,7 @@ package connections
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -20,6 +21,8 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 )
+
+var errTestHandshake = errors.New("test handshake error")
 
 type testConn struct {
 	remotePeer      peer.ID

--- a/network/peers/connections/helpers_test.go
+++ b/network/peers/connections/helpers_test.go
@@ -1,11 +1,17 @@
 package connections
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
@@ -14,6 +20,165 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 )
+
+type testConn struct {
+	remotePeer      peer.ID
+	localMultiaddr  ma.Multiaddr
+	remoteMultiaddr ma.Multiaddr
+	stats           libp2pnetwork.ConnStats
+}
+
+func (c *testConn) Close() error { return nil }
+
+func (c *testConn) LocalPeer() peer.ID { return "" }
+
+func (c *testConn) LocalPrivateKey() libp2pcrypto.PrivKey { return nil }
+
+func (c *testConn) RemotePeer() peer.ID { return c.remotePeer }
+
+func (c *testConn) RemotePublicKey() libp2pcrypto.PubKey { return nil }
+
+func (c *testConn) ConnState() libp2pnetwork.ConnectionState { return libp2pnetwork.ConnectionState{} }
+
+func (c *testConn) LocalMultiaddr() ma.Multiaddr { return c.localMultiaddr }
+
+func (c *testConn) RemoteMultiaddr() ma.Multiaddr { return c.remoteMultiaddr }
+
+func (c *testConn) Stat() libp2pnetwork.ConnStats { return c.stats }
+
+func (c *testConn) Scope() libp2pnetwork.ConnScope { return nil }
+
+func (c *testConn) ID() string { return "test-conn" }
+
+func (c *testConn) NewStream(context.Context) (libp2pnetwork.Stream, error) { return nil, nil }
+
+func (c *testConn) GetStreams() []libp2pnetwork.Stream { return nil }
+
+func (c *testConn) IsClosed() bool { return false }
+
+func (c *testConn) CloseWithError(libp2pnetwork.ConnErrorCode) error { return nil }
+
+func (c *testConn) As(any) bool { return false }
+
+type testHandshaker struct {
+	mu      sync.Mutex
+	calls   []peer.ID
+	started chan struct{}
+	release chan struct{}
+	err     error
+}
+
+func (h *testHandshaker) Handshake(_ *zap.Logger, conn libp2pnetwork.Conn) error {
+	h.mu.Lock()
+	h.calls = append(h.calls, conn.RemotePeer())
+	started := h.started
+	release := h.release
+	err := h.err
+	h.mu.Unlock()
+
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		<-release
+	}
+	return err
+}
+
+func (h *testHandshaker) Handler() libp2pnetwork.StreamHandler { return nil }
+
+func (h *testHandshaker) CallCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return len(h.calls)
+}
+
+type testNetwork struct {
+	mu            sync.Mutex
+	connectedness map[peer.ID]libp2pnetwork.Connectedness
+	closedPeers   []peer.ID
+	peers         []peer.ID
+}
+
+func newTestNetwork() *testNetwork {
+	return &testNetwork{
+		connectedness: map[peer.ID]libp2pnetwork.Connectedness{},
+	}
+}
+
+func (n *testNetwork) Peerstore() peerstore.Peerstore { return nil }
+
+func (n *testNetwork) LocalPeer() peer.ID { return "local" }
+
+func (n *testNetwork) DialPeer(context.Context, peer.ID) (libp2pnetwork.Conn, error) { return nil, nil }
+
+func (n *testNetwork) ClosePeer(id peer.ID) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.closedPeers = append(n.closedPeers, id)
+	n.connectedness[id] = libp2pnetwork.NotConnected
+	return nil
+}
+
+func (n *testNetwork) Connectedness(id peer.ID) libp2pnetwork.Connectedness {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	return n.connectedness[id]
+}
+
+func (n *testNetwork) Peers() []peer.ID {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	peers := make([]peer.ID, len(n.peers))
+	copy(peers, n.peers)
+	return peers
+}
+
+func (n *testNetwork) Conns() []libp2pnetwork.Conn { return nil }
+
+func (n *testNetwork) ConnsToPeer(peer.ID) []libp2pnetwork.Conn { return nil }
+
+func (n *testNetwork) Notify(libp2pnetwork.Notifiee) {}
+
+func (n *testNetwork) StopNotify(libp2pnetwork.Notifiee) {}
+
+func (n *testNetwork) CanDial(peer.ID, ma.Multiaddr) bool { return true }
+
+func (n *testNetwork) Close() error { return nil }
+
+func (n *testNetwork) SetStreamHandler(libp2pnetwork.StreamHandler) {}
+
+func (n *testNetwork) NewStream(context.Context, peer.ID) (libp2pnetwork.Stream, error) {
+	return nil, nil
+}
+
+func (n *testNetwork) Listen(...ma.Multiaddr) error { return nil }
+
+func (n *testNetwork) ListenAddresses() []ma.Multiaddr { return nil }
+
+func (n *testNetwork) InterfaceListenAddresses() ([]ma.Multiaddr, error) { return nil, nil }
+
+func (n *testNetwork) ResourceManager() libp2pnetwork.ResourceManager { return nil }
+
+func (n *testNetwork) ClosedPeers() []peer.ID {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	closedPeers := make([]peer.ID, len(n.closedPeers))
+	copy(closedPeers, n.closedPeers)
+	return closedPeers
+}
+
+func mustMultiaddr(addr string) ma.Multiaddr {
+	return ma.StringCast(addr)
+}
 
 type TestData struct {
 	NetworkPrivateKey libp2pcrypto.PrivKey


### PR DESCRIPTION
## Summary
Add test coverage for peer connection management across the networking stack.

Addresses:

`T-ssv-022` Zero Tests for ConnectionGater
`T-ssv-023` Zero Tests for ConnectionHandler
`T-ssv-024` No Tests for ConnManager

This PR adds coverage for:
- `connGater` address dial filtering, inbound/max-peer limits, IP rate limiting, and recently-trimmed/bad-peer rejection
- `connHandler` outbound handshake flow, concurrent handshake deduplication, inbound handshake waiting, subnet checks, and disconnect handling
- `ConnManager` peer trimming, bad-peer disconnection, and irrelevant-peer disconnection with quota handling