### PR TITLE
chore (cleanup) - p2p package, remove unused code

### DIFF
--- a/protocol/v2/p2p/network.go
+++ b/protocol/v2/p2p/network.go
@@ -25,24 +25,6 @@ type Broadcaster interface {
 	Broadcast(id spectypes.MessageID, message *spectypes.SignedSSVMessage) error
 }
 
-// SyncResult holds the result of a sync request, including the actual message and the sender
-type SyncResult struct {
-	Msg    *spectypes.SSVMessage
-	Sender string
-}
-
-type SyncResults []SyncResult
-
-// SyncProtocol represent the type of sync protocols
-type SyncProtocol int32
-
-const (
-	// LastDecidedProtocol is the last decided protocol type
-	LastDecidedProtocol SyncProtocol = iota
-	// DecidedHistoryProtocol is the decided history protocol type
-	DecidedHistoryProtocol
-)
-
 // MsgValidationResult helps other components to report message validation with a generic results scheme
 type MsgValidationResult int32
 


### PR DESCRIPTION
## Summary

- Remove dead sync protocol abstraction (~15 lines) from `protocol/v2/p2p/network.go`: `SyncResult` struct, `SyncResults` type, `SyncProtocol` type, `LastDecidedProtocol` and `DecidedHistoryProtocol` constants
- These types have zero callers and are remnants of a removed peer sync feature

Closes https://github.com/ssvlabs/ssv-node-board/issues/547
