### PR TITLE
perf: reduce default validator queue capacity from 1000 to 128

### DIFF
--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -171,7 +171,7 @@ func (c *Committee) getQueue(logger *zap.Logger, slot phase0.Slot) queueContaine
 		q = queueContainer{
 			Q: queue.New(
 				logger,
-				1000,
+				defaultValidatorQueueSize,
 				queue.WithInboxSizeMetric(
 					queue.InboxSizeMetric,
 					queue.CommitteeQueueMetricType,

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -18,6 +18,14 @@ import (
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
+// defaultValidatorQueueSize is the default capacity of the per-validator-per-role
+// message queue and per-committee-per-slot message queue. Observed peak depth in
+// production is single-digit messages per queue (see ssv_queue_inbox_size metric);
+// 128 keeps a 30x+ headroom while keeping memory footprint bounded. The
+// `warnIfInboxIsTooBig` log fires at >50% capacity and will surface any tuning
+// regression. Full nodes still bump this to max(default, historySyncBatchSize*2).
+const defaultValidatorQueueSize = 128
+
 // Options represents validator-specific options.
 type Options struct {
 	CommonOptions
@@ -74,7 +82,7 @@ func NewCommonOptions(
 		NewDecidedHandler:   newDecidedHandler,
 		FullNode:            fullNode,
 		ExporterOptions:     exporterOptions,
-		QueueSize:           1000,
+		QueueSize:           defaultValidatorQueueSize,
 		GasLimit:            gasLimit,
 		MessageValidator:    messageValidator,
 		Graffiti:            graffiti,


### PR DESCRIPTION
## Summary

Reduces the default capacity of per-validator-per-role and per-committee-per-slot message queues from **1000 → 128**. Production telemetry shows actual queue depth never approaches the current cap, leaving most of the 8 KB-per-queue buffer wasted.

Single change to a constant. No API change, no config change.

## Evidence

Stage cluster 1-4 telemetry over the last 24h:

| Signal | Value |
|---|---|
| `max_over_time(ssv_queue_inbox_size[1h])` | **4 messages** across all queues |
| Most observed queue depths | 2–3 |
| `"queue is half-full"` log (fires at >50% cap) | **never fires in 24h** |
| Pyroscope `inuse_space` attribution to `queue.New` | **15% of heap** (~95 MB/node) |

So the cap of 1000 is sized for a worst case that hasn't been seen, while burning ~76 MB/node on empty buffer slots.

## Numbers

Per queue allocation (channel of `*SSVMessage`):

| Capacity | Buffer (cap × 8 B ptr) | Per-queue total |
|---|---|---|
| 1000 (today) | 8,000 B | ~8.7 KB |
| 128 (new) | 1,024 B | ~1.7 KB (**−80%**) |

Estimated heap savings from Pyroscope baseline:

- Stage operator (~600 MB heap, 15% from queue.New): **~76 MB saved per node (~12% heap)**
- Mainnet operators (more validators/committees) scale linearly

## Safety

- The existing floor for full nodes is preserved: `result.QueueSize = max(default, historySyncBatchSize*2) = max(128, 50) = 128`. No change to that branch.
- The existing `warnIfInboxIsTooBig` log fires at >50% capacity (i.e., 64+ messages on the new default). Any workload that pushes deeper than expected surfaces immediately in logs.
- **Exporter is unaffected**: exporter mode returns early from `InitValidators` (no per-validator queues created) and routes messages through `messageWorker` with its own `QueueBufferSize` buffer (default 65536, env `MSG_WORKER_BUFFER_SIZE`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./protocol/v2/ssv/validator/ -run 'TestCommittee|TestQueue|Queue' -count=1` passes
- [ ] Deploy to a small operator subset on stage, observe for 24h:
  - `max_over_time(ssv_queue_inbox_size[1h])` — confirm peak stays below 64
  - Grep for `"queue is half-full"` — confirm doesn't appear
  - Compare `go_memstats_alloc_bytes` and `process_resident_memory_bytes` against an undeployed control group
  - Compare `ssv_runner_consensus_duration_seconds` to confirm no consensus-timing regression

## Future work (out of scope)

The committee queue pruning at `committee.go:160` is opportunistic (only triggered when a new runner is created). Since duties happen most slots, this works in practice — but a long-idle committee retains stale queues. Could be made periodic if profiling shows it matters. Not changing here.

Closes ssvlabs/ssv-node-board#1051