### PR TITLE
fix(qbft): stop timer leak in RoundTimer.TimeoutForRound

### DIFF
--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -141,7 +141,8 @@ func (t *RoundTimer) OnTimeout(done OnRoundTimeoutF) {
 	t.done = done
 }
 
-// TimeoutForRound stops any running timer and schedules a callback for the given round.
+// TimeoutForRound stops any running timer, waits for any in-flight callback to
+// finish, and schedules a new callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
 	// Optimistic early-exit: a narrow window exists between this check and
 	// timer creation where ctx could be canceled; the callback re-checks

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -149,6 +149,9 @@ func (t *RoundTimer) Round() specqbft.Round {
 
 // TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
+	// Optimistic early-exit: a narrow window exists between this check and
+	// timer creation where ctx could be canceled; the callback re-checks
+	// ctx.Err() to handle that case.
 	if t.ctx.Err() != nil {
 		return
 	}
@@ -158,6 +161,8 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	t.mtx.Lock()
 	atomic.StoreUint64(&t.round, uint64(round))
 	if t.timer != nil {
+		// Stop prevents future fires; if it returns false the callback goroutine
+		// may already be running — it will be suppressed by the round-number check.
 		t.timer.Stop()
 	}
 	t.timer = time.AfterFunc(timeout, func() {

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -3,7 +3,6 @@ package roundtimer
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -48,7 +47,7 @@ type RoundTimer struct {
 	// result holds the result of the timer
 	done OnRoundTimeoutF
 	// round is the current round of the timer
-	round uint64
+	round specqbft.Round
 	// timeoutOptions holds the timeoutOptions for the timer
 	timeoutOptions TimeoutOptions
 	// role is the role of the instance
@@ -142,11 +141,6 @@ func (t *RoundTimer) OnTimeout(done OnRoundTimeoutF) {
 	t.done = done
 }
 
-// Round returns a round.
-func (t *RoundTimer) Round() specqbft.Round {
-	return specqbft.Round(atomic.LoadUint64(&t.round)) // #nosec G115
-}
-
 // TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
 	// Optimistic early-exit: a narrow window exists between this check and
@@ -159,10 +153,7 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	timeout := t.RoundTimeout(height, round)
 
 	t.mtx.Lock()
-	// round is read lock-free via Round(), so accesses stay atomic.
-	// The store happens while t.mtx is held only to keep round updates
-	// linearized with timer/done/deferred state changes.
-	atomic.StoreUint64(&t.round, uint64(round))
+	t.round = round
 	if t.timer != nil {
 		// Stop prevents future fires; if it returns false the callback goroutine
 		// may already be running — it will be suppressed by the round-number check.
@@ -175,13 +166,13 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 			return
 		}
 		t.mtx.RLock()
-		currentRound := t.Round()
-		done := t.done
-		t.mtx.RUnlock()
-		if currentRound != round || done == nil {
+		defer t.mtx.RUnlock()
+		if t.round != round {
 			return
 		}
-		done(round)
+		if t.done != nil {
+			t.done(round)
+		}
 	})
 	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -159,12 +159,17 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	timeout := t.RoundTimeout(height, round)
 
 	t.mtx.Lock()
+	// round is read lock-free via Round(), so accesses stay atomic.
+	// The store happens while t.mtx is held only to keep round updates
+	// linearized with timer/done/deferred state changes.
 	atomic.StoreUint64(&t.round, uint64(round))
 	if t.timer != nil {
 		// Stop prevents future fires; if it returns false the callback goroutine
 		// may already be running — it will be suppressed by the round-number check.
 		t.timer.Stop()
 	}
+	// timeout can be negative for late-start duties — AfterFunc fires
+	// immediately but the callback blocks on RLock until we release mtx.
 	t.timer = time.AfterFunc(timeout, func() {
 		if t.ctx.Err() != nil {
 			return

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -147,40 +147,31 @@ func (t *RoundTimer) Round() specqbft.Round {
 	return specqbft.Round(atomic.LoadUint64(&t.round)) // #nosec G115
 }
 
-// TimeoutForRound times out for a given round.
+// TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
-	atomic.StoreUint64(&t.round, uint64(round))
+	if t.ctx.Err() != nil {
+		return
+	}
+
 	timeout := t.RoundTimeout(height, round)
 
-	// preparing the underlying timer
-	timer := t.timer
-	if timer == nil {
-		timer = time.NewTimer(timeout)
-	} else {
-		timer.Stop()
-		// draining the channel of existing timer
-		select {
-		case <-timer.C:
-		default:
-		}
+	t.mtx.Lock()
+	atomic.StoreUint64(&t.round, uint64(round))
+	if t.timer != nil {
+		t.timer.Stop()
 	}
-	timer.Reset(timeout)
-	// spawns a new goroutine to listen to the timer
-	go t.waitForRound(round, timer.C)
-}
-
-func (t *RoundTimer) waitForRound(round specqbft.Round, timeout <-chan time.Time) {
-	select {
-	case <-t.ctx.Done():
-	case <-timeout:
-		if t.Round() == round {
-			func() {
-				t.mtx.RLock() // read t.done
-				defer t.mtx.RUnlock()
-				if done := t.done; done != nil {
-					done(round)
-				}
-			}()
+	t.timer = time.AfterFunc(timeout, func() {
+		if t.ctx.Err() != nil {
+			return
 		}
-	}
+		t.mtx.RLock()
+		currentRound := t.Round()
+		done := t.done
+		t.mtx.RUnlock()
+		if currentRound != round || done == nil {
+			return
+		}
+		done(round)
+	})
+	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -1,6 +1,7 @@
 package roundtimer
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -51,6 +52,24 @@ func TestTimeoutForRound(t *testing.T) {
 		t.Run(fmt.Sprintf("TimeoutForRound - %s: before elapsed", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundElapsed(t, role, specqbft.Round(2))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: timer stored and reused", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundTimerStored(t, role, specqbft.Round(1))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled before arm", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundContextCancelled(t, role, specqbft.Round(1))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled after arm", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundContextCancelledAfterArm(t, role, specqbft.Round(1))
 			})
 		})
 
@@ -126,6 +145,82 @@ func testTimeoutForRoundElapsed(t *testing.T, role spectypes.RunnerRole, thresho
 	require.Equal(t, int32(0), atomic.LoadInt32(&count))
 	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
 	require.Equal(t, int32(1), atomic.LoadInt32(&count))
+}
+
+func testTimeoutForRoundTimerStored(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+	timer := setupTimer(t, testBeaconConfig, func(specqbft.Round) {}, role, threshold)
+
+	require.Nil(t, timer.timer, "timer should be nil before first call")
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+
+	timer.mtx.RLock()
+	firstTimer := timer.timer
+	timer.mtx.RUnlock()
+	require.NotNil(t, firstTimer, "timer must be stored after TimeoutForRound")
+
+	// Second call must replace the timer (stop old, create new).
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.Round(2))
+
+	timer.mtx.RLock()
+	secondTimer := timer.timer
+	timer.mtx.RUnlock()
+	require.NotNil(t, secondTimer, "timer must be stored after second TimeoutForRound")
+	require.NotSame(t, firstTimer, secondTimer, "each call must create a new timer")
+}
+
+func testTimeoutForRoundContextCancelled(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	var count int32
+	onTimeout := func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before arming
+
+	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: threshold,
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+
+	// Early return should skip timer creation entirely.
+	timer.mtx.RLock()
+	require.Nil(t, timer.timer, "timer must not be created when context is already cancelled")
+	timer.mtx.RUnlock()
+
+	// Wait for the full round timeout to confirm no callback fires.
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, threshold) + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire after context cancellation")
+}
+
+func testTimeoutForRoundContextCancelledAfterArm(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	var count int32
+	onTimeout := func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: threshold,
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+	cancel() // cancel after arming but before timeout fires
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, threshold) + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire after context cancellation")
 }
 
 func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -61,13 +61,13 @@ func TestTimeoutForRound(t *testing.T) {
 			})
 		})
 
-		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled before arm", role), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context canceled before arm", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundContextCancelled(t, role, specqbft.Round(1))
 			})
 		})
 
-		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled after arm", role), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context canceled after arm", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundContextCancelledAfterArm(t, role, specqbft.Round(1))
 			})
@@ -192,7 +192,7 @@ func testTimeoutForRoundContextCancelled(t *testing.T, role spectypes.RunnerRole
 
 	// Early return should skip timer creation entirely.
 	timer.mtx.RLock()
-	require.Nil(t, timer.timer, "timer must not be created when context is already cancelled")
+	require.Nil(t, timer.timer, "timer must not be created when context is already canceled")
 	timer.mtx.RUnlock()
 
 	// Wait for the full round timeout to confirm no callback fires.


### PR DESCRIPTION
## Summary

- Replace leaky goroutine+channel pattern in `RoundTimer.TimeoutForRound` with `time.AfterFunc` — each call now stops the previous timer and schedules a new one, eliminating timer and goroutine leaks (up to ~12 per QBFT instance)
- Move round update inside mutex to linearize with timer replacement, snapshot round+done under same RLock in callback, call done after releasing lock
- Remove `waitForRound` method entirely

## Finding

F-ssv-001 — RoundTimer: Timer Field Never Stored Back — Goroutine and Timer Leak

## Follow-up

Pre-existing done=nil registration race discovered during review: #2753

## Test

- 15 existing tests pass unchanged
- Added `timer_stored_and_reused` — guards the defect class directly (would fail on old code where `t.timer` stayed nil)
- Added `context_cancelled_before_arm` — verifies early return skips timer creation, no callback fires
- Added `context_cancelled_after_arm` — verifies callback is suppressed when context cancelled after arming
- 27 total tests, all passing across 4 roles
