### PR TITLE
chore: remove MinParticipationEpoch protection

### DIFF
--- a/operator/duties/attester_test.go
+++ b/operator/duties/attester_test.go
@@ -11,13 +11,44 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
+
+func TestAttesterHandlerShouldExecuteRespectsMinParticipationEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	share := activeShare(1)
+	share.ValidatorPubKey = spectypes.ValidatorPK{1, 2, 3}
+	share.SetMinParticipationEpoch(1)
+
+	validatorProvider := NewMockValidatorProvider(ctrl)
+	validatorProvider.EXPECT().Validator(share.ValidatorPubKey[:]).Return(share, true)
+
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	beaconCfg.GenesisTime = time.Now()
+	beaconCfg.SlotDuration = time.Hour
+	beaconCfg.SlotsPerEpoch = testSlotsPerEpoch
+
+	handler := NewAttesterHandler(dutystore.NewDuties[eth2apiv1.AttesterDuty](), false)
+	handler.logger = zap.NewNop()
+	handler.beaconConfig = &beaconCfg
+	handler.validatorProvider = validatorProvider
+
+	shouldExecute := handler.shouldExecute(&eth2apiv1.AttesterDuty{
+		PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+		Slot:           0,
+		ValidatorIndex: share.ValidatorIndex,
+	})
+
+	require.False(t, shouldExecute)
+}
 
 func setupAttesterDutiesMock(
 	s *Scheduler,

--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -245,10 +245,6 @@ func (h *CommitteeHandler) shouldExecuteSync(duty *eth2apiv1.SyncCommitteeDuty, 
 
 	currentSlot := h.beaconConfig.EstimatedCurrentSlot()
 
-	if participates := h.canParticipate(share, currentSlot); !participates {
-		return false
-	}
-
 	// execute task if slot already began and not pass 1 slot
 	if currentSlot == slot {
 		return true

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -995,6 +995,50 @@ func TestCommitteeHandlerShouldExecuteSyncIgnoresMinParticipationEpoch(t *testin
 	require.True(t, shouldExecute)
 }
 
+func TestCommitteeHandlerBuildCommitteeDutiesIncludesSyncButNotAttesterDuringParticipationDelay(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	share := activeShare(1)
+	share.ValidatorPubKey = spectypes.ValidatorPK{1, 2, 3}
+	share.SetMinParticipationEpoch(1)
+
+	validatorProvider := NewMockValidatorProvider(ctrl)
+	validatorProvider.EXPECT().SelfParticipatingValidators(phase0.Epoch(0)).Return([]*ssvtypes.SSVShare{share})
+	validatorProvider.EXPECT().Validator(share.ValidatorPubKey[:]).Return(share, true).Times(2)
+
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	beaconCfg.GenesisTime = time.Now()
+	beaconCfg.SlotDuration = time.Hour
+	beaconCfg.SlotsPerEpoch = testSlotsPerEpoch
+
+	dutyStore := dutystore.New()
+	handler := NewCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+	handler.logger = zap.NewNop()
+	handler.beaconConfig = &beaconCfg
+	handler.validatorProvider = validatorProvider
+
+	committeeMap := handler.buildCommitteeDuties(
+		[]*eth2apiv1.AttesterDuty{{
+			PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+			Slot:           0,
+			ValidatorIndex: share.ValidatorIndex,
+		}},
+		[]*eth2apiv1.SyncCommitteeDuty{{
+			PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+			ValidatorIndex: share.ValidatorIndex,
+		}},
+		0,
+		0,
+	)
+
+	require.Len(t, committeeMap, 1)
+	committeeDuty := committeeMap[share.CommitteeID()]
+	require.NotNil(t, committeeDuty)
+	require.Len(t, committeeDuty.duty.ValidatorDuties, 1)
+	require.Equal(t, spectypes.BNRoleSyncCommittee, committeeDuty.duty.ValidatorDuties[0].Type)
+	require.Equal(t, share.ValidatorIndex, committeeDuty.duty.ValidatorDuties[0].ValidatorIndex)
+}
+
 // The purpose of the test is to ensure that the scheduler can handle the case where the indices change
 // at the last slot of the epoch, and it does not affect the execution of the duties for the next epoch first slot.
 func TestScheduler_Committee_Indices_Changed_At_The_Last_Slot_Of_The_Epoch(t *testing.T) {

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
@@ -964,6 +965,34 @@ func TestScheduler_Committee_Early_Block(t *testing.T) {
 		require.NoError(t, scheduler.Wait())
 		ticker.WaitShutdown()
 	})
+}
+
+func TestCommitteeHandlerShouldExecuteSyncIgnoresMinParticipationEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	share := activeShare(1)
+	share.ValidatorPubKey = spectypes.ValidatorPK{1, 2, 3}
+	share.SetMinParticipationEpoch(1)
+
+	validatorProvider := NewMockValidatorProvider(ctrl)
+	validatorProvider.EXPECT().Validator(share.ValidatorPubKey[:]).Return(share, true)
+
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	beaconCfg.GenesisTime = time.Now()
+	beaconCfg.SlotDuration = time.Hour
+	beaconCfg.SlotsPerEpoch = testSlotsPerEpoch
+
+	handler := NewCommitteeHandler(dutystore.New().Attester, dutystore.New().SyncCommittee)
+	handler.logger = zap.NewNop()
+	handler.beaconConfig = &beaconCfg
+	handler.validatorProvider = validatorProvider
+
+	shouldExecute := handler.shouldExecuteSync(&eth2apiv1.SyncCommitteeDuty{
+		PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+		ValidatorIndex: share.ValidatorIndex,
+	}, 0, 0)
+
+	require.True(t, shouldExecute)
 }
 
 // The purpose of the test is to ensure that the scheduler can handle the case where the indices change

--- a/operator/duties/sync_committee.go
+++ b/operator/duties/sync_committee.go
@@ -389,20 +389,10 @@ func (h *SyncCommitteeHandler) toSpecDuty(duty *eth2apiv1.SyncCommitteeDuty, slo
 
 func (h *SyncCommitteeHandler) shouldExecute(duty *eth2apiv1.SyncCommitteeDuty, slot phase0.Slot) bool {
 	currentSlot := h.beaconConfig.EstimatedCurrentSlot()
-	currentEpoch := h.beaconConfig.EstimatedEpochAtSlot(currentSlot)
 
-	v, exists := h.validatorProvider.Validator(duty.PubKey[:])
+	_, exists := h.validatorProvider.Validator(duty.PubKey[:])
 	if !exists {
 		h.logger.Warn("validator not found", fields.Validator(duty.PubKey[:]))
-		return false
-	}
-
-	if v.MinParticipationEpoch() > currentEpoch {
-		h.logger.Debug("validator not yet participating",
-			fields.Validator(duty.PubKey[:]),
-			zap.Uint64("min_participation_epoch", uint64(v.MinParticipationEpoch())),
-			zap.Uint64("current_epoch", uint64(currentEpoch)),
-		)
 		return false
 	}
 

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -11,13 +11,43 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
+
+func TestSyncCommitteeHandlerShouldExecuteIgnoresMinParticipationEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	share := activeShare(1)
+	share.ValidatorPubKey = spectypes.ValidatorPK{1, 2, 3}
+	share.SetMinParticipationEpoch(1)
+
+	validatorProvider := NewMockValidatorProvider(ctrl)
+	validatorProvider.EXPECT().Validator(share.ValidatorPubKey[:]).Return(share, true)
+
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	beaconCfg.GenesisTime = time.Now()
+	beaconCfg.SlotDuration = time.Hour
+	beaconCfg.SlotsPerEpoch = testSlotsPerEpoch
+
+	handler := NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+	handler.logger = zap.NewNop()
+	handler.beaconConfig = &beaconCfg
+	handler.validatorProvider = validatorProvider
+
+	shouldExecute := handler.shouldExecute(&v1.SyncCommitteeDuty{
+		PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+		ValidatorIndex: share.ValidatorIndex,
+	}, 0)
+
+	require.True(t, shouldExecute)
+}
 
 func setupSyncCommitteeDutiesMock(
 	s *Scheduler,


### PR DESCRIPTION
Addresses `F-ssv-119`

Implementation status:

  - operator/duties/committee.go still applies MinParticipationEpoch only through canParticipate() in shouldExecuteAtt().
  - operator/duties/committee.go no longer calls canParticipate() from shouldExecuteSync().
  - operator/duties/attester.go still blocks attester duties during participation delay.
  - operator/duties/sync_committee.go no longer blocks sync duties on MinParticipationEpoch.

  Added tests:

  - operator/duties/sync_committee_test.go: TestSyncCommitteeHandlerShouldExecuteIgnoresMinParticipationEpoch
  - operator/duties/attester_test.go: TestAttesterHandlerShouldExecuteRespectsMinParticipationEpoch
  - operator/duties/committee_test.go: TestCommitteeHandlerBuildCommitteeDutiesIncludesSyncButNotAttesterDuringParticipationDelay
  - Existing focused committee sync test remains in operator/duties/committee_test.go: TestCommitteeHandlerShouldExecuteSyncIgnoresMinParticipationEpoch