### PR TITLE
Adding updates to #2756

### DIFF
--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -318,8 +318,6 @@ func (h *AttesterHandler) prepareCurrentEpoch(ctx context.Context, logger *zap.L
 		h.dutyFetchIntents[currentEpoch] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the current epoch succeeded")
-	} else {
-		span.AddEvent("no unfulfilled intent for current epoch")
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -348,8 +346,6 @@ func (h *AttesterHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logg
 		h.dutyFetchIntents[currentEpoch+1] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the next epoch succeeded")
-	} else {
-		span.AddEvent("no unfulfilled intent for next epoch")
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -177,7 +177,6 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 			logger.Info("🔀 reorg event received",
 				zap.Any("event", reorgEvent),
 				zap.Bool("refetch_current_epoch_duties", refetchCurrentEpoch),
-				zap.Bool("refetch_next_epoch_duties", true),
 			)
 
 			func() {
@@ -189,10 +188,9 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 				defer cancel()
 
 				// 1) Declare intents.
-				// Depending on whether the current or previous duty dependent root has changed, we might need to
-				// re-fetch the duties for the current epoch (if the current duty dependent root has changed) and/or
-				// next epoch (if the previous duty dependent root has changed) to ensure we have the up-to-date
-				// duties for all validators for both epochs.
+				// Attester duties for the current epoch are determined by the previous duty dependent root,
+				// so we re-fetch the current epoch only if it has changed. The next epoch is always re-fetched
+				// on any reorg to ensure we have the up-to-date duties for all validators.
 				if refetchCurrentEpoch {
 					h.dutyFetchIntents[currentEpoch] = false
 				}
@@ -299,21 +297,44 @@ func (h *AttesterHandler) executeAggregatorDuties(ctx context.Context, epoch pha
 }
 
 func (h *AttesterHandler) prepareCurrentEpoch(ctx context.Context, logger *zap.Logger, currentEpoch phase0.Epoch, currentSlot phase0.Slot) {
+	ctx, span := tracer.Start(ctx,
+		observability.InstrumentName(observabilityNamespace, "attester.prepare_current_epoch"),
+		trace.WithAttributes(
+			observability.BeaconEpochAttribute(currentEpoch),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleAttester),
+		))
+	defer span.End()
+
 	if fulfilled, ok := h.dutyFetchIntents[currentEpoch]; ok && !fulfilled {
 		logger.Debug("fetching duties for the current epoch")
 
 		err := h.fetchAndProcessDuties(ctx, logger, currentEpoch, currentSlot)
 		if err != nil {
 			logger.Error("fetching duties for the current epoch failed", zap.Error(err))
+			span.SetStatus(codes.Error, err.Error())
 			return
 		}
 		h.dutyFetchIntents[currentEpoch] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the current epoch succeeded")
+	} else {
+		span.AddEvent("no unfulfilled intent for current epoch")
 	}
+
+	span.SetStatus(codes.Ok, "")
 }
 
 func (h *AttesterHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logger, currentEpoch phase0.Epoch, currentSlot phase0.Slot) {
+	ctx, span := tracer.Start(ctx,
+		observability.InstrumentName(observabilityNamespace, "attester.prepare_next_epoch"),
+		trace.WithAttributes(
+			observability.BeaconEpochAttribute(currentEpoch+1),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleAttester),
+		))
+	defer span.End()
+
 	// Delaying the duty fetch until it's a "good time" allows us to do it when the beacon node should be less busy.
 	if fulfilled, ok := h.dutyFetchIntents[currentEpoch+1]; ok && !fulfilled && h.shouldFetchNextEpoch(currentSlot) {
 		logger.Debug("fetching duties for the next epoch")
@@ -321,12 +342,17 @@ func (h *AttesterHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logg
 		err := h.fetchAndProcessDuties(ctx, logger, currentEpoch+1, currentSlot)
 		if err != nil {
 			logger.Error("fetching duties for the next epoch failed", zap.Error(err))
+			span.SetStatus(codes.Error, err.Error())
 			return
 		}
 		h.dutyFetchIntents[currentEpoch+1] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the next epoch succeeded")
+	} else {
+		span.AddEvent("no unfulfilled intent for next epoch")
 	}
+
+	span.SetStatus(codes.Ok, "")
 }
 
 func (h *AttesterHandler) fetchAndProcessDuties(ctx context.Context, logger *zap.Logger, targetEpoch phase0.Epoch, currentSlot phase0.Slot) error {

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -169,7 +169,6 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 			logger.Info("🔀 reorg event received",
 				zap.Any("event", reorgEvent),
 				zap.Bool("refetch_current_epoch_duties", refetchCurrentEpoch),
-				zap.Bool("refetch_next_epoch_duties", true),
 			)
 
 			func() {
@@ -240,21 +239,44 @@ func (h *ProposerHandler) HandleInitialDuties(ctx context.Context) {
 }
 
 func (h *ProposerHandler) prepareCurrentEpoch(ctx context.Context, logger *zap.Logger, currentEpoch phase0.Epoch, currentSlot phase0.Slot) {
+	ctx, span := tracer.Start(ctx,
+		observability.InstrumentName(observabilityNamespace, "proposer.prepare_current_epoch"),
+		trace.WithAttributes(
+			observability.BeaconEpochAttribute(currentEpoch),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleProposer),
+		))
+	defer span.End()
+
 	if fulfilled, ok := h.dutyFetchIntents[currentEpoch]; ok && !fulfilled {
 		logger.Debug("fetching duties for the current epoch")
 
 		err := h.fetchAndProcessDuties(ctx, logger, currentEpoch, currentSlot)
 		if err != nil {
 			logger.Error("fetching duties for the current epoch failed", zap.Error(err))
+			span.SetStatus(codes.Error, err.Error())
 			return
 		}
 		h.dutyFetchIntents[currentEpoch] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the current epoch succeeded")
+	} else {
+		span.AddEvent("no unfulfilled intent for current epoch")
 	}
+
+	span.SetStatus(codes.Ok, "")
 }
 
 func (h *ProposerHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logger, currentEpoch phase0.Epoch, currentSlot phase0.Slot) {
+	ctx, span := tracer.Start(ctx,
+		observability.InstrumentName(observabilityNamespace, "proposer.prepare_next_epoch"),
+		trace.WithAttributes(
+			observability.BeaconEpochAttribute(currentEpoch+1),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleProposer),
+		))
+	defer span.End()
+
 	// Delaying the duty fetch until it's a "good time" allows us to do it when the beacon node should be less busy.
 	if fulfilled, ok := h.dutyFetchIntents[currentEpoch+1]; ok && !fulfilled && h.shouldFetchNextEpoch(currentSlot) {
 		logger.Debug("fetching duties for the next epoch")
@@ -262,12 +284,17 @@ func (h *ProposerHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logg
 		err := h.fetchAndProcessDuties(ctx, logger, currentEpoch+1, currentSlot)
 		if err != nil {
 			logger.Error("fetching duties for the next epoch failed", zap.Error(err))
+			span.SetStatus(codes.Error, err.Error())
 			return
 		}
 		h.dutyFetchIntents[currentEpoch+1] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the next epoch succeeded")
+	} else {
+		span.AddEvent("no unfulfilled intent for next epoch")
 	}
+
+	span.SetStatus(codes.Ok, "")
 }
 
 func (h *ProposerHandler) processExecution(ctx context.Context, epoch phase0.Epoch, slot phase0.Slot) {

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -260,8 +260,6 @@ func (h *ProposerHandler) prepareCurrentEpoch(ctx context.Context, logger *zap.L
 		h.dutyFetchIntents[currentEpoch] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the current epoch succeeded")
-	} else {
-		span.AddEvent("no unfulfilled intent for current epoch")
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -290,8 +288,6 @@ func (h *ProposerHandler) prepareNextEpoch(ctx context.Context, logger *zap.Logg
 		h.dutyFetchIntents[currentEpoch+1] = true // the intent has been fulfilled
 
 		logger.Debug("fetching duties for the next epoch succeeded")
-	} else {
-		span.AddEvent("no unfulfilled intent for next epoch")
 	}
 
 	span.SetStatus(codes.Ok, "")


### PR DESCRIPTION
- Adds OpenTelemetry in the fetching of duties in proposer for better Diagnostics
- Additionally fixes the outdated comment about reorg events in attester
- Remove the Hardcoded TRUE diagnostic of refetching next epoch duties on reorg events, as it would be TRUE in all cases be it previous root reorg or current root reorg


This is a PR to continue contributing to ``duty-fetching-rework-proposer`` #2756 , above are the initial changes highlighted. 