### PR TITLE
fix(p2p): reject bad peers early in InterceptPeerDial

### DIFF
--- a/network/peers/connections/conn_gater.go
+++ b/network/peers/connections/conn_gater.go
@@ -64,6 +64,10 @@ func NewConnectionGater(
 // to the addresses of that peer being available/resolved. Blocking connections
 // at this stage is typical for blacklisting scenarios
 func (n *connGater) InterceptPeerDial(id peer.ID) bool {
+	if n.isBadPeer(id) {
+		n.logger.Debug("preventing outbound dial to bad peer", fields.PeerID(id))
+		return false
+	}
 	return true
 }
 

--- a/network/peers/connections/conn_gater.go
+++ b/network/peers/connections/conn_gater.go
@@ -63,7 +63,7 @@ func NewConnectionGater(
 // InterceptPeerDial is called on an imminent outbound peer dial request, prior
 // to the addresses of that peer being available/resolved. Blocking connections
 // at this stage is typical for blacklisting scenarios
-func (n *connGater) InterceptPeerDial(id peer.ID) bool {
+func (n *connGater) InterceptPeerDial(id peer.ID) (allow bool) {
 	if n.isBadPeer(id) {
 		n.logger.Debug("preventing outbound dial to bad peer", fields.PeerID(id))
 		return false
@@ -74,7 +74,7 @@ func (n *connGater) InterceptPeerDial(id peer.ID) bool {
 // InterceptAddrDial is called on an imminent outbound dial to a peer on a
 // particular address. Blocking connections at this stage is typical for
 // address filtering.
-func (n *connGater) InterceptAddrDial(id peer.ID, multiaddr ma.Multiaddr) bool {
+func (n *connGater) InterceptAddrDial(id peer.ID, multiaddr ma.Multiaddr) (allow bool) {
 	if n.isBadPeer(id) {
 		n.logger.Debug("preventing outbound connection due to bad peer", fields.PeerID(id))
 		return false
@@ -86,7 +86,7 @@ func (n *connGater) InterceptAddrDial(id peer.ID, multiaddr ma.Multiaddr) bool {
 // inbound connection request, before any upgrade takes place. Transports who
 // accept already secure and/or multiplexed connections (e.g. possibly QUIC)
 // MUST call this method regardless, for correctness/consistency.
-func (n *connGater) InterceptAccept(multiaddrs libp2pnetwork.ConnMultiaddrs) bool {
+func (n *connGater) InterceptAccept(multiaddrs libp2pnetwork.ConnMultiaddrs) (allow bool) {
 	if n.disable {
 		return true
 	}
@@ -107,7 +107,7 @@ func (n *connGater) InterceptAccept(multiaddrs libp2pnetwork.ConnMultiaddrs) boo
 
 // InterceptSecured is called for both inbound and outbound connections,
 // after a security handshake has taken place and we've authenticated the peer.
-func (n *connGater) InterceptSecured(direction libp2pnetwork.Direction, id peer.ID, multiaddrs libp2pnetwork.ConnMultiaddrs) bool {
+func (n *connGater) InterceptSecured(direction libp2pnetwork.Direction, id peer.ID, multiaddrs libp2pnetwork.ConnMultiaddrs) (allow bool) {
 	if n.trimmedRecently.Has(id) {
 		n.logger.Debug(
 			"InterceptSecured: trying to connect a peer we've recently trimmed",
@@ -127,7 +127,7 @@ func (n *connGater) InterceptSecured(direction libp2pnetwork.Direction, id peer.
 // InterceptUpgraded is called for inbound and outbound connections, after
 // libp2p has finished upgrading the connection entirely to a secure,
 // multiplexed channel.
-func (n *connGater) InterceptUpgraded(conn libp2pnetwork.Conn) (bool, control.DisconnectReason) {
+func (n *connGater) InterceptUpgraded(conn libp2pnetwork.Conn) (allow bool, reason control.DisconnectReason) {
 	return true, 0
 }
 

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -25,9 +25,14 @@ func TestConnGaterInterceptAddrDial(t *testing.T) {
 }
 
 func TestConnGaterInterceptPeerDial(t *testing.T) {
-	gater := &connGater{}
+	gater := &connGater{
+		logger:          zap.NewNop(),
+		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
+	}
 
-	require.True(t, gater.InterceptPeerDial("peer"))
+	require.False(t, gater.InterceptPeerDial("bad-peer"))
+	require.True(t, gater.InterceptPeerDial("good-peer"))
 }
 
 func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -13,26 +13,32 @@ import (
 	"github.com/ssvlabs/ssv/utils/ttl"
 )
 
+const (
+	badPeerID     peer.ID = "bad-peer"
+	goodPeerID    peer.ID = "good-peer"
+	trimmedPeerID peer.ID = "trimmed-peer"
+)
+
 func TestConnGaterInterceptAddrDial(t *testing.T) {
 	gater := &connGater{
 		logger:          zap.NewNop(),
-		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
 	}
 
-	require.False(t, gater.InterceptAddrDial("bad-peer", mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
-	require.True(t, gater.InterceptAddrDial("good-peer", mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
+	require.False(t, gater.InterceptAddrDial(badPeerID, mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
+	require.True(t, gater.InterceptAddrDial(goodPeerID, mustMultiaddr("/ip4/127.0.0.1/tcp/13000")))
 }
 
 func TestConnGaterInterceptPeerDial(t *testing.T) {
 	gater := &connGater{
 		logger:          zap.NewNop(),
-		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
 	}
 
-	require.False(t, gater.InterceptPeerDial("bad-peer"))
-	require.True(t, gater.InterceptPeerDial("good-peer"))
+	require.False(t, gater.InterceptPeerDial(badPeerID))
+	require.True(t, gater.InterceptPeerDial(goodPeerID))
 }
 
 func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
@@ -105,17 +111,17 @@ func TestConnGaterInterceptAcceptRejectsDNSAddresses(t *testing.T) {
 
 func TestConnGaterInterceptSecured(t *testing.T) {
 	trimmedRecently := ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute)
-	trimmedRecently.Set("trimmed-peer", struct{}{})
+	trimmedRecently.Set(trimmedPeerID, struct{}{})
 
 	gater := &connGater{
 		logger:          zap.NewNop(),
-		isBadPeer:       func(id peer.ID) bool { return id == "bad-peer" },
+		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: trimmedRecently,
 	}
 
-	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "trimmed-peer", nil))
-	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, "bad-peer", nil))
-	require.True(t, gater.InterceptSecured(libp2pnetwork.DirOutbound, "good-peer", nil))
+	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, trimmedPeerID, nil))
+	require.False(t, gater.InterceptSecured(libp2pnetwork.DirInbound, badPeerID, nil))
+	require.True(t, gater.InterceptSecured(libp2pnetwork.DirOutbound, goodPeerID, nil))
 }
 
 func TestConnGaterInterceptUpgraded(t *testing.T) {


### PR DESCRIPTION
## Summary
- `InterceptPeerDial` unconditionally returned `true`, allowing outbound dials to known-bad peers
- Added `isBadPeer` check to reject bad peers before address resolution, avoiding wasted TCP connection resources
- Same check already exists in `InterceptAddrDial` (per-address) and `InterceptSecured` (post-handshake) — this moves rejection to the earliest possible stage

## Finding
F-ssv-128 — Connection gater InterceptPeerDial always returns true (P1/HIGH Security)

## Test
- Updated `TestConnGaterInterceptPeerDial` to cover bad-peer rejection and good-peer passthrough
- All connection gater tests pass with `-race`