### PR TITLE
Swap gossipsub score index atomically

### DIFF
--- a/network/peers/gossip_score_index_test.go
+++ b/network/peers/gossip_score_index_test.go
@@ -56,17 +56,32 @@ func TestSetScores(t *testing.T) {
 	require.Equal(t, 0.0, score3)
 }
 
-func TestClear(t *testing.T) {
+func TestSetScoresClearsExisting(t *testing.T) {
 	index := NewGossipScoreIndex()
 	peerID := peer.ID("peer1")
 
 	index.SetScores(map[peer.ID]float64{
 		peerID: 10.0,
 	})
-	index.clear()
+	index.SetScores(map[peer.ID]float64{})
 	score, exists := index.GetGossipScore(peerID)
 	require.False(t, exists)
 	require.Equal(t, 0.0, score)
+}
+
+func TestSetScoresCopiesInputMap(t *testing.T) {
+	index := NewGossipScoreIndex()
+	peerID := peer.ID("peer1")
+
+	input := map[peer.ID]float64{peerID: 10.0}
+	index.SetScores(input)
+
+	// Mutate the caller map after SetScores; the index must remain unchanged.
+	input[peerID] = 20.0
+
+	score, exists := index.GetGossipScore(peerID)
+	require.True(t, exists)
+	require.Equal(t, 10.0, score)
 }
 
 func TestHasBadGossipScore(t *testing.T) {

--- a/network/peers/gossipsub_score_index.go
+++ b/network/peers/gossipsub_score_index.go
@@ -37,16 +37,14 @@ func (g *gossipScoreIndex) GetGossipScore(peerID peer.ID) (float64, bool) {
 }
 
 func (g *gossipScoreIndex) SetScores(peerScores map[peer.ID]float64) {
+	// Build the new map first so readers never observe a partially-updated index.
+	// Also ensures we don't retain the caller's map, which may be mutated elsewhere.
+	newScores := make(map[peer.ID]float64, len(peerScores))
+	maps.Copy(newScores, peerScores)
+
 	g.mutex.Lock()
-	defer g.mutex.Unlock()
-
-	g.clear()
-	// Copy the map
-	maps.Copy(g.score, peerScores)
-}
-
-func (g *gossipScoreIndex) clear() {
-	g.score = make(map[peer.ID]float64)
+	g.score = newScores
+	g.mutex.Unlock()
 }
 
 func (g *gossipScoreIndex) HasBadGossipScore(peerID peer.ID) (bool, float64) {


### PR DESCRIPTION
## Context
Ticket: F-ssv-129

## Problem
`SetScores` rebuilt the internal map by first clearing it, then copying. Ticket claims that Between those steps concurrent readers could temporarily observe an empty map and treat bad peers as unscored.

## Changes
- Build a new scores map from the input, then swap it under the lock.
- Keep semantics the same (latest inspection cycle fully replaces the index) without an empty window.

## Outcome
- Reduce lock contention by copying without lock

## Tests
- `go test ./network/peers -run "Test(GetGossipScore|SetScores|HasBadGossipScore)"`
