### PR TITLE
fix: remove stale and misleading TODO comments

### DIFF
--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -19,9 +19,6 @@ import (
 
 //go:generate go tool -modfile=../../tool.mod mockgen -package=eventsyncer -destination=./event_syncer_mock.go -source=./event_syncer.go
 
-// TODO: check if something from these PRs need to be ported:
-// https://github.com/ssvlabs/ssv/pull/1053
-
 const (
 	defaultStalenessThreshold = 300 * time.Second
 )

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -179,7 +179,6 @@ func (mv *messageValidator) handleSignedSSVMessage(
 		return decodedMessage, err
 	}
 
-	// TODO: leverage the validatorStore to keep track of committees' indices and return them in Committee methods (which already return a Committee struct that we should add an Indices filter to): https://github.com/ssvlabs/ssv/pull/1393#discussion_r1667681686
 	committeeInfo, err := mv.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 	if err != nil {
 		return decodedMessage, err

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -156,7 +156,6 @@ func (dvs *DiscV5Service) Node(logger *zap.Logger, info peer.AddrInfo) (*enode.N
 // which lets other components to determine whether we'll want to connect to this node or not.
 func (dvs *DiscV5Service) Bootstrap(handler HandleNewPeer) error {
 	// Log every 10th skipped peer.
-	// TODO: remove once we've merged https://github.com/ssvlabs/ssv/pull/1803
 	const logFrequency = 10
 	var skippedPeers uint64 = 0
 
@@ -191,7 +190,6 @@ func (dvs *DiscV5Service) Bootstrap(handler HandleNewPeer) error {
 
 func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 	// Get the peer's domain type, skipping if it mismatches ours.
-	// TODO: uncomment errors once there are sufficient nodes with domain type.
 	peerDiscoveriesCounter.Add(ctx, 1)
 	nodeDomainType, err := records.GetDomainTypeEntry(e.Node.Record(), records.KeyDomainType)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove 4 stale/misleading TODO comments across 3 files (F-ssv-078, F-ssv-081)
- Zero behavior change — comment-only deletions

## Details

| File | TODO | Why stale |
|------|------|-----------|
| `dv5_service.go:193` | "uncomment errors once sufficient nodes with domain type" | Errors were uncommented long ago when domain type rollout completed |
| `dv5_service.go:159` | "remove once we've merged PR #1803" | PR #1803 was closed, not merged; `logFrequency` mitigation is the permanent solution |
| `event_syncer.go:22` | "check if something from PR #1053 needs porting" | PR #1053 merged Jul 2023; entire eth1 sync stack was rewritten in Aug 2023 |
| `validation.go:182` | "leverage validatorStore for committee indices" (PR #1393) | Already implemented — `Committee.Indices` field exists, `ValidatorStore` maintains it |

## Finding
F-ssv-078, F-ssv-081

## Test
Comment-only deletions, no test needed.