### PR TITLE
encrypt persisted p2p network key

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -1127,7 +1128,10 @@ func probeRemoteNetworkKeyProtector(
 	ctx context.Context,
 	client *ssvsigner.Client,
 ) error {
-	probeKey := []byte("p2p-network-key-probe")
+	probeKey := make([]byte, 32)
+	if _, err := crand.Read(probeKey); err != nil {
+		return fmt.Errorf("generate remote data protector probe: %w", err)
+	}
 	encrypted, err := client.OperatorEncrypt(ctx, probeKey)
 	if err != nil {
 		return fmt.Errorf("probe remote data protector encrypt: %w", err)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -446,7 +446,7 @@ var StartNodeCmd = &cobra.Command{
 		cfg.P2pNetworkConfig.MessageValidator = messageValidator
 		cfg.SSVOptions.ValidatorOptions.MessageValidator = messageValidator
 
-		p2pNetwork := setupP2P(logger, db)
+		p2pNetwork := setupP2P(cmd.Context(), logger, db, operatorPrivKey, ssvSignerClient)
 
 		cfg.SSVOptions.Context = cmd.Context()
 		cfg.SSVOptions.DB = db
@@ -1071,9 +1071,46 @@ func setupSSVNetwork(logger *zap.Logger) (*networkconfig.SSV, error) {
 	return ssvConfig, nil
 }
 
-func setupP2P(logger *zap.Logger, db basedb.Database) network.P2PNetwork {
-	istore := ssv_identity.NewIdentityStore(logger, db)
-	netPrivKey, err := istore.SetupNetworkKey(cfg.NetworkPrivateKey)
+func setupP2P(ctx context.Context, logger *zap.Logger, db basedb.Database, operatorPrivKey keys.OperatorPrivateKey, signerClient *ssvsigner.Client) network.P2PNetwork {
+	var protectFn func(context.Context, []byte) ([]byte, error)
+	var unprotectFn func(context.Context, []byte) ([]byte, error)
+
+	// The configured startup mode determines how the persisted P2P network key is protected.
+	if operatorPrivKey != nil {
+		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
+		if err != nil {
+			logger.Fatal("failed to derive operator-based network key protection secret", zap.Error(err))
+		}
+		protectFn = func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(encryptionKey, plaintext)
+		}
+		unprotectFn = func(_ context.Context, protectedValue []byte) ([]byte, error) {
+			return keys.DecryptPayload(encryptionKey, protectedValue)
+		}
+	} else if signerClient != nil {
+		err := probeRemoteNetworkKeyProtector(ctx, signerClient)
+		if err == nil {
+			protectFn = signerClient.OperatorEncrypt
+			unprotectFn = signerClient.OperatorDecrypt
+		} else if !errors.Is(err, ssvsigner.ErrOperatorDataProtectionUnsupported) {
+			logger.Fatal("failed to probe ssv-signer p2p network key protection", zap.Error(err))
+		} else {
+			hasEncryptedKey, hasEncryptedKeyErr := ssv_identity.HasEncryptedNetworkKey(db)
+			if hasEncryptedKeyErr != nil {
+				logger.Fatal("failed to inspect stored p2p network private key format", zap.Error(hasEncryptedKeyErr))
+			}
+			if hasEncryptedKey {
+				logger.Fatal("existing database contains an encrypted p2p network private key, but the configured ssv-signer cannot encrypt or decrypt it. Upgrade ssv-signer to a version that supports /v1/operator/encrypt and /v1/operator/decrypt, or restore the operator key and signing mode that originally encrypted this database", zap.Error(err))
+			}
+
+			logger.Warn("ssv-signer does not support remote p2p network key protection, falling back to local compatibility mode",
+				zap.Error(err),
+			)
+		}
+	}
+
+	istore := ssv_identity.NewIdentityStore(logger, db, protectFn, unprotectFn)
+	netPrivKey, err := istore.SetupNetworkKey(ctx, cfg.NetworkPrivateKey)
 	if err != nil {
 		logger.Fatal("failed to setup network private key", zap.Error(err))
 	}
@@ -1084,6 +1121,25 @@ func setupP2P(logger *zap.Logger, db basedb.Database) network.P2PNetwork {
 		logger.Fatal("failed to setup p2p network", zap.Error(err))
 	}
 	return n
+}
+
+func probeRemoteNetworkKeyProtector(
+	ctx context.Context,
+	client *ssvsigner.Client,
+) error {
+	probeKey := []byte("p2p-network-key-probe")
+	encrypted, err := client.OperatorEncrypt(ctx, probeKey)
+	if err != nil {
+		return fmt.Errorf("probe remote data protector encrypt: %w", err)
+	}
+	decrypted, err := client.OperatorDecrypt(ctx, encrypted)
+	if err != nil {
+		return fmt.Errorf("probe remote data protector decrypt: %w", err)
+	}
+	if !bytes.Equal(decrypted, probeKey) {
+		return errors.New("probe remote network key protector mismatch")
+	}
+	return nil
 }
 
 // syncContractEvents blocks until historical events are synced and then spawns a goroutine syncing ongoing events.

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -1,7 +1,12 @@
 package operator
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
@@ -13,9 +18,22 @@ import (
 
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
+	"github.com/ssvlabs/ssv/ssvsigner"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
+
+func newTestSSVSignerClient(t *testing.T, register func(mux *http.ServeMux)) *ssvsigner.Client {
+	mux := http.NewServeMux()
+	if register != nil {
+		register(mux)
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return ssvsigner.NewClient(server.URL, ssvsigner.WithLogger(zap.NewNop()))
+}
 
 func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
 	t.Parallel()
@@ -358,5 +376,48 @@ func Test_validateProposerDelayConfig(t *testing.T) {
 				require.Equal(t, 1000*time.Millisecond, fields["max_safe_proposer_delay"])
 			})
 		}
+	})
+}
+
+func Test_probeRemoteNetworkKeyProtector(t *testing.T) {
+	t.Run("uses remote signer encrypt and decrypt endpoints when supported", func(t *testing.T) {
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				_, err = w.Write(append([]byte("encrypted:"), payload...))
+				require.NoError(t, err)
+			})
+			mux.HandleFunc(ssvsigner.PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				_, err = w.Write(bytes.TrimPrefix(payload, []byte("encrypted:")))
+				require.NoError(t, err)
+			})
+		})
+
+		err := probeRemoteNetworkKeyProtector(context.Background(), client)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns unsupported when remote signer does not support remote data protection", func(t *testing.T) {
+		client := newTestSSVSignerClient(t, nil)
+
+		err := probeRemoteNetworkKeyProtector(context.Background(), client)
+		require.ErrorIs(t, err, ssvsigner.ErrOperatorDataProtectionUnsupported)
+	})
+
+	t.Run("fails instead of downgrading on transient remote signer fetch error", func(t *testing.T) {
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "temporary upstream failure", http.StatusInternalServerError)
+			})
+		})
+
+		err := probeRemoteNetworkKeyProtector(context.Background(), client)
+		require.ErrorContains(t, err, "probe remote data protector encrypt")
+		require.ErrorContains(t, err, "unexpected status: 500")
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.6
 	github.com/ssvlabs/ssv-spec v1.2.2
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20251027161822-0b67ab2cd4f3
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20260330141425-a81fe06c7bec
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/identity/store.go
+++ b/identity/store.go
@@ -1,10 +1,13 @@
 package p2p
 
 import (
+	"bytes"
+	"context"
 	"crypto/ecdsa"
+	"errors"
+	"fmt"
 
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/observability/log"
@@ -22,29 +25,39 @@ var (
 	// netKeyPrefix = []byte("network-key/")
 	// operatorKeyPrefix is the prefix for operator key
 	// operatorKeyPrefix = []byte("operator-key/")
+	encryptedPrefix = []byte("enc:")
 )
 
 // Store represents the interface for accessing the node's keys (operator and network keys)
 type Store interface {
-	GetNetworkKey() (*ecdsa.PrivateKey, bool, error)
-	SetupNetworkKey(skEncoded string) (*ecdsa.PrivateKey, error)
+	GetNetworkKey(ctx context.Context) (*ecdsa.PrivateKey, bool, error)
+	SetupNetworkKey(ctx context.Context, skEncoded string) (*ecdsa.PrivateKey, error)
 }
 
 type identityStore struct {
-	logger *zap.Logger
-	db     basedb.Database
+	logger      *zap.Logger
+	db          basedb.Database
+	protectFn   func(ctx context.Context, plaintext []byte) ([]byte, error)
+	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error)
 }
 
 // NewIdentityStore creates a new identity store
-func NewIdentityStore(logger *zap.Logger, db basedb.Database) Store {
+func NewIdentityStore(
+	logger *zap.Logger,
+	db basedb.Database,
+	protectFn func(ctx context.Context, plaintext []byte) ([]byte, error),
+	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error),
+) Store {
 	es := identityStore{
-		logger: logger.Named(log.NameP2PStorage),
-		db:     db,
+		logger:      logger.Named(log.NameP2PStorage),
+		db:          db,
+		protectFn:   protectFn,
+		unprotectFn: unprotectFn,
 	}
 	return &es
 }
 
-func (s identityStore) GetNetworkKey() (*ecdsa.PrivateKey, bool, error) {
+func (s identityStore) GetNetworkKey(ctx context.Context) (*ecdsa.PrivateKey, bool, error) {
 	obj, found, err := s.db.Get(prefix, netKeyPrefix)
 	if !found {
 		return nil, false, nil
@@ -52,42 +65,131 @@ func (s identityStore) GetNetworkKey() (*ecdsa.PrivateKey, bool, error) {
 	if err != nil {
 		return nil, found, err
 	}
-	pk, err := decode(obj.Value)
-	pk.Curve = gcrypto.S256() // temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1
+	pk, _, err := decodeNetworkKey(ctx, obj.Value, s.unprotectFn)
 	if err != nil {
-		return nil, found, errors.WithMessage(err, "failed to decode private key")
+		return nil, found, fmt.Errorf("failed to decode private key: %w", err)
 	}
+	pk.Curve = gcrypto.S256() // temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1
 	return pk, found, nil
 }
 
-func (s identityStore) SetupNetworkKey(skEncoded string) (*ecdsa.PrivateKey, error) {
-	privateKey, found, err := s.GetNetworkKey()
-	if err != nil {
-		return nil, errors.WithMessage(err, "failed to get privateKey")
+func (s identityStore) SetupNetworkKey(ctx context.Context, skEncoded string) (*ecdsa.PrivateKey, error) {
+	var (
+		privateKey *ecdsa.PrivateKey
+		found      bool
+		encrypted  bool
+		err        error
+	)
+	if skEncoded == "" {
+		obj, keyFound, err := s.db.Get(prefix, netKeyPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get privateKey: %w", err)
+		}
+		if keyFound {
+			privateKey, encrypted, err = decodeNetworkKey(ctx, obj.Value, s.unprotectFn)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get privateKey: %w", err)
+			}
+			privateKey.Curve = gcrypto.S256() // temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1
+			found = true
+		}
 	}
 	if skEncoded == "" && found && privateKey != nil {
+		if !encrypted {
+			if s.hasProtectedStorage() {
+				s.logger.Info("migrating plaintext p2p network private key to encrypted storage")
+				if err := s.saveNetworkKey(ctx, privateKey); err != nil {
+					return nil, err
+				}
+			} else {
+				s.logger.Warn("using legacy plaintext p2p network private key from storage; configure a local operator key or use an ssv-signer deployment that supports remote network-key protection to encrypt it at rest")
+			}
+		}
 		s.logger.Debug("using p2p network privateKey from storage")
 		return privateKey, nil
 	}
 	privateKey, err = utils.ECDSAPrivateKey(s.logger, skEncoded)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to generate private key")
+		return nil, fmt.Errorf("failed to generate private key: %w", err)
 	}
 
-	return privateKey, s.saveNetworkKey(privateKey)
+	if !s.hasProtectedStorage() {
+		s.logger.Warn("persisting p2p network private key in legacy plaintext storage because no network key encryption secret is configured; configure a local operator key or use an ssv-signer deployment that supports remote network-key protection to encrypt it at rest")
+		return privateKey, s.saveNetworkKeyPlaintext(privateKey)
+	}
+
+	return privateKey, s.saveNetworkKey(ctx, privateKey)
 }
 
-func (s identityStore) saveNetworkKey(privateKey *ecdsa.PrivateKey) error {
-	if err := s.db.Set(prefix, netKeyPrefix, encode(privateKey)); err != nil {
-		return errors.WithMessage(err, "failed to save to db")
+func (s identityStore) saveNetworkKey(ctx context.Context, privateKey *ecdsa.PrivateKey) error {
+	protectedValue, err := encodeNetworkKey(ctx, privateKey, s.protectFn)
+	if err != nil {
+		return fmt.Errorf("failed to protect private key: %w", err)
+	}
+	if err := s.db.Set(prefix, netKeyPrefix, protectedValue); err != nil {
+		return fmt.Errorf("failed to save to db: %w", err)
 	}
 	return nil
 }
 
-func encode(privateKey *ecdsa.PrivateKey) []byte {
-	return gcrypto.FromECDSA(privateKey)
+func (s identityStore) hasProtectedStorage() bool {
+	return s.protectFn != nil && s.unprotectFn != nil
 }
 
-func decode(b []byte) (*ecdsa.PrivateKey, error) {
-	return gcrypto.ToECDSA(b)
+func (s identityStore) saveNetworkKeyPlaintext(privateKey *ecdsa.PrivateKey) error {
+	if err := s.db.Set(prefix, netKeyPrefix, gcrypto.FromECDSA(privateKey)); err != nil {
+		return fmt.Errorf("failed to save to db: %w", err)
+	}
+	return nil
+}
+
+// HasEncryptedNetworkKey reports whether the stored network key already uses the
+// encrypted-at-rest storage format.
+func HasEncryptedNetworkKey(db basedb.Database) (bool, error) {
+	obj, found, err := db.Get(prefix, netKeyPrefix)
+	if err != nil || !found {
+		return false, err
+	}
+
+	return bytes.HasPrefix(obj.Value, encryptedPrefix), nil
+}
+
+func encodeNetworkKey(
+	ctx context.Context,
+	privateKey *ecdsa.PrivateKey,
+	protectFn func(ctx context.Context, plaintext []byte) ([]byte, error),
+) ([]byte, error) {
+	plaintext := gcrypto.FromECDSA(privateKey)
+	if protectFn == nil {
+		return nil, errors.New("network key protector is required")
+	}
+	protectedValue, err := protectFn(ctx, plaintext)
+	if err != nil {
+		return nil, err
+	}
+	storedValue := make([]byte, 0, len(encryptedPrefix)+len(protectedValue))
+	storedValue = append(storedValue, encryptedPrefix...)
+	storedValue = append(storedValue, protectedValue...)
+	return storedValue, nil
+}
+
+func decodeNetworkKey(
+	ctx context.Context,
+	storedValue []byte,
+	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error),
+) (*ecdsa.PrivateKey, bool, error) {
+	if bytes.HasPrefix(storedValue, encryptedPrefix) {
+		if unprotectFn == nil {
+			return nil, true, errors.New("network key is encrypted but no compatible network key protector is configured")
+		}
+		decrypted, err := unprotectFn(ctx, storedValue[len(encryptedPrefix):])
+		if err != nil {
+			return nil, true, err
+		}
+		pk, err := gcrypto.ToECDSA(decrypted)
+		return pk, true, err
+	}
+
+	pk, err := gcrypto.ToECDSA(storedValue)
+	return pk, false, err
 }

--- a/identity/store.go
+++ b/identity/store.go
@@ -59,11 +59,11 @@ func NewIdentityStore(
 
 func (s identityStore) GetNetworkKey(ctx context.Context) (*ecdsa.PrivateKey, bool, error) {
 	obj, found, err := s.db.Get(prefix, netKeyPrefix)
-	if !found {
-		return nil, false, nil
-	}
 	if err != nil {
 		return nil, found, err
+	}
+	if !found {
+		return nil, false, nil
 	}
 	pk, _, err := decodeNetworkKey(ctx, obj.Value, s.unprotectFn)
 	if err != nil {
@@ -88,7 +88,7 @@ func (s identityStore) SetupNetworkKey(ctx context.Context, skEncoded string) (*
 		if keyFound {
 			privateKey, encrypted, err = decodeNetworkKey(ctx, obj.Value, s.unprotectFn)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get privateKey: %w", err)
+				return nil, fmt.Errorf("decode network key: %w", err)
 			}
 			privateKey.Curve = gcrypto.S256() // temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1
 			found = true

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -1,25 +1,60 @@
 package p2p
 
 import (
+	"bytes"
+	"context"
 	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/observability/log"
+	"github.com/ssvlabs/ssv/ssvsigner"
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
 var (
-	sk  = "ba03f90c6e2e6d67e4a4682621412ddbafeb6bffdc169df8f2bd31f193f001d4"
-	sk2 = "2340652c367bf8d17de1bc0454e6aa73e2eedd4a51686887d98d6b8813e5fb4a"
+	sk                      = "ba03f90c6e2e6d67e4a4682621412ddbafeb6bffdc169df8f2bd31f193f001d4"
+	sk2                     = "2340652c367bf8d17de1bc0454e6aa73e2eedd4a51686887d98d6b8813e5fb4a"
+	networkKeyEncryptionKey = []byte("0123456789abcdef0123456789abcdef")
 )
+
+func newTestSSVSignerClient(t *testing.T) *ssvsigner.Client {
+	mux := http.NewServeMux()
+	mux.HandleFunc(ssvsigner.PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+		payload, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		encrypted, err := keys.EncryptPayload(networkKeyEncryptionKey, payload)
+		require.NoError(t, err)
+		_, err = w.Write(encrypted)
+		require.NoError(t, err)
+	})
+	mux.HandleFunc(ssvsigner.PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+		payload, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		decrypted, err := keys.DecryptPayload(networkKeyEncryptionKey, payload)
+		require.NoError(t, err)
+		_, err = w.Write(decrypted)
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return ssvsigner.NewClient(server.URL, ssvsigner.WithLogger(zap.NewNop()))
+}
 
 func TestSetupPrivateKey(t *testing.T) {
 	logger := log.TestLogger(t)
+	ctx := context.Background()
 
 	tests := []struct {
 		name      string
@@ -57,13 +92,19 @@ func TestSetupPrivateKey(t *testing.T) {
 			p2pStorage := identityStore{
 				db:     db,
 				logger: logger,
+				protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+					return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+				},
+				unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+					return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+				},
 			}
 
 			if test.existKey != "" { // mock exist key
 				privKey, err := gcrypto.HexToECDSA(test.existKey)
 				require.NoError(t, err)
-				require.NoError(t, p2pStorage.saveNetworkKey(privKey))
-				sk, found, err := p2pStorage.GetNetworkKey()
+				require.NoError(t, p2pStorage.saveNetworkKey(ctx, privKey))
+				sk, found, err := p2pStorage.GetNetworkKey(ctx)
 				require.True(t, found)
 				require.NoError(t, err)
 				require.NotNil(t, sk)
@@ -75,9 +116,9 @@ func TestSetupPrivateKey(t *testing.T) {
 				require.Equal(t, test.existKey, hex.EncodeToString(b))
 			}
 
-			_, err = p2pStorage.SetupNetworkKey(test.passedKey)
+			_, err = p2pStorage.SetupNetworkKey(ctx, test.passedKey)
 			require.NoError(t, err)
-			privateKey, found, err := p2pStorage.GetNetworkKey()
+			privateKey, found, err := p2pStorage.GetNetworkKey(ctx)
 			require.NoError(t, err)
 			require.True(t, found)
 			require.NoError(t, err)
@@ -103,13 +144,304 @@ func TestSetupPrivateKey(t *testing.T) {
 		})
 	}
 
+	t.Run("migrates legacy plaintext key to encrypted storage", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		privKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, db.Set(prefix, netKeyPrefix, gcrypto.FromECDSA(privKey)))
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		storedBefore, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, gcrypto.FromECDSA(privKey), storedBefore.Value)
+
+		loadedKey, err := p2pStorage.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, loadedKey)
+
+		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, bytes.HasPrefix(storedAfter.Value, encryptedPrefix))
+		require.NotEqual(t, gcrypto.FromECDSA(privKey), storedAfter.Value)
+	})
+
+	t.Run("persists configured key in legacy plaintext when encryption secret is missing", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, gcrypto.FromECDSA(privateKey), storedAfter.Value)
+	})
+
+	t.Run("uses legacy plaintext key from storage when encryption secret is missing", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		privKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		legacyEncoded := gcrypto.FromECDSA(privKey)
+		require.NoError(t, db.Set(prefix, netKeyPrefix, legacyEncoded))
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, legacyEncoded, storedAfter.Value)
+	})
+
+	t.Run("generates and persists a legacy plaintext key when encryption secret is missing", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, gcrypto.FromECDSA(privateKey), storedAfter.Value)
+	})
+
 	t.Run("NewIdentityStore", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
 
-		p2pStorage := NewIdentityStore(logger, db)
+		p2pStorage := NewIdentityStore(
+			logger,
+			db,
+			func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		)
 
 		require.NotNil(t, p2pStorage)
+	})
+}
+
+func TestEKMEncryptionKey(t *testing.T) {
+	operatorPrivKey, err := keys.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
+	require.NoError(t, err)
+	require.Len(t, encryptionKey, 32)
+
+	encryptionKey2, err := operatorPrivKey.EKMEncryptionKey()
+	require.NoError(t, err)
+	require.Equal(t, encryptionKey, encryptionKey2)
+}
+
+func TestEncryptedNetworkKey(t *testing.T) {
+	logger := log.TestLogger(t)
+	ctx := context.Background()
+
+	t.Run("stores and loads encrypted network key", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedObj, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, bytes.HasPrefix(storedObj.Value, encryptedPrefix))
+
+		loadedKey, found, err := p2pStorage.GetNetworkKey(ctx)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.NotNil(t, loadedKey)
+
+		interfacePriv, err := commons.ECDSAPrivToInterface(loadedKey)
+		require.NoError(t, err)
+		raw, err := interfacePriv.Raw()
+		require.NoError(t, err)
+		require.Equal(t, sk, hex.EncodeToString(raw))
+	})
+
+	t.Run("detects encrypted network key format", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+
+		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.True(t, hasEncryptedKey)
+	})
+
+	t.Run("errors clearly when encrypted key cannot be decrypted", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+
+		storeWithoutProtector := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		_, _, err = storeWithoutProtector.GetNetworkKey(ctx)
+		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
+	})
+
+	t.Run("stores and loads remotely protected network key using encrypted format", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		signerClient := newTestSSVSignerClient(t)
+		p2pStorage := identityStore{
+			db:          db,
+			logger:      logger,
+			protectFn:   signerClient.OperatorEncrypt,
+			unprotectFn: signerClient.OperatorDecrypt,
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedObj, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, bytes.HasPrefix(storedObj.Value, encryptedPrefix))
+
+		loadedKey, found, err := p2pStorage.GetNetworkKey(ctx)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.NotNil(t, loadedKey)
+	})
+
+	t.Run("detects remotely protected network key as encrypted format", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		signerClient := newTestSSVSignerClient(t)
+		p2pStorage := identityStore{
+			db:          db,
+			logger:      logger,
+			protectFn:   signerClient.OperatorEncrypt,
+			unprotectFn: signerClient.OperatorDecrypt,
+		}
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+
+		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.True(t, hasEncryptedKey)
+	})
+
+	t.Run("errors clearly when remotely protected key cannot be unprotected", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		signerClient := newTestSSVSignerClient(t)
+		p2pStorage := identityStore{
+			db:          db,
+			logger:      logger,
+			protectFn:   signerClient.OperatorEncrypt,
+			unprotectFn: signerClient.OperatorDecrypt,
+		}
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+
+		storeWithoutProtector := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		_, _, err = storeWithoutProtector.GetNetworkKey(ctx)
+		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
 	})
 }

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -50,6 +51,18 @@ func newTestSSVSignerClient(t *testing.T) *ssvsigner.Client {
 	t.Cleanup(server.Close)
 
 	return ssvsigner.NewClient(server.URL, ssvsigner.WithLogger(zap.NewNop()))
+}
+
+type getOverrideDB struct {
+	basedb.Database
+	getFn func(prefix []byte, key []byte) (basedb.Obj, bool, error)
+}
+
+func (db getOverrideDB) Get(prefix []byte, key []byte) (basedb.Obj, bool, error) {
+	if db.getFn != nil {
+		return db.getFn(prefix, key)
+	}
+	return db.Database.Get(prefix, key)
 }
 
 func TestSetupPrivateKey(t *testing.T) {
@@ -243,6 +256,51 @@ func TestSetupPrivateKey(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Equal(t, gcrypto.FromECDSA(privateKey), storedAfter.Value)
+	})
+
+	t.Run("returns DB errors from GetNetworkKey even when key is not found", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		expectedErr := errors.New("db read failed")
+		p2pStorage := identityStore{
+			db: getOverrideDB{
+				Database: db,
+				getFn: func(prefix []byte, key []byte) (basedb.Obj, bool, error) {
+					return basedb.Obj{}, false, expectedErr
+				},
+			},
+			logger: logger,
+		}
+
+		_, _, err = p2pStorage.GetNetworkKey(ctx)
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("returns decode-specific error when stored key cannot be decrypted", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return bytes.Repeat([]byte{0xff}, 32), nil
+			},
+		}
+
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, "")
+		require.ErrorContains(t, err, "decode network key")
 	})
 
 	t.Run("NewIdentityStore", func(t *testing.T) {

--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -119,6 +119,8 @@ BATCH_SIZE=20 \
 | `/v1/validators/sign/{pubkey}` | POST | Sign beacon object with validator share |
 | `/v1/operator/identity` | GET | Get operator RSA public key |
 | `/v1/operator/sign` | POST | Sign data with operator RSA key |
+| `/v1/operator/encrypt` | POST | Encrypt data with the operator-derived storage key using the same encrypted format as local mode |
+| `/v1/operator/decrypt` | POST | Decrypt data from that same encrypted format |
 
 ## Key Flows
 
@@ -150,6 +152,7 @@ BATCH_SIZE=20 \
 ### Integration with SSV Node
 - SSV node uses `RemoteKeyManager` when configured with `SSVSignerEndpoint`
 - On startup, node validates signer availability and operator key consistency
+- On startup, node probes `/v1/operator/encrypt` and `/v1/operator/decrypt` to decide whether the persisted P2P network key can be protected with the remote operator key. Older `ssv-signer` versions that explicitly do not implement these endpoints still work for legacy plaintext records, but encrypted records require these endpoints or the original local operator key. Other fetch failures should fail startup instead of silently downgrading protection.
 - Configuration is locked to prevent switching between local/remote signing
 
 ### Error Handling

--- a/ssvsigner/DESIGN.md
+++ b/ssvsigner/DESIGN.md
@@ -22,7 +22,7 @@ ssv-signer is a lightweight remote signing service inspired by Web3Signer. It wi
 
     Be preconfigured with a Web3Signer endpoint and an operator private key keystore.
 
-    Provide 3 essential API endpoints:
+    Provide validator-management APIs plus operator-key APIs for identity, signing, and P2P network-key encryption:
 
 #### API Endpoints
 
@@ -43,6 +43,10 @@ ssv-signer is a lightweight remote signing service inspired by Web3Signer. It wi
 - `GET /v1/operator/identity` - returns RSA public key, used by the node on startup to determine its own public key and therefore operator ID
 
 - `POST /v1/operator/sign` - signs a payload using the operator rsa key
+
+- `POST /v1/operator/encrypt` - encrypts data using the same encrypted-at-rest format that local operator-key deployments produce.
+
+- `POST /v1/operator/decrypt` - decrypts data from that same encrypted-at-rest format.
 
 
 #### Packages
@@ -69,6 +73,7 @@ With the introduction of ssv-signer, a third option will be added with `SSVSigne
 - Check ConfigLock to make sure remote signing is enabled in existing database, if any.
 - Fail if remote signer is offline.
 - Get ssv-signer operator public key and persist it to database. Crash if it already exists and is different (changing operators with same DB is not allowed, like today).
+- Probe `/v1/operator/encrypt` and `/v1/operator/decrypt`. If they are available, use them to protect the persisted P2P network key with the same encrypted-at-rest format used by local operator-key deployments. If the signer explicitly reports that these endpoints are unsupported, preserve legacy plaintext-at-rest behavior for backwards compatibility. If the database already contains an encrypted P2P network key, startup must fail until an `ssv-signer` with data-protection support or the original local operator key is restored. Other fetch failures should be treated as startup errors rather than silently downgrading protection.
 - Check that all the keys its supposed to have are available. (ssv-signer checks in web3signer)
 
 #### Startup (with remote signing disabled)

--- a/ssvsigner/README.md
+++ b/ssvsigner/README.md
@@ -370,6 +370,14 @@ SSV-Signer exposes the following API endpoints:
 | `/v1/validators/sign/{identifier}` | POST   | Sign a payload with a specific validator share          |
 | `/v1/operator/identity`            | GET    | Get the operator's public key                           |
 | `/v1/operator/sign`                | POST   | Sign data with the operator's key                       |
+| `/v1/operator/encrypt`             | POST   | Encrypt data with the operator-derived storage key using the same encrypted format as local mode |
+| `/v1/operator/decrypt`             | POST   | Decrypt data from that same encrypted format |
+
+The SSV node probes `/v1/operator/encrypt` and `/v1/operator/decrypt` on startup. Older `ssv-signer` versions that
+explicitly do not expose these endpoints remain supported for legacy plaintext network-key storage, but a database
+that already contains an encrypted P2P network key requires an `ssv-signer` version that supports these endpoints
+or the original local operator key that encrypted that database. Other fetch failures are treated as startup
+errors rather than downgrading protection silently.
 
 ## Common Issues and Troubleshooting
 

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -233,7 +233,7 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
-		recordClientRequest(ctx, opSignOperator, err, duration)
+		recordClientRequest(ctx, opOperatorSign, err, duration)
 		c.logger.Debug("requested to sign with operator key", zap.Duration("duration", duration), zap.Error(err))
 	}()
 	err = requests.
@@ -245,6 +245,58 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		ToBytesBuffer(&respBuf).
 		Fetch(ctx)
 	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return respBuf.Bytes(), nil
+}
+
+func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted []byte, err error) {
+	var respBuf bytes.Buffer
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		recordClientRequest(ctx, opOperatorEncrypt, err, duration)
+		c.logger.Debug("requested operator encrypt", zap.Duration("duration", duration), zap.Error(err))
+	}()
+	err = requests.
+		URL(c.baseURL).
+		Client(c.httpClient).
+		Path(PathOperatorEncrypt).
+		BodyBytes(payload).
+		Post().
+		ToBytesBuffer(&respBuf).
+		Fetch(ctx)
+	if err != nil {
+		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
+			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
+		}
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return respBuf.Bytes(), nil
+}
+
+func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted []byte, err error) {
+	var respBuf bytes.Buffer
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		recordClientRequest(ctx, opOperatorDecrypt, err, duration)
+		c.logger.Debug("requested operator decrypt", zap.Duration("duration", duration), zap.Error(err))
+	}()
+	err = requests.
+		URL(c.baseURL).
+		Client(c.httpClient).
+		Path(PathOperatorDecrypt).
+		BodyBytes(payload).
+		Post().
+		ToBytesBuffer(&respBuf).
+		Fetch(ctx)
+	if err != nil {
+		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
+			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
+		}
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -596,6 +596,91 @@ func (s *SSVSignerClientSuite) TestOperatorSign() {
 	}
 }
 
+func (s *SSVSignerClientSuite) TestOperatorDataProtection() {
+	t := s.T()
+
+	payload := bytes.Repeat([]byte{0x23}, 32)
+	encryptedPayload := bytes.Repeat([]byte{0x42}, 64)
+
+	t.Run("encrypt success", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusOK)
+			w.Write(encryptedPayload)
+		})
+
+		result, err := s.client.OperatorEncrypt(t.Context(), payload)
+		require.NoError(t, err)
+		assert.Equal(t, encryptedPayload, result)
+		assert.Equal(t, 1, s.serverHits)
+	})
+
+	t.Run("decrypt success", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusOK)
+			w.Write(payload)
+		})
+
+		result, err := s.client.OperatorDecrypt(t.Context(), encryptedPayload)
+		require.NoError(t, err)
+		assert.Equal(t, payload, result)
+		assert.Equal(t, 1, s.serverHits)
+	})
+
+	t.Run("returns unsupported sentinel on encrypt 404", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		_, err := s.client.OperatorEncrypt(t.Context(), payload)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrOperatorDataProtectionUnsupported)
+		assert.Equal(t, 1, s.serverHits)
+	})
+
+	t.Run("returns unsupported sentinel on decrypt 404", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		_, err := s.client.OperatorDecrypt(t.Context(), encryptedPayload)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrOperatorDataProtectionUnsupported)
+		assert.Equal(t, 1, s.serverHits)
+	})
+
+	t.Run("keeps non-unsupported encrypt failures as request errors", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		_, err := s.client.OperatorEncrypt(t.Context(), payload)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "request failed")
+		require.NotErrorIs(t, err, ErrOperatorDataProtectionUnsupported)
+		assert.Equal(t, 1, s.serverHits)
+	})
+
+	t.Run("keeps non-unsupported decrypt failures as request errors", func(t *testing.T) {
+		s.resetMux()
+		s.mux.HandleFunc(PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		_, err := s.client.OperatorDecrypt(t.Context(), encryptedPayload)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "request failed")
+		require.NotErrorIs(t, err, ErrOperatorDataProtectionUnsupported)
+		assert.Equal(t, 1, s.serverHits)
+	})
+}
+
 // TestMissingKeys tests the MissingKeys method which identifies keys present in local storage
 // but missing from the remote SSV signer service. It verifies proper key difference calculation
 // and error handling for various key combinations and server response scenarios.

--- a/ssvsigner/ekm/signer_storage.go
+++ b/ssvsigner/ekm/signer_storage.go
@@ -1,13 +1,9 @@
 package ekm
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -22,6 +18,7 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
 	registry "github.com/ssvlabs/ssv/protocol/v2/blockchain/eth1"
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
@@ -402,7 +399,7 @@ func (s *storage) decryptData(objectValue []byte) ([]byte, error) {
 		return objectValue, nil
 	}
 
-	decryptedData, err := s.decrypt(objectValue)
+	decryptedData, err := keys.DecryptPayload(s.encryptionKey, objectValue)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt wallet: %w", err)
 	}
@@ -415,45 +412,10 @@ func (s *storage) encryptData(objectValue []byte) ([]byte, error) {
 		return objectValue, nil
 	}
 
-	encryptedData, err := s.encrypt(objectValue)
+	encryptedData, err := keys.EncryptPayload(s.encryptionKey, objectValue)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt wallet: %w", err)
 	}
 
 	return encryptedData, nil
-}
-
-func (s *storage) encrypt(plaintext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(s.encryptionKey)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
-}
-
-func (s *storage) decrypt(nonceCipherText []byte) ([]byte, error) {
-	block, err := aes.NewCipher(s.encryptionKey)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonceSize := gcm.NonceSize()
-	if len(nonceCipherText) < nonceSize {
-		return nil, errors.New("malformed ciphertext")
-	}
-
-	nonce, ciphertext := nonceCipherText[:nonceSize], nonceCipherText[nonceSize:]
-	// #nosec G407 false positive: https://github.com/securego/gosec/issues/1211
-	return gcm.Open(nil, nonce, ciphertext, nil)
 }

--- a/ssvsigner/internal/mocks/mocks.go
+++ b/ssvsigner/internal/mocks/mocks.go
@@ -17,12 +17,24 @@ var (
 
 // TestOperatorPublicKey implements a mock operator public key for testing.
 type TestOperatorPublicKey struct {
-	PubKeyBase64 string
-	Base64Error  error
+	PubKeyBase64  string
+	Base64Error   error
+	EncryptResult []byte
+	EncryptError  error
+	EncryptFunc   func([]byte) ([]byte, error)
 }
 
 // Encrypt mocks encryption with the public key.
 func (t *TestOperatorPublicKey) Encrypt(data []byte) ([]byte, error) {
+	if t.EncryptFunc != nil {
+		return t.EncryptFunc(data)
+	}
+	if t.EncryptError != nil {
+		return nil, t.EncryptError
+	}
+	if t.EncryptResult != nil {
+		return t.EncryptResult, nil
+	}
 	return data, nil
 }
 
@@ -43,8 +55,11 @@ type TestOperatorPrivateKey struct {
 	StorageHashValue      []byte
 	EkmHashValue          []byte
 	EkmEncryptionKeyValue []byte
+	EKMEncryptionKeyFunc  func() ([]byte, error)
+	EKMEncryptionKeyError error
 	DecryptResult         []byte
 	DecryptError          error
+	DecryptFunc           func([]byte) ([]byte, error)
 	SignResult            []byte
 	SignError             error
 	PublicKey             keys.OperatorPublicKey
@@ -65,7 +80,10 @@ func (t *TestOperatorPrivateKey) Public() keys.OperatorPublicKey {
 }
 
 // Decrypt mocks decryption of encrypted data.
-func (t *TestOperatorPrivateKey) Decrypt([]byte) ([]byte, error) {
+func (t *TestOperatorPrivateKey) Decrypt(data []byte) ([]byte, error) {
+	if t.DecryptFunc != nil {
+		return t.DecryptFunc(data)
+	}
 	if t.DecryptError != nil {
 		return nil, t.DecryptError
 	}
@@ -85,6 +103,12 @@ func (t *TestOperatorPrivateKey) EKMHash() []byte {
 
 // EKMEncryptionKey returns a mock EKM encryption key.
 func (t *TestOperatorPrivateKey) EKMEncryptionKey() ([]byte, error) {
+	if t.EKMEncryptionKeyFunc != nil {
+		return t.EKMEncryptionKeyFunc()
+	}
+	if t.EKMEncryptionKeyError != nil {
+		return nil, t.EKMEncryptionKeyError
+	}
 	return t.EkmEncryptionKeyValue, nil
 }
 

--- a/ssvsigner/keys/aes.go
+++ b/ssvsigner/keys/aes.go
@@ -34,7 +34,7 @@ func DecryptPayload(encryptionKey, nonceCipherText []byte) ([]byte, error) {
 		return nil, err
 	}
 	nonceSize := gcm.NonceSize()
-	if len(nonceCipherText) < nonceSize {
+	if len(nonceCipherText) <= nonceSize {
 		return nil, errors.New("malformed ciphertext")
 	}
 

--- a/ssvsigner/keys/aes.go
+++ b/ssvsigner/keys/aes.go
@@ -4,9 +4,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 func EncryptPayload(encryptionKey, plaintext []byte) ([]byte, error) {

--- a/ssvsigner/keys/aes.go
+++ b/ssvsigner/keys/aes.go
@@ -1,0 +1,44 @@
+package keys
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+func EncryptPayload(encryptionKey, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func DecryptPayload(encryptionKey, nonceCipherText []byte) ([]byte, error) {
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(nonceCipherText) < nonceSize {
+		return nil, errors.New("malformed ciphertext")
+	}
+
+	nonce, ciphertext := nonceCipherText[:nonceSize], nonceCipherText[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}

--- a/ssvsigner/observability.go
+++ b/ssvsigner/observability.go
@@ -25,7 +25,9 @@ const (
 	opRemoveValidator  = "remove_validator"
 	opSignValidator    = "sign_validator"
 	opOperatorIdentity = "operator_identity"
-	opSignOperator     = "sign_operator"
+	opOperatorSign     = "operator_sign"
+	opOperatorEncrypt  = "operator_encrypt"
+	opOperatorDecrypt  = "operator_decrypt"
 
 	// Remote Signer operations called by server
 	opRemoteSignerListKeys       = "remote_signer_list_keys"

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -489,8 +489,9 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 
 	payload := ctx.PostBody()
 	if len(payload) == 0 {
-		logger.Warn("request has no payload")
-		s.writeJSONErr(ctx, logger, fasthttp.StatusBadRequest, errors.New("request payload is empty"))
+		err := errors.New("request payload is empty")
+		logger.Warn("invalid request", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusBadRequest, err)
 		return
 	}
 

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -2,12 +2,15 @@ package ssvsigner
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"strings"
@@ -38,6 +41,8 @@ const (
 	PathValidatorsSign   = "/v1/validators/sign/"  // TODO: /api/v1/eth2/sign/ ?
 	PathOperatorIdentity = "/v1/operator/identity" // TODO: /api/v1/ssv/identity ?
 	PathOperatorSign     = "/v1/operator/sign"     // TODO: /api/v1/ssv/sign ?
+	PathOperatorEncrypt  = "/v1/operator/encrypt"  // TODO: /api/v1/ssv/encrypt ?
+	PathOperatorDecrypt  = "/v1/operator/decrypt"  // TODO: /api/v1/ssv/decrypt ?
 )
 
 const (
@@ -78,7 +83,9 @@ func NewServer(
 	r.POST(PathValidatorsSign+"{identifier}", server.handleSignValidator)
 
 	r.GET(PathOperatorIdentity, server.handleOperatorIdentity)
-	r.POST(PathOperatorSign, server.handleSignOperator)
+	r.POST(PathOperatorSign, server.handleOperatorSign)
+	r.POST(PathOperatorEncrypt, server.handleOperatorEncrypt)
+	r.POST(PathOperatorDecrypt, server.handleOperatorDecrypt)
 
 	return server
 }
@@ -412,11 +419,11 @@ func (s *Server) handleOperatorIdentity(ctx *fasthttp.RequestCtx) {
 	s.writeString(ctx, logger, pubKeyB64)
 }
 
-func (s *Server) handleSignOperator(ctx *fasthttp.RequestCtx) {
+func (s *Server) handleOperatorSign(ctx *fasthttp.RequestCtx) {
 	payload := ctx.PostBody()
 
 	logger := s.logger.With(
-		zap.String("method", "handleSignOperator"),
+		zap.String("method", "handleOperatorSign"),
 		zap.Int("payload_size", len(payload)),
 	)
 
@@ -440,6 +447,74 @@ func (s *Server) handleSignOperator(ctx *fasthttp.RequestCtx) {
 	s.writeBytes(ctx, logger, signature)
 }
 
+func (s *Server) handleOperatorEncrypt(ctx *fasthttp.RequestCtx) {
+	logger := s.logger.With(
+		zap.String("method", "handleOperatorEncrypt"),
+		zap.Int("payload_size", len(ctx.PostBody())),
+	)
+
+	logger.Debug("received request")
+
+	payload := ctx.PostBody()
+	if len(payload) == 0 {
+		err := errors.New("request payload is empty")
+		logger.Warn("invalid request", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusBadRequest, err)
+		return
+	}
+
+	encryptionKey, err := s.operatorPrivKey.EKMEncryptionKey()
+	if err != nil {
+		logger.Error("request failed", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
+		return
+	}
+
+	encrypted, err := encryptPayload(encryptionKey, payload)
+	if err != nil {
+		logger.Error("request failed", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
+		return
+	}
+
+	logger.Info("request finished successfully")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	s.writeBytes(ctx, logger, encrypted)
+}
+
+func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
+	logger := s.logger.With(
+		zap.String("method", "handleOperatorDecrypt"),
+		zap.Int("payload_size", len(ctx.PostBody())),
+	)
+
+	logger.Debug("received request")
+
+	payload := ctx.PostBody()
+	if len(payload) == 0 {
+		logger.Warn("request has no payload")
+		s.writeJSONErr(ctx, logger, fasthttp.StatusBadRequest, errors.New("request payload is empty"))
+		return
+	}
+
+	encryptionKey, err := s.operatorPrivKey.EKMEncryptionKey()
+	if err != nil {
+		logger.Error("request failed", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
+		return
+	}
+
+	decrypted, err := decryptPayload(encryptionKey, payload)
+	if err != nil {
+		logger.Error("request failed", zap.Error(err))
+		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
+		return
+	}
+	logger.Info("request finished successfully")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	s.writeBytes(ctx, logger, decrypted)
+}
+
 func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, resp any, err error) {
 	statusCode := fasthttp.StatusInternalServerError
 	if he := new(web3signer.HTTPResponseError); errors.As(err, &he) {
@@ -453,6 +528,40 @@ func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logge
 	)
 	ctx.SetStatusCode(statusCode)
 	s.writeJSON(ctx, logger, resp)
+}
+
+func encryptPayload(encryptionKey, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func decryptPayload(encryptionKey, nonceCipherText []byte) ([]byte, error) {
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(nonceCipherText) < nonceSize {
+		return nil, errors.New("malformed ciphertext")
+	}
+
+	nonce, ciphertext := nonceCipherText[:nonceSize], nonceCipherText[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
 func (s *Server) writeString(ctx *fasthttp.RequestCtx, logger *zap.Logger, str string) {

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -2,15 +2,12 @@ package ssvsigner
 
 import (
 	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"net"
 	"strings"
@@ -470,7 +467,7 @@ func (s *Server) handleOperatorEncrypt(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	encrypted, err := encryptPayload(encryptionKey, payload)
+	encrypted, err := keys.EncryptPayload(encryptionKey, payload)
 	if err != nil {
 		logger.Error("request failed", zap.Error(err))
 		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
@@ -504,7 +501,7 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	decrypted, err := decryptPayload(encryptionKey, payload)
+	decrypted, err := keys.DecryptPayload(encryptionKey, payload)
 	if err != nil {
 		logger.Error("request failed", zap.Error(err))
 		s.writeJSONErr(ctx, logger, fasthttp.StatusInternalServerError, err)
@@ -528,40 +525,6 @@ func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logge
 	)
 	ctx.SetStatusCode(statusCode)
 	s.writeJSON(ctx, logger, resp)
-}
-
-func encryptPayload(encryptionKey, plaintext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(encryptionKey)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
-}
-
-func decryptPayload(encryptionKey, nonceCipherText []byte) ([]byte, error) {
-	block, err := aes.NewCipher(encryptionKey)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonceSize := gcm.NonceSize()
-	if len(nonceCipherText) < nonceSize {
-		return nil, errors.New("malformed ciphertext")
-	}
-
-	nonce, ciphertext := nonceCipherText[:nonceSize], nonceCipherText[nonceSize:]
-	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
 func (s *Server) writeString(ctx *fasthttp.RequestCtx, logger *zap.Logger, str string) {

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -456,6 +456,17 @@ func (s *ServerTestSuite) TestOperatorDataProtection() {
 		assert.Equal(t, payload, resp.Body())
 	})
 
+	t.Run("returns internal error when operator key derivation fails on decrypt", func(t *testing.T) {
+		s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) {
+			return nil, errors.New("derive failed")
+		}
+		defer func() { s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) { return encryptionKey, nil } }()
+
+		resp, err := s.ServeHTTP("POST", PathOperatorDecrypt, encryptedPayload)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+	})
+
 	t.Run("returns internal error when operator key derivation fails", func(t *testing.T) {
 		s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) {
 			return nil, errors.New("derive failed")
@@ -469,6 +480,12 @@ func (s *ServerTestSuite) TestOperatorDataProtection() {
 
 	t.Run("returns bad request when encrypt payload is empty", func(t *testing.T) {
 		resp, err := s.ServeHTTP("POST", PathOperatorEncrypt, nil)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusBadRequest, resp.StatusCode())
+	})
+
+	t.Run("returns bad request when decrypt payload is empty", func(t *testing.T) {
+		resp, err := s.ServeHTTP("POST", PathOperatorDecrypt, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusBadRequest, resp.StatusCode())
 	})

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -1,6 +1,7 @@
 package ssvsigner
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -423,6 +424,53 @@ func (s *ServerTestSuite) TestOperatorSign() {
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
 
 		s.operatorPrivKey.SignError = nil
+	})
+}
+
+func (s *ServerTestSuite) TestOperatorDataProtection() {
+	t := s.T()
+
+	encryptionKey := []byte("0123456789abcdef0123456789abcdef")
+	payload := bytes.Repeat([]byte{0x23}, 32)
+	encryptedPayload, err := encryptPayload(encryptionKey, payload)
+	require.NoError(t, err)
+
+	s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) {
+		return encryptionKey, nil
+	}
+	t.Cleanup(func() { s.operatorPrivKey.EKMEncryptionKeyFunc = nil })
+
+	t.Run("encrypt success", func(t *testing.T) {
+		resp, err := s.ServeHTTP("POST", PathOperatorEncrypt, payload)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, resp.StatusCode())
+		decrypted, err := decryptPayload(encryptionKey, resp.Body())
+		require.NoError(t, err)
+		assert.Equal(t, payload, decrypted)
+	})
+
+	t.Run("decrypt success", func(t *testing.T) {
+		resp, err := s.ServeHTTP("POST", PathOperatorDecrypt, encryptedPayload)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, resp.StatusCode())
+		assert.Equal(t, payload, resp.Body())
+	})
+
+	t.Run("returns internal error when operator key derivation fails", func(t *testing.T) {
+		s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) {
+			return nil, errors.New("derive failed")
+		}
+		defer func() { s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) { return encryptionKey, nil } }()
+
+		resp, err := s.ServeHTTP("POST", PathOperatorEncrypt, payload)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+	})
+
+	t.Run("returns bad request when encrypt payload is empty", func(t *testing.T) {
+		resp, err := s.ServeHTTP("POST", PathOperatorEncrypt, nil)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusBadRequest, resp.StatusCode())
 	})
 }
 

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/ssvsigner/internal/mocks"
-
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
 )
 
@@ -432,7 +432,7 @@ func (s *ServerTestSuite) TestOperatorDataProtection() {
 
 	encryptionKey := []byte("0123456789abcdef0123456789abcdef")
 	payload := bytes.Repeat([]byte{0x23}, 32)
-	encryptedPayload, err := encryptPayload(encryptionKey, payload)
+	encryptedPayload, err := keys.EncryptPayload(encryptionKey, payload)
 	require.NoError(t, err)
 
 	s.operatorPrivKey.EKMEncryptionKeyFunc = func() ([]byte, error) {
@@ -444,7 +444,7 @@ func (s *ServerTestSuite) TestOperatorDataProtection() {
 		resp, err := s.ServeHTTP("POST", PathOperatorEncrypt, payload)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusOK, resp.StatusCode())
-		decrypted, err := decryptPayload(encryptionKey, resp.Body())
+		decrypted, err := keys.DecryptPayload(encryptionKey, resp.Body())
 		require.NoError(t, err)
 		assert.Equal(t, payload, decrypted)
 	})

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -1,11 +1,15 @@
 package ssvsigner
 
 import (
+	"errors"
+
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type ShareDecryptionError error
+
+var ErrOperatorDataProtectionUnsupported = errors.New("operator data protection is unsupported by this ssv-signer")
 
 type AddValidatorRequest struct {
 	ShareKeys []ShareKeys `json:"share_keys"`


### PR DESCRIPTION
Fixes `F-ssv-185`.

## Summary

Encrypt the node's persisted P2P network private key instead of storing raw key bytes in the DB.

## What changed

- add encrypted `enc:` storage format for the persisted P2P network key
- keep backward compatibility with legacy plaintext DB entries
- lazily migrate legacy plaintext keys to encrypted storage when protection is available
- use local operator-key-derived encryption in local signer mode
- use `ssv-signer` `/v1/operator/encrypt` and `/v1/operator/decrypt` in remote signer mode
- keep legacy plaintext fallback with a warning when no compatible protection source exists
- fail startup clearly if the DB already contains an encrypted network key but the configured `ssv-signer` is too old to decrypt it
- update root `go.mod` to the latest `ssvsigner` version with operator encrypt/decrypt support

## Migration

- Existing plaintext DB entries remain supported.
- On first startup with a compatible protection source, the node lazily rewrites the stored P2P network key from legacy plaintext to encrypted `enc:` format.
- Local operator-key deployments encrypt automatically after upgrade.
- Remote-signer deployments encrypt automatically only when `ssv-signer` is upgraded first to a version that supports `/v1/operator/encrypt` and `/v1/operator/decrypt`.
- If `ssv-signer` is still old, the node keeps using legacy plaintext storage with a warning and does not break existing setups.
- Once the DB entry is migrated to `enc:` format, older node versions cannot read it and downgrading is not supported.

## Rollback to a previous version

If startup fails because the DB contains an encrypted persisted P2P network key, recover by setting the previous raw `NETWORK_PRIVATE_KEY`. If that key is not available, wipe/reset the DB and let a new P2P key be generated.
