### PR TITLE
optimize validator queue message keys (F-ssv-157)

### DIFF
--- a/protocol/v2/ssv/validator/msg_queue.go
+++ b/protocol/v2/ssv/validator/msg_queue.go
@@ -2,7 +2,9 @@ package validator
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -33,6 +35,37 @@ type messageProcessingState struct {
 
 type messageKey string
 
+func writeUint64(b *strings.Builder, v uint64) {
+	var buf [20]byte
+	out := strconv.AppendUint(buf[:0], v, 10)
+	_, _ = b.Write(out)
+}
+
+func writeInt64(b *strings.Builder, v int64) {
+	var buf [20]byte
+	out := strconv.AppendInt(buf[:0], v, 10)
+	_, _ = b.Write(out)
+}
+
+func writeMsgIDHex(b *strings.Builder, id spectypes.MessageID) {
+	// MessageID.String() allocates; encoding directly avoids that.
+	const msgIDHexLen = len(spectypes.MessageID{}) * 2
+	var buf [msgIDHexLen]byte
+	hex.Encode(buf[:], id[:])
+	_, _ = b.Write(buf[:])
+}
+
+func writeOperatorIDs(b *strings.Builder, operatorIDs []spectypes.OperatorID) {
+	b.WriteByte('[')
+	for i, operatorID := range operatorIDs {
+		if i > 0 {
+			b.WriteByte('-')
+		}
+		writeUint64(b, operatorID)
+	}
+	b.WriteByte(']')
+}
+
 // mKey returns an ID that represents a potentially retryable message (msg.ID is the same for messages
 // with different signers, slots, types, rounds, etc. - so we can't use just msg.ID as a unique identifier)
 func mKey(msg *queue.SSVMessage) (messageKey, error) {
@@ -55,23 +88,57 @@ func mKey(msg *queue.SSVMessage) (messageKey, error) {
 			}
 			round = uint64(timeoutData.Round)
 		}
-		return messageKey(fmt.Sprintf("%d-%d-%d-%d-%s", msgSlot, msg.MsgType, eventMsg.Type, round, msg.MsgID)), nil
+		var b strings.Builder
+		b.Grow(160)
+		writeUint64(&b, uint64(msgSlot))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(msg.MsgType))
+		b.WriteByte('-')
+		writeInt64(&b, int64(eventMsg.Type))
+		b.WriteByte('-')
+		writeUint64(&b, round)
+		b.WriteByte('-')
+		writeMsgIDHex(&b, msg.MsgID)
+		return messageKey(b.String()), nil
 	}
 	if msg.MsgType == spectypes.SSVConsensusMsgType {
 		sm, ok := msg.Body.(*specqbft.Message)
 		if !ok || sm == nil {
 			return "", fmt.Errorf("qbft message: invalid msg body, type: %T", msg.Body)
 		}
-		signers := strings.Join(strings.Fields(fmt.Sprint(msg.SignedSSVMessage.OperatorIDs)), "-")
-		return messageKey(fmt.Sprintf("%d-%d-%d-%d-%s-%s", msgSlot, msg.MsgType, sm.MsgType, sm.Round, msg.MsgID, signers)), nil
+		var b strings.Builder
+		b.Grow(224)
+		writeUint64(&b, uint64(msgSlot))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(msg.MsgType))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(sm.MsgType))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(sm.Round))
+		b.WriteByte('-')
+		writeMsgIDHex(&b, msg.MsgID)
+		b.WriteByte('-')
+		writeOperatorIDs(&b, msg.SignedSSVMessage.OperatorIDs)
+		return messageKey(b.String()), nil
 	}
 	if msg.MsgType == spectypes.SSVPartialSignatureMsgType {
 		psm, ok := msg.Body.(*spectypes.PartialSignatureMessages)
 		if !ok || psm == nil {
 			return "", fmt.Errorf("partial-sig message: invalid msg body, type: %T", msg.Body)
 		}
-		signer := fmt.Sprintf("%d", ssvtypes.PartialSigMsgSigner(psm)) // same signer for all messages
-		return messageKey(fmt.Sprintf("%d-%d-%d-%s-%s", msgSlot, msg.MsgType, psm.Type, msg.MsgID, signer)), nil
+		var b strings.Builder
+		b.Grow(200)
+		writeUint64(&b, uint64(msgSlot))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(msg.MsgType))
+		b.WriteByte('-')
+		writeUint64(&b, uint64(psm.Type))
+		b.WriteByte('-')
+		writeMsgIDHex(&b, msg.MsgID)
+		b.WriteByte('-')
+		// same signer for all messages
+		writeUint64(&b, ssvtypes.PartialSigMsgSigner(psm))
+		return messageKey(b.String()), nil
 	}
 
 	return "", fmt.Errorf("unexpected message type (expected types: event, qbft, partial-sig): %d", msg.MsgType)

--- a/protocol/v2/ssv/validator/msg_queue.go
+++ b/protocol/v2/ssv/validator/msg_queue.go
@@ -89,7 +89,7 @@ func mKey(msg *queue.SSVMessage) (messageKey, error) {
 			round = uint64(timeoutData.Round)
 		}
 		var b strings.Builder
-		b.Grow(160)
+		b.Grow(200)
 		writeUint64(&b, uint64(msgSlot))
 		b.WriteByte('-')
 		writeUint64(&b, uint64(msg.MsgType))

--- a/protocol/v2/ssv/validator/msg_queue.go
+++ b/protocol/v2/ssv/validator/msg_queue.go
@@ -35,14 +35,16 @@ type messageProcessingState struct {
 
 type messageKey string
 
+const maxInt64DecimalLen = 20 // enough for uint64 max or int64 min in base 10
+
 func writeUint64(b *strings.Builder, v uint64) {
-	var buf [20]byte
+	var buf [maxInt64DecimalLen]byte
 	out := strconv.AppendUint(buf[:0], v, 10)
 	_, _ = b.Write(out)
 }
 
 func writeInt64(b *strings.Builder, v int64) {
-	var buf [20]byte
+	var buf [maxInt64DecimalLen]byte
 	out := strconv.AppendInt(buf[:0], v, 10)
 	_, _ = b.Write(out)
 }

--- a/protocol/v2/ssv/validator/msg_queue_test.go
+++ b/protocol/v2/ssv/validator/msg_queue_test.go
@@ -1,0 +1,130 @@
+package validator
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/protocol/v2/message"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+func TestMKey_Format(t *testing.T) {
+	t.Parallel()
+
+	var msgID spectypes.MessageID
+	for i := range msgID {
+		msgID[i] = byte(i)
+	}
+	msgIDHex := hex.EncodeToString(msgID[:])
+
+	timeoutDataBytes, err := json.Marshal(&ssvtypes.TimeoutData{
+		Height: specqbft.Height(12345),
+		Round:  specqbft.Round(7),
+	})
+	require.NoError(t, err)
+
+	executeDutyBytes, err := json.Marshal(&ssvtypes.ExecuteDutyData{
+		Duty: &spectypes.ValidatorDuty{
+			Slot: phase0.Slot(54321),
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		msg      *queue.SSVMessage
+		expected string
+	}{
+		{
+			name: "event/timeout",
+			msg: &queue.SSVMessage{
+				SSVMessage: &spectypes.SSVMessage{
+					MsgType: message.SSVEventMsgType,
+					MsgID:   msgID,
+				},
+				Body: &ssvtypes.EventMsg{
+					Type: ssvtypes.Timeout,
+					Data: timeoutDataBytes,
+				},
+			},
+			expected: fmt.Sprintf("%d-%d-%d-%d-%s", 12345, message.SSVEventMsgType, ssvtypes.Timeout, 7, msgIDHex),
+		},
+		{
+			name: "event/execute-duty",
+			msg: &queue.SSVMessage{
+				SSVMessage: &spectypes.SSVMessage{
+					MsgType: message.SSVEventMsgType,
+					MsgID:   msgID,
+				},
+				Body: &ssvtypes.EventMsg{
+					Type: ssvtypes.ExecuteDuty,
+					Data: executeDutyBytes,
+				},
+			},
+			expected: fmt.Sprintf("%d-%d-%d-%d-%s", 54321, message.SSVEventMsgType, ssvtypes.ExecuteDuty, 0, msgIDHex),
+		},
+		{
+			name: "qbft/consensus",
+			msg: &queue.SSVMessage{
+				SSVMessage: &spectypes.SSVMessage{
+					MsgType: spectypes.SSVConsensusMsgType,
+					MsgID:   msgID,
+				},
+				SignedSSVMessage: &spectypes.SignedSSVMessage{
+					OperatorIDs: []spectypes.OperatorID{1, 22, 333},
+				},
+				Body: &specqbft.Message{
+					MsgType: specqbft.PrepareMsgType,
+					Height:  specqbft.Height(777),
+					Round:   specqbft.Round(3),
+				},
+			},
+			expected: fmt.Sprintf(
+				"%d-%d-%d-%d-%s-%s",
+				777,
+				spectypes.SSVConsensusMsgType,
+				specqbft.PrepareMsgType,
+				3,
+				msgIDHex,
+				"[1-22-333]",
+			),
+		},
+		{
+			name: "partial-sig",
+			msg: &queue.SSVMessage{
+				SSVMessage: &spectypes.SSVMessage{
+					MsgType: spectypes.SSVPartialSignatureMsgType,
+					MsgID:   msgID,
+				},
+				Body: &spectypes.PartialSignatureMessages{
+					Type: spectypes.RandaoPartialSig,
+					Slot: phase0.Slot(888),
+					Messages: []*spectypes.PartialSignatureMessage{
+						{
+							Signer: 42,
+						},
+					},
+				},
+			},
+			expected: fmt.Sprintf("%d-%d-%d-%s-%d", 888, spectypes.SSVPartialSignatureMsgType, spectypes.RandaoPartialSig, msgIDHex, 42),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := mKey(tt.msg)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(key))
+		})
+	}
+}


### PR DESCRIPTION
Ticket: F-ssv-157

This removes `fmt.Sprintf` / `fmt.Sprint`-based message key construction from the validator message queue hot path.

Changes
- Build message keys using `strings.Builder` + `strconv.Append*`.
- Hex-encode `spectypes.MessageID` directly to avoid `MessageID.String()` allocations.
- Replace operator ID formatting with a stable, allocation-light join.

Why
Keys are generated for every enqueue/dequeue/lookup; avoiding reflection/interface boxing and reducing allocations lowers latency under load.