### PR TITLE
pebble-db: define temporary DB

### DIFF
--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -18,7 +18,7 @@ import (
 func Test_verifyConfig(t *testing.T) {
 	logger := zap.New(zapcore.NewNopCore(), zap.WithFatalHook(zapcore.WriteThenPanic))
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -153,7 +153,7 @@ func setupEventHandler(
 	ownerAddress *ethcommon.Address,
 	useMockCtrl bool,
 ) (*eventhandler.EventHandler, *mocks.MockTaskExecutor, *gomock.Controller, operatorstorage.Storage, error) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{
+	db, err := pebble.NewTempDB(logger, basedb.Options{
 		Ctx: ctx,
 	})
 	if err != nil {

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -1358,7 +1358,7 @@ func setupEventHandler(
 	operator *testOperator,
 	useMockCtrl bool,
 ) (*EventHandler, *mocks.MockTaskExecutor, error) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{
+	db, err := pebble.NewTempDB(logger, basedb.Options{
 		Ctx: ctx,
 	})
 	require.NoError(t, err)

--- a/eth/eventhandler/validation_test.go
+++ b/eth/eventhandler/validation_test.go
@@ -19,7 +19,7 @@ import (
 func Test_validateValidatorAddedEvent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -107,7 +107,7 @@ func TestEventSyncer(t *testing.T) {
 	}
 
 	t.Run("client closed", func(t *testing.T) {
-		db, err := pebble.NewTemporary(logger, basedb.Options{
+		db, err := pebble.NewTempDB(logger, basedb.Options{
 			Ctx: ctx,
 		})
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestEventSyncer(t *testing.T) {
 	})
 
 	t.Run("context canceled", func(t *testing.T) {
-		db, err := pebble.NewTemporary(logger, basedb.Options{
+		db, err := pebble.NewTempDB(logger, basedb.Options{
 			Ctx: ctx,
 		})
 		require.NoError(t, err)
@@ -191,7 +191,7 @@ func setupEventHandler(
 	t *testing.T,
 	ctx context.Context,
 	logger *zap.Logger,
-	db *pebble.DBTemporary,
+	db *pebble.TempDB,
 	nodeStorage operatorstorage.Storage,
 	operatorData *registrystorage.OperatorData,
 	privateKey keys.OperatorPrivateKey,

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -191,7 +191,7 @@ func setupEventHandler(
 	t *testing.T,
 	ctx context.Context,
 	logger *zap.Logger,
-	db *pebble.DB,
+	db *pebble.DBTemporary,
 	nodeStorage operatorstorage.Storage,
 	operatorData *registrystorage.OperatorData,
 	privateKey keys.OperatorPrivateKey,

--- a/exporter/api/query_handlers_test.go
+++ b/exporter/api/query_handlers_test.go
@@ -199,7 +199,7 @@ func newParticipantsAPIMsg(pk string, role spectypes.BeaconRole, from, to uint64
 }
 
 func newDBAndLoggerForTest(logger *zap.Logger) (basedb.Database, *zap.Logger, func()) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, nil, func() {}
 	}

--- a/exporter/store/store_test.go
+++ b/exporter/store/store_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestSaveCommitteeDutyLinks(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -53,7 +53,7 @@ func TestSaveCommitteeDutyLinks(t *testing.T) {
 
 func TestSaveCommitteeDutyLink(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -79,7 +79,7 @@ func TestSaveCommitteeDutyLink(t *testing.T) {
 
 func TestSaveCommitteeDutyTrace(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -101,7 +101,7 @@ func TestSaveCommitteeDutyTrace(t *testing.T) {
 
 func TestSaveCommitteeDuties(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -127,7 +127,7 @@ func TestSaveCommitteeDuties(t *testing.T) {
 
 func TestSaveValidatorDutyTrace(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -162,7 +162,7 @@ func TestSaveValidatorDutyTrace(t *testing.T) {
 
 func TestSaveValidatorDuties(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -196,7 +196,7 @@ func TestSaveValidatorDuties(t *testing.T) {
 
 func TestSaveScheduledDuties(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -231,7 +231,7 @@ func TestSaveScheduledDuties(t *testing.T) {
 
 func TestAddScheduledRole_UnionsIndices(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -248,7 +248,7 @@ func TestAddScheduledRole_UnionsIndices(t *testing.T) {
 
 func TestSaveScheduledMergesExistingBitmaps(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -273,7 +273,7 @@ func TestSaveScheduledMergesExistingBitmaps(t *testing.T) {
 
 func TestDeleteScheduledRoleAndSlot(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -296,7 +296,7 @@ func TestDeleteScheduledRoleAndSlot(t *testing.T) {
 
 func TestGetScheduledRoleMissing(t *testing.T) {
 	logger := zap.NewNop()
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/ibft/storage/store_test.go
+++ b/ibft/storage/store_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestRemoveSlot(t *testing.T) {
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	t.Cleanup(func() { _ = db.Close() })
 	assert.NoError(t, err)
 
@@ -110,7 +110,7 @@ func TestSlotCleanupJob(t *testing.T) {
 	// and then on next tick (5) slot 3 will be removed as well keeping back slot 4.
 
 	// setup
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -50,7 +50,7 @@ func TestSetupPrivateKey(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := pebble.NewTemporary(logger, basedb.Options{})
+			db, err := pebble.NewTempDB(logger, basedb.Options{})
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -104,7 +104,7 @@ func TestSetupPrivateKey(t *testing.T) {
 	}
 
 	t.Run("NewIdentityStore", func(t *testing.T) {
-		db, err := pebble.NewTemporary(logger, basedb.Options{})
+		db, err := pebble.NewTempDB(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
 

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -69,7 +69,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	logger := zaptest.NewLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/migrations/migration_7_derive_signer_key_with_hkdf_test.go
+++ b/migrations/migration_7_derive_signer_key_with_hkdf_test.go
@@ -161,7 +161,7 @@ func setupTest(t *testing.T) (basedb.Database, *zap.Logger) {
 	t.Helper()
 
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -16,7 +16,7 @@ import (
 
 func setupOptions(ctx context.Context, t *testing.T) (Options, error) {
 	// Create in-memory test DB.
-	db, err := pebble.NewTemporary(log.TestLogger(t), basedb.Options{
+	db, err := pebble.NewTempDB(log.TestLogger(t), basedb.Options{
 		Ctx: ctx,
 	})
 	if err != nil {

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -179,7 +179,7 @@ func (ln *LocalNet) NewTestP2pNetwork(t gotesting.TB, ctx context.Context, nodeI
 		return nil, err
 	}
 
-	db, err := storagepebble.NewTemporary(logger, basedb.Options{})
+	db, err := storagepebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -407,7 +407,7 @@ func newPeer(ctx context.Context, logger *zap.Logger, t *testing.T, msgValidator
 		// TODO: add mock for peers.ScoreIndex
 	}
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/network/topics/msg_validator_test.go
+++ b/network/topics/msg_validator_test.go
@@ -38,7 +38,7 @@ func TestMsgValidator(t *testing.T) {
 		Liquidated: false,
 	}
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/operator/dutytracer/collector_bench_test.go
+++ b/operator/dutytracer/collector_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkTracer(b *testing.B) {
 
 	_ = f.Close()
 
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -920,7 +920,7 @@ func generateDecidedMessage(t *testing.T, identifier spectypes.MessageID) []byte
 }
 
 func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
@@ -1169,7 +1169,7 @@ func TestCollector_FlushPending_Timestamps(t *testing.T) {
 }
 
 func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/operator/dutytracer/store_test.go
+++ b/operator/dutytracer/store_test.go
@@ -32,7 +32,7 @@ func setCommitteeLink(c *Collector, slot phase0.Slot, validatorIndex phase0.Vali
 }
 
 func TestValidatorCommitteeMapping(t *testing.T) {
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 	defer ctrl.Finish()
 	vstore := registrymocks.NewMockValidatorStore(ctrl)
 
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 	index1 := phase0.ValidatorIndex(1)
 
 	// Setup db, shares & collector
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 	dutyStore := store.New(db)
@@ -372,7 +372,7 @@ func TestValidatorDutyStore(t *testing.T) {
 	defer ctrl.Finish()
 	vstore := registrymocks.NewMockValidatorStore(ctrl)
 
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/fee_recipient/controller_test.go
+++ b/operator/fee_recipient/controller_test.go
@@ -311,7 +311,7 @@ func TestSubmitProposal(t *testing.T) {
 
 func createStorage(t *testing.T) (basedb.Database, registrystorage.Shares) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -77,7 +77,7 @@ func newWSQueryHarness(t *testing.T) *wsQueryHarness {
 	ctrl := gomock.NewController(t)
 	validatorMock := registrystoragemocks.NewMockValidatorStore(ctrl)
 
-	db, err := pebble.NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := pebble.NewTempDB(zap.NewNop(), basedb.Options{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/operator/storage/storage_test.go
+++ b/operator/storage/storage_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestSaveAndGetPrivateKeyHash(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()
@@ -60,7 +60,7 @@ func TestSaveAndGetPrivateKeyHash(t *testing.T) {
 
 func TestDropRegistryData(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()
@@ -153,7 +153,7 @@ func TestDropRegistryData(t *testing.T) {
 
 func TestNetworkAndLocalEventsConfig(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()
@@ -192,7 +192,7 @@ func TestNetworkAndLocalEventsConfig(t *testing.T) {
 
 func TestGetOperatorsPrefix(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	defer func() {
 		_ = db.Close()
 	}()
@@ -206,7 +206,7 @@ func TestGetOperatorsPrefix(t *testing.T) {
 
 func Test_Config(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	defer func() {
 		_ = db.Close()
 	}()
@@ -241,7 +241,7 @@ func Test_Config(t *testing.T) {
 
 func Test_LastProcessedBlock(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	defer func() {
 		_ = db.Close()
 	}()
@@ -266,7 +266,7 @@ func Test_LastProcessedBlock(t *testing.T) {
 
 func Test_OperatorData(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	defer func() {
 		_ = db.Close()
 	}()
@@ -312,7 +312,7 @@ func Test_OperatorData(t *testing.T) {
 
 func Test_NonceBumping(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	defer func() {
 		_ = db.Close()
 	}()

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -874,7 +874,7 @@ func setupTestValidator(t *testing.T, validatorPk spectypes.ValidatorPK, ownerAd
 }
 
 func getBaseStorage(t *testing.T, logger *zap.Logger) (basedb.Database, error) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -940,7 +940,7 @@ func createPubKey(input byte) spectypes.ValidatorPK {
 }
 
 func newOperatorStorageForTest(logger *zap.Logger) (registrystorage.Operators, func()) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, func() {}
 	}

--- a/protocol/v2/ssv/testing/storage.go
+++ b/protocol/v2/ssv/testing/storage.go
@@ -15,7 +15,7 @@ import (
 func newDB(t *testing.T, logger *zap.Logger) basedb.Database {
 	t.Helper()
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		t.Fatalf("create temporary pebble db: %v", err)
 	}

--- a/registry/storage/operators_test.go
+++ b/registry/storage/operators_test.go
@@ -190,7 +190,7 @@ func TestStorage_DeleteOperatorAndDropOperators(t *testing.T) {
 }
 
 func newOperatorStorageForTest(logger *zap.Logger) (storage.Operators, func()) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, func() {}
 	}

--- a/registry/storage/recipients_test.go
+++ b/registry/storage/recipients_test.go
@@ -327,7 +327,7 @@ func TestStorage_NonceManagement(t *testing.T) {
 
 func TestStorage_Persistence(t *testing.T) {
 	logger := log.TestLogger(t)
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -502,7 +502,7 @@ func TestGetFeeRecipient(t *testing.T) {
 }
 
 func newRecipientStorageForTest(logger *zap.Logger) (storage.Recipients, func()) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, func() {}
 	}

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -700,7 +700,7 @@ func generateMaxPossibleShare() (*Share, error) {
 }
 
 type testStorage struct {
-	db             *pebble.DBTemporary
+	db             *pebble.TempDB
 	Operators      Operators
 	Shares         Shares
 	ValidatorStore ValidatorStore
@@ -708,7 +708,7 @@ type testStorage struct {
 }
 
 func newTestStorage(logger *zap.Logger) (*testStorage, error) {
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +743,7 @@ func (t *testStorage) Recreate(logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	t.db, err = pebble.NewTemporary(logger, basedb.Options{})
+	t.db, err = pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return err
 	}

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -700,7 +700,7 @@ func generateMaxPossibleShare() (*Share, error) {
 }
 
 type testStorage struct {
-	db             *pebble.DB
+	db             *pebble.DBTemporary
 	Operators      Operators
 	Shares         Shares
 	ValidatorStore ValidatorStore

--- a/ssvsigner/ekm/signer_storage_test.go
+++ b/ssvsigner/ekm/signer_storage_test.go
@@ -32,7 +32,7 @@ func _byteArray(input string) []byte {
 func getBaseStorage(t *testing.T, logger *zap.Logger) (basedb.Database, error) {
 	t.Helper()
 
-	db, err := pebble.NewTemporary(logger, basedb.Options{})
+	db, err := pebble.NewTempDB(logger, basedb.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/storage/pebble/pebble.go
+++ b/storage/pebble/pebble.go
@@ -2,9 +2,7 @@ package pebble
 
 import (
 	"context"
-	"errors"
 	"io"
-	"os"
 
 	"github.com/cockroachdb/pebble"
 	"go.uber.org/zap"
@@ -16,8 +14,7 @@ var _ basedb.Database = &DB{}
 
 type DB struct {
 	*pebble.DB
-	logger      *zap.Logger
-	cleanupPath string
+	logger *zap.Logger
 }
 
 func New(logger *zap.Logger, path string, opts *pebble.Options) (*DB, error) {
@@ -36,9 +33,6 @@ func (pdb *DB) Close() error {
 	var err error
 	if pdb.DB != nil {
 		err = pdb.DB.Close()
-	}
-	if pdb.cleanupPath != "" {
-		err = errors.Join(err, os.RemoveAll(pdb.cleanupPath))
 	}
 	return err
 }

--- a/storage/pebble/pebble_test.go
+++ b/storage/pebble/pebble_test.go
@@ -23,7 +23,7 @@ func setupTestDB(t *testing.T) *DB {
 }
 
 func TestPebbleDB_NewTemporary_RemovesDirectoryOnClose(t *testing.T) {
-	db, err := NewTemporary(zap.NewNop(), basedb.Options{})
+	db, err := NewTempDB(zap.NewNop(), basedb.Options{})
 	require.NoError(t, err)
 
 	tempDir := db.cleanupPath

--- a/storage/pebble/testutils.go
+++ b/storage/pebble/testutils.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-type DBTemporary struct {
+type TempDB struct {
 	*DB
 	cleanupPath string
 }
 
-func (pdb *DBTemporary) Close() error {
+func (pdb *TempDB) Close() error {
 	var err error
 	if pdb.DB != nil {
 		err = pdb.DB.Close()
@@ -26,8 +26,8 @@ func (pdb *DBTemporary) Close() error {
 	return err
 }
 
-// NewTemporary creates a temporary Pebble-backed DB and removes it on Close.
-func NewTemporary(logger *zap.Logger, _ basedb.Options) (*DBTemporary, error) {
+// NewTempDB creates a temporary Pebble-backed DB and removes it on Close.
+func NewTempDB(logger *zap.Logger, _ basedb.Options) (*TempDB, error) {
 	path, err := os.MkdirTemp("", "ssv-pebble-test-*")
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func NewTemporary(logger *zap.Logger, _ basedb.Options) (*DBTemporary, error) {
 		return nil, err
 	}
 
-	return &DBTemporary{
+	return &TempDB{
 		DB:          db,
 		cleanupPath: path,
 	}, nil

--- a/storage/pebble/testutils.go
+++ b/storage/pebble/testutils.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"errors"
 	"os"
 
 	"github.com/cockroachdb/pebble"
@@ -9,8 +10,24 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
+type DBTemporary struct {
+	*DB
+	cleanupPath string
+}
+
+func (pdb *DBTemporary) Close() error {
+	var err error
+	if pdb.DB != nil {
+		err = pdb.DB.Close()
+	}
+	if pdb.cleanupPath != "" {
+		err = errors.Join(err, os.RemoveAll(pdb.cleanupPath))
+	}
+	return err
+}
+
 // NewTemporary creates a temporary Pebble-backed DB and removes it on Close.
-func NewTemporary(logger *zap.Logger, _ basedb.Options) (*DB, error) {
+func NewTemporary(logger *zap.Logger, _ basedb.Options) (*DBTemporary, error) {
 	path, err := os.MkdirTemp("", "ssv-pebble-test-*")
 	if err != nil {
 		return nil, err
@@ -21,7 +38,9 @@ func NewTemporary(logger *zap.Logger, _ basedb.Options) (*DB, error) {
 		_ = os.RemoveAll(path)
 		return nil, err
 	}
-	db.cleanupPath = path
 
-	return db, nil
+	return &DBTemporary{
+		DB:          db,
+		cleanupPath: path,
+	}, nil
 }


### PR DESCRIPTION
To keep production code straightforward.