### PR TITLE
Remove duplication in Runner delegation code

### DIFF
--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -125,14 +125,14 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 
 	// reconstruct selection proof sig
 	span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	fullSig, err := r.State.ReconstructBeaconSig(r.State.PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 
-	duty := r.state().CurrentDuty.(*spectypes.ValidatorDuty)
+	duty := r.State.CurrentDuty.(*spectypes.ValidatorDuty)
 	span.SetAttributes(
 		observability.CommitteeIndexAttribute(duty.CommitteeIndex),
 		observability.ValidatorIndexAttribute(duty.ValidatorIndex),
@@ -142,7 +142,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	// to perform this aggregation duty or not
 	ok := r.IsAggregator(r.NetworkConfig.TargetAggregatorsPerCommittee, duty.CommitteeLength, fullSig)
 	if !ok {
-		r.state().Finished = true
+		r.State.Finished = true
 		r.measurements.EndDutyFlow()
 		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregator, 0)
 		return nil
@@ -295,17 +295,17 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	root := roots[0]
 
 	span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-	sig, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	sig, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], sig)
 
 	cd := &spectypes.ValidatorConsensusData{}
-	err = cd.Decode(r.state().DecidedValue)
+	err = cd.Decode(r.State.DecidedValue)
 	if err != nil {
 		return fmt.Errorf("could not decode consensus data: %w", err)
 	}
@@ -330,19 +330,19 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 		logger.Error(errMsg, fields.Took(time.Since(start)), zap.Error(err))
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
-	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleAggregator)
+	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()), spectypes.BNRoleAggregator)
 	const submittedSignedAggregateProofEvent = "✅ successfully submitted signed aggregate and proof"
 	span.AddEvent(submittedSignedAggregateProofEvent)
 	logger.Debug(submittedSignedAggregateProofEvent, fields.Took(time.Since(start)))
 
-	r.state().Finished = true
+	r.State.Finished = true
 	r.measurements.EndDutyFlow()
-	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregator, r.state().RunningInstance.State.Round)
+	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregator, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent,
 		fields.PreConsensusTime(r.measurements.PreConsensusTime()),
 		fields.ConsensusTime(r.measurements.ConsensusTime()),
-		fields.ConsensusRounds(uint64(r.state().RunningInstance.State.Round)),
+		fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
 		fields.PostConsensusTime(r.measurements.PostConsensusTime()),
 		fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
 		fields.TotalDutyTime(r.measurements.TotalDutyTime()),
@@ -352,18 +352,14 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	return nil
 }
 
-func (r *AggregatorRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
-}
-
 func (r *AggregatorRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	return []ssz.HashRoot{spectypes.SSZUint64(r.state().CurrentDuty.DutySlot())}, spectypes.DomainSelectionProof, nil
+	return []ssz.HashRoot{spectypes.SSZUint64(r.State.CurrentDuty.DutySlot())}, spectypes.DomainSelectionProof, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *AggregatorRunner) expectedPostConsensusRootsAndDomain(context.Context) ([]ssz.HashRoot, phase0.DomainType, error) {
 	cd := &spectypes.ValidatorConsensusData{}
-	err := cd.Decode(r.state().DecidedValue)
+	err := cd.Decode(r.State.DecidedValue)
 	if err != nil {
 		return nil, spectypes.DomainError, errors.Wrap(err, "could not create consensus data")
 	}
@@ -454,10 +450,6 @@ func (r *AggregatorRunner) GetShare() *spectypes.Share {
 		return share
 	}
 	return nil
-}
-
-func (r *AggregatorRunner) state() *State {
-	return r.State
 }
 
 func (r *AggregatorRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -213,6 +213,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		r.State.CurrentDuty.(*spectypes.ValidatorDuty),
 		aggregateAndProofHashRoot,
 		decidedValue.Duty.Slot,
@@ -388,6 +389,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		duty.(*spectypes.ValidatorDuty),
 		spectypes.SSZUint64(duty.DutySlot()),
 		duty.DutySlot(),
@@ -462,15 +464,15 @@ func (r *AggregatorRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
 func (r *AggregatorRunner) MarshalJSON() ([]byte, error) {
 	type aggregatorRunnerJSON struct {
 		BaseRunner *BaseRunner `json:"BaseRunner"`
-		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// ValCheck is intentionally kept in the JSON to preserve the historical runner state shape
 		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
-		// is ignored on decode.
+		// is ignored on decode, so it is always marshaled as `null` for determinism.
 		ValCheck any `json:"ValCheck"`
 	}
 
 	return json.Marshal(&aggregatorRunnerJSON{
 		BaseRunner: r.BaseRunner,
-		ValCheck:   r.ValCheck,
+		ValCheck:   nil,
 	})
 }
 
@@ -483,6 +485,10 @@ func (r *AggregatorRunner) UnmarshalJSON(data []byte) error {
 	aux := &aggregatorRunnerJSON{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
 	}
 
 	r.BaseRunner = aux.BaseRunner

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -32,7 +32,7 @@ import (
 )
 
 type AggregatorRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	beacon         beacon.BeaconNode
 	network        specqbft.Network
@@ -96,19 +96,14 @@ func NewAggregatorRunner(
 }
 
 func (r *AggregatorRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty, quorum uint64) error {
-	return r.BaseRunner.baseStartNewDuty(ctx, logger, r, duty, quorum)
-}
-
-// HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)
-func (r *AggregatorRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.baseStartNewDuty(ctx, logger, r, duty, quorum)
 }
 
 func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -133,7 +128,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 
@@ -145,7 +140,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 
 	// this is the earliest in aggregator runner flow where we get to know whether we are meant
 	// to perform this aggregation duty or not
-	ok := r.IsAggregator(r.BaseRunner.NetworkConfig.TargetAggregatorsPerCommittee, duty.CommitteeLength, fullSig)
+	ok := r.IsAggregator(r.NetworkConfig.TargetAggregatorsPerCommittee, duty.CommitteeLength, fullSig)
 	if !ok {
 		r.state().Finished = true
 		r.measurements.EndDutyFlow()
@@ -177,7 +172,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	}
 
 	r.measurements.StartConsensus()
-	if err := r.BaseRunner.decide(ctx, logger, duty.Slot, input, r.ValCheck); err != nil {
+	if err := r.decide(ctx, logger, duty.Slot, input, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)
 	}
 
@@ -189,7 +184,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	span := trace.SpanFromContext(ctx)
 
 	span.AddEvent("processing QBFT consensus msg")
-	decided, encDecidedValue, err := r.BaseRunner.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
+	decided, encDecidedValue, err := r.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
 	if err != nil {
 		return fmt.Errorf("failed processing consensus message: %w", err)
 	}
@@ -218,7 +213,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	msg, err := signBeaconObject(
 		ctx,
 		r,
-		r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty),
+		r.State.CurrentDuty.(*spectypes.ValidatorDuty),
 		aggregateAndProofHashRoot,
 		decidedValue.Duty.Slot,
 		spectypes.DomainAggregateAndProof,
@@ -233,7 +228,7 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 
 	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
@@ -274,7 +269,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -303,7 +298,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	sig, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -335,7 +330,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 		logger.Error(errMsg, fields.Took(time.Since(start)), zap.Error(err))
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
-	recordSuccessfulSubmission(ctx, 1, r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleAggregator)
+	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleAggregator)
 	const submittedSignedAggregateProofEvent = "✅ successfully submitted signed aggregate and proof"
 	span.AddEvent(submittedSignedAggregateProofEvent)
 	logger.Debug(submittedSignedAggregateProofEvent, fields.Took(time.Since(start)))
@@ -412,7 +407,7 @@ func (r *AggregatorRunner) executeDuty(ctx context.Context, logger *zap.Logger, 
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode selection proof partial signature message: %w", err)
@@ -449,24 +444,20 @@ func (r *AggregatorRunner) GetNetwork() specqbft.Network {
 	return r.network
 }
 
-func (r *AggregatorRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
-}
-
 func (r *AggregatorRunner) GetBeaconNode() beacon.BeaconNode {
 	return r.beacon
 }
 
 func (r *AggregatorRunner) GetShare() *spectypes.Share {
 	// TODO better solution for this
-	for _, share := range r.BaseRunner.Share {
+	for _, share := range r.Share {
 		return share
 	}
 	return nil
 }
 
 func (r *AggregatorRunner) state() *State {
-	return r.BaseRunner.State
+	return r.State
 }
 
 func (r *AggregatorRunner) GetSigner() ekm.BeaconSigner {
@@ -476,36 +467,36 @@ func (r *AggregatorRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
 	return r.operatorSigner
 }
 
-func (r *AggregatorRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
+func (r *AggregatorRunner) MarshalJSON() ([]byte, error) {
+	type aggregatorRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
+		// is ignored on decode.
+		ValCheck any `json:"ValCheck"`
+	}
+
+	return json.Marshal(&aggregatorRunnerJSON{
+		BaseRunner: r.BaseRunner,
+		ValCheck:   r.ValCheck,
+	})
 }
 
-func (r *AggregatorRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
+func (r *AggregatorRunner) UnmarshalJSON(data []byte) error {
+	type aggregatorRunnerJSON struct {
+		BaseRunner *BaseRunner     `json:"BaseRunner"`
+		ValCheck   json.RawMessage `json:"ValCheck"`
+	}
 
-func (r *AggregatorRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
+	aux := &aggregatorRunnerJSON{}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
 
-func (r *AggregatorRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *AggregatorRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *AggregatorRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *AggregatorRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *AggregatorRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
+	r.BaseRunner = aux.BaseRunner
+	// ValCheck is not restored from JSON. Callers must rehydrate it explicitly.
+	r.ValCheck = nil
+	return nil
 }
 
 // Encode returns the encoded struct in bytes or error
@@ -515,7 +506,7 @@ func (r *AggregatorRunner) Encode() ([]byte, error) {
 
 // Decode returns error if decoding failed
 func (r *AggregatorRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 // GetRoot returns the root used for signing and verification

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -209,10 +209,6 @@ func (r *CommitteeRunner) GetBeaconSigner() ekm.BeaconSigner {
 	return r.signer
 }
 
-func (r *CommitteeRunner) state() *State {
-	return r.State
-}
-
 func (r *CommitteeRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	return errors.New("no pre consensus phase for committee runner")
 }
@@ -789,7 +785,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		const dutyFinishedEvent = "✔️finished duty processing (100% success)"
 		logger.Info(dutyFinishedEvent,
 			fields.ConsensusTime(r.measurements.ConsensusTime()),
-			fields.ConsensusRounds(uint64(r.state().RunningInstance.State.Round)),
+			fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
 			fields.PostConsensusTime(r.measurements.PostConsensusTime()),
 			fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
 			fields.TotalDutyTime(r.measurements.TotalDutyTime()),
@@ -801,7 +797,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	const dutyFinishedEvent = "✔️finished duty processing (partial success)"
 	logger.Info(dutyFinishedEvent,
 		fields.ConsensusTime(r.measurements.ConsensusTime()),
-		fields.ConsensusRounds(uint64(r.state().RunningInstance.State.Round)),
+		fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
 		fields.PostConsensusTime(r.measurements.PostConsensusTime()),
 		fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
 		fields.TotalDutyTime(r.measurements.TotalDutyTime()),
@@ -809,10 +805,6 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	span.AddEvent(dutyFinishedEvent)
 
 	return nil
-}
-
-func (r *CommitteeRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
 }
 
 // HasSubmittedAllValidatorDuties -- Returns true if the runner has done submissions for all validators for the given slot

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -187,6 +187,10 @@ func (r *CommitteeRunner) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
+	}
+
 	// Assign fields
 	r.BaseRunner = aux.BaseRunner
 	r.beacon = aux.beacon
@@ -328,6 +332,7 @@ func (r *CommitteeRunner) ProcessConsensus(ctx context.Context, logger *zap.Logg
 					partialSigMsg, err := signBeaconObject(
 						ctx,
 						r,
+						r.NetworkConfig,
 						validatorDuty,
 						spectypes.SSZBytes(beaconVote.BlockRoot[:]),
 						validatorDuty.DutySlot(),
@@ -453,6 +458,7 @@ func (r *CommitteeRunner) signAttesterDuty(
 	partialMsg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		validatorDuty,
 		attestationData,
 		validatorDuty.DutySlot(),

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -42,7 +42,7 @@ type CommitteeDutyGuard interface {
 }
 
 type CommitteeRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	// attestingValidators is a list of validator this committee-runner will be processing attestation duties for.
 	attestingValidators []phase0.BLSPubKey
@@ -76,6 +76,7 @@ func NewCommitteeRunner(
 	if len(share) == 0 {
 		return nil, errors.New("no shares")
 	}
+
 	return &CommitteeRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType: spectypes.RoleCommittee,
@@ -117,7 +118,7 @@ func (r *CommitteeRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, 
 			)
 		}
 	}
-	err := r.BaseRunner.baseStartNewDuty(ctx, logger, r, duty, quorum)
+	err := r.baseStartNewDuty(ctx, logger, r, duty, quorum)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,7 @@ func (r *CommitteeRunner) Encode() ([]byte, error) {
 }
 
 func (r *CommitteeRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 func (r *CommitteeRunner) GetRoot() ([32]byte, error) {
@@ -196,38 +197,6 @@ func (r *CommitteeRunner) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *CommitteeRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
-}
-
-func (r *CommitteeRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
-
-func (r *CommitteeRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
-
-func (r *CommitteeRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *CommitteeRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *CommitteeRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *CommitteeRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *CommitteeRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
-}
-
 func (r *CommitteeRunner) GetBeaconNode() beacon.BeaconNode {
 	return r.beacon
 }
@@ -236,20 +205,12 @@ func (r *CommitteeRunner) GetNetwork() specqbft.Network {
 	return r.network
 }
 
-func (r *CommitteeRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
-}
-
 func (r *CommitteeRunner) GetBeaconSigner() ekm.BeaconSigner {
 	return r.signer
 }
 
 func (r *CommitteeRunner) state() *State {
-	return r.BaseRunner.State
-}
-
-func (r *CommitteeRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.State
 }
 
 func (r *CommitteeRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
@@ -261,7 +222,7 @@ func (r *CommitteeRunner) ProcessConsensus(ctx context.Context, logger *zap.Logg
 	span := trace.SpanFromContext(ctx)
 
 	span.AddEvent("processing QBFT consensus msg")
-	decided, decidedValue, err := r.BaseRunner.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, msg, &spectypes.BeaconVote{})
+	decided, decidedValue, err := r.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, msg, &spectypes.BeaconVote{})
 	if err != nil {
 		return fmt.Errorf("failed processing consensus message: %w", err)
 	}
@@ -274,15 +235,15 @@ func (r *CommitteeRunner) ProcessConsensus(ctx context.Context, logger *zap.Logg
 	r.measurements.EndConsensus()
 	recordConsensusDuration(ctx, r.measurements.ConsensusTime(), spectypes.RoleCommittee)
 
-	duty := r.BaseRunner.State.CurrentDuty
+	duty := r.State.CurrentDuty
 	postConsensusMsg := &spectypes.PartialSignatureMessages{
 		Type:     spectypes.PostConsensusPartialSig,
 		Slot:     duty.DutySlot(),
 		Messages: []*spectypes.PartialSignatureMessage{},
 	}
 
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(duty.DutySlot())
-	version, _ := r.BaseRunner.NetworkConfig.ForkAtEpoch(epoch)
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(duty.DutySlot())
+	version, _ := r.NetworkConfig.ForkAtEpoch(epoch)
 
 	committeeDuty, ok := duty.(*spectypes.CommitteeDuty)
 	if !ok {
@@ -437,9 +398,9 @@ listener:
 	ssvMsg := &spectypes.SSVMessage{
 		MsgType: spectypes.SSVPartialSignatureMsgType,
 		MsgID: spectypes.NewMsgID(
-			r.BaseRunner.NetworkConfig.DomainType,
-			r.BaseRunner.QBFTController.CommitteeMember.CommitteeID[:],
-			r.BaseRunner.RunnerRoleType,
+			r.NetworkConfig.DomainType,
+			r.QBFTController.CommitteeMember.CommitteeID[:],
+			r.RunnerRoleType,
 		),
 	}
 	ssvMsg.Data, err = postConsensusMsg.Encode()
@@ -455,7 +416,7 @@ listener:
 
 	msgToBroadcast := &spectypes.SignedSSVMessage{
 		Signatures:  [][]byte{sig},
-		OperatorIDs: []spectypes.OperatorID{r.BaseRunner.QBFTController.CommitteeMember.OperatorID},
+		OperatorIDs: []spectypes.OperatorID{r.QBFTController.CommitteeMember.OperatorID},
 		SSVMessage:  ssvMsg,
 	}
 
@@ -529,7 +490,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	span := trace.SpanFromContext(ctx)
 
 	span.AddEvent("base post consensus message processing")
-	hasQuorum, roots, err := r.BaseRunner.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) {
 		err = NewRetryableError(err)
 	}
@@ -598,7 +559,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			// call above are optimistic - some of these quorums might have been invalidated now, hence, to avoid an
 			// unnecessary unsuccessful BLS signature reconstruction attempt we need to check if root+validator pair
 			// still has quorum.
-			gotQuorum, quorumSigners := r.BaseRunner.State.PostConsensusContainer.HasQuorum(validator, root)
+			gotQuorum, quorumSigners := r.State.PostConsensusContainer.HasQuorum(validator, root)
 			if !gotQuorum {
 				continue
 			}
@@ -611,7 +572,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			go func(validatorIndex phase0.ValidatorIndex, root [32]byte) {
 				defer wg.Done()
 
-				share := r.BaseRunner.Share[validatorIndex]
+				share := r.Share[validatorIndex]
 				pubKey := share.ValidatorPubKey
 
 				vLogger := logger.With(
@@ -621,7 +582,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					zap.Uint64s("quorum_signers", quorumSigners),
 				)
 
-				sig, err := r.BaseRunner.State.ReconstructBeaconSig(r.BaseRunner.State.PostConsensusContainer, root, pubKey[:], validatorIndex)
+				sig, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, pubKey[:], validatorIndex)
 				if err != nil {
 					// If the reconstructed signature verification failed, fall back to verifying each individual
 					// partial signature + discarding the invalid ones. This should not happen often in practice,
@@ -638,7 +599,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					//    this is why we are parallelizing by validators only (and not by root+validator), processing
 					//    each root sequentially
 					for _, root := range roots[i:] {
-						r.BaseRunner.FallBackAndVerifyEachSignature(r.BaseRunner.State.PostConsensusContainer, root, share.Committee, validatorIndex)
+						r.FallBackAndVerifyEachSignature(r.State.PostConsensusContainer, root, share.Committee, validatorIndex)
 					}
 					const eventMsg = "got post-consensus quorum but it has invalid signatures"
 					span.AddEvent(eventMsg)
@@ -739,7 +700,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			return fmt.Errorf("%s: %w", errMsg, err)
 		}
 
-		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot()), spectypes.BNRoleAttester)
+		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()), spectypes.BNRoleAttester)
 		attData, err := attestations[0].Data()
 		if err != nil {
 			return fmt.Errorf("could not get attestation data: %w", err)
@@ -747,7 +708,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		const eventMsg = "✅ successfully submitted attestations"
 		span.AddEvent(eventMsg, trace.WithAttributes(
 			observability.BeaconBlockRootAttribute(attData.BeaconBlockRoot),
-			observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+			observability.DutyRoundAttribute(r.State.RunningInstance.State.Round),
 			observability.ValidatorCountAttribute(len(attestations)),
 		))
 		aLogger.Info(eventMsg,
@@ -791,15 +752,15 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordSuccessfulSubmission(
 				ctx,
 				int64(syncMsgsCount),
-				r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot()),
+				r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()),
 				spectypes.BNRoleSyncCommittee,
 			)
 		}
 
 		const eventMsg = "✅ successfully submitted sync committee"
 		span.AddEvent(eventMsg, trace.WithAttributes(
-			observability.BeaconSlotAttribute(r.BaseRunner.State.CurrentDuty.DutySlot()),
-			observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+			observability.BeaconSlotAttribute(r.State.CurrentDuty.DutySlot()),
+			observability.DutyRoundAttribute(r.State.RunningInstance.State.Round),
 			observability.BeaconBlockRootAttribute(syncCommitteeMessages[0].BeaconBlockRoot),
 			observability.ValidatorCountAttribute(len(syncCommitteeMessages)),
 			attribute.Float64("ssv.validator.duty.submission_time", time.Since(submissionStart).Seconds()),
@@ -822,9 +783,9 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	}
 
 	if r.HasSubmittedAllValidatorDuties(attestationMap, committeeMap) {
-		r.BaseRunner.State.Finished = true
+		r.State.Finished = true
 		r.measurements.EndDutyFlow()
-		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleCommittee, r.BaseRunner.State.RunningInstance.State.Round)
+		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleCommittee, r.State.RunningInstance.State.Round)
 		const dutyFinishedEvent = "✔️finished duty processing (100% success)"
 		logger.Info(dutyFinishedEvent,
 			fields.ConsensusTime(r.measurements.ConsensusTime()),
@@ -939,16 +900,16 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context
 	attestationMap = make(map[phase0.ValidatorIndex][32]byte)
 	syncCommitteeMap = make(map[phase0.ValidatorIndex][32]byte)
 	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]any)
-	duty := r.BaseRunner.State.CurrentDuty
-	beaconVoteData := r.BaseRunner.State.DecidedValue
+	duty := r.State.CurrentDuty
+	beaconVoteData := r.State.DecidedValue
 	beaconVote := &spectypes.BeaconVote{}
 	if err := beaconVote.Decode(beaconVoteData); err != nil {
 		return nil, nil, nil, fmt.Errorf("could not decode beacon vote: %w", err)
 	}
 
 	slot := duty.DutySlot()
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(slot)
-	dataVersion, _ := r.BaseRunner.NetworkConfig.ForkAtEpoch(epoch)
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(slot)
+	dataVersion, _ := r.NetworkConfig.ForkAtEpoch(epoch)
 
 	for _, validatorDuty := range duty.(*spectypes.CommitteeDuty).ValidatorDuties {
 		if validatorDuty == nil {
@@ -960,7 +921,7 @@ func (r *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(ctx context
 		}
 		logger := logger.With(fields.Validator(validatorDuty.PubKey[:]))
 		slot := validatorDuty.DutySlot()
-		epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(slot)
+		epoch := r.NetworkConfig.EstimatedEpochAtSlot(slot)
 		switch validatorDuty.Type {
 		case spectypes.BNRoleAttester:
 			// Attestation object
@@ -1060,7 +1021,7 @@ func (r *CommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, d
 		r.attestingValidators,
 		vote,
 	)
-	if err := r.BaseRunner.decide(ctx, logger, duty.DutySlot(), vote, r.ValCheck); err != nil {
+	if err := r.decide(ctx, logger, duty.DutySlot(), vote, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)
 	}
 

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -259,7 +259,7 @@ func TestCommitteeRunnerExecuteDuty_FetchesAttestationDataAndStartsConsensus(t *
 	env := newCommitteeRunnerEnv(t, []int{1}, &committeeDutyGuardStub{}, &doppelgangerStub{})
 	duty := spectestingutils.TestingAttesterDuty(spec.DataVersionElectra)
 
-	env.runner.BaseRunner.baseSetupForNewDuty(duty, env.sampleKey.Threshold)
+	env.runner.baseSetupForNewDuty(duty, env.sampleKey.Threshold)
 
 	require.NoError(t, env.runner.executeDuty(context.Background(), env.logger, duty))
 	require.NotNil(t, env.runner.ValCheck)

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -252,7 +252,7 @@ func TestCommitteeRunnerStartNewDuty_StartsGuardAndResetsSubmissions(t *testing.
 	}, gotRoles)
 	require.False(t, env.runner.HasSubmitted(spectypes.BNRoleAttester, 1))
 	require.False(t, env.runner.HasSubmitted(spectypes.BNRoleSyncCommittee, 2))
-	require.NotNil(t, env.runner.state().RunningInstance)
+	require.NotNil(t, env.runner.State.RunningInstance)
 }
 
 func TestCommitteeRunnerExecuteDuty_FetchesAttestationDataAndStartsConsensus(t *testing.T) {
@@ -263,8 +263,8 @@ func TestCommitteeRunnerExecuteDuty_FetchesAttestationDataAndStartsConsensus(t *
 
 	require.NoError(t, env.runner.executeDuty(context.Background(), env.logger, duty))
 	require.NotNil(t, env.runner.ValCheck)
-	require.NotNil(t, env.runner.state().RunningInstance)
-	require.Equal(t, specqbft.Height(duty.Slot), env.runner.state().RunningInstance.GetHeight())
+	require.NotNil(t, env.runner.State.RunningInstance)
+	require.Equal(t, specqbft.Height(duty.Slot), env.runner.State.RunningInstance.GetHeight())
 
 	expectedVote := &spectypes.BeaconVote{
 		BlockRoot: spectestingutils.TestBeaconVote.BlockRoot,
@@ -360,7 +360,7 @@ func TestCommitteeRunnerProcessPostConsensus_SubmitsElectraObjectsAndDeduplicate
 		}
 	}
 
-	require.True(t, env.runner.state().Finished)
+	require.True(t, env.runner.State.Finished)
 	require.Len(t, env.beacon.GetBroadcastedRoots(), 2)
 
 	attesterDuty := duty.ValidatorDuties[0]

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -261,6 +261,7 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		duty,
 		blkRootToSign,
 		cd.Duty.Slot,
@@ -463,6 +464,7 @@ func (r *ProposerRunner) executeDuty(ctx context.Context, logger *zap.Logger, du
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		proposerDuty,
 		spectypes.SSZUint64(epoch),
 		duty.DutySlot(),
@@ -549,15 +551,15 @@ func (r *ProposerRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
 func (r *ProposerRunner) MarshalJSON() ([]byte, error) {
 	type proposerRunnerJSON struct {
 		BaseRunner *BaseRunner `json:"BaseRunner"`
-		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// ValCheck is intentionally kept in the JSON to preserve the historical runner state shape
 		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
-		// is ignored on decode.
+		// is ignored on decode, so it is always marshaled as `null` for determinism.
 		ValCheck any `json:"ValCheck"`
 	}
 
 	return json.Marshal(&proposerRunnerJSON{
 		BaseRunner: r.BaseRunner,
-		ValCheck:   r.ValCheck,
+		ValCheck:   nil,
 	})
 }
 
@@ -570,6 +572,10 @@ func (r *ProposerRunner) UnmarshalJSON(data []byte) error {
 	aux := &proposerRunnerJSON{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
 	}
 
 	r.BaseRunner = aux.BaseRunner

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -33,7 +33,7 @@ import (
 )
 
 type ProposerRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	beacon              beacon.BeaconNode
 	network             specqbft.Network
@@ -103,19 +103,14 @@ func NewProposerRunner(
 }
 
 func (r *ProposerRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty, quorum uint64) error {
-	return r.BaseRunner.baseStartNewDuty(ctx, logger, r, duty, quorum)
-}
-
-// HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)
-func (r *ProposerRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.baseStartNewDuty(ctx, logger, r, duty, quorum)
 }
 
 func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -138,7 +133,7 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 
@@ -214,7 +209,7 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	}
 
 	r.measurements.StartConsensus()
-	if err := r.BaseRunner.decide(ctx, logger, duty.Slot, input, r.ValCheck); err != nil {
+	if err := r.decide(ctx, logger, duty.Slot, input, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)
 	}
 
@@ -226,7 +221,7 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 	span := trace.SpanFromContext(ctx)
 
 	span.AddEvent("processing QBFT consensus msg")
-	decided, decidedValue, err := r.BaseRunner.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
+	decided, decidedValue, err := r.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
 	if err != nil {
 		return fmt.Errorf("failed processing consensus message: %w", err)
 	}
@@ -256,7 +251,7 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 		span.AddEvent("decided has a vanilla block")
 	}
 
-	duty := r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty)
+	duty := r.State.CurrentDuty.(*spectypes.ValidatorDuty)
 	if !r.doppelgangerHandler.CanSign(duty.ValidatorIndex) {
 		logger.Warn("Signing not permitted due to Doppelganger protection", fields.ValidatorIndex(duty.ValidatorIndex))
 		return nil
@@ -281,7 +276,7 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode post consensus partial signature message: %w", err)
@@ -325,7 +320,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -347,7 +342,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	sig, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -398,11 +393,11 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 		recordFailedSubmission(ctx, spectypes.BNRoleProposer)
 		return fmt.Errorf("submit beacon block: %w", err)
 	}
-	recordSuccessfulSubmission(ctx, 1, r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleProposer)
+	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleProposer)
 	const submittedBlockProposalEvent = "✅ successfully submitted block proposal"
 	submittedAttrs := append([]attribute.KeyValue{
-		observability.BeaconSlotAttribute(r.BaseRunner.State.CurrentDuty.DutySlot()),
-		observability.DutyRoundAttribute(r.BaseRunner.State.RunningInstance.State.Round),
+		observability.BeaconSlotAttribute(r.State.CurrentDuty.DutySlot()),
+		observability.DutyRoundAttribute(r.State.RunningInstance.State.Round),
 	}, proposalTraceAttrs...)
 	span.AddEvent(submittedBlockProposalEvent, trace.WithAttributes(submittedAttrs...))
 	logger.Info(submittedBlockProposalEvent, fields.Took(time.Since(start)))
@@ -425,7 +420,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 }
 
 func (r *ProposerRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
 	return []ssz.HashRoot{spectypes.SSZUint64(epoch)}, spectypes.DomainRandao, nil
 }
 
@@ -468,7 +463,7 @@ func (r *ProposerRunner) executeDuty(ctx context.Context, logger *zap.Logger, du
 
 	// sign partial randao
 	span.AddEvent("signing beacon object")
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(duty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(duty.DutySlot())
 	msg, err := signBeaconObject(
 		ctx,
 		r,
@@ -487,7 +482,7 @@ func (r *ProposerRunner) executeDuty(ctx context.Context, logger *zap.Logger, du
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode randao partial signature message: %w", err)
@@ -522,12 +517,8 @@ func (r *ProposerRunner) executeDuty(ctx context.Context, logger *zap.Logger, du
 	return nil
 }
 
-func (r *ProposerRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
-}
-
 func (r *ProposerRunner) remainingProposerDelay(slot phase0.Slot, now time.Time) time.Duration {
-	slotTime := r.BaseRunner.NetworkConfig.SlotStartTime(slot)
+	slotTime := r.NetworkConfig.SlotStartTime(slot)
 	proposeTime := slotTime.Add(r.proposerDelay)
 	if wait := proposeTime.Sub(now); wait > 0 {
 		return wait
@@ -535,40 +526,8 @@ func (r *ProposerRunner) remainingProposerDelay(slot phase0.Slot, now time.Time)
 	return 0
 }
 
-func (r *ProposerRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
-
-func (r *ProposerRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
-
-func (r *ProposerRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *ProposerRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *ProposerRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *ProposerRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *ProposerRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
-}
-
 func (r *ProposerRunner) GetNetwork() specqbft.Network {
 	return r.network
-}
-
-func (r *ProposerRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
 }
 
 func (r *ProposerRunner) GetBeaconNode() beacon.BeaconNode {
@@ -577,14 +536,14 @@ func (r *ProposerRunner) GetBeaconNode() beacon.BeaconNode {
 
 func (r *ProposerRunner) GetShare() *spectypes.Share {
 	// TODO better solution for this
-	for _, share := range r.BaseRunner.Share {
+	for _, share := range r.Share {
 		return share
 	}
 	return nil
 }
 
 func (r *ProposerRunner) state() *State {
-	return r.BaseRunner.State
+	return r.State
 }
 
 func (r *ProposerRunner) GetSigner() ekm.BeaconSigner {
@@ -595,6 +554,38 @@ func (r *ProposerRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
 	return r.operatorSigner
 }
 
+func (r *ProposerRunner) MarshalJSON() ([]byte, error) {
+	type proposerRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
+		// is ignored on decode.
+		ValCheck any `json:"ValCheck"`
+	}
+
+	return json.Marshal(&proposerRunnerJSON{
+		BaseRunner: r.BaseRunner,
+		ValCheck:   r.ValCheck,
+	})
+}
+
+func (r *ProposerRunner) UnmarshalJSON(data []byte) error {
+	type proposerRunnerJSON struct {
+		BaseRunner *BaseRunner     `json:"BaseRunner"`
+		ValCheck   json.RawMessage `json:"ValCheck"`
+	}
+
+	aux := &proposerRunnerJSON{}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	r.BaseRunner = aux.BaseRunner
+	// ValCheck is not restored from JSON. Callers must rehydrate it explicitly.
+	r.ValCheck = nil
+	return nil
+}
+
 // Encode returns the encoded struct in bytes or error
 func (r *ProposerRunner) Encode() ([]byte, error) {
 	return json.Marshal(r)
@@ -602,7 +593,7 @@ func (r *ProposerRunner) Encode() ([]byte, error) {
 
 // Decode returns error if decoding failed
 func (r *ProposerRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 // GetRoot returns the root used for signing and verification

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -130,14 +130,14 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	// only 1 root, verified in expectedPreConsensusRootsAndDomain
 	root := roots[0]
 
-	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	fullSig, err := r.State.ReconstructBeaconSig(r.State.PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 
-	duty := r.state().CurrentDuty.(*spectypes.ValidatorDuty)
+	duty := r.State.CurrentDuty.(*spectypes.ValidatorDuty)
 
 	// Sleep the remaining proposerDelay since slot start, ensuring on-time proposals even if duty began late.
 	if timeLeft := r.remainingProposerDelay(duty.Slot, time.Now()); timeLeft > 0 {
@@ -152,7 +152,7 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	logger.Debug(waitedOutProposerDelayEvent)
 	span.AddEvent(waitedOutProposerDelayEvent)
 
-	duty = r.state().CurrentDuty.(*spectypes.ValidatorDuty)
+	duty = r.State.CurrentDuty.(*spectypes.ValidatorDuty)
 
 	// Fetch the block our operator will propose if it is a Leader (note, even if our operator
 	// isn't leading the 1st QBFT round it might become a Leader in case of round change - hence
@@ -312,10 +312,6 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 	return nil
 }
 
-func (r *ProposerRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
-}
-
 func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
@@ -339,10 +335,10 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	// only 1 root, verified by expectedPostConsensusRootsAndDomain
 	root := roots[0]
 
-	sig, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	sig, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -362,7 +358,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	// TODO: should we send the block at all if we're not the leader? It's probably not effective but
 	//		I left it for now to keep backwards compatibility.
 	validatorConsensusData := &spectypes.ValidatorConsensusData{}
-	err = validatorConsensusData.Decode(r.state().DecidedValue)
+	err = validatorConsensusData.Decode(r.State.DecidedValue)
 	if err != nil {
 		return fmt.Errorf("could not decode decided validator consensus data: %w", err)
 	}
@@ -370,7 +366,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	if err != nil {
 		return fmt.Errorf("could not get block data from consensus data: %w", err)
 	}
-	leaderID := r.state().RunningInstance.Proposer()
+	leaderID := r.State.RunningInstance.Proposer()
 	if r.cachedFullBlock != nil && leaderID == r.operatorSigner.GetOperatorID() {
 		if bytes.Equal(validatorConsensusData.DataSSZ, r.cachedBlindedBlockSSZ) {
 			logger.Debug("leader will use the original full block for proposal submission")
@@ -393,7 +389,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 		recordFailedSubmission(ctx, spectypes.BNRoleProposer)
 		return fmt.Errorf("submit beacon block: %w", err)
 	}
-	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleProposer)
+	recordSuccessfulSubmission(ctx, 1, r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()), spectypes.BNRoleProposer)
 	const submittedBlockProposalEvent = "✅ successfully submitted block proposal"
 	submittedAttrs := append([]attribute.KeyValue{
 		observability.BeaconSlotAttribute(r.State.CurrentDuty.DutySlot()),
@@ -402,14 +398,14 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	span.AddEvent(submittedBlockProposalEvent, trace.WithAttributes(submittedAttrs...))
 	logger.Info(submittedBlockProposalEvent, fields.Took(time.Since(start)))
 
-	r.state().Finished = true
+	r.State.Finished = true
 	r.measurements.EndDutyFlow()
-	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleProposer, r.state().RunningInstance.State.Round)
+	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleProposer, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent,
 		fields.PreConsensusTime(r.measurements.PreConsensusTime()),
 		fields.ConsensusTime(r.measurements.ConsensusTime()),
-		fields.ConsensusRounds(uint64(r.state().RunningInstance.State.Round)),
+		fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
 		fields.PostConsensusTime(r.measurements.PostConsensusTime()),
 		fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
 		fields.TotalDutyTime(r.measurements.TotalDutyTime()),
@@ -420,14 +416,14 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 }
 
 func (r *ProposerRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot())
 	return []ssz.HashRoot{spectypes.SSZUint64(epoch)}, spectypes.DomainRandao, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *ProposerRunner) expectedPostConsensusRootsAndDomain(context.Context) ([]ssz.HashRoot, phase0.DomainType, error) {
 	validatorConsensusData := &spectypes.ValidatorConsensusData{}
-	err := validatorConsensusData.Decode(r.state().DecidedValue)
+	err := validatorConsensusData.Decode(r.State.DecidedValue)
 	if err != nil {
 		return nil, phase0.DomainType{}, errors.Wrap(err, "could not decode consensus data")
 	}
@@ -540,10 +536,6 @@ func (r *ProposerRunner) GetShare() *spectypes.Share {
 		return share
 	}
 	return nil
-}
-
-func (r *ProposerRunner) state() *State {
-	return r.State
 }
 
 func (r *ProposerRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/proposer_test.go
+++ b/protocol/v2/ssv/runner/proposer_test.go
@@ -108,8 +108,8 @@ func TestProposerRunnerProcessPreConsensusCachesFullBlockAndFetchesWithReconstru
 		require.NoError(t, runner.ProcessPreConsensus(ctx, logger, msg))
 	}
 
-	expectedRandao, err := runner.state().ReconstructBeaconSig(
-		runner.state().PreConsensusContainer,
+	expectedRandao, err := runner.State.ReconstructBeaconSig(
+		runner.State.PreConsensusContainer,
 		expectedRoot,
 		runner.GetShare().ValidatorPubKey[:],
 		runner.GetShare().ValidatorIndex,
@@ -127,7 +127,7 @@ func TestProposerRunnerProcessPreConsensusCachesFullBlockAndFetchesWithReconstru
 	require.Equal(t, expectedRandao, beacon.lastGetRandao)
 	require.Same(t, fullBlock, runner.cachedFullBlock)
 	require.Equal(t, expectedBlindedSSZ, runner.cachedBlindedBlockSSZ)
-	require.NotNil(t, runner.state().RunningInstance)
+	require.NotNil(t, runner.State.RunningInstance)
 }
 
 func TestProposerRunnerProcessPreConsensusDoesNotCacheBlindedBlock(t *testing.T) {
@@ -177,7 +177,7 @@ func TestProposerRunnerProcessPreConsensusReturnsContextCanceledDuringProposerDe
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, 0, beacon.getCalls)
 	require.Nil(t, runner.cachedFullBlock)
-	require.Nil(t, runner.state().RunningInstance)
+	require.Nil(t, runner.State.RunningInstance)
 }
 
 func TestRemainingProposerDelay(t *testing.T) {
@@ -247,8 +247,8 @@ func TestProposerRunnerStartNewDutySkipsRandaoSigningWhenDoppelgangerBlocks(t *t
 	require.Equal(t, 0, countPartialSignatureBroadcastsByType(t, network, spectypes.RandaoPartialSig))
 	require.Equal(t, 0, beacon.getCalls)
 	require.Nil(t, runner.cachedFullBlock)
-	require.Nil(t, runner.state().RunningInstance)
-	require.False(t, runner.state().Finished)
+	require.Nil(t, runner.State.RunningInstance)
+	require.False(t, runner.State.Finished)
 	require.Empty(t, dg.reportQuorum)
 }
 
@@ -280,10 +280,10 @@ func TestProposerRunnerProcessConsensusSkipsPostConsensusSigningWhenDoppelganger
 		require.NoError(t, runner.ProcessConsensus(context.Background(), zap.NewNop(), msg))
 	}
 
-	require.NotNil(t, runner.state().DecidedValue)
+	require.NotNil(t, runner.State.DecidedValue)
 	require.Equal(t, 0, countPartialSignatureBroadcastsByType(t, network, spectypes.PostConsensusPartialSig))
 	require.Equal(t, 1, countPartialSignatureBroadcastsByType(t, network, spectypes.RandaoPartialSig))
-	require.False(t, runner.state().Finished)
+	require.False(t, runner.State.Finished)
 }
 
 func TestProposerRunnerProcessPostConsensusLeaderUsesCachedFullBlockWhenDecisionMatches(t *testing.T) {
@@ -307,7 +307,7 @@ func TestProposerRunnerProcessPostConsensusLeaderUsesCachedFullBlockWhenDecision
 	require.False(t, beacon.submittedBlocks[0].Blinded)
 	require.NotEqual(t, phase0.BLSSignature{}, beacon.submittedSig[0])
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.state().Finished)
+	require.True(t, runner.State.Finished)
 }
 
 func TestProposerRunnerProcessPostConsensusLeaderFallsBackToDecidedBlindedBlockOnCacheMismatch(t *testing.T) {
@@ -328,7 +328,7 @@ func TestProposerRunnerProcessPostConsensusLeaderFallsBackToDecidedBlindedBlockO
 	require.Len(t, beacon.submittedBlocks, 1)
 	require.True(t, beacon.submittedBlocks[0].Blinded)
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.state().Finished)
+	require.True(t, runner.State.Finished)
 }
 
 func TestProposerRunnerProcessPostConsensusNonLeaderKeepsDecidedBlindedBlock(t *testing.T) {
@@ -350,7 +350,7 @@ func TestProposerRunnerProcessPostConsensusNonLeaderKeepsDecidedBlindedBlock(t *
 	require.Len(t, beacon.submittedBlocks, 1)
 	require.True(t, beacon.submittedBlocks[0].Blinded)
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.state().Finished)
+	require.True(t, runner.State.Finished)
 }
 
 func newProposerRunnerForTest(
@@ -439,7 +439,7 @@ func setupRunnerForPostConsensus(
 
 	encodedDecidedValue, err := consensusData.Encode()
 	require.NoError(t, err)
-	runner.state().DecidedValue = encodedDecidedValue
+	runner.State.DecidedValue = encodedDecidedValue
 
 	msgID := spectypes.NewMsgID(runner.NetworkConfig.DomainType, runner.GetShare().ValidatorPubKey[:], runner.RunnerRoleType)
 	qbftConfig := protocoltesting.TestingConfig(zap.NewNop(), keySet)
@@ -449,7 +449,7 @@ func setupRunnerForPostConsensus(
 	qbftConfig.Network = runner.network
 	qbftConfig.BeaconSigner = runner.signer
 
-	runner.state().RunningInstance = instance.NewInstance(
+	runner.State.RunningInstance = instance.NewInstance(
 		zap.NewNop(),
 		qbftConfig,
 		spectestingutils.TestingCommitteeMember(keySet),
@@ -457,8 +457,8 @@ func setupRunnerForPostConsensus(
 		specqbft.Height(duty.Slot),
 		runner.operatorSigner,
 	)
-	runner.state().RunningInstance.State.Decided = true
-	runner.state().RunningInstance.State.DecidedValue = encodedDecidedValue
+	runner.State.RunningInstance.State.Decided = true
+	runner.State.RunningInstance.State.DecidedValue = encodedDecidedValue
 }
 
 func processPreConsensusQuorum(t *testing.T, runner *ProposerRunner, keySet *spectestingutils.TestKeySet, version spec.DataVersion) {

--- a/protocol/v2/ssv/runner/proposer_test.go
+++ b/protocol/v2/ssv/runner/proposer_test.go
@@ -268,10 +268,10 @@ func TestProposerRunnerProcessConsensusSkipsPostConsensusSigningWhenDoppelganger
 
 	consensusData := spectestingutils.TestProposerBlindedBlockConsensusDataV(version)
 	runner.measurements.StartConsensus()
-	require.NoError(t, runner.BaseRunner.decide(context.Background(), zap.NewNop(), duty.Slot, consensusData, runner.ValCheck))
+	require.NoError(t, runner.decide(context.Background(), zap.NewNop(), duty.Slot, consensusData, runner.ValCheck))
 	consensusMsgs := spectestingutils.SSVDecidingMsgsForHeight(
 		consensusData,
-		runner.BaseRunner.QBFTController.Identifier,
+		runner.QBFTController.Identifier,
 		specqbft.Height(consensusData.Duty.Slot),
 		keySet,
 	)
@@ -431,7 +431,7 @@ func setupRunnerForPostConsensus(
 	t.Helper()
 
 	duty := spectestingutils.TestingProposerDutyV(consensusData.Version)
-	runner.BaseRunner.baseSetupForNewDuty(duty, keySet.Threshold)
+	runner.baseSetupForNewDuty(duty, keySet.Threshold)
 	runner.measurements.StartDutyFlow()
 	runner.measurements.StartConsensus()
 	runner.measurements.EndConsensus()
@@ -441,7 +441,7 @@ func setupRunnerForPostConsensus(
 	require.NoError(t, err)
 	runner.state().DecidedValue = encodedDecidedValue
 
-	msgID := spectypes.NewMsgID(runner.BaseRunner.NetworkConfig.DomainType, runner.GetShare().ValidatorPubKey[:], runner.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(runner.NetworkConfig.DomainType, runner.GetShare().ValidatorPubKey[:], runner.RunnerRoleType)
 	qbftConfig := protocoltesting.TestingConfig(zap.NewNop(), keySet)
 	qbftConfig.ProposerF = func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
 		return leaderID

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -124,6 +124,10 @@ func (b *BaseRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
 	return b.Share
 }
 
+func (b *BaseRunner) HasRunningDuty() bool {
+	return b.hasRunningDuty()
+}
+
 func (b *BaseRunner) GetRole() spectypes.RunnerRole {
 	return b.RunnerRoleType
 }
@@ -149,6 +153,10 @@ func (b *BaseRunner) GetStateRoot() ([32]byte, error) {
 	return b.State.GetRoot()
 }
 
+func (b *BaseRunner) GetNetworkConfig() *networkconfig.Network {
+	return b.NetworkConfig
+}
+
 func (b *BaseRunner) SetTimeoutFunc(fn TimeoutF) {
 	b.TimeoutF = fn
 }
@@ -158,7 +166,12 @@ func (b *BaseRunner) Encode() ([]byte, error) {
 }
 
 func (b *BaseRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &b)
+	if b == nil {
+		return fmt.Errorf("nil BaseRunner")
+	}
+	// Unmarshal into the receiver, not into a copy of the pointer.
+	// Unmarshalling into `&b` would only update the local pointer variable.
+	return json.Unmarshal(data, b)
 }
 
 func (b *BaseRunner) MarshalJSON() ([]byte, error) {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -39,7 +39,6 @@ type Getters interface {
 	GetSigner() ekm.BeaconSigner
 	GetOperatorSigner() ssvtypes.OperatorSigner
 	GetNetwork() specqbft.Network
-	GetNetworkConfig() *networkconfig.Network
 }
 
 type Setters interface {
@@ -99,7 +98,7 @@ type BaseRunner struct {
 
 func (b *BaseRunner) HasRunningQBFTInstance() bool {
 	var runningInstance *instance.Instance
-	if b.hasRunningDuty() {
+	if b.HasRunningDuty() {
 		runningInstance = b.State.RunningInstance
 		if runningInstance != nil {
 			decided, _ := runningInstance.IsDecided()
@@ -111,7 +110,7 @@ func (b *BaseRunner) HasRunningQBFTInstance() bool {
 
 func (b *BaseRunner) HasAcceptedProposalForCurrentRound() bool {
 	var runningInstance *instance.Instance
-	if b.hasRunningDuty() {
+	if b.HasRunningDuty() {
 		runningInstance = b.State.RunningInstance
 		if runningInstance != nil {
 			return runningInstance.State.ProposalAcceptedForCurrentRound != nil
@@ -125,7 +124,14 @@ func (b *BaseRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
 }
 
 func (b *BaseRunner) HasRunningDuty() bool {
-	return b.hasRunningDuty()
+	b.mtx.RLock() // reads b.State
+	defer b.mtx.RUnlock()
+
+	if b.State == nil {
+		return false
+	}
+
+	return !b.State.Finished
 }
 
 func (b *BaseRunner) GetRole() spectypes.RunnerRole {
@@ -140,7 +146,7 @@ func (b *BaseRunner) GetLastHeight() specqbft.Height {
 }
 
 func (b *BaseRunner) GetLastRound() specqbft.Round {
-	if b.hasRunningDuty() {
+	if b.HasRunningDuty() {
 		inst := b.State.RunningInstance
 		if inst != nil {
 			return inst.State.Round
@@ -151,10 +157,6 @@ func (b *BaseRunner) GetLastRound() specqbft.Round {
 
 func (b *BaseRunner) GetStateRoot() ([32]byte, error) {
 	return b.State.GetRoot()
-}
-
-func (b *BaseRunner) GetNetworkConfig() *networkconfig.Network {
-	return b.NetworkConfig
 }
 
 func (b *BaseRunner) SetTimeoutFunc(fn TimeoutF) {
@@ -283,7 +285,7 @@ func (b *BaseRunner) baseConsensusMsgProcessing(ctx context.Context, logger *zap
 	span := trace.SpanFromContext(ctx)
 
 	prevDecided := false
-	if b.hasRunningDuty() && b.State != nil && b.State.RunningInstance != nil {
+	if b.HasRunningDuty() && b.State != nil && b.State.RunningInstance != nil {
 		prevDecided, _ = b.State.RunningInstance.IsDecided()
 	}
 	if prevDecided {
@@ -298,7 +300,7 @@ func (b *BaseRunner) baseConsensusMsgProcessing(ctx context.Context, logger *zap
 		return false, nil, err
 	}
 
-	if !b.hasRunningDuty() {
+	if !b.HasRunningDuty() {
 		logger.Debug("no running duty, applied consensus message but cannot progress further")
 		return false, nil, nil
 	}
@@ -478,18 +480,6 @@ func (b *BaseRunner) decide(
 	b.registerTimeoutHandler(ctx, logger, newInstance, b.QBFTController.Height)
 
 	return nil
-}
-
-// hasRunningDuty returns true if a new duty didn't start or an existing duty marked as finished
-func (b *BaseRunner) hasRunningDuty() bool {
-	b.mtx.RLock() // reads b.State
-	defer b.mtx.RUnlock()
-
-	if b.State == nil {
-		return false
-	}
-
-	return !b.State.Finished
 }
 
 func (b *BaseRunner) hasDutyAssigned() bool {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -165,6 +165,10 @@ func (b *BaseRunner) Encode() ([]byte, error) {
 	return json.Marshal(b)
 }
 
+// Decode unmarshals persisted runner state into the receiver.
+//
+// Note: decoded runners are intentionally partial; runtime dependencies (e.g. `NetworkConfig`, `TimeoutF`, and
+// runner-specific value checkers) must be rehydrated by the caller after decode.
 func (b *BaseRunner) Decode(data []byte) error {
 	if b == nil {
 		return fmt.Errorf("nil BaseRunner")

--- a/protocol/v2/ssv/runner/runner_decode_test.go
+++ b/protocol/v2/ssv/runner/runner_decode_test.go
@@ -58,14 +58,21 @@ func TestAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	beforeRoot, err := r.GetRoot()
+	require.NoError(t, err)
+
 	data, err := r.Encode()
 	require.NoError(t, err)
-	require.Contains(t, string(data), "\"ValCheck\"")
+	require.Contains(t, string(data), "\"ValCheck\":null")
 
 	var decoded AggregatorRunner
 	require.NoError(t, decoded.Decode(data))
 	decoded.NetworkConfig = cloneTestNetworkConfig()
 
+	afterRoot, err := decoded.GetRoot()
+	require.NoError(t, err)
+
+	require.Equal(t, beforeRoot, afterRoot)
 	require.Equal(t, spectypes.RoleAggregator, decoded.GetRole())
 	require.False(t, decoded.HasRunningDuty())
 	require.Len(t, decoded.GetShares(), 1)
@@ -96,14 +103,21 @@ func TestProposerRunnerDecodeIgnoresValCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	r := runnerIface.(*ProposerRunner)
+	beforeRoot, err := r.GetRoot()
+	require.NoError(t, err)
+
 	data, err := r.Encode()
 	require.NoError(t, err)
-	require.Contains(t, string(data), "\"ValCheck\"")
+	require.Contains(t, string(data), "\"ValCheck\":null")
 
 	var decoded ProposerRunner
 	require.NoError(t, decoded.Decode(data))
 	decoded.NetworkConfig = cloneTestNetworkConfig()
 
+	afterRoot, err := decoded.GetRoot()
+	require.NoError(t, err)
+
+	require.Equal(t, beforeRoot, afterRoot)
 	require.Equal(t, spectypes.RoleProposer, decoded.GetRole())
 	require.False(t, decoded.HasRunningDuty())
 	require.Len(t, decoded.GetShares(), 1)
@@ -130,14 +144,21 @@ func TestSyncCommitteeAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	r := runnerIface.(*SyncCommitteeAggregatorRunner)
+	beforeRoot, err := r.GetRoot()
+	require.NoError(t, err)
+
 	data, err := r.Encode()
 	require.NoError(t, err)
-	require.Contains(t, string(data), "\"ValCheck\"")
+	require.Contains(t, string(data), "\"ValCheck\":null")
 
 	var decoded SyncCommitteeAggregatorRunner
 	require.NoError(t, decoded.Decode(data))
 	decoded.NetworkConfig = cloneTestNetworkConfig()
 
+	afterRoot, err := decoded.GetRoot()
+	require.NoError(t, err)
+
+	require.Equal(t, beforeRoot, afterRoot)
 	require.Equal(t, spectypes.RoleSyncCommitteeContribution, decoded.GetRole())
 	require.False(t, decoded.HasRunningDuty())
 	require.Len(t, decoded.GetShares(), 1)

--- a/protocol/v2/ssv/runner/runner_decode_test.go
+++ b/protocol/v2/ssv/runner/runner_decode_test.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type dummyValueChecker struct{}
+
+func (dummyValueChecker) CheckValue([]byte) error { return nil }
+
+func TestBaseRunnerDecodePopulatesReceiver(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	br := &BaseRunner{
+		RunnerRoleType: spectypes.RoleProposer,
+		NetworkConfig:  cloneTestNetworkConfig(),
+		Share: map[phase0.ValidatorIndex]*spectypes.Share{
+			share.ValidatorIndex: share,
+		},
+	}
+
+	data, err := br.Encode()
+	require.NoError(t, err)
+
+	var decoded BaseRunner
+	require.NoError(t, decoded.Decode(data))
+
+	require.Equal(t, spectypes.RoleProposer, decoded.RunnerRoleType)
+	require.Len(t, decoded.Share, 1)
+	require.Equal(t, share.ValidatorIndex, decoded.Share[share.ValidatorIndex].ValidatorIndex)
+}
+
+func TestAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	r, err := NewAggregatorRunner(
+		cloneTestNetworkConfig(),
+		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		dummyValueChecker{},
+		0,
+	)
+	require.NoError(t, err)
+
+	data, err := r.Encode()
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\"ValCheck\"")
+
+	var decoded AggregatorRunner
+	require.NoError(t, decoded.Decode(data))
+	decoded.NetworkConfig = cloneTestNetworkConfig()
+
+	require.Equal(t, spectypes.RoleAggregator, decoded.GetRole())
+	require.False(t, decoded.HasRunningDuty())
+	require.Len(t, decoded.GetShares(), 1)
+	require.Nil(t, decoded.ValCheck)
+}
+
+func TestProposerRunnerDecodeIgnoresValCheck(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	runnerIface, err := NewProposerRunner(
+		zap.NewNop(),
+		cloneTestNetworkConfig(),
+		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		dummyValueChecker{},
+		0,
+		nil,
+		0,
+	)
+	require.NoError(t, err)
+
+	r := runnerIface.(*ProposerRunner)
+	data, err := r.Encode()
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\"ValCheck\"")
+
+	var decoded ProposerRunner
+	require.NoError(t, decoded.Decode(data))
+	decoded.NetworkConfig = cloneTestNetworkConfig()
+
+	require.Equal(t, spectypes.RoleProposer, decoded.GetRole())
+	require.False(t, decoded.HasRunningDuty())
+	require.Len(t, decoded.GetShares(), 1)
+	require.Nil(t, decoded.ValCheck)
+}
+
+func TestSyncCommitteeAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	runnerIface, err := NewSyncCommitteeAggregatorRunner(
+		cloneTestNetworkConfig(),
+		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		dummyValueChecker{},
+		0,
+	)
+	require.NoError(t, err)
+
+	r := runnerIface.(*SyncCommitteeAggregatorRunner)
+	data, err := r.Encode()
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\"ValCheck\"")
+
+	var decoded SyncCommitteeAggregatorRunner
+	require.NoError(t, decoded.Decode(data))
+	decoded.NetworkConfig = cloneTestNetworkConfig()
+
+	require.Equal(t, spectypes.RoleSyncCommitteeContribution, decoded.GetRole())
+	require.False(t, decoded.HasRunningDuty())
+	require.Len(t, decoded.GetShares(), 1)
+	require.Nil(t, decoded.ValCheck)
+}

--- a/protocol/v2/ssv/runner/runner_delegator_test.go
+++ b/protocol/v2/ssv/runner/runner_delegator_test.go
@@ -1,0 +1,105 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVoluntaryExitRunnerDecodePreservesEmbeddedBaseRunnerMethods(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	runnerIface, err := NewVoluntaryExitRunner(
+		cloneTestNetworkConfig(),
+		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	runner := runnerIface.(*VoluntaryExitRunner)
+	beforeRoot, err := runner.GetRoot()
+	require.NoError(t, err)
+
+	data, err := runner.Encode()
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\"BaseRunner\"")
+
+	var decoded VoluntaryExitRunner
+	require.NoError(t, decoded.Decode(data))
+	decoded.NetworkConfig = cloneTestNetworkConfig()
+
+	afterRoot, err := decoded.GetRoot()
+	require.NoError(t, err)
+
+	require.Equal(t, beforeRoot, afterRoot)
+	require.Equal(t, spectypes.RoleVoluntaryExit, decoded.GetRole())
+	require.False(t, decoded.HasRunningDuty())
+	require.Len(t, decoded.GetShares(), 1)
+	require.Equal(t, share.ValidatorIndex, decoded.GetShare().ValidatorIndex)
+}
+
+func TestVoluntaryExitRunnerUsesReplacedBaseRunner(t *testing.T) {
+	t.Parallel()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	runnerIface, err := NewVoluntaryExitRunner(
+		cloneTestNetworkConfig(),
+		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	runner := runnerIface.(*VoluntaryExitRunner)
+
+	replacementShare := spectestingutils.TestingShare(keySet, share.ValidatorIndex+1)
+	runner.BaseRunner = &BaseRunner{
+		RunnerRoleType: spectypes.RoleVoluntaryExit,
+		NetworkConfig:  cloneTestNetworkConfig(),
+		Share: map[phase0.ValidatorIndex]*spectypes.Share{
+			replacementShare.ValidatorIndex: replacementShare,
+		},
+	}
+
+	require.Equal(t, spectypes.RoleVoluntaryExit, runner.GetRole())
+	require.Len(t, runner.GetShares(), 1)
+	require.Equal(t, replacementShare.ValidatorIndex, runner.GetShare().ValidatorIndex)
+}
+
+func TestCommitteeRunnerDecodePreservesEmbeddedBaseRunnerMethods(t *testing.T) {
+	t.Parallel()
+
+	env := newCommitteeRunnerEnv(t, []int{spectestingutils.TestingValidatorIndex}, nil, nil)
+	env.runner.NetworkConfig = cloneTestNetworkConfig()
+	beforeRoot, err := env.runner.GetRoot()
+	require.NoError(t, err)
+
+	data, err := env.runner.Encode()
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\"BaseRunner\"")
+
+	var decoded CommitteeRunner
+	require.NoError(t, decoded.Decode(data))
+	decoded.NetworkConfig = cloneTestNetworkConfig()
+
+	afterRoot, err := decoded.GetRoot()
+	require.NoError(t, err)
+
+	require.Equal(t, beforeRoot, afterRoot)
+	require.Equal(t, spectypes.RoleCommittee, decoded.GetRole())
+	require.False(t, decoded.HasRunningDuty())
+	require.Len(t, decoded.GetShares(), 1)
+}

--- a/protocol/v2/ssv/runner/runner_signatures.go
+++ b/protocol/v2/ssv/runner/runner_signatures.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -17,12 +18,16 @@ import (
 func signBeaconObject(
 	ctx context.Context,
 	runner Runner,
+	networkConfig *networkconfig.Network,
 	duty *spectypes.ValidatorDuty,
 	obj ssz.HashRoot,
 	slot phase0.Slot,
 	signatureDomain phase0.DomainType,
 ) (*spectypes.PartialSignatureMessage, error) {
-	epoch := runner.GetNetworkConfig().EstimatedEpochAtSlot(slot)
+	if networkConfig == nil {
+		return nil, fmt.Errorf("network config is nil")
+	}
+	epoch := networkConfig.EstimatedEpochAtSlot(slot)
 	domain, err := runner.GetBeaconNode().DomainData(ctx, epoch, signatureDomain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch beacon domain: %w", err)

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -29,7 +29,7 @@ import (
 )
 
 type SyncCommitteeAggregatorRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	beacon         beacon.BeaconNode
 	network        specqbft.Network
@@ -78,19 +78,14 @@ func NewSyncCommitteeAggregatorRunner(
 }
 
 func (r *SyncCommitteeAggregatorRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty, quorum uint64) error {
-	return r.BaseRunner.baseStartNewDuty(ctx, logger, r, duty, quorum)
-}
-
-// HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)
-func (r *SyncCommitteeAggregatorRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.baseStartNewDuty(ctx, logger, r, duty, quorum)
 }
 
 func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -121,7 +116,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 		if err != nil {
 			// If the reconstructed signature verification failed, fall back to verifying each partial signature
 			for _, root := range roots {
-				r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+				r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 			}
 			return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 		}
@@ -181,7 +176,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	}
 
 	r.measurements.StartConsensus()
-	if err := r.BaseRunner.decide(ctx, logger, input.Duty.Slot, input, r.ValCheck); err != nil {
+	if err := r.decide(ctx, logger, input.Duty.Slot, input, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)
 	}
 
@@ -193,7 +188,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 	span := trace.SpanFromContext(ctx)
 
 	span.AddEvent("processing QBFT consensus msg")
-	decided, decidedValue, err := r.BaseRunner.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
+	decided, decidedValue, err := r.baseConsensusMsgProcessing(ctx, logger, r.ValCheck.CheckValue, signedMsg, &spectypes.ValidatorConsensusData{})
 	if err != nil {
 		return fmt.Errorf("failed processing consensus message: %w", err)
 	}
@@ -228,7 +223,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 		signed, err := signBeaconObject(
 			ctx,
 			r,
-			r.BaseRunner.State.CurrentDuty.(*spectypes.ValidatorDuty),
+			r.State.CurrentDuty.(*spectypes.ValidatorDuty),
 			contribAndProof,
 			cd.Duty.Slot,
 			spectypes.DomainContributionAndProof,
@@ -246,7 +241,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 		Messages: msgs,
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 
 	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
@@ -291,7 +286,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -331,7 +326,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 		if err != nil {
 			// If the reconstructed signature verification failed, fall back to verifying each partial signature
 			for _, root := range roots {
-				r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+				r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 			}
 			return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 		}
@@ -384,7 +379,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 			break
 		}
 	}
-	recordSuccessfulSubmission(ctx, successfullySubmittedContributions, r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleSyncCommitteeContribution)
+	recordSuccessfulSubmission(ctx, successfullySubmittedContributions, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleSyncCommitteeContribution)
 	const submittedSyncCommitteeEvent = "✅ successfully submitted sync committee contributions"
 	span.AddEvent(submittedSyncCommitteeEvent)
 	logger.Debug(submittedSyncCommitteeEvent,
@@ -420,7 +415,7 @@ func (r *SyncCommitteeAggregatorRunner) generateContributionAndProof(
 		SelectionProof:  proof,
 	}
 
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
 	dContribAndProof, err := r.GetBeaconNode().DomainData(ctx, epoch, spectypes.DomainContributionAndProof)
 	if err != nil {
 		return nil, phase0.Root{}, errors.Wrap(err, "could not get domain data")
@@ -515,7 +510,7 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 		r.rootToSyncCommitteeIdx[msg.SigningRoot] = phase0.ValidatorIndex(vIdx)
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode partial signature messages: %w", err)
@@ -548,44 +543,8 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 	return nil
 }
 
-func (r *SyncCommitteeAggregatorRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
-}
-
-func (r *SyncCommitteeAggregatorRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *SyncCommitteeAggregatorRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
-}
-
 func (r *SyncCommitteeAggregatorRunner) GetNetwork() specqbft.Network {
 	return r.network
-}
-
-func (r *SyncCommitteeAggregatorRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
 }
 
 func (r *SyncCommitteeAggregatorRunner) GetBeaconNode() beacon.BeaconNode {
@@ -594,14 +553,14 @@ func (r *SyncCommitteeAggregatorRunner) GetBeaconNode() beacon.BeaconNode {
 
 func (r *SyncCommitteeAggregatorRunner) GetShare() *spectypes.Share {
 	// TODO better solution for this
-	for _, share := range r.BaseRunner.Share {
+	for _, share := range r.Share {
 		return share
 	}
 	return nil
 }
 
 func (r *SyncCommitteeAggregatorRunner) state() *State {
-	return r.BaseRunner.State
+	return r.State
 }
 
 func (r *SyncCommitteeAggregatorRunner) GetSigner() ekm.BeaconSigner {
@@ -611,6 +570,38 @@ func (r *SyncCommitteeAggregatorRunner) GetOperatorSigner() ssvtypes.OperatorSig
 	return r.operatorSigner
 }
 
+func (r *SyncCommitteeAggregatorRunner) MarshalJSON() ([]byte, error) {
+	type syncCommitteeAggregatorRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
+		// is ignored on decode.
+		ValCheck any `json:"ValCheck"`
+	}
+
+	return json.Marshal(&syncCommitteeAggregatorRunnerJSON{
+		BaseRunner: r.BaseRunner,
+		ValCheck:   r.ValCheck,
+	})
+}
+
+func (r *SyncCommitteeAggregatorRunner) UnmarshalJSON(data []byte) error {
+	type syncCommitteeAggregatorRunnerJSON struct {
+		BaseRunner *BaseRunner     `json:"BaseRunner"`
+		ValCheck   json.RawMessage `json:"ValCheck"`
+	}
+
+	aux := &syncCommitteeAggregatorRunnerJSON{}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	r.BaseRunner = aux.BaseRunner
+	// ValCheck is not restored from JSON. Callers must rehydrate it explicitly.
+	r.ValCheck = nil
+	return nil
+}
+
 // Encode returns the encoded struct in bytes or error
 func (r *SyncCommitteeAggregatorRunner) Encode() ([]byte, error) {
 	return json.Marshal(r)
@@ -618,7 +609,7 @@ func (r *SyncCommitteeAggregatorRunner) Encode() ([]byte, error) {
 
 // Decode returns error if decoding failed
 func (r *SyncCommitteeAggregatorRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 // GetRoot returns the root used for signing and verification

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -223,6 +223,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 		signed, err := signBeaconObject(
 			ctx,
 			r,
+			r.NetworkConfig,
 			r.State.CurrentDuty.(*spectypes.ValidatorDuty),
 			contribAndProof,
 			cd.Duty.Slot,
@@ -492,6 +493,7 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 		msg, err := signBeaconObject(
 			ctx,
 			r,
+			r.NetworkConfig,
 			duty.(*spectypes.ValidatorDuty),
 			data,
 			duty.DutySlot(),
@@ -565,15 +567,15 @@ func (r *SyncCommitteeAggregatorRunner) GetOperatorSigner() ssvtypes.OperatorSig
 func (r *SyncCommitteeAggregatorRunner) MarshalJSON() ([]byte, error) {
 	type syncCommitteeAggregatorRunnerJSON struct {
 		BaseRunner *BaseRunner `json:"BaseRunner"`
-		// ValCheck is intentionally marshaled to preserve the historical runner state JSON shape
+		// ValCheck is intentionally kept in the JSON to preserve the historical runner state shape
 		// (and thus runner state roots used by spec tests). It is a runtime-only dependency and
-		// is ignored on decode.
+		// is ignored on decode, so it is always marshaled as `null` for determinism.
 		ValCheck any `json:"ValCheck"`
 	}
 
 	return json.Marshal(&syncCommitteeAggregatorRunnerJSON{
 		BaseRunner: r.BaseRunner,
-		ValCheck:   r.ValCheck,
+		ValCheck:   nil,
 	})
 }
 
@@ -586,6 +588,10 @@ func (r *SyncCommitteeAggregatorRunner) UnmarshalJSON(data []byte) error {
 	aux := &syncCommitteeAggregatorRunnerJSON{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
 	}
 
 	r.BaseRunner = aux.BaseRunner

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -112,11 +112,11 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	for _, root := range roots {
 		// reconstruct selection proof sig
 		span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-		sig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+		sig, err := r.State.ReconstructBeaconSig(r.State.PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 		if err != nil {
 			// If the reconstructed signature verification failed, fall back to verifying each partial signature
 			for _, root := range roots {
-				r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+				r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 			}
 			return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 		}
@@ -142,7 +142,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	}
 
 	if len(selectionProofs) == 0 {
-		r.state().Finished = true
+		r.State.Finished = true
 		r.measurements.EndDutyFlow()
 		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleSyncCommitteeContribution, 0)
 		const dutyFinishedNoProofsEvent = "✔️successfully finished duty processing (no selection proofs)"
@@ -155,7 +155,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 		return nil
 	}
 
-	duty := r.state().CurrentDuty.(*spectypes.ValidatorDuty)
+	duty := r.State.CurrentDuty.(*spectypes.ValidatorDuty)
 
 	span.AddEvent("fetching sync committee contributions")
 	contributions, ver, err := r.GetBeaconNode().GetSyncCommitteeContribution(ctx, duty.DutySlot(), selectionProofs, subnets)
@@ -278,10 +278,6 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 	return nil
 }
 
-func (r *SyncCommitteeAggregatorRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
-}
-
 func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
@@ -305,7 +301,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 
 	// get contributions
 	validatorConsensusData := &spectypes.ValidatorConsensusData{}
-	err = validatorConsensusData.Decode(r.state().DecidedValue)
+	err = validatorConsensusData.Decode(r.State.DecidedValue)
 	if err != nil {
 		return fmt.Errorf("could not decode decided validator consensus data: %w", err)
 	}
@@ -322,11 +318,11 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 	start := time.Now()
 	for _, root := range roots {
 		span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-		sig, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+		sig, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 		if err != nil {
 			// If the reconstructed signature verification failed, fall back to verifying each partial signature
 			for _, root := range roots {
-				r.FallBackAndVerifyEachSignature(r.state().PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+				r.FallBackAndVerifyEachSignature(r.State.PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 			}
 			return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
 		}
@@ -344,7 +340,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 				continue // not the correct root
 			}
 
-			signedContrib, err := r.state().ReconstructBeaconSig(r.state().PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+			signedContrib, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 			if err != nil {
 				return fmt.Errorf("could not reconstruct contribution and proof sig: %w", err)
 			}
@@ -379,7 +375,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 			break
 		}
 	}
-	recordSuccessfulSubmission(ctx, successfullySubmittedContributions, r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot()), spectypes.BNRoleSyncCommitteeContribution)
+	recordSuccessfulSubmission(ctx, successfullySubmittedContributions, r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()), spectypes.BNRoleSyncCommitteeContribution)
 	const submittedSyncCommitteeEvent = "✅ successfully submitted sync committee contributions"
 	span.AddEvent(submittedSyncCommitteeEvent)
 	logger.Debug(submittedSyncCommitteeEvent,
@@ -387,14 +383,14 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 		fields.Took(time.Since(start)),
 	)
 
-	r.state().Finished = true
+	r.State.Finished = true
 	r.measurements.EndDutyFlow()
-	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleSyncCommitteeContribution, r.state().RunningInstance.State.Round)
+	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleSyncCommitteeContribution, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent,
 		fields.PreConsensusTime(r.measurements.PreConsensusTime()),
 		fields.ConsensusTime(r.measurements.ConsensusTime()),
-		fields.ConsensusRounds(uint64(r.state().RunningInstance.State.Round)),
+		fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
 		fields.PostConsensusTime(r.measurements.PostConsensusTime()),
 		fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
 		fields.TotalDutyTime(r.measurements.TotalDutyTime()),
@@ -410,12 +406,12 @@ func (r *SyncCommitteeAggregatorRunner) generateContributionAndProof(
 	proof phase0.BLSSignature,
 ) (*altair.ContributionAndProof, phase0.Root, error) {
 	contribAndProof := &altair.ContributionAndProof{
-		AggregatorIndex: r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex,
+		AggregatorIndex: r.State.CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex,
 		Contribution:    &contrib,
 		SelectionProof:  proof,
 	}
 
-	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.state().CurrentDuty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot())
 	dContribAndProof, err := r.GetBeaconNode().DomainData(ctx, epoch, spectypes.DomainContributionAndProof)
 	if err != nil {
 		return nil, phase0.Root{}, errors.Wrap(err, "could not get domain data")
@@ -428,12 +424,12 @@ func (r *SyncCommitteeAggregatorRunner) generateContributionAndProof(
 }
 
 func (r *SyncCommitteeAggregatorRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	indices := r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices
+	indices := r.State.CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices
 	sszIndexes := make([]ssz.HashRoot, 0, len(indices))
 	for _, index := range indices {
 		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(index))
 		data := &altair.SyncAggregatorSelectionData{
-			Slot:              r.state().CurrentDuty.DutySlot(),
+			Slot:              r.State.CurrentDuty.DutySlot(),
 			SubcommitteeIndex: subnet,
 		}
 		sszIndexes = append(sszIndexes, data)
@@ -445,7 +441,7 @@ func (r *SyncCommitteeAggregatorRunner) expectedPreConsensusRootsAndDomain() ([]
 func (r *SyncCommitteeAggregatorRunner) expectedPostConsensusRootsAndDomain(ctx context.Context) ([]ssz.HashRoot, phase0.DomainType, error) {
 	// get contributions
 	validatorConsensusData := &spectypes.ValidatorConsensusData{}
-	err := validatorConsensusData.Decode(r.state().DecidedValue)
+	err := validatorConsensusData.Decode(r.State.DecidedValue)
 	if err != nil {
 		return nil, spectypes.DomainError, errors.Wrap(err, "could not create consensus data")
 	}
@@ -486,7 +482,7 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(ctx context.Context, logger 
 	// re-build the root->validator mapping for this duty
 	r.rootToSyncCommitteeIdx = make(map[phase0.Root]phase0.ValidatorIndex)
 
-	for _, vIdx := range r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices {
+	for _, vIdx := range r.State.CurrentDuty.(*spectypes.ValidatorDuty).ValidatorSyncCommitteeIndices {
 		subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(vIdx))
 		data := &altair.SyncAggregatorSelectionData{
 			Slot:              duty.DutySlot(),
@@ -557,10 +553,6 @@ func (r *SyncCommitteeAggregatorRunner) GetShare() *spectypes.Share {
 		return share
 	}
 	return nil
-}
-
-func (r *SyncCommitteeAggregatorRunner) state() *State {
-	return r.State
 }
 
 func (r *SyncCommitteeAggregatorRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -188,6 +188,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		duty.(*spectypes.ValidatorDuty),
 		vr,
 		duty.DutySlot(),
@@ -300,6 +301,10 @@ func (r *ValidatorRegistrationRunner) UnmarshalJSON(data []byte) error {
 	aux := &validatorRegistrationRunnerJSON{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
 	}
 
 	r.BaseRunner = aux.BaseRunner

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -108,10 +108,10 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	root := roots[0]
 
 	span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	fullSig, err := r.State.ReconstructBeaconSig(r.State.PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -142,7 +142,7 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 		zap.String("signature", hex.EncodeToString(specSig[:])),
 	)
 
-	r.state().Finished = true
+	r.State.Finished = true
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent)
 	span.AddEvent(dutyFinishedEvent)
@@ -152,10 +152,6 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 
 func (r *ValidatorRegistrationRunner) ProcessConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.SignedSSVMessage) error {
 	return spectypes.NewError(spectypes.ValidatorRegistrationNoConsensusPhaseErrorCode, "no consensus phase for validator registration")
-}
-
-func (r *ValidatorRegistrationRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
 }
 
 func (r *ValidatorRegistrationRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
@@ -277,10 +273,6 @@ func (r *ValidatorRegistrationRunner) GetShare() *spectypes.Share {
 		return share
 	}
 	return nil
-}
-
-func (r *ValidatorRegistrationRunner) state() *State {
-	return r.State
 }
 
 func (r *ValidatorRegistrationRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -36,7 +36,7 @@ const (
 )
 
 type ValidatorRegistrationRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	beacon                         beacon.BeaconNode
 	network                        specqbft.Network
@@ -82,19 +82,14 @@ func NewValidatorRegistrationRunner(
 }
 
 func (r *ValidatorRegistrationRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty, quorum uint64) error {
-	return r.BaseRunner.baseStartNewNonBeaconDuty(ctx, logger, r, duty.(*spectypes.ValidatorDuty), quorum)
-}
-
-// HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)
-func (r *ValidatorRegistrationRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.baseStartNewNonBeaconDuty(ctx, logger, r, duty.(*spectypes.ValidatorDuty), quorum)
 }
 
 func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -116,13 +111,13 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], fullSig)
 
-	registration, err := r.buildValidatorRegistration(r.BaseRunner.State.CurrentDuty.DutySlot())
+	registration, err := r.buildValidatorRegistration(r.State.CurrentDuty.DutySlot())
 	if err != nil {
 		return fmt.Errorf("could not calculate validator registration: %w", err)
 	}
@@ -168,10 +163,10 @@ func (r *ValidatorRegistrationRunner) ProcessPostConsensus(ctx context.Context, 
 }
 
 func (r *ValidatorRegistrationRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	if r.BaseRunner.State == nil || r.BaseRunner.State.CurrentDuty == nil {
+	if r.State == nil || r.State.CurrentDuty == nil {
 		return nil, spectypes.DomainError, fmt.Errorf("no running duty to compute preconsensus roots and domain")
 	}
-	vr, err := r.buildValidatorRegistration(r.BaseRunner.State.CurrentDuty.DutySlot())
+	vr, err := r.buildValidatorRegistration(r.State.CurrentDuty.DutySlot())
 	if err != nil {
 		return nil, spectypes.DomainError, fmt.Errorf("could not calculate validator registration: %w", err)
 	}
@@ -212,7 +207,7 @@ func (r *ValidatorRegistrationRunner) executeDuty(ctx context.Context, logger *z
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode validator registration partial sig message: %w", err)
@@ -260,53 +255,17 @@ func (r *ValidatorRegistrationRunner) buildValidatorRegistration(slot phase0.Slo
 		gasLimit = DefaultGasLimit
 	}
 
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(slot)
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(slot)
 	return &v1.ValidatorRegistration{
 		FeeRecipient: feeRecipient,
 		GasLimit:     gasLimit,
-		Timestamp:    r.BaseRunner.NetworkConfig.EpochStartTime(epoch),
+		Timestamp:    r.NetworkConfig.EpochStartTime(epoch),
 		Pubkey:       phase0.BLSPubKey(validatorPubKey),
 	}, nil
 }
 
-func (r *ValidatorRegistrationRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
-}
-
-func (r *ValidatorRegistrationRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
-
-func (r *ValidatorRegistrationRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
-
-func (r *ValidatorRegistrationRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *ValidatorRegistrationRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *ValidatorRegistrationRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *ValidatorRegistrationRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *ValidatorRegistrationRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
-}
-
 func (r *ValidatorRegistrationRunner) GetNetwork() specqbft.Network {
 	return r.network
-}
-
-func (r *ValidatorRegistrationRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
 }
 
 func (r *ValidatorRegistrationRunner) GetBeaconNode() beacon.BeaconNode {
@@ -314,14 +273,14 @@ func (r *ValidatorRegistrationRunner) GetBeaconNode() beacon.BeaconNode {
 }
 
 func (r *ValidatorRegistrationRunner) GetShare() *spectypes.Share {
-	for _, share := range r.BaseRunner.Share {
+	for _, share := range r.Share {
 		return share
 	}
 	return nil
 }
 
 func (r *ValidatorRegistrationRunner) state() *State {
-	return r.BaseRunner.State
+	return r.State
 }
 
 func (r *ValidatorRegistrationRunner) GetSigner() ekm.BeaconSigner {
@@ -331,6 +290,30 @@ func (r *ValidatorRegistrationRunner) GetOperatorSigner() ssvtypes.OperatorSigne
 	return r.operatorSigner
 }
 
+func (r *ValidatorRegistrationRunner) MarshalJSON() ([]byte, error) {
+	type validatorRegistrationRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+	}
+
+	return json.Marshal(&validatorRegistrationRunnerJSON{
+		BaseRunner: r.BaseRunner,
+	})
+}
+
+func (r *ValidatorRegistrationRunner) UnmarshalJSON(data []byte) error {
+	type validatorRegistrationRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+	}
+
+	aux := &validatorRegistrationRunnerJSON{}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	r.BaseRunner = aux.BaseRunner
+	return nil
+}
+
 // Encode returns the encoded struct in bytes or error
 func (r *ValidatorRegistrationRunner) Encode() ([]byte, error) {
 	return json.Marshal(r)
@@ -338,7 +321,7 @@ func (r *ValidatorRegistrationRunner) Encode() ([]byte, error) {
 
 // Decode returns error if decoding failed
 func (r *ValidatorRegistrationRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 // GetRoot returns the root used for signing and verification

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -28,7 +28,7 @@ import (
 // need consensus nor post-consensus, it just performs pre-consensus with VoluntaryExitPartialSig
 // over a VoluntaryExit object to create a SignedVoluntaryExit
 type VoluntaryExitRunner struct {
-	BaseRunner *BaseRunner
+	*BaseRunner
 
 	beacon         beacon.BeaconNode
 	network        specqbft.Network
@@ -65,12 +65,7 @@ func NewVoluntaryExitRunner(
 }
 
 func (r *VoluntaryExitRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty, quorum uint64) error {
-	return r.BaseRunner.baseStartNewNonBeaconDuty(ctx, logger, r, duty.(*spectypes.ValidatorDuty), quorum)
-}
-
-// HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)
-func (r *VoluntaryExitRunner) HasRunningDuty() bool {
-	return r.BaseRunner.hasRunningDuty()
+	return r.baseStartNewNonBeaconDuty(ctx, logger, r, duty.(*spectypes.ValidatorDuty), quorum)
 }
 
 // ProcessPreConsensus Check for quorum of partial signatures over VoluntaryExit and,
@@ -85,7 +80,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 		span.SetAttributes(observability.ValidatorIndexAttribute(validatorIndex))
 	}
 
-	hasQuorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
 	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
 		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
 		// also needs to be retried.
@@ -106,7 +101,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.BaseRunner.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -193,7 +188,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 		Messages: []*spectypes.PartialSignatureMessage{msg},
 	}
 
-	msgID := spectypes.NewMsgID(r.BaseRunner.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
+	msgID := spectypes.NewMsgID(r.NetworkConfig.DomainType, r.GetShare().ValidatorPubKey[:], r.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode PartialSignatureMessages: %w", err)
@@ -230,7 +225,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 
 // Returns *phase0.VoluntaryExit object with current epoch and own validator index
 func (r *VoluntaryExitRunner) calculateVoluntaryExit() (*phase0.VoluntaryExit, error) {
-	epoch := r.BaseRunner.NetworkConfig.EstimatedEpochAtSlot(r.BaseRunner.State.CurrentDuty.DutySlot())
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot())
 	validatorIndex := r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex
 	return &phase0.VoluntaryExit{
 		Epoch:          epoch,
@@ -238,44 +233,8 @@ func (r *VoluntaryExitRunner) calculateVoluntaryExit() (*phase0.VoluntaryExit, e
 	}, nil
 }
 
-func (r *VoluntaryExitRunner) HasRunningQBFTInstance() bool {
-	return r.BaseRunner.HasRunningQBFTInstance()
-}
-
-func (r *VoluntaryExitRunner) HasAcceptedProposalForCurrentRound() bool {
-	return r.BaseRunner.HasAcceptedProposalForCurrentRound()
-}
-
-func (r *VoluntaryExitRunner) GetShares() map[phase0.ValidatorIndex]*spectypes.Share {
-	return r.BaseRunner.GetShares()
-}
-
-func (r *VoluntaryExitRunner) GetRole() spectypes.RunnerRole {
-	return r.BaseRunner.GetRole()
-}
-
-func (r *VoluntaryExitRunner) GetLastHeight() specqbft.Height {
-	return r.BaseRunner.GetLastHeight()
-}
-
-func (r *VoluntaryExitRunner) GetLastRound() specqbft.Round {
-	return r.BaseRunner.GetLastRound()
-}
-
-func (r *VoluntaryExitRunner) GetStateRoot() ([32]byte, error) {
-	return r.BaseRunner.GetStateRoot()
-}
-
-func (r *VoluntaryExitRunner) SetTimeoutFunc(fn TimeoutF) {
-	r.BaseRunner.SetTimeoutFunc(fn)
-}
-
 func (r *VoluntaryExitRunner) GetNetwork() specqbft.Network {
 	return r.network
-}
-
-func (r *VoluntaryExitRunner) GetNetworkConfig() *networkconfig.Network {
-	return r.BaseRunner.NetworkConfig
 }
 
 func (r *VoluntaryExitRunner) GetBeaconNode() beacon.BeaconNode {
@@ -283,14 +242,14 @@ func (r *VoluntaryExitRunner) GetBeaconNode() beacon.BeaconNode {
 }
 
 func (r *VoluntaryExitRunner) GetShare() *spectypes.Share {
-	for _, share := range r.BaseRunner.Share {
+	for _, share := range r.Share {
 		return share
 	}
 	return nil
 }
 
 func (r *VoluntaryExitRunner) state() *State {
-	return r.BaseRunner.State
+	return r.State
 }
 
 func (r *VoluntaryExitRunner) GetSigner() ekm.BeaconSigner {
@@ -300,6 +259,30 @@ func (r *VoluntaryExitRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
 	return r.operatorSigner
 }
 
+func (r *VoluntaryExitRunner) MarshalJSON() ([]byte, error) {
+	type voluntaryExitRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+	}
+
+	return json.Marshal(&voluntaryExitRunnerJSON{
+		BaseRunner: r.BaseRunner,
+	})
+}
+
+func (r *VoluntaryExitRunner) UnmarshalJSON(data []byte) error {
+	type voluntaryExitRunnerJSON struct {
+		BaseRunner *BaseRunner `json:"BaseRunner"`
+	}
+
+	aux := &voluntaryExitRunnerJSON{}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	r.BaseRunner = aux.BaseRunner
+	return nil
+}
+
 // Encode returns the encoded struct in bytes or error
 func (r *VoluntaryExitRunner) Encode() ([]byte, error) {
 	return json.Marshal(r)
@@ -307,7 +290,7 @@ func (r *VoluntaryExitRunner) Encode() ([]byte, error) {
 
 // Decode returns error if decoding failed
 func (r *VoluntaryExitRunner) Decode(data []byte) error {
-	return json.Unmarshal(data, &r)
+	return json.Unmarshal(data, r)
 }
 
 // GetRoot returns the root used for signing and verification

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -98,10 +98,10 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	// only 1 root, verified in basePreConsensusMsgProcessing
 	root := roots[0]
 	span.AddEvent("reconstructing beacon signature", trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
-	fullSig, err := r.state().ReconstructBeaconSig(r.state().PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
+	fullSig, err := r.State.ReconstructBeaconSig(r.State.PreConsensusContainer, root, r.GetShare().ValidatorPubKey[:], r.GetShare().ValidatorIndex)
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
-		r.FallBackAndVerifyEachSignature(r.state().PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
+		r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
 		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
 	}
 	specSig := phase0.BLSSignature{}
@@ -126,7 +126,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 		zap.String("signature", hex.EncodeToString(specSig[:])),
 	)
 
-	r.state().Finished = true
+	r.State.Finished = true
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent)
 	span.AddEvent(dutyFinishedEvent)
@@ -136,10 +136,6 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 
 func (r *VoluntaryExitRunner) ProcessConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.SignedSSVMessage) error {
 	return spectypes.NewError(spectypes.ValidatorExitNoConsensusPhaseErrorCode, "no consensus phase for voluntary exit")
-}
-
-func (r *VoluntaryExitRunner) OnTimeoutQBFT(ctx context.Context, logger *zap.Logger, timeoutData *ssvtypes.TimeoutData) error {
-	return r.BaseRunner.OnTimeoutQBFT(ctx, logger, timeoutData)
 }
 
 func (r *VoluntaryExitRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
@@ -226,7 +222,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 // Returns *phase0.VoluntaryExit object with current epoch and own validator index
 func (r *VoluntaryExitRunner) calculateVoluntaryExit() (*phase0.VoluntaryExit, error) {
 	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot())
-	validatorIndex := r.state().CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex
+	validatorIndex := r.State.CurrentDuty.(*spectypes.ValidatorDuty).ValidatorIndex
 	return &phase0.VoluntaryExit{
 		Epoch:          epoch,
 		ValidatorIndex: validatorIndex,
@@ -246,10 +242,6 @@ func (r *VoluntaryExitRunner) GetShare() *spectypes.Share {
 		return share
 	}
 	return nil
-}
-
-func (r *VoluntaryExitRunner) state() *State {
-	return r.State
 }
 
 func (r *VoluntaryExitRunner) GetSigner() ekm.BeaconSigner {

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -169,6 +169,7 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 	msg, err := signBeaconObject(
 		ctx,
 		r,
+		r.NetworkConfig,
 		duty.(*spectypes.ValidatorDuty),
 		voluntaryExit,
 		duty.DutySlot(),
@@ -269,6 +270,10 @@ func (r *VoluntaryExitRunner) UnmarshalJSON(data []byte) error {
 	aux := &voluntaryExitRunnerJSON{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
 	}
 
 	r.BaseRunner = aux.BaseRunner

--- a/protocol/v2/ssv/spectest/committee_msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/committee_msg_processing_type.go
@@ -199,7 +199,7 @@ func overrideStateComparisonCommitteeSpecTest(t *testing.T, test *CommitteeSpecT
 	committee.Shares = specCommittee.Share
 	committee.CommitteeMember = &specCommittee.CommitteeMember
 	for slot := range committee.Runners {
-		committee.Runners[slot].BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		committee.Runners[slot].NetworkConfig = networkconfig.TestNetwork
 		// Use test runner as signer source since deserialized runner has no signer
 		var signerSource runner.Runner
 		if testRunner, ok := test.Committee.Runners[slot]; ok {

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -76,25 +76,25 @@ func (test *MsgProcessingSpecTest) runPreTesting(ctx context.Context, logger *za
 	valCheck := createValueChecker(test.Runner)
 	switch test.Runner.(type) {
 	case *runner.CommitteeRunner:
-		for _, inst := range test.Runner.(*runner.CommitteeRunner).BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range test.Runner.(*runner.CommitteeRunner).QBFTController.StoredInstances {
 			if inst.ValueChecker == nil {
 				inst.ValueChecker = valCheck
 			}
 		}
 	case *runner.AggregatorRunner:
-		for _, inst := range test.Runner.(*runner.AggregatorRunner).BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range test.Runner.(*runner.AggregatorRunner).QBFTController.StoredInstances {
 			if inst.ValueChecker == nil {
 				inst.ValueChecker = valCheck
 			}
 		}
 	case *runner.ProposerRunner:
-		for _, inst := range test.Runner.(*runner.ProposerRunner).BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range test.Runner.(*runner.ProposerRunner).QBFTController.StoredInstances {
 			if inst.ValueChecker == nil {
 				inst.ValueChecker = valCheck
 			}
 		}
 	case *runner.SyncCommitteeAggregatorRunner:
-		for _, inst := range test.Runner.(*runner.SyncCommitteeAggregatorRunner).BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range test.Runner.(*runner.SyncCommitteeAggregatorRunner).QBFTController.StoredInstances {
 			if inst.ValueChecker == nil {
 				inst.ValueChecker = valCheck
 			}
@@ -116,8 +116,8 @@ func (test *MsgProcessingSpecTest) runPreTesting(ctx context.Context, logger *za
 			c.Runners[test.Duty.DutySlot()] = r
 
 			// Inform the duty guard of the running duty, if any, so that it won't reject it.
-			if r.BaseRunner.State != nil && r.BaseRunner.State.CurrentDuty != nil {
-				duty, ok := r.BaseRunner.State.CurrentDuty.(*spectypes.CommitteeDuty)
+			if r.State != nil && r.State.CurrentDuty != nil {
+				duty, ok := r.State.CurrentDuty.(*spectypes.CommitteeDuty)
 				if !ok {
 					panic("starting duty not found")
 				}
@@ -286,9 +286,9 @@ var baseCommitteeWithRunnerSample = func(
 			shareMap,
 			attestingValidators,
 			controller.NewController(
-				runnerSample.BaseRunner.QBFTController.Identifier,
-				runnerSample.BaseRunner.QBFTController.CommitteeMember,
-				runnerSample.BaseRunner.QBFTController.GetConfig(),
+				runnerSample.QBFTController.Identifier,
+				runnerSample.QBFTController.CommitteeMember,
+				runnerSample.QBFTController.GetConfig(),
 				spectestingutils.TestingOperatorSigner(keySetSample),
 				false,
 			),
@@ -304,7 +304,7 @@ var baseCommitteeWithRunnerSample = func(
 
 	c := validator.NewCommittee(
 		logger,
-		runnerSample.BaseRunner.NetworkConfig,
+		runnerSample.NetworkConfig,
 		spectestingutils.TestingCommitteeMember(keySetSample),
 		createRunnerF,
 		shareMap,

--- a/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
+++ b/protocol/v2/ssv/spectest/multi_start_new_runner_duty_type.go
@@ -93,32 +93,32 @@ func (test *StartNewRunnerDutySpecTest) RunAsPartOfMultiTest(t *testing.T, logge
 
 	switch r := test.Runner.(type) {
 	case *runner.CommitteeRunner:
-		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range r.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.State.RunningInstance != nil {
+			r.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.AggregatorRunner:
-		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range r.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.State.RunningInstance != nil {
+			r.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.ProposerRunner:
-		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range r.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.State.RunningInstance != nil {
+			r.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	case *runner.SyncCommitteeAggregatorRunner:
-		for _, inst := range r.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range r.QBFTController.StoredInstances {
 			inst.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
-		if r.BaseRunner.State.RunningInstance != nil {
-			r.BaseRunner.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
+		if r.State.RunningInstance != nil {
+			r.State.RunningInstance.ValueChecker = protocoltesting.TestingValueChecker{}
 		}
 	}
 

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -587,7 +587,7 @@ func fixCommitteeForRun(t *testing.T, logger *zap.Logger, committeeMap map[strin
 
 	for slot := range c.Runners {
 		var shareInstance *spectypes.Share
-		for _, share := range c.Runners[slot].BaseRunner.Share {
+		for _, share := range c.Runners[slot].Share {
 			shareInstance = share
 			break
 		}

--- a/protocol/v2/ssv/spectest/util.go
+++ b/protocol/v2/ssv/spectest/util.go
@@ -43,52 +43,52 @@ func runnerForTest(t *testing.T, runnerType runner.Runner, name string, testType
 	switch runnerType.(type) {
 	case *runner.CommitteeRunner:
 		cr := r.(*runner.CommitteeRunner)
-		cr.BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		cr.NetworkConfig = networkconfig.TestNetwork
 		valCheck := createValueChecker(r, runnerType)
 		cr.ValCheck = valCheck
-		for _, inst := range cr.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range cr.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if cr.BaseRunner.State != nil && cr.BaseRunner.State.RunningInstance != nil {
-			cr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if cr.State != nil && cr.State.RunningInstance != nil {
+			cr.State.RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.AggregatorRunner:
 		ar := r.(*runner.AggregatorRunner)
-		ar.BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		ar.NetworkConfig = networkconfig.TestNetwork
 		valCheck := createValueChecker(r, runnerType)
 		ar.ValCheck = valCheck
-		for _, inst := range ar.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range ar.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if ar.BaseRunner.State != nil && ar.BaseRunner.State.RunningInstance != nil {
-			ar.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if ar.State != nil && ar.State.RunningInstance != nil {
+			ar.State.RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.ProposerRunner:
 		pr := r.(*runner.ProposerRunner)
-		pr.BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		pr.NetworkConfig = networkconfig.TestNetwork
 		valCheck := createValueChecker(r, runnerType)
 		pr.ValCheck = valCheck
-		for _, inst := range pr.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range pr.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if pr.BaseRunner.State != nil && pr.BaseRunner.State.RunningInstance != nil {
-			pr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if pr.State != nil && pr.State.RunningInstance != nil {
+			pr.State.RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.SyncCommitteeAggregatorRunner:
 		scr := r.(*runner.SyncCommitteeAggregatorRunner)
-		scr.BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		scr.NetworkConfig = networkconfig.TestNetwork
 		valCheck := createValueChecker(r, runnerType)
 		scr.ValCheck = valCheck
-		for _, inst := range scr.BaseRunner.QBFTController.StoredInstances {
+		for _, inst := range scr.QBFTController.StoredInstances {
 			inst.ValueChecker = valCheck
 		}
-		if scr.BaseRunner.State != nil && scr.BaseRunner.State.RunningInstance != nil {
-			scr.BaseRunner.State.RunningInstance.ValueChecker = valCheck
+		if scr.State != nil && scr.State.RunningInstance != nil {
+			scr.State.RunningInstance.ValueChecker = valCheck
 		}
 	case *runner.ValidatorRegistrationRunner:
-		r.(*runner.ValidatorRegistrationRunner).BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		r.(*runner.ValidatorRegistrationRunner).NetworkConfig = networkconfig.TestNetwork
 	case *runner.VoluntaryExitRunner:
-		r.(*runner.VoluntaryExitRunner).BaseRunner.NetworkConfig = networkconfig.TestNetwork
+		r.(*runner.VoluntaryExitRunner).NetworkConfig = networkconfig.TestNetwork
 	default:
 		t.Fatalf("unknown runner type")
 	}
@@ -100,7 +100,7 @@ func normalizeExpectedProposerStartValues(pr *runner.ProposerRunner) {
 	if pr == nil || pr.BaseRunner == nil {
 		return
 	}
-	if state := pr.BaseRunner.State; state != nil {
+	if state := pr.State; state != nil {
 		state.DecidedValue = normalizeProposerConsensusValue(state.DecidedValue)
 		if state.RunningInstance != nil {
 			state.RunningInstance.StartValue = normalizeProposerConsensusValue(state.RunningInstance.StartValue)
@@ -110,10 +110,10 @@ func normalizeExpectedProposerStartValues(pr *runner.ProposerRunner) {
 			}
 		}
 	}
-	if pr.BaseRunner.QBFTController == nil {
+	if pr.QBFTController == nil {
 		return
 	}
-	for _, inst := range pr.BaseRunner.QBFTController.StoredInstances {
+	for _, inst := range pr.QBFTController.StoredInstances {
 		if inst == nil {
 			continue
 		}

--- a/protocol/v2/ssv/spectest/value_checker.go
+++ b/protocol/v2/ssv/spectest/value_checker.go
@@ -228,8 +228,8 @@ func createValueChecker(r runner.Runner, signerSource ...runner.Runner) ssv.Valu
 
 		// Get slot from state or use testing default
 		slot := phase0.Slot(spectestingutils.TestingDutySlot)
-		if typedRunner.BaseRunner.State != nil && typedRunner.BaseRunner.State.CurrentDuty != nil {
-			slot = typedRunner.BaseRunner.State.CurrentDuty.DutySlot()
+		if typedRunner.State != nil && typedRunner.State.CurrentDuty != nil {
+			slot = typedRunner.State.CurrentDuty.DutySlot()
 		}
 
 		// Construct expected vote from TestingAttestationData (same pattern as testing/runner.go:69-73)

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -222,7 +222,7 @@ var ConstructBaseRunner = func(
 			dutyGuard,
 			dgHandler,
 		)
-		r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType
+		r.(*runner.CommitteeRunner).RunnerRoleType = spectestingutils.UnknownDutyType
 	default:
 		return nil, fmt.Errorf("unknown role type: %s", role)
 	}
@@ -486,7 +486,7 @@ var ConstructBaseRunnerWithShareMap = func(
 			dgHandler,
 		)
 		if r != nil {
-			r.(*runner.CommitteeRunner).BaseRunner.RunnerRoleType = spectestingutils.UnknownDutyType
+			r.(*runner.CommitteeRunner).RunnerRoleType = spectestingutils.UnknownDutyType
 		}
 	default:
 		return nil, fmt.Errorf("unknown role type: %s", role)

--- a/protocol/v2/ssv/validator/committee_queue_test.go
+++ b/protocol/v2/ssv/validator/committee_queue_test.go
@@ -780,7 +780,7 @@ func TestCommitteeQueueFilteringScenarios(t *testing.T) {
 
 			// Set runner state based on hasRunningDuty parameter
 			if !tc.hasRunningDuty {
-				committeeRunner.BaseRunner.State.Finished = true // This makes HasRunningDuty() return false
+				committeeRunner.State.Finished = true // This makes HasRunningDuty() return false
 			}
 
 			msgChannel := make(chan *queue.SSVMessage, len(tc.messagesTypes))
@@ -1766,7 +1766,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 		ctx2, cancel2 := context.WithCancel(ctx)
 		defer cancel2()
 
-		committeeRunner.BaseRunner.State.RunningInstance.State.ProposalAcceptedForCurrentRound =
+		committeeRunner.State.RunningInstance.State.ProposalAcceptedForCurrentRound =
 			&specqbft.ProcessingMessage{QBFTMessage: proposal}
 
 		// Restart consumption


### PR DESCRIPTION
**Fix for:**

F-ssv-034 P1
~600 lines of identical Runner delegation boilerplate across 5 runners
ssv · Code Quality — Code Duplication · Assigned: dev4 · Effort: —
Each Runner has ~15 identical single-line methods delegating to `r.BaseRunner.X()`: `GetRole()`, `GetLastHeight()`, `GetLastRound()`, `GetStateRoot()`, `SetTimeoutFunc()`, etc. Could be eliminated with Go struct embedding.

Impact: ~600 lines of pure boilerplate. Every new delegation method must be added to all 5 runners.

-------------------

**What changed:**

- Most changes are replacing r.BaseRunner.X forwarders with embedded *BaseRunner method promotion.
- One intentional semantic change is a correctness fix: Decode() now actually populates the receiver (previous json.Unmarshal(data, &b) / &r was wrong for pointer receivers). See protocol/v2/ssv/runner/runner.go:168.
- JSON/root stability is accounted for via custom MarshalJSON/UnmarshalJSON on runners where embedding would have changed the encoded shape (and ValCheck is intentionally not restored on decode).
