### PR TITLE
duty-fetching: rework reorg detection

### DIFF
--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -166,13 +166,17 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 
 			slotNumber := uint64(currentSlot)%h.beaconConfig.SlotsPerEpoch + 1
 			buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, slotNumber)
-			refetchCurrentEpoch := reorgEvent.PreviousDutyDependentRootChanged
 
 			logger := h.logger.With(
 				zap.String("epoch_slot_pos", buildStr),
 				zap.Uint64("current_epoch", uint64(currentEpoch)),
 				zap.Uint64("current_slot", uint64(currentSlot)),
 			)
+
+			// Attester duties for the current epoch are determined by the "previous duty dependent root",
+			// so we re-fetch the current epoch only if it has changed. The next epoch is always re-fetched
+			// on any reorg to ensure we have the up-to-date duties for all validators.
+			refetchCurrentEpoch := reorgEvent.PreviousDutyDependentRootChanged
 
 			logger.Info("🔀 reorg event received",
 				zap.Any("event", reorgEvent),
@@ -188,9 +192,6 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 				defer cancel()
 
 				// 1) Declare intents.
-				// Attester duties for the current epoch are determined by the previous duty dependent root,
-				// so we re-fetch the current epoch only if it has changed. The next epoch is always re-fetched
-				// on any reorg to ensure we have the up-to-date duties for all validators.
 				if refetchCurrentEpoch {
 					h.dutyFetchIntents[currentEpoch] = false
 				}

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -157,14 +157,17 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 
 			slotNumber := uint64(currentSlot)%h.beaconConfig.SlotsPerEpoch + 1
 			buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, slotNumber)
-			refetchCurrentEpoch := reorgEvent.CurrentDutyDependentRootChanged ||
-				(reorgEvent.PreviousDutyDependentRootChanged && reorgEvent.EpochTransition)
 
 			logger := h.logger.With(
 				zap.String("epoch_slot_pos", buildStr),
 				zap.Uint64("current_epoch", uint64(currentEpoch)),
 				zap.Uint64("current_slot", uint64(currentSlot)),
 			)
+
+			// Proposer duties for the current epoch are determined by the "current duty dependent root",
+			// so we re-fetch the current epoch only if it has changed. The next epoch is always re-fetched
+			// on any reorg to ensure we have the up-to-date duties for all validators.
+			refetchCurrentEpoch := reorgEvent.CurrentDutyDependentRootChanged
 
 			logger.Info("🔀 reorg event received",
 				zap.Any("event", reorgEvent),
@@ -179,8 +182,7 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 				reorgCtx, cancel := context.WithDeadline(ctx, h.beaconConfig.SlotStartTime(currentSlot+2))
 				defer cancel()
 
-				// Reorg with "CurrentDutyDependentRoot changed in the same epoch", or "PreviousDutyDependentRoot changed during the epoch transition" potentially affects duties for the current epoch.
-				// Any reorg always potentially affects duties for the next epoch.
+				// 1) Declare intents.
 				if refetchCurrentEpoch {
 					h.dutyFetchIntents[currentEpoch] = false
 				}

--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -466,8 +466,8 @@ func TestScheduler_Proposer_Reorg_Previous_Indices_Changed(t *testing.T) {
 	})
 }
 
-// reorg previous dependent root changed
-func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
+// reorg current dependent root changed during epoch transition
+func TestScheduler_Proposer_Reorg_Epoch_Transition(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
 			handler       = NewProposerHandler(dutystore.NewDuties[eth2apiv1.ProposerDuty](), false)
@@ -500,7 +500,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 		e := &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch*2 - 1,
-				CurrentDutyDependentRoot:  phase0.Root{0x01},
+				Block:                     phase0.Root{0x03},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
 				PreviousDutyDependentRoot: phase0.Root{0x01},
 			},
 		}
@@ -516,6 +517,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 		e = &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch * 2,
+				Block:                     phase0.Root{0x05},
+				CurrentDutyDependentRoot:  phase0.Root{0x04},
 				PreviousDutyDependentRoot: phase0.Root{0x02},
 			},
 		}
@@ -527,8 +530,9 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 			},
 		})
 
-		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
-		// have been changed, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to the latest event.Block
+		// from the last epoch not matching the CurrentDutyDependentRoot on this event, allowing for refetching the
+		// duties in current Epoch.
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
@@ -558,8 +562,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 	})
 }
 
-// reorg previous dependent root changed and the indices changed as well
-func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *testing.T) {
+// reorg current dependent root changed during epoch transition, and the indices changed as well
+func TestScheduler_Proposer_Reorg_Epoch_Transition_Indices_Changed(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
 			handler       = NewProposerHandler(dutystore.NewDuties[eth2apiv1.ProposerDuty](), false)
@@ -590,7 +594,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 		e := &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch*2 - 1,
-				CurrentDutyDependentRoot:  phase0.Root{0x01},
+				Block:                     phase0.Root{0x03},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
 				PreviousDutyDependentRoot: phase0.Root{0x01},
 			},
 		}
@@ -607,6 +612,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 		e = &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch * 2,
+				Block:                     phase0.Root{0x05},
+				CurrentDutyDependentRoot:  phase0.Root{0x04},
 				PreviousDutyDependentRoot: phase0.Root{0x02},
 			},
 		}
@@ -618,8 +625,9 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 			},
 		})
 
-		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
-		// have been changed, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to the latest event.Block
+		// from the last epoch not matching the CurrentDutyDependentRoot on this event, allowing for refetching the
+		// duties in current Epoch.
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 

--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -527,7 +527,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 			},
 		})
 
-		// The HandleHeadEvent should set the EpochTransition and PreviousDutyDependentRootChanged to true, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
+		// have been changed, allowing for refetching the duties in current Epoch
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
@@ -617,7 +618,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 			},
 		})
 
-		// The HandleHeadEvent should set the EpochTransition and PreviousDutyDependentRootChanged to true, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
+		// have been changed, allowing for refetching the duties in current Epoch
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -365,7 +365,8 @@ func (s *Scheduler) SlotTicker(ctx context.Context) {
 func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1.HeadEvent) {
 	return func(ctx context.Context, event *eth2apiv1.HeadEvent) {
 		if event.Slot != s.beaconConfig.EstimatedCurrentSlot() {
-			// No need to process outdated events here.
+			// No need to process outdated events here. Future events shouldn't be possible, unless there is
+			// a very large clock-drift - for simplicity, we don't handle this case either.
 			return
 		}
 
@@ -386,6 +387,7 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 				//   the expected previous dependent root
 				// - we cannot have any expectations for the current root since we don't have any recorded current root
 				//   to compare against
+
 				expectedPreviousDutyDependentRoot := s.currentDutyDependentRoot[:]
 
 				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
@@ -404,6 +406,8 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 					}
 				}
 			} else {
+				// Epoch in-progress case, either current or previous dependent root might have changed.
+
 				expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
 				expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -392,7 +392,7 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
 
 				if previousDutyDependentRootChanged {
-					logger.Debug("🔀 reorg detected upon epoch transition: previuos dependent root changed",
+					logger.Debug("🔀 reorg detected upon epoch transition: previous dependent root changed",
 						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
 						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
 						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -117,12 +117,17 @@ type Scheduler struct {
 	indicesChg chan struct{}
 	ticker     slotticker.SlotTicker
 
-	// waitCond coordinates access to headSlot for different go-routines
+	// waitCond coordinates access to headSlot for different go-routines.
 	waitCond *sync.Cond
 	headSlot phase0.Slot
 
-	lastBlockEpoch            phase0.Epoch
-	currentDutyDependentRoot  phase0.Root
+	// lastEpoch records the epoch of the last observed block.
+	lastEpoch phase0.Epoch
+	// lastBlockRoot records the root of the last observed block.
+	lastBlockRoot phase0.Root
+	// currentDutyDependentRoot records the canonical root of epoch CURRENT-1.
+	currentDutyDependentRoot phase0.Root
+	// previousDutyDependentRoot records the canonical root of epoch CURRENT-2.
 	previousDutyDependentRoot phase0.Root
 
 	exporterMode bool
@@ -362,12 +367,6 @@ func (s *Scheduler) SlotTicker(ctx context.Context) {
 // HandleHeadEvent handles the "head" events from the beacon node.
 func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1.HeadEvent) {
 	return func(ctx context.Context, event *eth2apiv1.HeadEvent) {
-		if event.Slot != s.beaconConfig.EstimatedCurrentSlot() {
-			// No need to process outdated events here. Future events shouldn't be possible, unless there is
-			// a very large clock-drift - for simplicity, we don't handle this case either.
-			return
-		}
-
 		currentSlot := event.Slot
 		currentEpoch := s.beaconConfig.EstimatedEpochAtSlot(currentSlot)
 		slotNumber := uint64(currentSlot)%s.beaconConfig.SlotsPerEpoch + 1
@@ -375,60 +374,56 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 		buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, slotNumber)
 		logger := s.logger.With(zap.String("epoch_slot_pos", buildStr))
 
+		if event.Slot < s.beaconConfig.EstimatedCurrentSlot() {
+			// No need to process outdated events here.
+			return
+		}
+		if event.Slot > s.beaconConfig.EstimatedCurrentSlot() {
+			// We don't handle future events to keep things simpple.
+			logger.Warn("got future head event from EL, most likely cause is clock-skew between SSV node and EL")
+			return
+		}
+
 		// Check for reorg & fire corresponding ReorgEvent if needed.
-		if s.lastBlockEpoch != 0 {
+		if s.lastEpoch != 0 {
 			zeroRoot := new(phase0.Root)[:]
 
-			if currentEpoch > s.lastBlockEpoch {
+			epochTransition := false
+			expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
+			expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
+			if currentEpoch > s.lastEpoch {
 				// Epoch transition case:
 				// - the root tracked in s.currentDutyDependentRoot now describes the previous epoch, hence becomes
 				//   the expected previous dependent root
-				// - we cannot have any expectations for the current root since we don't have any recorded current root
-				//   to compare against
+				// - we use the latest observed block-root from the previous epoch as the expected current dependent
+				//   root since it's the only thing we can compare the current dependent root we got with
+				epochTransition = true
+				expectedCurrentDutyDependentRoot = s.lastBlockRoot[:]
+				expectedPreviousDutyDependentRoot = s.currentDutyDependentRoot[:]
+			}
 
-				expectedPreviousDutyDependentRoot := s.currentDutyDependentRoot[:]
+			currentDutyDependentRootChanged := !bytes.Equal(expectedCurrentDutyDependentRoot, zeroRoot) &&
+				!bytes.Equal(expectedCurrentDutyDependentRoot, event.CurrentDutyDependentRoot[:])
+			previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
+				!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
 
-				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
-
-				if previousDutyDependentRootChanged {
-					logger.Debug("🔀 reorg detected upon epoch transition: previous dependent root changed",
-						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
-						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
-						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
-					)
-					s.reorg <- ReorgEvent{
-						CurrentDutyDependentRootChanged:  true, // because previous dependent root changed
-						PreviousDutyDependentRootChanged: true,
-					}
-				}
-			} else {
-				// Epoch in-progress case, either current or previous dependent root might have changed.
-
-				expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
-				expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
-
-				currentDutyDependentRootChanged := !bytes.Equal(expectedCurrentDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedCurrentDutyDependentRoot, event.CurrentDutyDependentRoot[:])
-				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
-
-				if currentDutyDependentRootChanged || previousDutyDependentRootChanged {
-					logger.Debug("🔀 reorg detected: dependent root(s) changed",
-						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
-						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
-						zap.String("expected_current_dependent_root", fmt.Sprintf("%#x", expectedCurrentDutyDependentRoot)),
-						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
-					)
-					s.reorg <- ReorgEvent{
-						CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
-						PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
-					}
+			if currentDutyDependentRootChanged || previousDutyDependentRootChanged {
+				logger.Debug("🔀 reorg detected: dependent root(s) changed",
+					zap.Bool("epoch_transition", epochTransition),
+					zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
+					zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
+					zap.String("expected_current_dependent_root", fmt.Sprintf("%#x", expectedCurrentDutyDependentRoot)),
+					zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
+				)
+				s.reorg <- ReorgEvent{
+					CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
+					PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
 				}
 			}
 		}
 
-		s.lastBlockEpoch = currentEpoch
+		s.lastEpoch = currentEpoch
+		s.lastBlockRoot = event.Block
 		s.previousDutyDependentRoot = event.PreviousDutyDependentRoot
 		s.currentDutyDependentRoot = event.CurrentDutyDependentRoot
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -174,8 +174,6 @@ func NewScheduler(logger *zap.Logger, opts *SchedulerOptions) *Scheduler {
 }
 
 type ReorgEvent struct {
-	// Slot is the reorg slot.
-	Slot phase0.Slot
 	// CurrentDutyDependentRootChanged indicates if the current duty dependent root change has been detected.
 	CurrentDutyDependentRootChanged bool
 	// PreviousDutyDependentRootChanged indicates if the previous duty dependent root change has been detected.
@@ -400,7 +398,6 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
 					)
 					s.reorg <- ReorgEvent{
-						Slot:                             event.Slot,
 						CurrentDutyDependentRootChanged:  true, // because previous dependent root changed
 						PreviousDutyDependentRootChanged: true,
 					}
@@ -424,7 +421,6 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
 					)
 					s.reorg <- ReorgEvent{
-						Slot:                             event.Slot,
 						CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
 						PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
 					}

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -176,12 +176,10 @@ func NewScheduler(logger *zap.Logger, opts *SchedulerOptions) *Scheduler {
 type ReorgEvent struct {
 	// Slot is the reorg slot.
 	Slot phase0.Slot
-	// CurrentDutyDependentRootChanged indicates if the current duty dependent root has changed.
+	// CurrentDutyDependentRootChanged indicates if the current duty dependent root change has been detected.
 	CurrentDutyDependentRootChanged bool
-	// PreviousDutyDependentRootChanged indicates if the previous duty dependent root has changed.
+	// PreviousDutyDependentRootChanged indicates if the previous duty dependent root change has been detected.
 	PreviousDutyDependentRootChanged bool
-	// EpochTransition indicates if there has been an epoch transition.
-	EpochTransition bool
 }
 
 // Start initializes the Scheduler and begins its operation.
@@ -366,65 +364,65 @@ func (s *Scheduler) SlotTicker(ctx context.Context) {
 // HandleHeadEvent handles the "head" events from the beacon node.
 func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1.HeadEvent) {
 	return func(ctx context.Context, event *eth2apiv1.HeadEvent) {
-		var zeroRoot phase0.Root
-
 		if event.Slot != s.beaconConfig.EstimatedCurrentSlot() {
 			// No need to process outdated events here.
 			return
 		}
 
-		// check for reorg
 		currentSlot := event.Slot
 		currentEpoch := s.beaconConfig.EstimatedEpochAtSlot(currentSlot)
 		slotNumber := uint64(currentSlot)%s.beaconConfig.SlotsPerEpoch + 1
+
 		buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, slotNumber)
 		logger := s.logger.With(zap.String("epoch_slot_pos", buildStr))
-		if s.lastBlockEpoch != 0 {
-			if currentEpoch > s.lastBlockEpoch {
-				// Change of epoch.
-				// Ensure that the new previous dependent root is the same as the old current root.
-				if !bytes.Equal(s.previousDutyDependentRoot[:], zeroRoot[:]) &&
-					!bytes.Equal(s.currentDutyDependentRoot[:], event.PreviousDutyDependentRoot[:]) {
-					logger.Debug("🔀 Previous duty dependent root has changed on epoch transition",
-						zap.String("old_current_dependent_root", fmt.Sprintf("%#x", s.currentDutyDependentRoot[:])),
-						zap.String("new_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])))
 
+		// Check for reorg & fire corresponding ReorgEvent if needed.
+		if s.lastBlockEpoch != 0 {
+			zeroRoot := new(phase0.Root)[:]
+
+			if currentEpoch > s.lastBlockEpoch {
+				// Epoch transition case:
+				// - the root tracked in s.currentDutyDependentRoot now describes the previous epoch, hence becomes
+				//   the expected previous dependent root
+				// - we cannot have any expectations for the current root since we don't have any recorded current root
+				//   to compare against
+				expectedPreviousDutyDependentRoot := s.currentDutyDependentRoot[:]
+
+				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
+					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
+
+				if previousDutyDependentRootChanged {
+					logger.Debug("🔀 reorg detected upon epoch transition: previuos dependent root changed",
+						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
+						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
+						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
+					)
 					s.reorg <- ReorgEvent{
 						Slot:                             event.Slot,
-						CurrentDutyDependentRootChanged:  false,
+						CurrentDutyDependentRootChanged:  true, // because previous dependent root changed
 						PreviousDutyDependentRootChanged: true,
-						EpochTransition:                  true,
 					}
 				}
 			} else {
-				// Same epoch
-				// Ensure that the previous dependent roots are the same.
-				if !bytes.Equal(s.previousDutyDependentRoot[:], zeroRoot[:]) &&
-					!bytes.Equal(s.previousDutyDependentRoot[:], event.PreviousDutyDependentRoot[:]) {
-					logger.Debug("🔀 Previous duty dependent root has changed",
-						zap.String("old_previous_dependent_root", fmt.Sprintf("%#x", s.previousDutyDependentRoot[:])),
-						zap.String("new_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])))
+				expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
+				expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
 
+				currentDutyDependentRootChanged := !bytes.Equal(expectedCurrentDutyDependentRoot, zeroRoot) &&
+					!bytes.Equal(expectedCurrentDutyDependentRoot, event.CurrentDutyDependentRoot[:])
+				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
+					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
+
+				if currentDutyDependentRootChanged || previousDutyDependentRootChanged {
+					logger.Debug("🔀 reorg detected: dependent root(s) changed",
+						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
+						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
+						zap.String("expected_current_dependent_root", fmt.Sprintf("%#x", expectedCurrentDutyDependentRoot)),
+						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
+					)
 					s.reorg <- ReorgEvent{
 						Slot:                             event.Slot,
-						CurrentDutyDependentRootChanged:  false,
-						PreviousDutyDependentRootChanged: true,
-						EpochTransition:                  false,
-					}
-				}
-
-				// Ensure that the current dependent roots are the same.
-				if !bytes.Equal(s.currentDutyDependentRoot[:], zeroRoot[:]) &&
-					!bytes.Equal(s.currentDutyDependentRoot[:], event.CurrentDutyDependentRoot[:]) {
-					logger.Debug("🔀 Current duty dependent root has changed",
-						zap.String("old_current_dependent_root", fmt.Sprintf("%#x", s.currentDutyDependentRoot[:])),
-						zap.String("new_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])))
-
-					s.reorg <- ReorgEvent{
-						Slot:                             event.Slot,
-						CurrentDutyDependentRootChanged:  true,
-						PreviousDutyDependentRootChanged: false,
-						EpochTransition:                  false,
+						CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
+						PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
 					}
 				}
 			}


### PR DESCRIPTION
This PR extends https://github.com/ssvlabs/ssv/pull/2756 to clarify and improve the reorg detection implemented by `Scheduler.HandleHeadEvent` func.