### PR TITLE
tests: resolve flaky p2p-discovery tests

### DIFF
--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -11,10 +11,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	defaultIteratorTimeout = 5 * time.Second
-)
-
 // forkingDV5Listener wraps a pre-fork and a post-fork listener.
 // Before the fork, it performs operations on both services.
 // After the fork, it performs operations only on the post-fork service.
@@ -26,9 +22,6 @@ type forkingDV5Listener struct {
 }
 
 func NewForkingDV5Listener(logger *zap.Logger, preFork, postFork Listener, iteratorTimeout time.Duration) *forkingDV5Listener {
-	if iteratorTimeout == 0 {
-		iteratorTimeout = defaultIteratorTimeout
-	}
 	return &forkingDV5Listener{
 		logger:           logger,
 		preForkListener:  preFork,

--- a/network/discovery/forking_dv5_listener_test.go
+++ b/network/discovery/forking_dv5_listener_test.go
@@ -167,5 +167,5 @@ func requireNextTimeout(t *testing.T, expected bool, iter enode.Iterator, timeou
 	case <-ctx.Done():
 	}
 
-	assert.Equalf(t, expected, got, "expected iter.Next to be %v", expected)
+	require.Equalf(t, expected, got, "expected iter.Next to be %v", expected)
 }

--- a/network/discovery/forking_dv5_listener_test.go
+++ b/network/discovery/forking_dv5_listener_test.go
@@ -65,7 +65,7 @@ func TestForkListener_RandomNodes(t *testing.T) {
 	assert.Equal(t, nodes[1], nodeFromPostForkListener)
 
 	// No more next
-	requireNextTimeout(t, false, iter, 10*time.Millisecond)
+	requireNextTimeout(t, false, iter, 400*time.Millisecond)
 }
 
 func TestForkListener_AllNodes(t *testing.T) {

--- a/network/discovery/forking_dv5_listener_test.go
+++ b/network/discovery/forking_dv5_listener_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const iteratorTimeout = 5 * time.Millisecond
+const iteratorTimeout = 500 * time.Millisecond
 
 func TestForkListener_Create(t *testing.T) {
 	localNode := NewLocalNode(t)

--- a/network/discovery/forking_dv5_listener_test.go
+++ b/network/discovery/forking_dv5_listener_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -51,12 +52,12 @@ func TestForkListener_RandomNodes(t *testing.T) {
 
 	forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout)
 
-	iter := forkListener.RandomNodes()
-	defer iter.Close()
+	iterator := forkListener.RandomNodes()
+	defer iterator.Close()
 	var nodes []*enode.Node
 	for i := 0; i < 2; i++ {
-		require.True(t, iter.Next())
-		nodes = append(nodes, iter.Node())
+		require.True(t, iterator.Next())
+		nodes = append(nodes, iterator.Node())
 	}
 
 	assert.Len(t, nodes, 2)
@@ -65,7 +66,7 @@ func TestForkListener_RandomNodes(t *testing.T) {
 	assert.Equal(t, nodes[1], nodeFromPostForkListener)
 
 	// No more next
-	requireNextTimeout(t, false, iter, 400*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 50*time.Millisecond)
 }
 
 func TestForkListener_AllNodes(t *testing.T) {
@@ -147,36 +148,24 @@ func TestForkListener_Close(t *testing.T) {
 }
 
 func requireNextTimeout(t *testing.T, expected bool, iter enode.Iterator, timeout time.Duration) {
-	const maxTries = 10
-	var deadline = time.After(timeout)
-	next := make(chan bool)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+
+	result := make(chan bool)
 	go func() {
-		defer close(next)
-		for {
-			ok := iter.Next()
-			select {
-			case next <- ok:
-			case <-deadline:
-				return
-			}
-			if ok {
-				return
-			}
-			time.Sleep(timeout / maxTries)
+		next := iter.Next()
+		select {
+		case result <- next:
+		case <-ctx.Done():
 		}
 	}()
-	for {
-		select {
-		case ok := <-next:
-			require.Equal(t, expected, ok, "expected next to be %v", expected)
-			if ok {
-				return
-			}
-		case <-deadline:
-			if expected {
-				require.Fail(t, "expected next to be %v", expected)
-			}
-			return
-		}
+
+	got := false
+	select {
+	case next := <-result:
+		got = next
+	case <-ctx.Done():
 	}
+
+	assert.Equalf(t, expected, got, "expected iter.Next to be %v", expected)
 }

--- a/network/discovery/iterator_test.go
+++ b/network/discovery/iterator_test.go
@@ -27,7 +27,7 @@ func TestFairMixIterator_Next(t *testing.T) {
 	require.ElementsMatch(t, expectedNodes, actualNodes)
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 50*time.Millisecond)
 }
 
 func TestFairMixIterator_Next_False(t *testing.T) {
@@ -65,7 +65,7 @@ func TestFairMixIterator_Next_False(t *testing.T) {
 	require.ElementsMatch(t, expectedNodes, actualNodes)
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 50*time.Millisecond)
 }
 
 func TestFairMixIterator_PostForkEmpty(t *testing.T) {
@@ -93,7 +93,7 @@ func TestFairMixIterator_PostForkEmpty(t *testing.T) {
 	require.Equal(t, node1, iterator.Node())
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 50*time.Millisecond)
 }
 
 func TestFairMixIterator_PreForkEmpty(t *testing.T) {
@@ -119,5 +119,5 @@ func TestFairMixIterator_PreForkEmpty(t *testing.T) {
 	require.Equal(t, node2, iterator.Node())
 
 	// No more elements even after switch
-	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 50*time.Millisecond)
 }

--- a/network/discovery/iterator_test.go
+++ b/network/discovery/iterator_test.go
@@ -27,7 +27,7 @@ func TestFairMixIterator_Next(t *testing.T) {
 	require.ElementsMatch(t, expectedNodes, actualNodes)
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
 }
 
 func TestFairMixIterator_Next_False(t *testing.T) {
@@ -59,13 +59,13 @@ func TestFairMixIterator_Next_False(t *testing.T) {
 
 	var actualNodes []*enode.Node
 	for i := 0; i < len(expectedNodes); i++ {
-		requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+		requireNextTimeout(t, true, iterator, 400*time.Millisecond)
 		actualNodes = append(actualNodes, iterator.Node())
 	}
 	require.ElementsMatch(t, expectedNodes, actualNodes)
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
 }
 
 func TestFairMixIterator_PostForkEmpty(t *testing.T) {
@@ -85,15 +85,15 @@ func TestFairMixIterator_PostForkEmpty(t *testing.T) {
 	require.False(t, postFork.closed) // postFork iterator must start openened
 
 	// First check: preFork first node after switch
-	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	requireNextTimeout(t, true, iterator, 400*time.Millisecond)
 	require.Equal(t, node2, iterator.Node())
 
 	// Second check: preFork second node
-	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	requireNextTimeout(t, true, iterator, 400*time.Millisecond)
 	require.Equal(t, node1, iterator.Node())
 
 	// No more elements
-	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
 }
 
 func TestFairMixIterator_PreForkEmpty(t *testing.T) {
@@ -111,13 +111,13 @@ func TestFairMixIterator_PreForkEmpty(t *testing.T) {
 	iterator.AddSource(postFork)
 
 	// First check: postFork first node
-	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	requireNextTimeout(t, true, iterator, 400*time.Millisecond)
 	require.Equal(t, node1, iterator.Node())
 
 	// Second check: postFork second node
-	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	requireNextTimeout(t, true, iterator, 400*time.Millisecond)
 	require.Equal(t, node2, iterator.Node())
 
 	// No more elements even after switch
-	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+	requireNextTimeout(t, false, iterator, 400*time.Millisecond)
 }


### PR DESCRIPTION
Saw this [pipeline fail recently](https://github.com/ssvlabs/ssv/actions/runs/24090131290/job/70273906810?pr=2756):
```
--- FAIL: TestFairMixIterator_PreForkEmpty (0.01s)
    forking_dv5_listener_test.go:177: 
        	Error Trace:	/home/runner/work/ssv/ssv/network/discovery/forking_dv5_listener_test.go:177
        	            				/home/runner/work/ssv/ssv/network/discovery/iterator_test.go:114
        	Error:      	expected next to be %v
        	Test:       	TestFairMixIterator_PreForkEmpty
        	Messages:   	true
FAIL
coverage: 65.4% of statements
FAIL	github.com/ssvlabs/ssv/network/discovery	1.598s
```
This PR bumps the deadlines these tests use up to `400ms` - which is experimentally verified stable/reliable sleep-amount, this should solve flakyness.