### PR TITLE
protocol/v2/ssv/queue: cache inbox metric attrs for push path

### DIFF
--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -52,20 +52,22 @@ type priorityQueue struct {
 	inbox    chan *SSVMessage
 	lastRead time.Time
 
-	// queueType enriches inboxSizeMetric to describe what type of queue this is.
-	queueType string
-	// queueId enriches inboxSizeMetric to describe which exact queue this is.
-	queueId         string
-	inboxSizeMetric metric.Int64Gauge
+	telemetryCtx       context.Context
+	inboxSizeMetric    metric.Int64Gauge
+	inboxSizeRecordOps []metric.RecordOption
 }
 
 type Option func(*priorityQueue)
 
 func WithInboxSizeMetric(inboxSizeMetric metric.Int64Gauge, queueType string, queueId string) Option {
+	attrSet := attribute.NewSet(
+		attribute.String("ssv.queue.type", queueType),
+		attribute.String("ssv.queue.id", queueId),
+	)
+
 	return func(q *priorityQueue) {
-		q.queueType = queueType
-		q.queueId = queueId
 		q.inboxSizeMetric = inboxSizeMetric
+		q.inboxSizeRecordOps = []metric.RecordOption{metric.WithAttributeSet(attrSet)}
 	}
 }
 
@@ -73,8 +75,9 @@ func WithInboxSizeMetric(inboxSizeMetric metric.Int64Gauge, queueType string, qu
 // Pops aren't thread-safe, so don't call Pop from multiple goroutines.
 func New(logger *zap.Logger, capacity int, opts ...Option) Queue {
 	q := &priorityQueue{
-		logger: logger.Named(log.NameSSVMessageQueue),
-		inbox:  make(chan *SSVMessage, capacity),
+		logger:       logger.Named(log.NameSSVMessageQueue),
+		inbox:        make(chan *SSVMessage, capacity),
+		telemetryCtx: context.Background(),
 	}
 
 	for _, opt := range opts {
@@ -233,10 +236,9 @@ func (q *priorityQueue) recordInboxSize(inboxSize int64) {
 		return
 	}
 	q.inboxSizeMetric.Record(
-		context.Background(),
+		q.telemetryCtx,
 		inboxSize,
-		metric.WithAttributes(attribute.String("ssv.queue.type", q.queueType)),
-		metric.WithAttributes(attribute.String("ssv.queue.id", q.queueId)),
+		q.inboxSizeRecordOps...,
 	)
 }
 

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -52,7 +52,6 @@ type priorityQueue struct {
 	inbox    chan *SSVMessage
 	lastRead time.Time
 
-	telemetryCtx       context.Context
 	inboxSizeMetric    metric.Int64Gauge
 	inboxSizeRecordOps []metric.RecordOption
 }
@@ -75,9 +74,8 @@ func WithInboxSizeMetric(inboxSizeMetric metric.Int64Gauge, queueType string, qu
 // Pops aren't thread-safe, so don't call Pop from multiple goroutines.
 func New(logger *zap.Logger, capacity int, opts ...Option) Queue {
 	q := &priorityQueue{
-		logger:       logger.Named(log.NameSSVMessageQueue),
-		inbox:        make(chan *SSVMessage, capacity),
-		telemetryCtx: context.Background(),
+		logger: logger.Named(log.NameSSVMessageQueue),
+		inbox:  make(chan *SSVMessage, capacity),
 	}
 
 	for _, opt := range opts {
@@ -236,7 +234,7 @@ func (q *priorityQueue) recordInboxSize(inboxSize int64) {
 		return
 	}
 	q.inboxSizeMetric.Record(
-		q.telemetryCtx,
+		context.Background(),
 		inboxSize,
 		q.inboxSizeRecordOps...,
 	)

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
@@ -267,6 +269,46 @@ func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.
 
 	// Ensure that the queue still contains the non-matching messages.
 	require.False(t, queue.Empty())
+}
+
+func TestPriorityQueue_InboxSizeMetricAttributes(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	testMeter := provider.Meter("test")
+
+	gauge, err := testMeter.Int64Gauge("test_inbox_size")
+	require.NoError(t, err)
+
+	const (
+		queueType = ValidatorQueueMetricType
+		queueID   = "attester"
+	)
+
+	queue := New(log.TestLogger(t), 4, WithInboxSizeMetric(gauge, queueType, queueID))
+	decodeAndPush(t, queue, mockConsensusMessage{Height: 100, Type: specqbft.PrepareMsgType}, mockState)
+
+	var rm metricdata.ResourceMetrics
+	err = reader.Collect(t.Context(), &rm)
+	require.NoError(t, err)
+
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+	require.Equal(t, "test_inbox_size", rm.ScopeMetrics[0].Metrics[0].Name)
+
+	gaugeData, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Len(t, gaugeData.DataPoints, 1)
+
+	dataPoint := gaugeData.DataPoints[0]
+	require.EqualValues(t, 1, dataPoint.Value)
+
+	queueTypeAttr, ok := dataPoint.Attributes.Value("ssv.queue.type")
+	require.True(t, ok)
+	require.Equal(t, queueType, queueTypeAttr.AsString())
+
+	queueIDAttr, ok := dataPoint.Attributes.Value("ssv.queue.id")
+	require.True(t, ok)
+	require.Equal(t, queueID, queueIDAttr.AsString())
 }
 
 func BenchmarkPriorityQueue_Parallel(b *testing.B) {


### PR DESCRIPTION
**F-ssv-159: Context & Attribute Re-creation on Every Queue Operation**

This PR addresses `F-ssv-159` by reducing per-message telemetry overhead in the SSV queue hot path.

Previously, every `Push` and `TryPush` rebuilt OpenTelemetry measurement attributes and passed a fresh background context into `Record`, adding avoidable allocation work on a high-frequency path. This change precomputes the queue’s static attribute set once in `WithInboxSizeMetric` and reuses a stable telemetry context for each metric record.

It also adds a queue-level observability test to verify the inbox size metric still emits the expected `ssv.queue.type` and `ssv.queue.id` attributes.

Verification:
- `go test ./protocol/v2/ssv/queue`