### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/dutytracer-bench.yml
+++ b/.github/workflows/dutytracer-bench.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           lfs: true # Ensure Git LFS files are fetched
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/spec-alignment.yml
+++ b/.github/workflows/spec-alignment.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Upload output.diff
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: output.diff
           path: ./scripts/spec-alignment/output.diff

--- a/.github/workflows/spec-test-raceless.yml
+++ b/.github/workflows/spec-test-raceless.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/spec-test-raceless.yml
+++ b/.github/workflows/spec-test-raceless.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 

--- a/.github/workflows/ssvsigner-e2e-test.yml
+++ b/.github/workflows/ssvsigner-e2e-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.1.0
+      - uses: actions/stale@v10.2.0
         with:
           days-before-stale: 60
           days-before-close: 30

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           lfs: true
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.x"
 
@@ -32,7 +32,7 @@ jobs:
         run: make unit-test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.3
         with:
           files: ./coverage.out,./ssvsigner/coverage.out
         env:


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.