### PR TITLE
chore(ci): update actions refs for stage branch

### DIFF
--- a/.github/workflows/dutytracer-bench.yml
+++ b/.github/workflows/dutytracer-bench.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           lfs: true # Ensure Git LFS files are fetched
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Setup Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (lint)
-        uses: actions/cache@v4
+        uses: actions/cache.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         id: setup-go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (lint)
-        uses: actions/cache.0.4
+        uses: actions/cache@v5.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/spec-alignment.yml
+++ b/.github/workflows/spec-alignment.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload output.diff
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: output.diff
           path: ./scripts/spec-alignment/output.diff

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -28,7 +28,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (spec)
-        uses: actions/cache.0.4
+        uses: actions/cache@v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Cache generated spec artifacts
-        uses: actions/cache.0.4
+        uses: actions/cache@v5.0.4
         with:
           path: .cache/spec-tests
           key: ${{ runner.os }}-spec-artifacts-${{ hashFiles('go.sum') }}

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         id: setup-go

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Setup Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore

--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -28,7 +28,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (spec)
-        uses: actions/cache@v4
+        uses: actions/cache.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Cache generated spec artifacts
-        uses: actions/cache@v4
+        uses: actions/cache.0.4
         with:
           path: .cache/spec-tests
           key: ${{ runner.os }}-spec-artifacts-${{ hashFiles('go.sum') }}

--- a/.github/workflows/ssvsigner-e2e-test.yml
+++ b/.github/workflows/ssvsigner-e2e-test.yml
@@ -27,10 +27,10 @@ jobs:
           cache-dependency-path: ssvsigner/go.sum
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action.0.0
 
       - name: Build ssv-signer image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action.0.0
         with:
           context: .
           file: ssvsigner/Dockerfile

--- a/.github/workflows/ssvsigner-e2e-test.yml
+++ b/.github/workflows/ssvsigner-e2e-test.yml
@@ -27,10 +27,10 @@ jobs:
           cache-dependency-path: ssvsigner/go.sum
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action.0.0
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Build ssv-signer image (cached)
-        uses: docker/build-push-action.0.0
+        uses: docker/build-push-action@v7.0.0
         with:
           context: .
           file: ssvsigner/Dockerfile

--- a/.github/workflows/ssvsigner-e2e-test.yml
+++ b/.github/workflows/ssvsigner-e2e-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: ssvsigner/go.mod
           cache: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.1.0
+      - uses: actions/stale@v10.2.0
         with:
           days-before-stale: 60
           days-before-close: 30

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,7 +30,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (ssv)
-        uses: actions/cache@v4
+        uses: actions/cache.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -67,7 +67,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (ssvsigner)
-        uses: actions/cache@v4
+        uses: actions/cache.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           lfs: true
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         id: setup-go

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Setup Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore
@@ -44,7 +44,7 @@ jobs:
         run: make unit-test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.3
         with:
           files: ./coverage.out
           flags: core
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: ssvsigner/go.mod
           # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore
@@ -81,7 +81,7 @@ jobs:
         run: make ssvsigner-test
 
       - name: Upload ssvsigner coverage report to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.3
         with:
           files: ./ssvsigner/coverage.out
           flags: ssvsigner

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,7 +30,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (ssv)
-        uses: actions/cache.0.4
+        uses: actions/cache@v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -67,7 +67,7 @@ jobs:
           cache: false
 
       - name: Restore Go cache (ssvsigner)
-        uses: actions/cache.0.4
+        uses: actions/cache@v5.0.4
         with:
           path: |
             ~/go/pkg/mod


### PR DESCRIPTION
Recreates the CI action-reference updates from #2752 on top of `stage`.

Commits:
- chore(ci) - Update actions base image to node:24
- fix(ci): update single-line uses action refs

Note: `stage` does not contain `.github/workflows/full-test.yml` or `.github/workflows/spec-test-raceless.yml`, so equivalent updates were applied to the workflows that exist on `stage`.
