### PR TITLE
perf: use [32]byte map keys in PartialSigContainer

### DIFF
--- a/protocol/v2/ssv/partial_sig_container.go
+++ b/protocol/v2/ssv/partial_sig_container.go
@@ -171,6 +171,8 @@ func (ps *PartialSigContainer) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes hex-string signing roots back to [32]byte keys.
+// No lock: only called during state recovery (Decode) before the container
+// is shared across goroutines.
 func (ps *PartialSigContainer) UnmarshalJSON(data []byte) error {
 	type jsonContainer struct {
 		Signatures map[phase0.ValidatorIndex]map[string]map[spectypes.OperatorID]spectypes.Signature

--- a/protocol/v2/ssv/partial_sig_container.go
+++ b/protocol/v2/ssv/partial_sig_container.go
@@ -2,49 +2,51 @@ package ssv
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"maps"
 	"slices"
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/pkg/errors"
-	specssv "github.com/ssvlabs/ssv-spec/ssv"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/threshold"
 )
 
-type SigningRoot string
-
+// PartialSigContainer collects partial signatures during post-consensus.
+// Signatures are indexed by validator, signing root, and operator.
 type PartialSigContainer struct {
 	// signaturesMu protects access to the Signatures map to prevent concurrent read/write access
 	// from multiple goroutines
 	signaturesMu sync.RWMutex
-	// Signature map: validator index -> signing root -> operator id (signer) -> signature (from the signer for the validator's signing root)
-	Signatures map[phase0.ValidatorIndex]map[specssv.SigningRoot]map[spectypes.OperatorID]spectypes.Signature
+	// Signature map: validator index -> signing root -> operator id (signer) -> signature
+	Signatures map[phase0.ValidatorIndex]map[[32]byte]map[spectypes.OperatorID]spectypes.Signature
 	// Quorum is the number of min signatures needed for quorum
 	Quorum uint64
 }
 
+// NewPartialSigContainer creates a container that collects partial signatures until quorum.
 func NewPartialSigContainer(quorum uint64) *PartialSigContainer {
 	return &PartialSigContainer{
 		Quorum:     quorum,
-		Signatures: make(map[phase0.ValidatorIndex]map[specssv.SigningRoot]map[spectypes.OperatorID]spectypes.Signature),
+		Signatures: make(map[phase0.ValidatorIndex]map[[32]byte]map[spectypes.OperatorID]spectypes.Signature),
 	}
 }
 
+// AddSignature stores a partial signature if one does not already exist for the signer.
 func (ps *PartialSigContainer) AddSignature(sigMsg *spectypes.PartialSignatureMessage) {
 	ps.signaturesMu.Lock()
 	defer ps.signaturesMu.Unlock()
 
 	if ps.Signatures[sigMsg.ValidatorIndex] == nil {
-		ps.Signatures[sigMsg.ValidatorIndex] = make(map[specssv.SigningRoot]map[spectypes.OperatorID]spectypes.Signature)
+		ps.Signatures[sigMsg.ValidatorIndex] = make(map[[32]byte]map[spectypes.OperatorID]spectypes.Signature)
 	}
-	if ps.Signatures[sigMsg.ValidatorIndex][signingRootHex(sigMsg.SigningRoot)] == nil {
-		ps.Signatures[sigMsg.ValidatorIndex][signingRootHex(sigMsg.SigningRoot)] = make(map[spectypes.OperatorID]spectypes.Signature)
+	if ps.Signatures[sigMsg.ValidatorIndex][sigMsg.SigningRoot] == nil {
+		ps.Signatures[sigMsg.ValidatorIndex][sigMsg.SigningRoot] = make(map[spectypes.OperatorID]spectypes.Signature)
 	}
-	m := ps.Signatures[sigMsg.ValidatorIndex][signingRootHex(sigMsg.SigningRoot)]
+	m := ps.Signatures[sigMsg.ValidatorIndex][sigMsg.SigningRoot]
 
 	if m[sigMsg.Signer] == nil {
 		m[sigMsg.Signer] = make([]byte, 96)
@@ -52,94 +54,85 @@ func (ps *PartialSigContainer) AddSignature(sigMsg *spectypes.PartialSignatureMe
 	}
 }
 
-// HasSignature returns true if container has signature for signer and signing root, else it returns false
+// HasSignature returns true if a signature exists for the given signer and signing root.
 func (ps *PartialSigContainer) HasSignature(validatorIndex phase0.ValidatorIndex, signer spectypes.OperatorID, signingRoot [32]byte) bool {
-	_, err := ps.GetSignature(validatorIndex, signer, signingRoot)
-	return err == nil
+	ps.signaturesMu.RLock()
+	defer ps.signaturesMu.RUnlock()
+
+	return ps.Signatures[validatorIndex][signingRoot][signer] != nil
 }
 
-// GetSignature returns the signature for a given root and signer
+// GetSignature returns the signature for a given root and signer.
 func (ps *PartialSigContainer) GetSignature(validatorIndex phase0.ValidatorIndex, signer spectypes.OperatorID, signingRoot [32]byte) (spectypes.Signature, error) {
 	ps.signaturesMu.RLock()
 	defer ps.signaturesMu.RUnlock()
 
-	if ps.Signatures[validatorIndex] == nil {
-		return nil, errors.New("Dont have signature for the given validator index")
+	sig := ps.Signatures[validatorIndex][signingRoot][signer]
+	if sig == nil {
+		return nil, fmt.Errorf("no signature for validator %d root %x signer %d", validatorIndex, signingRoot, signer)
 	}
-	if ps.Signatures[validatorIndex][signingRootHex(signingRoot)] == nil {
-		return nil, errors.New("Dont have signature for the given signing root")
-	}
-	if ps.Signatures[validatorIndex][signingRootHex(signingRoot)][signer] == nil {
-		return nil, errors.New("Dont have signature on signing root for the given signer")
-	}
-	return ps.Signatures[validatorIndex][signingRootHex(signingRoot)][signer], nil
+	return sig, nil
 }
 
-// GetSignatures Return signature map for given root
+// GetSignatures returns a copy of the signature map for a given root.
 func (ps *PartialSigContainer) GetSignatures(validatorIndex phase0.ValidatorIndex, signingRoot [32]byte) map[spectypes.OperatorID]spectypes.Signature {
 	ps.signaturesMu.RLock()
 	defer ps.signaturesMu.RUnlock()
 
-	signatures := ps.Signatures[validatorIndex][signingRootHex(signingRoot)]
+	signatures := ps.Signatures[validatorIndex][signingRoot]
 	if signatures == nil {
 		return nil
 	}
 
+	// Return a copy to avoid external mutation and data races
 	signaturesCopy := make(map[spectypes.OperatorID]spectypes.Signature, len(signatures))
 	maps.Copy(signaturesCopy, signatures)
 
-	// Return a copy to avoid external mutation and avoid data races
 	return signaturesCopy
 }
 
-// Remove signer from signature map
+// Remove deletes a signer from the signature map.
 func (ps *PartialSigContainer) Remove(validatorIndex phase0.ValidatorIndex, signer uint64, signingRoot [32]byte) {
 	ps.signaturesMu.Lock()
 	defer ps.signaturesMu.Unlock()
 
-	if ps.Signatures[validatorIndex] == nil {
+	signers := ps.Signatures[validatorIndex][signingRoot]
+	if signers == nil {
 		return
 	}
-	if ps.Signatures[validatorIndex][signingRootHex(signingRoot)] == nil {
-		return
-	}
-	if ps.Signatures[validatorIndex][signingRootHex(signingRoot)][signer] == nil {
-		return
-	}
-	delete(ps.Signatures[validatorIndex][signingRootHex(signingRoot)], signer)
+	delete(signers, signer)
 }
 
+// ReconstructSignature aggregates collected partial sigs and verifies the result.
 func (ps *PartialSigContainer) ReconstructSignature(root [32]byte, validatorPubKey []byte, validatorIndex phase0.ValidatorIndex) ([]byte, error) {
 	ps.signaturesMu.RLock()
 	defer ps.signaturesMu.RUnlock()
 
-	// Reconstruct signatures
-	if ps.Signatures[validatorIndex] == nil {
-		return nil, errors.New("no signatures for the given validator index")
-	}
-	if ps.Signatures[validatorIndex][signingRootHex(root)] == nil {
-		return nil, errors.New("no signatures for the given signing root")
+	rootSigs := ps.Signatures[validatorIndex][root]
+	if rootSigs == nil {
+		return nil, fmt.Errorf("no signatures for validator %d root %x", validatorIndex, root)
 	}
 
-	operatorsSignatures := make(map[uint64][]byte)
-	for operatorID, sig := range ps.Signatures[validatorIndex][signingRootHex(root)] {
+	operatorsSignatures := make(map[uint64][]byte, len(rootSigs))
+	for operatorID, sig := range rootSigs {
 		operatorsSignatures[operatorID] = sig
 	}
 	signature, err := threshold.ReconstructSignatures(operatorsSignatures)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to reconstruct signatures")
+		return nil, fmt.Errorf("reconstruct signatures: %w", err)
 	}
 
-	// Get validator pub key copy (This avoids cgo Go pointer to Go pointer issue)
+	// Copy to avoid cgo Go pointer to Go pointer issue
 	validatorPubKeyCopy := make([]byte, len(validatorPubKey))
 	copy(validatorPubKeyCopy, validatorPubKey)
 
 	if err := types.VerifyReconstructedSignature(signature, validatorPubKeyCopy, root); err != nil {
-		return nil, errors.Wrap(err, "failed to verify reconstruct signature")
+		return nil, fmt.Errorf("verify reconstructed signature: %w", err)
 	}
 	return signature.Serialize(), nil
 }
 
+// HasQuorum returns true if enough signatures exist for the given root.
 func (ps *PartialSigContainer) HasQuorum(validatorIndex phase0.ValidatorIndex, root [32]byte) (
 	ok bool,
 	signers []spectypes.OperatorID,
@@ -147,11 +140,66 @@ func (ps *PartialSigContainer) HasQuorum(validatorIndex phase0.ValidatorIndex, r
 	ps.signaturesMu.RLock()
 	defer ps.signaturesMu.RUnlock()
 
-	rootSigs := ps.Signatures[validatorIndex][signingRootHex(root)]
+	rootSigs := ps.Signatures[validatorIndex][root]
 
 	return uint64(len(rootSigs)) >= ps.Quorum, slices.Collect(maps.Keys(rootSigs))
 }
 
-func signingRootHex(r [32]byte) specssv.SigningRoot {
-	return specssv.SigningRoot(hex.EncodeToString(r[:]))
+// MarshalJSON preserves the hex-string signing root format for backward-compatible JSON.
+func (ps *PartialSigContainer) MarshalJSON() ([]byte, error) {
+	ps.signaturesMu.RLock()
+	defer ps.signaturesMu.RUnlock()
+
+	type jsonContainer struct {
+		Signatures map[phase0.ValidatorIndex]map[string]map[spectypes.OperatorID]spectypes.Signature
+		Quorum     uint64
+	}
+
+	jc := jsonContainer{
+		Quorum:     ps.Quorum,
+		Signatures: make(map[phase0.ValidatorIndex]map[string]map[spectypes.OperatorID]spectypes.Signature, len(ps.Signatures)),
+	}
+
+	for vi, roots := range ps.Signatures {
+		jc.Signatures[vi] = make(map[string]map[spectypes.OperatorID]spectypes.Signature, len(roots))
+		for root, ops := range roots {
+			jc.Signatures[vi][hex.EncodeToString(root[:])] = ops
+		}
+	}
+
+	return json.Marshal(jc)
+}
+
+// UnmarshalJSON decodes hex-string signing roots back to [32]byte keys.
+func (ps *PartialSigContainer) UnmarshalJSON(data []byte) error {
+	type jsonContainer struct {
+		Signatures map[phase0.ValidatorIndex]map[string]map[spectypes.OperatorID]spectypes.Signature
+		Quorum     uint64
+	}
+
+	var jc jsonContainer
+	if err := json.Unmarshal(data, &jc); err != nil {
+		return err
+	}
+
+	ps.Quorum = jc.Quorum
+	ps.Signatures = make(map[phase0.ValidatorIndex]map[[32]byte]map[spectypes.OperatorID]spectypes.Signature, len(jc.Signatures))
+
+	for vi, roots := range jc.Signatures {
+		ps.Signatures[vi] = make(map[[32]byte]map[spectypes.OperatorID]spectypes.Signature, len(roots))
+		for rootHex, ops := range roots {
+			rootBytes, err := hex.DecodeString(rootHex)
+			if err != nil {
+				return fmt.Errorf("decode signing root: %w", err)
+			}
+			if len(rootBytes) != 32 {
+				return fmt.Errorf("invalid signing root length: %d", len(rootBytes))
+			}
+			var root [32]byte
+			copy(root[:], rootBytes)
+			ps.Signatures[vi][root] = ops
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

- Replace hex-encoded string map keys (`specssv.SigningRoot`) with native `[32]byte` arrays in `PartialSigContainer`, eliminating all `hex.EncodeToString` allocations on the post-consensus hot path
- Rewrite `HasSignature` as a direct map check instead of delegating to `GetSignature`, which allocated a `pkg/errors` error with 32-frame stack capture on every miss (the common case before quorum)
- Migrate `pkg/errors` to `fmt.Errorf` with `%w` wrapping
- Add `MarshalJSON`/`UnmarshalJSON` to preserve the hex-string JSON wire format for backward compatibility

## Finding

F-ssv-155: Hex Encoding as Map Keys in Hot Paths

## Motivation

Every method on `PartialSigContainer` converted `[32]byte` signing roots to 64-char hex strings via `signingRootHex()` — called ~27 times per validator through the full post-consensus flow. Additionally, `HasSignature` used `GetSignature` + error check, where `pkg/errors.New` captured a full stack trace on the normal "signature not yet present" path.

All method signatures already accepted `[32]byte`. The string type existed solely as a map key. Removing the conversion layer eliminates heap allocations on the hot path with zero caller changes.

## What Changed

- `Signatures` map key: `specssv.SigningRoot` (string) → `[32]byte`
- Deleted `func signingRootHex` and `type SigningRoot string`
- Simplified nil-check chains using Go's nil-map-read safety
- New `MarshalJSON`/`UnmarshalJSON` with root-length validation to preserve backward-compatible JSON format

## Test

- `go test -race ./protocol/v2/ssv/...` — all pass including spec conformance
- `make lint` — 0 issues
