### PR TITLE
duty-fetching: rework reorg detection (1st slot)

### DIFF
--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -530,8 +530,9 @@ func TestScheduler_Proposer_Reorg_Epoch_Transition(t *testing.T) {
 			},
 		})
 
-		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
-		// have been changed, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to the latest event.Block
+		// from the last epoch not matching the CurrentDutyDependentRoot on this event, allowing for refetching the
+		// duties in current Epoch.
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
@@ -624,8 +625,9 @@ func TestScheduler_Proposer_Reorg_Epoch_Transition_Indices_Changed(t *testing.T)
 			},
 		})
 
-		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to PreviousDutyDependentRoot
-		// have been changed, allowing for refetching the duties in current Epoch
+		// The HandleHeadEvent should set the CurrentDutyDependentRootChanged to true due to the latest event.Block
+		// from the last epoch not matching the CurrentDutyDependentRoot on this event, allowing for refetching the
+		// duties in current Epoch.
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*eth2apiv1.HeadEvent))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 

--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -466,8 +466,8 @@ func TestScheduler_Proposer_Reorg_Previous_Indices_Changed(t *testing.T) {
 	})
 }
 
-// reorg previous dependent root changed
-func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
+// reorg current dependent root changed during epoch transition
+func TestScheduler_Proposer_Reorg_Epoch_Transition(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
 			handler       = NewProposerHandler(dutystore.NewDuties[eth2apiv1.ProposerDuty](), false)
@@ -500,7 +500,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 		e := &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch*2 - 1,
-				CurrentDutyDependentRoot:  phase0.Root{0x01},
+				Block:                     phase0.Root{0x03},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
 				PreviousDutyDependentRoot: phase0.Root{0x01},
 			},
 		}
@@ -516,6 +517,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 		e = &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch * 2,
+				Block:                     phase0.Root{0x05},
+				CurrentDutyDependentRoot:  phase0.Root{0x04},
 				PreviousDutyDependentRoot: phase0.Root{0x02},
 			},
 		}
@@ -558,8 +561,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition(t *testing.T) {
 	})
 }
 
-// reorg previous dependent root changed and the indices changed as well
-func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *testing.T) {
+// reorg current dependent root changed during epoch transition, and the indices changed as well
+func TestScheduler_Proposer_Reorg_Epoch_Transition_Indices_Changed(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
 			handler       = NewProposerHandler(dutystore.NewDuties[eth2apiv1.ProposerDuty](), false)
@@ -590,7 +593,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 		e := &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch*2 - 1,
-				CurrentDutyDependentRoot:  phase0.Root{0x01},
+				Block:                     phase0.Root{0x03},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
 				PreviousDutyDependentRoot: phase0.Root{0x01},
 			},
 		}
@@ -607,6 +611,8 @@ func TestScheduler_Proposer_Reorg_Previous_Epoch_Transition_Indices_Changed(t *t
 		e = &eth2apiv1.Event{
 			Data: &eth2apiv1.HeadEvent{
 				Slot:                      testSlotsPerEpoch * 2,
+				Block:                     phase0.Root{0x05},
+				CurrentDutyDependentRoot:  phase0.Root{0x04},
 				PreviousDutyDependentRoot: phase0.Root{0x02},
 			},
 		}

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -367,18 +367,22 @@ func (s *Scheduler) SlotTicker(ctx context.Context) {
 // HandleHeadEvent handles the "head" events from the beacon node.
 func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1.HeadEvent) {
 	return func(ctx context.Context, event *eth2apiv1.HeadEvent) {
-		if event.Slot != s.beaconConfig.EstimatedCurrentSlot() {
-			// No need to process outdated events here. Future events shouldn't be possible, unless there is
-			// a very large clock-drift - for simplicity, we don't handle this case either.
-			return
-		}
-
 		currentSlot := event.Slot
 		currentEpoch := s.beaconConfig.EstimatedEpochAtSlot(currentSlot)
 		slotNumber := uint64(currentSlot)%s.beaconConfig.SlotsPerEpoch + 1
 
 		buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, slotNumber)
 		logger := s.logger.With(zap.String("epoch_slot_pos", buildStr))
+
+		if event.Slot < s.beaconConfig.EstimatedCurrentSlot() {
+			// No need to process outdated events here.
+			return
+		}
+		if event.Slot > s.beaconConfig.EstimatedCurrentSlot() {
+			// We don't handle future events to keep things simpple.
+			logger.Warn("got future head event from EL, most likely cause is clock-skew between SSV node and EL")
+			return
+		}
 
 		// Check for reorg & fire corresponding ReorgEvent if needed.
 		if s.lastEpoch != 0 {

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -117,12 +117,17 @@ type Scheduler struct {
 	indicesChg chan struct{}
 	ticker     slotticker.SlotTicker
 
-	// waitCond coordinates access to headSlot for different go-routines
+	// waitCond coordinates access to headSlot for different go-routines.
 	waitCond *sync.Cond
 	headSlot phase0.Slot
 
-	lastBlockEpoch            phase0.Epoch
-	currentDutyDependentRoot  phase0.Root
+	// lastEpoch records the epoch of the last observed block.
+	lastEpoch phase0.Epoch
+	// lastBlockRoot records the root of the last observed block.
+	lastBlockRoot phase0.Root
+	// currentDutyDependentRoot records the canonical root of epoch CURRENT-1.
+	currentDutyDependentRoot phase0.Root
+	// previousDutyDependentRoot records the canonical root of epoch CURRENT-2.
 	previousDutyDependentRoot phase0.Root
 
 	exporterMode bool
@@ -376,59 +381,45 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 		logger := s.logger.With(zap.String("epoch_slot_pos", buildStr))
 
 		// Check for reorg & fire corresponding ReorgEvent if needed.
-		if s.lastBlockEpoch != 0 {
+		if s.lastEpoch != 0 {
 			zeroRoot := new(phase0.Root)[:]
 
-			if currentEpoch > s.lastBlockEpoch {
+			epochTransition := false
+			expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
+			expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
+			if currentEpoch > s.lastEpoch {
 				// Epoch transition case:
 				// - the root tracked in s.currentDutyDependentRoot now describes the previous epoch, hence becomes
 				//   the expected previous dependent root
-				// - we cannot have any expectations for the current root since we don't have any recorded current root
-				//   to compare against
+				// - we use the lastest observed block-root from the previous epoch as the expected current dependent
+				//   root since it's the only thing we can compare the current dependent root we got with
+				epochTransition = true
+				expectedCurrentDutyDependentRoot = s.lastBlockRoot[:]
+				expectedPreviousDutyDependentRoot = s.currentDutyDependentRoot[:]
+			}
 
-				expectedPreviousDutyDependentRoot := s.currentDutyDependentRoot[:]
+			currentDutyDependentRootChanged := !bytes.Equal(expectedCurrentDutyDependentRoot, zeroRoot) &&
+				!bytes.Equal(expectedCurrentDutyDependentRoot, event.CurrentDutyDependentRoot[:])
+			previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
+				!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
 
-				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
-
-				if previousDutyDependentRootChanged {
-					logger.Debug("🔀 reorg detected upon epoch transition: previous dependent root changed",
-						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
-						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
-						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
-					)
-					s.reorg <- ReorgEvent{
-						CurrentDutyDependentRootChanged:  true, // because previous dependent root changed
-						PreviousDutyDependentRootChanged: true,
-					}
-				}
-			} else {
-				// Epoch in-progress case, either current or previous dependent root might have changed.
-
-				expectedCurrentDutyDependentRoot := s.currentDutyDependentRoot[:]
-				expectedPreviousDutyDependentRoot := s.previousDutyDependentRoot[:]
-
-				currentDutyDependentRootChanged := !bytes.Equal(expectedCurrentDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedCurrentDutyDependentRoot, event.CurrentDutyDependentRoot[:])
-				previousDutyDependentRootChanged := !bytes.Equal(expectedPreviousDutyDependentRoot, zeroRoot) &&
-					!bytes.Equal(expectedPreviousDutyDependentRoot, event.PreviousDutyDependentRoot[:])
-
-				if currentDutyDependentRootChanged || previousDutyDependentRootChanged {
-					logger.Debug("🔀 reorg detected: dependent root(s) changed",
-						zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
-						zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
-						zap.String("expected_current_dependent_root", fmt.Sprintf("%#x", expectedCurrentDutyDependentRoot)),
-						zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
-					)
-					s.reorg <- ReorgEvent{
-						CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
-						PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
-					}
+			if currentDutyDependentRootChanged || previousDutyDependentRootChanged {
+				logger.Debug("🔀 reorg detected: dependent root(s) changed",
+					zap.Bool("epoch_transition", epochTransition),
+					zap.String("expected_previous_dependent_root", fmt.Sprintf("%#x", expectedPreviousDutyDependentRoot)),
+					zap.String("got_previous_dependent_root", fmt.Sprintf("%#x", event.PreviousDutyDependentRoot[:])),
+					zap.String("expected_current_dependent_root", fmt.Sprintf("%#x", expectedCurrentDutyDependentRoot)),
+					zap.String("got_current_dependent_root", fmt.Sprintf("%#x", event.CurrentDutyDependentRoot[:])),
+				)
+				s.reorg <- ReorgEvent{
+					CurrentDutyDependentRootChanged:  currentDutyDependentRootChanged,
+					PreviousDutyDependentRootChanged: previousDutyDependentRootChanged,
 				}
 			}
 		}
 
-		s.lastBlockEpoch = currentEpoch
+		s.lastEpoch = currentEpoch
+		s.lastBlockRoot = event.Block
 		s.previousDutyDependentRoot = event.PreviousDutyDependentRoot
 		s.currentDutyDependentRoot = event.CurrentDutyDependentRoot
 

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -391,7 +391,7 @@ func (s *Scheduler) HandleHeadEvent() func(ctx context.Context, event *eth2apiv1
 				// Epoch transition case:
 				// - the root tracked in s.currentDutyDependentRoot now describes the previous epoch, hence becomes
 				//   the expected previous dependent root
-				// - we use the lastest observed block-root from the previous epoch as the expected current dependent
+				// - we use the latest observed block-root from the previous epoch as the expected current dependent
 				//   root since it's the only thing we can compare the current dependent root we got with
 				epochTransition = true
 				expectedCurrentDutyDependentRoot = s.lastBlockRoot[:]


### PR DESCRIPTION
This PR extends https://github.com/ssvlabs/ssv/pull/2767 to cover the scenario described in https://github.com/ssvlabs/ssv/pull/2756#discussion_r3008801386

The summary is: 
- if reorg happens during the very 1st slot of some epoch N (aka during epoch-transition from N-1 to N), we currently don't detect it (unless the "previous dependent root" also happened to change) - and it results into SSV node potentially failing to re-fetch the up-to-date duties for the entire epoch (current epoch for proposer, next epoch for attester)
- this PR tracks the root of the latest event received from EL, which is consulted in that case of epoch-transition to detect those reorgs (it might produce some "false positive reorg signal" due to: the latest block we receive from EL does not necessarily always become the canonical block for the corresponding epoch ... but it shouldn't happen often, and it shouldn't interfere with the duty execution much since EL rarely arrive close to the end of a slot)