### PR TITLE
perf: add in-memory pubkey index for O(1) operator lookup

### DIFF
--- a/operator/storage/storage.go
+++ b/operator/storage/storage.go
@@ -71,10 +71,15 @@ func NewNodeStorage(beaconCfg *networkconfig.Beacon, logger *zap.Logger, db base
 		return nil, fmt.Errorf("failed to create recipients storage: %w", err)
 	}
 
+	operatorStore, err := registrystorage.NewOperatorsStorage(logger, db, OperatorStoragePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("create operators storage: %w", err)
+	}
+
 	stg := &storage{
 		logger:         logger,
 		db:             db,
-		operatorStore:  registrystorage.NewOperatorsStorage(logger, db, OperatorStoragePrefix),
+		operatorStore:  operatorStore,
 		recipientStore: recipientStore,
 	}
 

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -939,7 +939,10 @@ func newOperatorStorageForTest(logger *zap.Logger) (registrystorage.Operators, f
 	if err != nil {
 		return nil, func() {}
 	}
-	s := registrystorage.NewOperatorsStorage(logger, db, []byte("test"))
+	s, err := registrystorage.NewOperatorsStorage(logger, db, []byte("test"))
+	if err != nil {
+		return nil, func() {}
+	}
 	return s, func() {
 		db.Close()
 	}

--- a/registry/storage/operators.go
+++ b/registry/storage/operators.go
@@ -258,11 +258,17 @@ func (s *operatorsStorage) DeleteOperatorData(rw basedb.ReadWriter, id spectypes
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if op, found, _ := s.getOperatorData(nil, id); found {
+	op, found, _ := s.getOperatorData(nil, id)
+
+	if err := s.db.Using(rw).Delete(s.prefix, buildOperatorKey(id)); err != nil {
+		return err
+	}
+
+	if found {
 		delete(s.pubkeyIdx, op.PublicKey)
 	}
 
-	return s.db.Using(rw).Delete(s.prefix, buildOperatorKey(id))
+	return nil
 }
 
 func (s *operatorsStorage) DropOperators() error {

--- a/registry/storage/operators.go
+++ b/registry/storage/operators.go
@@ -163,7 +163,14 @@ func (s *operatorsStorage) getOperatorDataByPubKey(
 	if !ok {
 		return nil, false, nil
 	}
-	return s.getOperatorData(r, id)
+	op, found, err := s.getOperatorData(r, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found || op.PublicKey != operatorPubKey {
+		return nil, false, nil
+	}
+	return op, true, nil
 }
 
 func (s *operatorsStorage) getOperatorData(
@@ -258,17 +265,7 @@ func (s *operatorsStorage) DeleteOperatorData(rw basedb.ReadWriter, id spectypes
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	op, found, _ := s.getOperatorData(nil, id)
-
-	if err := s.db.Using(rw).Delete(s.prefix, buildOperatorKey(id)); err != nil {
-		return err
-	}
-
-	if found {
-		delete(s.pubkeyIdx, op.PublicKey)
-	}
-
-	return nil
+	return s.db.Using(rw).Delete(s.prefix, buildOperatorKey(id))
 }
 
 func (s *operatorsStorage) DropOperators() error {

--- a/registry/storage/operators.go
+++ b/registry/storage/operators.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
@@ -76,19 +76,31 @@ type Operators interface {
 }
 
 type operatorsStorage struct {
-	logger *zap.Logger
-	db     basedb.Database
-	lock   sync.RWMutex
-	prefix []byte
+	logger    *zap.Logger
+	db        basedb.Database
+	lock      sync.RWMutex
+	prefix    []byte
+	pubkeyIdx map[string]spectypes.OperatorID
 }
 
-// NewOperatorsStorage creates a new instance of Storage
-func NewOperatorsStorage(logger *zap.Logger, db basedb.Database, prefix []byte) Operators {
-	return &operatorsStorage{
-		logger: logger,
-		db:     db,
-		prefix: prefix,
+// NewOperatorsStorage creates a new instance of Storage and loads the pubkey index from existing data.
+func NewOperatorsStorage(logger *zap.Logger, db basedb.Database, prefix []byte) (Operators, error) {
+	s := &operatorsStorage{
+		logger:    logger,
+		db:        db,
+		prefix:    prefix,
+		pubkeyIdx: make(map[string]spectypes.OperatorID),
 	}
+
+	operators, err := s.listOperators(nil, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("list operators: %w", err)
+	}
+	for _, op := range operators {
+		s.pubkeyIdx[op.PublicKey] = op.ID
+	}
+
+	return s, nil
 }
 
 // GetOperatorsPrefix returns DB prefix
@@ -147,16 +159,11 @@ func (s *operatorsStorage) getOperatorDataByPubKey(
 	r basedb.Reader,
 	operatorPubKey string,
 ) (*OperatorData, bool, error) {
-	operatorsData, err := s.listOperators(r, 0, 0)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "could not get all operators")
+	id, ok := s.pubkeyIdx[operatorPubKey]
+	if !ok {
+		return nil, false, nil
 	}
-	for _, op := range operatorsData {
-		if op.PublicKey == operatorPubKey {
-			return &op, true, nil
-		}
-	}
-	return nil, false, nil
+	return s.getOperatorData(r, id)
 }
 
 func (s *operatorsStorage) getOperatorData(
@@ -224,7 +231,7 @@ func (s *operatorsStorage) SaveOperatorData(
 
 	_, found, err := s.getOperatorData(nil, operatorData.ID)
 	if err != nil {
-		return found, errors.Wrap(err, "could not get operator data")
+		return found, fmt.Errorf("get operator data: %w", err)
 	}
 	if found {
 		s.logger.Debug("operator already exist",
@@ -235,15 +242,25 @@ func (s *operatorsStorage) SaveOperatorData(
 
 	raw, err := json.Marshal(operatorData)
 	if err != nil {
-		return found, errors.Wrap(err, "could not marshal operator data")
+		return found, fmt.Errorf("marshal operator data: %w", err)
 	}
 
-	return found, s.db.Using(rw).Set(s.prefix, buildOperatorKey(operatorData.ID), raw)
+	if err := s.db.Using(rw).Set(s.prefix, buildOperatorKey(operatorData.ID), raw); err != nil {
+		return found, fmt.Errorf("set operator data: %w", err)
+	}
+
+	s.pubkeyIdx[operatorData.PublicKey] = operatorData.ID
+
+	return found, nil
 }
 
 func (s *operatorsStorage) DeleteOperatorData(rw basedb.ReadWriter, id spectypes.OperatorID) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	if op, found, _ := s.getOperatorData(nil, id); found {
+		delete(s.pubkeyIdx, op.PublicKey)
+	}
 
 	return s.db.Using(rw).Delete(s.prefix, buildOperatorKey(id))
 }
@@ -252,10 +269,16 @@ func (s *operatorsStorage) DropOperators() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	return s.db.DropPrefix(bytes.Join(
+	if err := s.db.DropPrefix(bytes.Join(
 		[][]byte{s.prefix, operatorsPrefix, []byte("/")},
 		nil,
-	))
+	)); err != nil {
+		return err
+	}
+
+	s.pubkeyIdx = make(map[string]spectypes.OperatorID)
+
+	return nil
 }
 
 // buildOperatorKey builds operator key using operatorsPrefix & index, e.g. "operators/1"

--- a/registry/storage/operators_test.go
+++ b/registry/storage/operators_test.go
@@ -189,12 +189,81 @@ func TestStorage_DeleteOperatorAndDropOperators(t *testing.T) {
 	})
 }
 
+func TestStorage_PubKeyIndexConsistency(t *testing.T) {
+	logger := log.TestLogger(t)
+	s, done := newOperatorStorageForTest(logger)
+	require.NotNil(t, s)
+	defer done()
+
+	pk := base64.StdEncoding.EncodeToString([]byte("indexTestKey"))
+	op := storage.OperatorData{PublicKey: pk, ID: 100}
+
+	t.Run("save populates index", func(t *testing.T) {
+		_, err := s.SaveOperatorData(nil, &op)
+		require.NoError(t, err)
+
+		result, found, err := s.GetOperatorDataByPubKey(nil, pk)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, op.ID, result.ID)
+	})
+
+	t.Run("delete cleans index", func(t *testing.T) {
+		err := s.DeleteOperatorData(nil, op.ID)
+		require.NoError(t, err)
+
+		_, found, err := s.GetOperatorDataByPubKey(nil, pk)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("drop cleans index", func(t *testing.T) {
+		_, err := s.SaveOperatorData(nil, &op)
+		require.NoError(t, err)
+
+		err = s.DropOperators()
+		require.NoError(t, err)
+
+		_, found, err := s.GetOperatorDataByPubKey(nil, pk)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+}
+
+func TestStorage_PubKeyIndexPopulatedOnInit(t *testing.T) {
+	logger := log.TestLogger(t)
+	db, err := kv.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	prefix := []byte("test")
+	pk := base64.StdEncoding.EncodeToString([]byte("initTestKey"))
+	op := storage.OperatorData{PublicKey: pk, ID: 200}
+
+	s1, err := storage.NewOperatorsStorage(logger, db, prefix)
+	require.NoError(t, err)
+	_, err = s1.SaveOperatorData(nil, &op)
+	require.NoError(t, err)
+
+	// New instance from the same DB must build the index from existing data.
+	s2, err := storage.NewOperatorsStorage(logger, db, prefix)
+	require.NoError(t, err)
+
+	result, found, err := s2.GetOperatorDataByPubKey(nil, pk)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, op.ID, result.ID)
+}
+
 func newOperatorStorageForTest(logger *zap.Logger) (storage.Operators, func()) {
 	db, err := kv.NewInMemory(logger, basedb.Options{})
 	if err != nil {
 		return nil, func() {}
 	}
-	s := storage.NewOperatorsStorage(logger, db, []byte("test"))
+	s, err := storage.NewOperatorsStorage(logger, db, []byte("test"))
+	if err != nil {
+		return nil, func() {}
+	}
 	return s, func() {
 		db.Close()
 	}

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -730,7 +730,10 @@ func (t *testStorage) open(logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	t.Operators = NewOperatorsStorage(logger, t.db, []byte("test"))
+	t.Operators, err = NewOperatorsStorage(logger, t.db, []byte("test"))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Replace O(n) full-scan in `getOperatorDataByPubKey` with an in-memory `map[pubkey]operatorID`, eliminating O(n²) during initial historical sync (~1.84M unnecessary JSON deserializations at ~1920 mainnet operators)
- `NewOperatorsStorage` now returns an error if the index cannot be built, matching the pattern used by `NewRecipientsStorage` and `NewSharesStorage`
- Migrate `pkg/errors` to `fmt.Errorf` in touched code

## Finding
F-ssv-150 — N+1 Query Pattern in Operator Lookup

## Test
- `go test -race ./registry/storage/...` ✅
- `go test -race ./operator/storage/...` ✅
- `go test -race ./eth/eventhandler/...` ✅
- `golangci-lint run ./registry/storage/... ./operator/storage/...` ✅
- New tests: `TestStorage_PubKeyIndexConsistency` (save/delete/drop maintain index), `TestStorage_PubKeyIndexPopulatedOnInit` (constructor builds index from existing DB)
