### PR TITLE
eth/{eventhandler,eventsyncer}: add tests for inferior block

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -1190,6 +1190,9 @@ func syncContractEvents(
 
 		// Sync ongoing registry events in the background, crash if ongoing sync has stopped because
 		// the SSV node cannot work without being up to date with Ethereum events.
+		// When block ordering looks wrong, stop the node instead of continuing
+		// with possibly incorrect event state. Until reorg handling exists,
+		// restart from persisted state is safer than guessing in-process.
 		go func() {
 			err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64())
 			if err != nil && !errors.Is(err, context.Canceled) {

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -1350,6 +1350,37 @@ func TestHandleBlockEventsStream(t *testing.T) {
 	})
 }
 
+func TestHandleBlockEventsStreamReturnsErrInferiorBlock(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	ops, err := createOperators(1, 0)
+	require.NoError(t, err)
+
+	eh, _, err := setupEventHandler(t, ctx, logger, networkconfig.TestNetwork, ops[0], false)
+	require.NoError(t, err)
+
+	err = eh.nodeStorage.SaveLastProcessedBlock(nil, big.NewInt(10))
+	require.NoError(t, err)
+
+	eventsCh := make(chan executionclient.BlockLogs)
+	go func() {
+		defer close(eventsCh)
+		eventsCh <- executionclient.BlockLogs{BlockNumber: 9}
+	}()
+
+	lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+	require.ErrorIs(t, err, ErrInferiorBlock)
+	require.Zero(t, lastProcessedBlock)
+	require.False(t, progressed)
+
+	storedLastProcessedBlock, found, err := eh.nodeStorage.GetLastProcessedBlock(nil)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(10), storedLastProcessedBlock.Uint64())
+}
+
 func setupEventHandler(
 	t *testing.T,
 	ctx context.Context,

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http/httptest"
 	"strings"
@@ -305,4 +306,27 @@ func TestBlockBelowThreshold(t *testing.T) {
 		err := s.ensureBlockAboveThreshold(ctx, big.NewInt(1))
 		require.NoError(t, err)
 	})
+}
+
+func TestSyncOngoingPropagatesErrInferiorBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	executionClient := NewMockExecutionClient(ctrl)
+	eventHandlerMock := NewMockEventHandler(ctrl)
+
+	ctx := t.Context()
+	syncer := New(nil, executionClient, eventHandlerMock)
+
+	stream := make(chan executionclient.BlockLogs)
+
+	executionClient.EXPECT().
+		StreamLogs(ctx, uint64(11)).
+		Return(stream)
+	eventHandlerMock.EXPECT().
+		HandleBlockEventsStream(ctx, stream, true).
+		Return(uint64(12), true, fmt.Errorf("process block events: %w", eventhandler.ErrInferiorBlock))
+
+	err := syncer.SyncOngoing(ctx, 11)
+	require.Error(t, err)
+	require.ErrorIs(t, err, eventhandler.ErrInferiorBlock)
+	require.ErrorContains(t, err, "last processed block = 12")
 }


### PR DESCRIPTION
## Summary

Addresses `T-ssv-034` by adding regression coverage for the inferior-block path in the Ethereum event pipeline.

## Changes

- add an `eventhandler` test that verifies an inferior block:
  - returns `ErrInferiorBlock`
  - reports no progress
  - leaves `lastProcessedBlock` unchanged
- add an `eventsyncer` test that verifies `SyncOngoing`:
  - does not recover internally from `ErrInferiorBlock`
  - propagates the wrapped error to the caller
- clarify the `node.go` comment around ongoing sync shutdown on block-order violations
