### PR TITLE
dutystore: add regression coverage for independent duty-type locks

### DIFF
--- a/operator/duties/dutystore/duties_test.go
+++ b/operator/duties/dutystore/duties_test.go
@@ -1,6 +1,7 @@
 package dutystore
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -86,29 +87,38 @@ func TestStoreDutyTypesUseIndependentLocks(t *testing.T) {
 	store.Attester.mu.Lock()
 	defer store.Attester.mu.Unlock()
 
-	assertCompletesWithin(t, "proposer read", func() {
-		assert.NotNil(t, store.Proposer.ValidatorDuty(epoch, slot, 1))
+	assertCompletesWithin(t, "proposer read", func() error {
+		if store.Proposer.ValidatorDuty(epoch, slot, 1) == nil {
+			return fmt.Errorf("expected proposer duty for epoch %d slot %d validator 1", epoch, slot)
+		}
+		return nil
 	})
-	assertCompletesWithin(t, "sync committee read", func() {
-		assert.NotNil(t, store.SyncCommittee.Duty(period, 2))
+	assertCompletesWithin(t, "sync committee read", func() error {
+		if store.SyncCommittee.Duty(period, 2) == nil {
+			return fmt.Errorf("expected sync committee duty for period %d validator 2", period)
+		}
+		return nil
 	})
-	assertCompletesWithin(t, "voluntary exit write", func() {
+	assertCompletesWithin(t, "voluntary exit write", func() error {
 		store.VoluntaryExit.AddDuty(slot, pk)
-		assert.Equal(t, uint64(1), store.VoluntaryExit.GetDutyCount(slot, pk))
+		if count := store.VoluntaryExit.GetDutyCount(slot, pk); count != 1 {
+			return fmt.Errorf("expected voluntary exit count 1, got %d", count)
+		}
+		return nil
 	})
 }
 
-func assertCompletesWithin(t *testing.T, name string, fn func()) {
+func assertCompletesWithin(t *testing.T, name string, fn func() error) {
 	t.Helper()
 
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
-		fn()
-		close(done)
+		done <- fn()
 	}()
 
 	select {
-	case <-done:
+	case err := <-done:
+		require.NoError(t, err, name)
 	case <-time.After(time.Second):
 		t.Fatalf("%s blocked while a different duty type lock was held", name)
 	}

--- a/operator/duties/dutystore/duties_test.go
+++ b/operator/duties/dutystore/duties_test.go
@@ -97,6 +97,7 @@ func TestStoreDutyTypesUseIndependentLocks(t *testing.T) {
 				InCommittee:    true,
 			},
 		})
+		store.VoluntaryExit.AddDuty(slot, pk)
 
 		return store
 	}
@@ -156,7 +157,6 @@ func TestStoreDutyTypesUseIndependentLocks(t *testing.T) {
 				store.VoluntaryExit.mu.Unlock()
 			},
 			assertOpen: func(store *Store) error {
-				store.VoluntaryExit.AddDuty(slot, pk)
 				if count := store.VoluntaryExit.GetDutyCount(slot, pk); count != 1 {
 					return fmt.Errorf("expected voluntary exit count 1, got %d", count)
 				}

--- a/operator/duties/dutystore/duties_test.go
+++ b/operator/duties/dutystore/duties_test.go
@@ -60,52 +60,127 @@ func TestDutiesEraseEpochData(t *testing.T) {
 }
 
 func TestStoreDutyTypesUseIndependentLocks(t *testing.T) {
-	store := New()
-
 	epoch := phase0.Epoch(8)
 	slot := phase0.Slot(64)
 	period := uint64(2)
 	pk := phase0.BLSPubKey{1}
 
-	store.Proposer.Set(epoch, []StoreDuty[eth2apiv1.ProposerDuty]{
-		{
-			Slot:           slot,
-			ValidatorIndex: 1,
-			Duty:           &eth2apiv1.ProposerDuty{Slot: slot, ValidatorIndex: 1},
-			InCommittee:    true,
-		},
-	})
-	store.SyncCommittee.Set(period, []StoreSyncCommitteeDuty{
-		{
-			ValidatorIndex: 2,
-			Duty:           &eth2apiv1.SyncCommitteeDuty{ValidatorIndex: 2},
-			InCommittee:    true,
-		},
-	})
+	type dutyType struct {
+		name       string
+		lock       func(store *Store)
+		unlock     func(store *Store)
+		assertOpen func(store *Store) error
+	}
 
-	// Hold the attester write lock and verify other duty types still make progress.
-	store.Attester.mu.Lock()
-	defer store.Attester.mu.Unlock()
+	newStoreWithDuties := func() *Store {
+		store := New()
+		store.Attester.Set(epoch, []StoreDuty[eth2apiv1.AttesterDuty]{
+			{
+				Slot:           slot,
+				ValidatorIndex: 1,
+				Duty:           &eth2apiv1.AttesterDuty{Slot: slot, ValidatorIndex: 1},
+				InCommittee:    true,
+			},
+		})
+		store.Proposer.Set(epoch, []StoreDuty[eth2apiv1.ProposerDuty]{
+			{
+				Slot:           slot,
+				ValidatorIndex: 2,
+				Duty:           &eth2apiv1.ProposerDuty{Slot: slot, ValidatorIndex: 2},
+				InCommittee:    true,
+			},
+		})
+		store.SyncCommittee.Set(period, []StoreSyncCommitteeDuty{
+			{
+				ValidatorIndex: 3,
+				Duty:           &eth2apiv1.SyncCommitteeDuty{ValidatorIndex: 3},
+				InCommittee:    true,
+			},
+		})
 
-	assertCompletesWithin(t, "proposer read", func() error {
-		if store.Proposer.ValidatorDuty(epoch, slot, 1) == nil {
-			return fmt.Errorf("expected proposer duty for epoch %d slot %d validator 1", epoch, slot)
-		}
-		return nil
-	})
-	assertCompletesWithin(t, "sync committee read", func() error {
-		if store.SyncCommittee.Duty(period, 2) == nil {
-			return fmt.Errorf("expected sync committee duty for period %d validator 2", period)
-		}
-		return nil
-	})
-	assertCompletesWithin(t, "voluntary exit write", func() error {
-		store.VoluntaryExit.AddDuty(slot, pk)
-		if count := store.VoluntaryExit.GetDutyCount(slot, pk); count != 1 {
-			return fmt.Errorf("expected voluntary exit count 1, got %d", count)
-		}
-		return nil
-	})
+		return store
+	}
+
+	dutyTypes := []dutyType{
+		{
+			name: "attester",
+			lock: func(store *Store) {
+				store.Attester.mu.Lock()
+			},
+			unlock: func(store *Store) {
+				store.Attester.mu.Unlock()
+			},
+			assertOpen: func(store *Store) error {
+				if store.Attester.ValidatorDuty(epoch, slot, 1) == nil {
+					return fmt.Errorf("expected attester duty for epoch %d slot %d validator 1", epoch, slot)
+				}
+				return nil
+			},
+		},
+		{
+			name: "proposer",
+			lock: func(store *Store) {
+				store.Proposer.mu.Lock()
+			},
+			unlock: func(store *Store) {
+				store.Proposer.mu.Unlock()
+			},
+			assertOpen: func(store *Store) error {
+				if store.Proposer.ValidatorDuty(epoch, slot, 2) == nil {
+					return fmt.Errorf("expected proposer duty for epoch %d slot %d validator 2", epoch, slot)
+				}
+				return nil
+			},
+		},
+		{
+			name: "sync committee",
+			lock: func(store *Store) {
+				store.SyncCommittee.mu.Lock()
+			},
+			unlock: func(store *Store) {
+				store.SyncCommittee.mu.Unlock()
+			},
+			assertOpen: func(store *Store) error {
+				if store.SyncCommittee.Duty(period, 3) == nil {
+					return fmt.Errorf("expected sync committee duty for period %d validator 3", period)
+				}
+				return nil
+			},
+		},
+		{
+			name: "voluntary exit",
+			lock: func(store *Store) {
+				store.VoluntaryExit.mu.Lock()
+			},
+			unlock: func(store *Store) {
+				store.VoluntaryExit.mu.Unlock()
+			},
+			assertOpen: func(store *Store) error {
+				store.VoluntaryExit.AddDuty(slot, pk)
+				if count := store.VoluntaryExit.GetDutyCount(slot, pk); count != 1 {
+					return fmt.Errorf("expected voluntary exit count 1, got %d", count)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, holder := range dutyTypes {
+		t.Run(holder.name+" lock", func(t *testing.T) {
+			store := newStoreWithDuties()
+			holder.lock(store)
+			defer holder.unlock(store)
+
+			for _, other := range dutyTypes {
+				if other.name == holder.name {
+					continue
+				}
+				assertCompletesWithin(t, other.name+" remains available", func() error {
+					return other.assertOpen(store)
+				})
+			}
+		})
+	}
 }
 
 func assertCompletesWithin(t *testing.T, name string, fn func() error) {

--- a/operator/duties/dutystore/duties_test.go
+++ b/operator/duties/dutystore/duties_test.go
@@ -2,6 +2,7 @@ package dutystore
 
 import (
 	"testing"
+	"time"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -55,4 +56,60 @@ func TestDutiesEraseEpochData(t *testing.T) {
 	assert.Nil(t, duties.CommitteeSlotDuties(epoch, 10))
 	assert.Nil(t, duties.ValidatorDuty(epoch, 10, 1))
 	assert.Nil(t, duties.SlotIndices(epoch, 10))
+}
+
+func TestStoreDutyTypesUseIndependentLocks(t *testing.T) {
+	store := New()
+
+	epoch := phase0.Epoch(8)
+	slot := phase0.Slot(64)
+	period := uint64(2)
+	pk := phase0.BLSPubKey{1}
+
+	store.Proposer.Set(epoch, []StoreDuty[eth2apiv1.ProposerDuty]{
+		{
+			Slot:           slot,
+			ValidatorIndex: 1,
+			Duty:           &eth2apiv1.ProposerDuty{Slot: slot, ValidatorIndex: 1},
+			InCommittee:    true,
+		},
+	})
+	store.SyncCommittee.Set(period, []StoreSyncCommitteeDuty{
+		{
+			ValidatorIndex: 2,
+			Duty:           &eth2apiv1.SyncCommitteeDuty{ValidatorIndex: 2},
+			InCommittee:    true,
+		},
+	})
+
+	// Hold the attester write lock and verify other duty types still make progress.
+	store.Attester.mu.Lock()
+	defer store.Attester.mu.Unlock()
+
+	assertCompletesWithin(t, "proposer read", func() {
+		assert.NotNil(t, store.Proposer.ValidatorDuty(epoch, slot, 1))
+	})
+	assertCompletesWithin(t, "sync committee read", func() {
+		assert.NotNil(t, store.SyncCommittee.Duty(period, 2))
+	})
+	assertCompletesWithin(t, "voluntary exit write", func() {
+		store.VoluntaryExit.AddDuty(slot, pk)
+		assert.Equal(t, uint64(1), store.VoluntaryExit.GetDutyCount(slot, pk))
+	})
+}
+
+func assertCompletesWithin(t *testing.T, name string, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("%s blocked while a different duty type lock was held", name)
+	}
 }


### PR DESCRIPTION
## Summary

`F-ssv-160`

Adds a regression test for the duty store locking model.

The current `dutystore` implementation already keeps separate stores for attester, proposer, sync committee, and voluntary exit duties, with each store using its own `sync.RWMutex`. This PR adds coverage to make that behavior explicit and prevent regressions back to cross-duty-type lock contention.

## What changed

- Added `TestStoreDutyTypesUseIndependentLocks` in [duties_test.go](/Users/bloxmac/GolandProjects/ssv/operator/duties/dutystore/duties_test.go)
- The test holds the attester write lock and verifies that:
  - proposer reads still complete
  - sync committee reads still complete
  - voluntary exit writes still complete
- Added a small timeout helper used by the regression test

## Why

The `F-ssv-160` finding describes the duty store as if all duty types shared a single mutex. That does not match the current implementation on this branch. The new test documents the intended concurrency boundary and guards against future regressions.

## Verification

- Run `go test ./operator/duties/dutystore`