### PR TITLE
fix(qbft): defer RoundTimer arming until callback is registered

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1024,7 +1024,7 @@ func SetupCommitteeRunners(
 				return leader
 			},
 			Network:     options.Network,
-			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role, nil),
+			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role),
 			CutOffRound: roundtimer.CutOffRound,
 		}
 
@@ -1085,7 +1085,7 @@ func SetupRunners(
 				return leader
 			},
 			Network:     options.Network,
-			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role, nil),
+			Timer:       roundtimer.New(ctx, options.NetworkConfig.Beacon, role),
 			CutOffRound: roundtimer.CutOffRound,
 		}
 

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -196,9 +196,10 @@ func (t *RoundTimer) OnTimeout(height specqbft.Height, callback OnRoundTimeoutF)
 	}
 }
 
-// TimeoutForRound stops any running timer and schedules a callback for the given round.
-// If the callback is not yet registered for this duty's height (nil or stale from a
-// previous duty), the request is deferred until OnTimeout registers the correct callback.
+// TimeoutForRound stops any running timer, waits for any in-flight callback to
+// finish, and schedules a new callback for the given round. If the callback is
+// not yet registered for this duty's height (nil or stale from a previous duty),
+// the request is deferred until OnTimeout registers the correct callback.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
 	if t.ctx.Err() != nil {
 		return

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -149,6 +149,9 @@ func (t *RoundTimer) Round() specqbft.Round {
 
 // TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
+	// Optimistic early-exit: a narrow window exists between this check and
+	// timer creation where ctx could be canceled; the callback re-checks
+	// ctx.Err() to handle that case.
 	if t.ctx.Err() != nil {
 		return
 	}
@@ -158,6 +161,8 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	t.mtx.Lock()
 	atomic.StoreUint64(&t.round, uint64(round))
 	if t.timer != nil {
+		// Stop prevents future fires; if it returns false the callback goroutine
+		// may already be running — it will be suppressed by the round-number check.
 		t.timer.Stop()
 	}
 	t.timer = time.AfterFunc(timeout, func() {

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -39,14 +39,27 @@ type TimeoutOptions struct {
 	slow           time.Duration
 }
 
+// deferredTimeout stores a TimeoutForRound request that arrived before the
+// correct callback was registered for this duty's height. OnTimeout replays
+// it once the callback is set.
+type deferredTimeout struct {
+	height specqbft.Height
+	round  specqbft.Round
+}
+
 // RoundTimer helps to manage current instance rounds.
 type RoundTimer struct {
 	mtx *sync.RWMutex
 	ctx context.Context
 	// timer is the underlying time.Timer
 	timer *time.Timer
-	// result holds the result of the timer
+	// done is the timeout callback for the current duty
 	done OnRoundTimeoutF
+	// doneHeight is the height for which done was registered
+	doneHeight specqbft.Height
+	// deferred stores a pending arm request when TimeoutForRound is called
+	// before the correct callback is registered for this duty
+	deferred *deferredTimeout
 	// round is the current round of the timer
 	round uint64
 	// timeoutOptions holds the timeoutOptions for the timer
@@ -134,12 +147,46 @@ func (t *RoundTimer) RoundTimeout(height specqbft.Height, round specqbft.Round) 
 	return time.Until(dutyStartTime.Add(timeoutDuration))
 }
 
-// OnTimeout sets a function called on timeout.
-func (t *RoundTimer) OnTimeout(done OnRoundTimeoutF) {
-	t.mtx.Lock() // write to t.done
+// armLocked stops any running timer and schedules a new AfterFunc for the
+// given height and round. Caller must hold t.mtx.
+func (t *RoundTimer) armLocked(height specqbft.Height, round specqbft.Round) {
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+	t.timer = time.AfterFunc(t.RoundTimeout(height, round), func() {
+		if t.ctx.Err() != nil {
+			return
+		}
+		t.mtx.RLock()
+		currentRound := t.Round()
+		done := t.done
+		doneHeight := t.doneHeight
+		t.mtx.RUnlock()
+		if doneHeight != height || currentRound != round || done == nil {
+			return
+		}
+		done(round)
+	})
+}
+
+// OnTimeout registers the timeout callback for the given duty height.
+// If TimeoutForRound was called before the callback was registered (deferred),
+// OnTimeout replays the arm under the lock.
+func (t *RoundTimer) OnTimeout(height specqbft.Height, done OnRoundTimeoutF) {
+	t.mtx.Lock()
 	defer t.mtx.Unlock()
 
 	t.done = done
+	t.doneHeight = height
+	d := t.deferred
+	t.deferred = nil
+
+	// Replay the deferred arm now that the correct callback is registered.
+	// Done under the lock to linearize against concurrent TimeoutForRound
+	// calls from message processing (proposal, round-change, timeout bump).
+	if d != nil && d.height == height && t.ctx.Err() == nil {
+		t.armLocked(d.height, d.round)
+	}
 }
 
 // Round returns a round.
@@ -148,35 +195,31 @@ func (t *RoundTimer) Round() specqbft.Round {
 }
 
 // TimeoutForRound stops any running timer and schedules a callback for the given round.
+// If the callback is not yet registered for this duty's height (nil or stale from a
+// previous duty), the request is deferred until OnTimeout registers the correct callback.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
-	// Optimistic early-exit: a narrow window exists between this check and
-	// timer creation where ctx could be canceled; the callback re-checks
-	// ctx.Err() to handle that case.
 	if t.ctx.Err() != nil {
 		return
 	}
 
-	timeout := t.RoundTimeout(height, round)
-
 	t.mtx.Lock()
 	atomic.StoreUint64(&t.round, uint64(round))
-	if t.timer != nil {
-		// Stop prevents future fires; if it returns false the callback goroutine
-		// may already be running — it will be suppressed by the round-number check.
-		t.timer.Stop()
+
+	if t.done == nil || t.doneHeight != height {
+		// Callback missing or registered for a different duty (stale).
+		// Stop any running timer and nil out the stale callback so that an
+		// in-flight AfterFunc that is past Stop but waiting on RLock will
+		// see done == nil and bail out.
+		if t.timer != nil {
+			t.timer.Stop()
+			t.timer = nil
+		}
+		t.done = nil
+		t.deferred = &deferredTimeout{height: height, round: round}
+		t.mtx.Unlock()
+		return
 	}
-	t.timer = time.AfterFunc(timeout, func() {
-		if t.ctx.Err() != nil {
-			return
-		}
-		t.mtx.RLock()
-		currentRound := t.Round()
-		done := t.done
-		t.mtx.RUnlock()
-		if currentRound != round || done == nil {
-			return
-		}
-		done(round)
-	})
+	t.deferred = nil
+	t.armLocked(height, round)
 	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -3,7 +3,6 @@ package roundtimer
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -48,7 +47,7 @@ type RoundTimer struct {
 	// result holds the result of the timer
 	done OnRoundTimeoutF
 	// round is the current round of the timer
-	round uint64
+	round specqbft.Round
 	// timeoutOptions holds the timeoutOptions for the timer
 	timeoutOptions TimeoutOptions
 	// role is the role of the instance
@@ -142,11 +141,6 @@ func (t *RoundTimer) OnTimeout(done OnRoundTimeoutF) {
 	t.done = done
 }
 
-// Round returns a round.
-func (t *RoundTimer) Round() specqbft.Round {
-	return specqbft.Round(atomic.LoadUint64(&t.round)) // #nosec G115
-}
-
 // TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
 	// Optimistic early-exit: a narrow window exists between this check and
@@ -159,10 +153,7 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	timeout := t.RoundTimeout(height, round)
 
 	t.mtx.Lock()
-	// round is read lock-free via Round(), so accesses stay atomic.
-	// The store happens while t.mtx is held only to keep round updates
-	// linearized with timer/done/deferred state changes.
-	atomic.StoreUint64(&t.round, uint64(round))
+	t.round = round
 	if t.timer != nil {
 		// Stop prevents future fires; if it returns false the callback goroutine
 		// may already be running — it will be suppressed by the round-number check.
@@ -175,13 +166,13 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 			return
 		}
 		t.mtx.RLock()
-		currentRound := t.Round()
-		done := t.done
-		t.mtx.RUnlock()
-		if currentRound != round || done == nil {
+		defer t.mtx.RUnlock()
+		if t.round != round {
 			return
 		}
-		done(round)
+		if t.done != nil {
+			t.done(round)
+		}
 	})
 	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -70,13 +70,12 @@ type RoundTimer struct {
 	beaconConfig *networkconfig.Beacon
 }
 
-// New creates a new instance of RoundTimer.
-func New(ctx context.Context, beaconConfig *networkconfig.Beacon, role spectypes.RunnerRole, done OnRoundTimeoutF) *RoundTimer {
+// New creates a new instance of RoundTimer. The timeout callback must be
+// registered separately via OnTimeout(height, done) before arming.
+func New(ctx context.Context, beaconConfig *networkconfig.Beacon, role spectypes.RunnerRole) *RoundTimer {
 	return &RoundTimer{
 		mtx:          &sync.RWMutex{},
 		ctx:          ctx,
-		timer:        nil,
-		done:         done,
 		role:         role,
 		beaconConfig: beaconConfig,
 		timeoutOptions: TimeoutOptions{
@@ -203,6 +202,8 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	}
 
 	t.mtx.Lock()
+	defer t.mtx.Unlock()
+
 	atomic.StoreUint64(&t.round, uint64(round))
 
 	if t.done == nil || t.doneHeight != height {
@@ -216,10 +217,8 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 		}
 		t.done = nil
 		t.deferred = &deferredTimeout{height: height, round: round}
-		t.mtx.Unlock()
 		return
 	}
 	t.deferred = nil
 	t.armLocked(height, round)
-	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -54,7 +54,7 @@ type RoundTimer struct {
 	timer *time.Timer
 	// callback is the timeout callback for the current duty
 	callback OnRoundTimeoutF
-	// callbackHeight is the height for which callback was registered
+	// callbackHeight is the highest duty height seen (registered or deferred)
 	callbackHeight specqbft.Height
 	// deferred stores a pending arm request when TimeoutForRound is called
 	// before the correct callback is registered for this duty
@@ -207,6 +207,11 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 
+	// Reject stale calls from previous duties.
+	if height < t.callbackHeight {
+		return
+	}
+
 	if t.callback == nil || t.callbackHeight != height {
 		// Callback missing or registered for a different duty (stale).
 		// Stop any running timer and nil out the stale callback so that an
@@ -217,6 +222,7 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 			t.timer = nil
 		}
 		t.callback = nil
+		t.callbackHeight = height
 		t.deferred = &deferredTimeout{height: height, round: round}
 		return
 	}

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -159,12 +159,17 @@ func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Roun
 	timeout := t.RoundTimeout(height, round)
 
 	t.mtx.Lock()
+	// round is read lock-free via Round(), so accesses stay atomic.
+	// The store happens while t.mtx is held only to keep round updates
+	// linearized with timer/done/deferred state changes.
 	atomic.StoreUint64(&t.round, uint64(round))
 	if t.timer != nil {
 		// Stop prevents future fires; if it returns false the callback goroutine
 		// may already be running — it will be suppressed by the round-number check.
 		t.timer.Stop()
 	}
+	// timeout can be negative for late-start duties — AfterFunc fires
+	// immediately but the callback blocks on RLock until we release mtx.
 	t.timer = time.AfterFunc(timeout, func() {
 		if t.ctx.Err() != nil {
 			return

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -147,40 +147,31 @@ func (t *RoundTimer) Round() specqbft.Round {
 	return specqbft.Round(atomic.LoadUint64(&t.round)) // #nosec G115
 }
 
-// TimeoutForRound times out for a given round.
+// TimeoutForRound stops any running timer and schedules a callback for the given round.
 func (t *RoundTimer) TimeoutForRound(height specqbft.Height, round specqbft.Round) {
-	atomic.StoreUint64(&t.round, uint64(round))
+	if t.ctx.Err() != nil {
+		return
+	}
+
 	timeout := t.RoundTimeout(height, round)
 
-	// preparing the underlying timer
-	timer := t.timer
-	if timer == nil {
-		timer = time.NewTimer(timeout)
-	} else {
-		timer.Stop()
-		// draining the channel of existing timer
-		select {
-		case <-timer.C:
-		default:
-		}
+	t.mtx.Lock()
+	atomic.StoreUint64(&t.round, uint64(round))
+	if t.timer != nil {
+		t.timer.Stop()
 	}
-	timer.Reset(timeout)
-	// spawns a new goroutine to listen to the timer
-	go t.waitForRound(round, timer.C)
-}
-
-func (t *RoundTimer) waitForRound(round specqbft.Round, timeout <-chan time.Time) {
-	select {
-	case <-t.ctx.Done():
-	case <-timeout:
-		if t.Round() == round {
-			func() {
-				t.mtx.RLock() // read t.done
-				defer t.mtx.RUnlock()
-				if done := t.done; done != nil {
-					done(round)
-				}
-			}()
+	t.timer = time.AfterFunc(timeout, func() {
+		if t.ctx.Err() != nil {
+			return
 		}
-	}
+		t.mtx.RLock()
+		currentRound := t.Round()
+		done := t.done
+		t.mtx.RUnlock()
+		if currentRound != round || done == nil {
+			return
+		}
+		done(round)
+	})
+	t.mtx.Unlock()
 }

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -152,6 +152,8 @@ func (t *RoundTimer) armLocked(height specqbft.Height, round specqbft.Round) {
 	if t.timer != nil {
 		t.timer.Stop()
 	}
+	// RoundTimeout can be negative for late-start duties — AfterFunc fires
+	// immediately but the callback blocks on RLock until we release mtx.
 	t.timer = time.AfterFunc(t.RoundTimeout(height, round), func() {
 		if t.ctx.Err() != nil {
 			return

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -442,6 +442,58 @@ func testDeferredContextCancelled(t *testing.T, role spectypes.RunnerRole) {
 	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire when context is canceled")
 }
 
+func TestNegativeTimeout(t *testing.T) {
+	// Negative RoundTimeout only applies to roles that use time.Until(slotStart + offset),
+	// not proposer which returns fixed positive durations.
+	roles := []spectypes.RunnerRole{
+		spectypes.RoleCommittee,
+		spectypes.RoleAggregator,
+		spectypes.RoleSyncCommitteeContribution,
+	}
+
+	for _, role := range roles {
+		t.Run(fmt.Sprintf("NegativeTimeout - %s", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testNegativeTimeout(t, role)
+			})
+		})
+	}
+}
+
+// testNegativeTimeout verifies that a late-start duty (where RoundTimeout
+// returns a negative duration) fires the callback immediately without
+// deadlocking. time.AfterFunc with a negative duration starts the callback
+// goroutine right away; it blocks on RLock until the caller releases the
+// write lock.
+func testNegativeTimeout(t *testing.T, role spectypes.RunnerRole) {
+	config := *networkconfig.TestNetwork.Beacon
+	config.SlotDuration = slotDuration
+	// Set genesis far in the past so RoundTimeout returns a negative duration.
+	config.GenesisTime = time.Now().Add(-10 * time.Minute)
+
+	timer := New(t.Context(), &config, role)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	var count int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	})
+
+	// Verify the timeout is indeed negative.
+	timeout := timer.RoundTimeout(specqbft.FirstHeight, specqbft.FirstRound)
+	require.Less(t, timeout, time.Duration(0), "timeout must be negative for a late-start duty")
+
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+
+	// The callback should fire almost immediately (negative timeout).
+	<-time.After(safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&count), "callback must fire immediately for negative timeout")
+}
+
 func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
 	testBeaconConfig := setupTestBeaconConfig()
 

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -265,6 +265,12 @@ func TestDeferredArming(t *testing.T) {
 				testDeferredContextCancelled(t, role)
 			})
 		})
+
+		t.Run(fmt.Sprintf("DeferredArming - %s: stale call during deferred window", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testStaleDuringDeferredWindow(t, role)
+			})
+		})
 	}
 }
 
@@ -440,6 +446,67 @@ func testDeferredContextCancelled(t *testing.T, role spectypes.RunnerRole) {
 
 	<-time.After(quickTimeout + safeTestDelay)
 	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire when context is canceled")
+}
+
+// testStaleDuringDeferredWindow verifies that a stale TimeoutForRound or OnTimeout
+// for height H cannot clobber a deferred arm for height H+1 during the window
+// between TimeoutForRound(H+1) and OnTimeout(H+1).
+func testStaleDuringDeferredWindow(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	timer := New(t.Context(), testBeaconConfig, role)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	// Duty H: register callback and arm.
+	timer.OnTimeout(specqbft.FirstHeight, func(specqbft.Round) {})
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+
+	// Let duty H fire.
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.FirstRound) + safeTestDelay)
+
+	// Duty H+1: TimeoutForRound arrives before OnTimeout — enters deferred window.
+	newHeight := specqbft.FirstHeight + 1
+	timer.TimeoutForRound(newHeight, specqbft.FirstRound)
+
+	timer.mtx.RLock()
+	require.NotNil(t, timer.deferred, "must have deferred for H+1")
+	require.Equal(t, newHeight, timer.deferred.height)
+	timer.mtx.RUnlock()
+
+	// Stale TimeoutForRound(H) arrives during the deferred window.
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.Round(3))
+
+	// Deferred must still be for H+1, not overwritten by the stale call.
+	timer.mtx.RLock()
+	require.NotNil(t, timer.deferred, "deferred must survive stale call")
+	require.Equal(t, newHeight, timer.deferred.height, "deferred must still be for H+1")
+	timer.mtx.RUnlock()
+
+	// Stale OnTimeout(H) arrives during the deferred window.
+	timer.OnTimeout(specqbft.FirstHeight, func(specqbft.Round) {})
+
+	// Deferred must still be intact.
+	timer.mtx.RLock()
+	require.NotNil(t, timer.deferred, "deferred must survive stale OnTimeout")
+	require.Equal(t, newHeight, timer.deferred.height, "deferred must still be for H+1")
+	timer.mtx.RUnlock()
+
+	// Now the real OnTimeout(H+1) arrives — should replay.
+	var count int32
+	timer.OnTimeout(newHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	})
+
+	timer.mtx.RLock()
+	require.NotNil(t, timer.timer, "timer must be armed after OnTimeout(H+1) replay")
+	timer.mtx.RUnlock()
+
+	<-time.After(timer.RoundTimeout(newHeight, specqbft.FirstRound) + safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&count), "H+1 callback must fire exactly once")
 }
 
 func TestNegativeTimeout(t *testing.T) {

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -395,16 +395,16 @@ func testDeferredReplacedByNewRound(t *testing.T, role spectypes.RunnerRole) {
 	require.Equal(t, specqbft.Round(2), timer.deferred.round, "deferred must hold the latest round")
 	timer.mtx.RUnlock()
 
-	var firedRound specqbft.Round
+	var firedRound uint64
 	var count int32
 	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
 		atomic.AddInt32(&count, 1)
-		firedRound = round
+		atomic.StoreUint64(&firedRound, uint64(round))
 	})
 
 	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
 	require.Equal(t, int32(1), atomic.LoadInt32(&count), "callback must fire exactly once")
-	require.Equal(t, specqbft.Round(2), firedRound, "callback must fire for the latest round")
+	require.Equal(t, uint64(specqbft.Round(2)), atomic.LoadUint64(&firedRound), "callback must fire for the latest round")
 }
 
 // testDeferredContextCancelled verifies that if the context is canceled

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -223,6 +223,221 @@ func testTimeoutForRoundContextCancelledAfterArm(t *testing.T, role spectypes.Ru
 	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire after context cancellation")
 }
 
+func TestDeferredArming(t *testing.T) {
+	roles := []spectypes.RunnerRole{
+		spectypes.RoleCommittee,
+		spectypes.RoleAggregator,
+		spectypes.RoleProposer,
+		spectypes.RoleSyncCommitteeContribution,
+	}
+
+	for _, role := range roles {
+		t.Run(fmt.Sprintf("DeferredArming - %s: first duty nil callback", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testDeferredArming(t, role)
+			})
+		})
+
+		t.Run(fmt.Sprintf("DeferredArming - %s: stale callback from previous duty", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testDeferredArmingWithStaleCallback(t, role)
+			})
+		})
+
+		t.Run(fmt.Sprintf("DeferredArming - %s: stale timer stopped", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testStaleTimerStopped(t, role)
+			})
+		})
+
+		t.Run(fmt.Sprintf("DeferredArming - %s: deferred replaced by new round", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testDeferredReplacedByNewRound(t, role)
+			})
+		})
+
+		t.Run(fmt.Sprintf("DeferredArming - %s: context canceled before OnTimeout", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testDeferredContextCancelled(t, role)
+			})
+		})
+	}
+}
+
+// testDeferredArming verifies the first-duty case: done=nil, TimeoutForRound defers,
+// OnTimeout replays and the callback fires.
+func testDeferredArming(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	// Create timer with nil callback (matches real construction in controller.go).
+	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	// Arm with FirstHeight — should defer because done is nil.
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+
+	timer.mtx.RLock()
+	require.Nil(t, timer.timer, "timer must not be armed before callback is registered")
+	require.NotNil(t, timer.deferred, "deferred must be stored")
+	timer.mtx.RUnlock()
+
+	// Register callback — should replay the deferred arm.
+	var count int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	})
+
+	timer.mtx.RLock()
+	require.NotNil(t, timer.timer, "timer must be armed after OnTimeout replay")
+	timer.mtx.RUnlock()
+
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.FirstRound) + safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&count), "callback must fire exactly once")
+}
+
+// testDeferredArmingWithStaleCallback verifies the duty N+1 case: done holds
+// a stale callback from the previous duty, TimeoutForRound defers and stops
+// the stale timer, OnTimeout replays with the correct callback.
+func testDeferredArmingWithStaleCallback(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	// Duty N: register callback and arm normally.
+	var oldCount int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&oldCount, 1)
+	})
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+
+	// Let duty N's timer fire.
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.FirstRound) + safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&oldCount), "duty N callback must fire")
+
+	// Duty N+1: arm with new height BEFORE registering the new callback.
+	// This is the exact hazardous case — same FirstRound, different height.
+	newHeight := specqbft.FirstHeight + 1
+	timer.TimeoutForRound(newHeight, specqbft.FirstRound)
+
+	timer.mtx.RLock()
+	require.Nil(t, timer.timer, "timer must not be armed with stale callback")
+	timer.mtx.RUnlock()
+
+	// Register the new callback — should replay.
+	var newCount int32
+	timer.OnTimeout(newHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&newCount, 1)
+	})
+
+	<-time.After(timer.RoundTimeout(newHeight, specqbft.FirstRound) + safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&oldCount), "old callback must not fire again")
+	require.Equal(t, int32(1), atomic.LoadInt32(&newCount), "new callback must fire exactly once")
+}
+
+// testStaleTimerStopped verifies that when TimeoutForRound defers for a new
+// duty, it stops the running timer from the previous duty.
+func testStaleTimerStopped(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	// Duty N: register callback and arm with a round that has a long timeout.
+	var oldCount int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&oldCount, 1)
+	})
+	// Use threshold+1 to get the slow timeout path (longer).
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.Round(2))
+
+	// Duty N+1: arm before the old timer fires — should stop it.
+	newHeight := specqbft.FirstHeight + 1
+	timer.TimeoutForRound(newHeight, specqbft.FirstRound)
+
+	// Wait long enough for the old timer to have fired if it wasn't stopped.
+	// Use the actual computed timeout (which includes slot-based base duration
+	// for non-proposer roles) rather than just slowTimeout.
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&oldCount), "stale timer must be stopped and not fire")
+}
+
+// testDeferredReplacedByNewRound verifies that multiple TimeoutForRound calls
+// before OnTimeout result in only the latest round being replayed.
+func testDeferredReplacedByNewRound(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(2),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	// Two deferred arms — second should overwrite the first.
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.Round(2))
+
+	timer.mtx.RLock()
+	require.NotNil(t, timer.deferred)
+	require.Equal(t, specqbft.Round(2), timer.deferred.round, "deferred must hold the latest round")
+	timer.mtx.RUnlock()
+
+	var firedRound specqbft.Round
+	var count int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+		firedRound = round
+	})
+
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
+	require.Equal(t, int32(1), atomic.LoadInt32(&count), "callback must fire exactly once")
+	require.Equal(t, specqbft.Round(2), firedRound, "callback must fire for the latest round")
+}
+
+// testDeferredContextCancelled verifies that if the context is canceled
+// before OnTimeout is called, the deferred arm is not replayed.
+func testDeferredContextCancelled(t *testing.T, role spectypes.RunnerRole) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	timer := New(ctx, testBeaconConfig, role, nil)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: specqbft.Round(1),
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
+	cancel() // Cancel before OnTimeout
+
+	var count int32
+	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	})
+
+	// Verify no timer was armed (ctx check in OnTimeout replay).
+	timer.mtx.RLock()
+	require.Nil(t, timer.timer, "timer must not be armed when context is canceled")
+	timer.mtx.RUnlock()
+
+	<-time.After(quickTimeout + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire when context is canceled")
+}
+
 func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
 	testBeaconConfig := setupTestBeaconConfig()
 

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -1,6 +1,7 @@
 package roundtimer
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -51,6 +52,24 @@ func TestTimeoutForRound(t *testing.T) {
 		t.Run(fmt.Sprintf("TimeoutForRound - %s: before elapsed", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundElapsed(t, role, specqbft.Round(2))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: timer stored and reused", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundTimerStored(t, role, specqbft.Round(1))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled before arm", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundContextCancelled(t, role, specqbft.Round(1))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled after arm", role), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				testTimeoutForRoundContextCancelledAfterArm(t, role, specqbft.Round(1))
 			})
 		})
 
@@ -126,6 +145,82 @@ func testTimeoutForRoundElapsed(t *testing.T, role spectypes.RunnerRole, thresho
 	require.Equal(t, int32(0), atomic.LoadInt32(&count))
 	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
 	require.Equal(t, int32(1), atomic.LoadInt32(&count))
+}
+
+func testTimeoutForRoundTimerStored(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+	timer := setupTimer(t, testBeaconConfig, func(specqbft.Round) {}, role, threshold)
+
+	require.Nil(t, timer.timer, "timer should be nil before first call")
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+
+	timer.mtx.RLock()
+	firstTimer := timer.timer
+	timer.mtx.RUnlock()
+	require.NotNil(t, firstTimer, "timer must be stored after TimeoutForRound")
+
+	// Second call must replace the timer (stop old, create new).
+	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.Round(2))
+
+	timer.mtx.RLock()
+	secondTimer := timer.timer
+	timer.mtx.RUnlock()
+	require.NotNil(t, secondTimer, "timer must be stored after second TimeoutForRound")
+	require.NotSame(t, firstTimer, secondTimer, "each call must create a new timer")
+}
+
+func testTimeoutForRoundContextCancelled(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	var count int32
+	onTimeout := func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before arming
+
+	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: threshold,
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+
+	// Early return should skip timer creation entirely.
+	timer.mtx.RLock()
+	require.Nil(t, timer.timer, "timer must not be created when context is already cancelled")
+	timer.mtx.RUnlock()
+
+	// Wait for the full round timeout to confirm no callback fires.
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, threshold) + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire after context cancellation")
+}
+
+func testTimeoutForRoundContextCancelledAfterArm(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
+	testBeaconConfig := setupTestBeaconConfig()
+
+	var count int32
+	onTimeout := func(round specqbft.Round) {
+		atomic.AddInt32(&count, 1)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer.timeoutOptions = TimeoutOptions{
+		quickThreshold: threshold,
+		quick:          quickTimeout,
+		slow:           slowTimeout,
+	}
+
+	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
+	cancel() // cancel after arming but before timeout fires
+	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, threshold) + safeTestDelay)
+	require.Equal(t, int32(0), atomic.LoadInt32(&count), "callback must not fire after context cancellation")
 }
 
 func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -395,16 +395,16 @@ func testDeferredReplacedByNewRound(t *testing.T, role spectypes.RunnerRole) {
 	require.Equal(t, specqbft.Round(2), timer.deferred.round, "deferred must hold the latest round")
 	timer.mtx.RUnlock()
 
-	var firedRound uint64
+	var firedRound atomic.Uint64
 	var count int32
 	timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) {
 		atomic.AddInt32(&count, 1)
-		atomic.StoreUint64(&firedRound, uint64(round))
+		firedRound.Store(uint64(round))
 	})
 
 	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.Round(2)) + safeTestDelay)
 	require.Equal(t, int32(1), atomic.LoadInt32(&count), "callback must fire exactly once")
-	require.Equal(t, uint64(specqbft.Round(2)), atomic.LoadUint64(&firedRound), "callback must fire for the latest round")
+	require.Equal(t, specqbft.Round(2), specqbft.Round(firedRound.Load()), "callback must fire for the latest round")
 }
 
 // testDeferredContextCancelled verifies that if the context is canceled

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -61,13 +61,13 @@ func TestTimeoutForRound(t *testing.T) {
 			})
 		})
 
-		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled before arm", role), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context canceled before arm", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundContextCancelled(t, role, specqbft.Round(1))
 			})
 		})
 
-		t.Run(fmt.Sprintf("TimeoutForRound - %s: context cancelled after arm", role), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TimeoutForRound - %s: context canceled after arm", role), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				testTimeoutForRoundContextCancelledAfterArm(t, role, specqbft.Round(1))
 			})
@@ -192,7 +192,7 @@ func testTimeoutForRoundContextCancelled(t *testing.T, role spectypes.RunnerRole
 
 	// Early return should skip timer creation entirely.
 	timer.mtx.RLock()
-	require.Nil(t, timer.timer, "timer must not be created when context is already cancelled")
+	require.Nil(t, timer.timer, "timer must not be created when context is already canceled")
 	timer.mtx.RUnlock()
 
 	// Wait for the full round timeout to confirm no callback fires.

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -98,11 +98,10 @@ func setupTestBeaconConfig() *networkconfig.Beacon {
 func setupTimer(
 	t *testing.T,
 	beaconConfig *networkconfig.Beacon,
-	onTimeout OnRoundTimeoutF,
 	role spectypes.RunnerRole,
 	round specqbft.Round,
 ) *RoundTimer {
-	timer := New(t.Context(), beaconConfig, role, onTimeout)
+	timer := New(t.Context(), beaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: round,
 		quick:          quickTimeout,
@@ -120,7 +119,8 @@ func testTimeoutForRound(t *testing.T, role spectypes.RunnerRole, threshold spec
 		atomic.AddInt32(&count, 1)
 	}
 
-	timer := setupTimer(t, testBeaconConfig, onTimeout, role, threshold)
+	timer := setupTimer(t, testBeaconConfig, role, threshold)
+	timer.OnTimeout(specqbft.FirstHeight, onTimeout)
 
 	require.Equal(t, int32(0), atomic.LoadInt32(&count))
 
@@ -137,7 +137,8 @@ func testTimeoutForRoundElapsed(t *testing.T, role spectypes.RunnerRole, thresho
 		atomic.AddInt32(&count, 1)
 	}
 
-	timer := setupTimer(t, testBeaconConfig, onTimeout, role, threshold)
+	timer := setupTimer(t, testBeaconConfig, role, threshold)
+	timer.OnTimeout(specqbft.FirstHeight, onTimeout)
 
 	timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
 	<-time.After(timer.RoundTimeout(specqbft.FirstHeight, specqbft.FirstRound) / 2)
@@ -149,7 +150,8 @@ func testTimeoutForRoundElapsed(t *testing.T, role spectypes.RunnerRole, thresho
 
 func testTimeoutForRoundTimerStored(t *testing.T, role spectypes.RunnerRole, threshold specqbft.Round) {
 	testBeaconConfig := setupTestBeaconConfig()
-	timer := setupTimer(t, testBeaconConfig, func(specqbft.Round) {}, role, threshold)
+	timer := setupTimer(t, testBeaconConfig, role, threshold)
+	timer.OnTimeout(specqbft.FirstHeight, func(specqbft.Round) {})
 
 	require.Nil(t, timer.timer, "timer should be nil before first call")
 
@@ -181,12 +183,13 @@ func testTimeoutForRoundContextCancelled(t *testing.T, role spectypes.RunnerRole
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel before arming
 
-	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer := New(ctx, testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: threshold,
 		quick:          quickTimeout,
 		slow:           slowTimeout,
 	}
+	timer.OnTimeout(specqbft.FirstHeight, onTimeout)
 
 	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
 
@@ -210,12 +213,13 @@ func testTimeoutForRoundContextCancelledAfterArm(t *testing.T, role spectypes.Ru
 
 	ctx, cancel := context.WithCancel(t.Context())
 
-	timer := New(ctx, testBeaconConfig, role, onTimeout)
+	timer := New(ctx, testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: threshold,
 		quick:          quickTimeout,
 		slow:           slowTimeout,
 	}
+	timer.OnTimeout(specqbft.FirstHeight, onTimeout)
 
 	timer.TimeoutForRound(specqbft.FirstHeight, threshold)
 	cancel() // cancel after arming but before timeout fires
@@ -270,7 +274,7 @@ func testDeferredArming(t *testing.T, role spectypes.RunnerRole) {
 	testBeaconConfig := setupTestBeaconConfig()
 
 	// Create timer with nil callback (matches real construction in controller.go).
-	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer := New(t.Context(), testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(1),
 		quick:          quickTimeout,
@@ -305,7 +309,7 @@ func testDeferredArming(t *testing.T, role spectypes.RunnerRole) {
 func testDeferredArmingWithStaleCallback(t *testing.T, role spectypes.RunnerRole) {
 	testBeaconConfig := setupTestBeaconConfig()
 
-	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer := New(t.Context(), testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(1),
 		quick:          quickTimeout,
@@ -348,7 +352,7 @@ func testDeferredArmingWithStaleCallback(t *testing.T, role spectypes.RunnerRole
 func testStaleTimerStopped(t *testing.T, role spectypes.RunnerRole) {
 	testBeaconConfig := setupTestBeaconConfig()
 
-	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer := New(t.Context(), testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(1),
 		quick:          quickTimeout,
@@ -379,7 +383,7 @@ func testStaleTimerStopped(t *testing.T, role spectypes.RunnerRole) {
 func testDeferredReplacedByNewRound(t *testing.T, role spectypes.RunnerRole) {
 	testBeaconConfig := setupTestBeaconConfig()
 
-	timer := New(t.Context(), testBeaconConfig, role, nil)
+	timer := New(t.Context(), testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(2),
 		quick:          quickTimeout,
@@ -414,7 +418,7 @@ func testDeferredContextCancelled(t *testing.T, role spectypes.RunnerRole) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 
-	timer := New(ctx, testBeaconConfig, role, nil)
+	timer := New(ctx, testBeaconConfig, role)
 	timer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(1),
 		quick:          quickTimeout,
@@ -454,11 +458,12 @@ func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold
 
 	for i := 0; i < 4; i++ {
 		go func(index int) {
-			timer := New(t.Context(), testBeaconConfig, role, func(round specqbft.Round) { onTimeout(index) })
+			timer := New(t.Context(), testBeaconConfig, role)
 			timer.timeoutOptions = TimeoutOptions{
 				quickThreshold: threshold,
 				quick:          quickTimeout,
 			}
+			timer.OnTimeout(specqbft.FirstHeight, func(round specqbft.Round) { onTimeout(index) })
 			timer.TimeoutForRound(specqbft.FirstHeight, specqbft.FirstRound)
 		}(i)
 		// Introduce a sleep between creating timers to simulate a real-world scenario.
@@ -467,7 +472,7 @@ func testTimeoutForRoundMulti(t *testing.T, role spectypes.RunnerRole, threshold
 
 	// To set up the correct expectations, we need to know when exactly this particular `role` is supposed to
 	// timeout (different roles time out at different times into slot). We need to use a reference-timer for that.
-	referenceTimer := New(t.Context(), testBeaconConfig, role, nil)
+	referenceTimer := New(t.Context(), testBeaconConfig, role)
 	referenceTimer.timeoutOptions = TimeoutOptions{
 		quickThreshold: specqbft.Round(1),
 		quick:          quickTimeout,

--- a/protocol/v2/ssv/runner/timer.go
+++ b/protocol/v2/ssv/runner/timer.go
@@ -17,6 +17,6 @@ func (b *BaseRunner) registerTimeoutHandler(ctx context.Context, logger *zap.Log
 	identifier := spectypes.MessageID(instance.State.ID)
 	timer, ok := instance.GetConfig().GetTimer().(*roundtimer.RoundTimer)
 	if ok {
-		timer.OnTimeout(b.TimeoutF(ctx, logger, identifier, height))
+		timer.OnTimeout(height, b.TimeoutF(ctx, logger, identifier, height))
 	}
 }


### PR DESCRIPTION
## Summary

- Defer `RoundTimer` arming when the timeout callback is missing or stale from a previous duty, preventing silently dropped first-round timeouts on late-start duties
- Add height-aware `OnTimeout(height, done)` so `TimeoutForRound` can distinguish the current duty's callback from a stale one — deferred requests are replayed under the lock via `armLocked` once the correct callback is registered
- Stop and nil stale timers in the deferred path to suppress in-flight callbacks from previous duties

Closes #2753

## Finding

#2753 — RoundTimer first-round timeout silently dropped due to late callback registration

## Test

- 20 new deferred-arming tests across all 4 roles: first-duty nil callback, stale callback on duty N+1, stale timer stopped, deferred replaced by new round, context canceled before OnTimeout
- 28 existing tests pass unchanged
- `golangci-lint`: 0 issues
