### PR TITLE
docs(discovery): clarify filters for Bootstrap, FindPeers, PublishENR

### DIFF
--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -24,16 +24,6 @@ func (dvs *DiscV5Service) limitNodeFilter(node *enode.Node) bool {
 	return !dvs.conns.AtLimit(libp2pnetwork.DirOutbound)
 }
 
-//// forkVersionFilter checks if the node has the same fork version
-// func (dvs *DiscV5Service) forkVersionFilter(node *enode.Node) bool {
-//	forkv, err := records.GetForkVersionEntry(node.Record())
-//	if err != nil {
-//		dvs.logger.Warn("could not read fork version from node record", zap.Error(err))
-//		return false
-//	}
-//	return dvs.forkv == forkv
-//}
-
 // badNodeFilter checks if the node was pruned or have a bad score
 func (dvs *DiscV5Service) badNodeFilter() func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {

--- a/network/discovery/dv5_routing.go
+++ b/network/discovery/dv5_routing.go
@@ -43,7 +43,20 @@ func (dvs *DiscV5Service) Advertise(ctx context.Context, ns string, opt ...disco
 	return opts.Ttl, nil
 }
 
-// FindPeers discovers peers providing a service implementation of discovery.Discoverer
+// FindPeers discovers peers providing a service implementation of discovery.Discoverer.
+// Called by libp2p pubsub (via pubsub.WithDiscovery) to find additional peers for a
+// specific subnet/topic.
+//
+// Unlike Bootstrap — which builds a broad candidate pool scored by subnet coverage —
+// FindPeers is a targeted, on-demand search: pubsub needs peers for one specific
+// subnet it is trying to gossip on. This drives the filter differences:
+//
+//   - subnetFilter(subnet) instead of sharedSubnetsFilter: pubsub asks "give me peers
+//     for subnet X", not "peers sharing any subnet with me".
+//   - No alreadyDiscoveredFilter: pubsub may call FindPeers repeatedly for the same
+//     subnet and expects fresh candidate lists; there is no candidate pool to dedup against.
+//   - ssvNodeFilter, badNodeFilter, alreadyConnectedFilter, recentlyTrimmedFilter:
+//     same as Bootstrap — basic validity and connection-state checks still apply.
 func (dvs *DiscV5Service) FindPeers(ctx context.Context, ns string, opt ...discovery.Option) (<-chan peer.AddrInfo, error) {
 	logger := log.FromContext(ctx).Named(log.NameDiscoveryService)
 	subnet, err := dvs.nsToSubnet(ns)

--- a/network/discovery/dv5_routing.go
+++ b/network/discovery/dv5_routing.go
@@ -53,10 +53,12 @@ func (dvs *DiscV5Service) Advertise(ctx context.Context, ns string, opt ...disco
 //
 //   - subnetFilter(subnet) instead of sharedSubnetsFilter: pubsub asks "give me peers
 //     for subnet X", not "peers sharing any subnet with me".
-//   - No alreadyDiscoveredFilter: pubsub may call FindPeers repeatedly for the same
-//     subnet and expects fresh candidate lists; there is no candidate pool to dedup against.
 //   - ssvNodeFilter, badNodeFilter, alreadyConnectedFilter, recentlyTrimmedFilter:
 //     same as Bootstrap — basic validity and connection-state checks still apply.
+//   - No alreadyDiscoveredFilter: pubsub may call FindPeers repeatedly for the same
+//     subnet and expects fresh candidate lists; there is no candidate pool to dedup against.
+//   - No domainTypeFilter: pubsub operates within a pre-established topic namespace that
+//     already implies domain alignment; a separate domain-type check is not required here.
 func (dvs *DiscV5Service) FindPeers(ctx context.Context, ns string, opt ...discovery.Option) (<-chan peer.AddrInfo, error) {
 	logger := log.FromContext(ctx).Named(log.NameDiscoveryService)
 	subnet, err := dvs.nsToSubnet(ns)

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -156,6 +156,9 @@ func (dvs *DiscV5Service) Node(logger *zap.Logger, info peer.AddrInfo) (*enode.N
 // Bootstrap start looking for new nodes, note that this function blocks.
 // if we reached peers limit, make sure to accept peers with more than 1 shared subnet,
 // which lets other components to determine whether we'll want to connect to this node or not.
+//
+// All peer filtering is done inside checkPeer (not as discover() filters) so that
+// every skip reason is tracked with structured metrics and windowed summary logs.
 func (dvs *DiscV5Service) Bootstrap(handler HandleNewPeer) error {
 	const logWindowSize = 50
 
@@ -506,7 +509,12 @@ func (dvs *DiscV5Service) PublishENR() {
 	pings, errs := 0, 0
 	peerIDs := map[peer.ID]struct{}{}
 
-	// Publish ENR.
+	// Publish ENR by pinging random SSV nodes so they learn our updated record.
+	// Minimal filtering: we only require valid SSV nodes that aren't marked bad.
+	// We intentionally omit connection-state filters (alreadyConnected, recentlyTrimmed)
+	// because wider propagation is more important — pings are cheap and already-connected
+	// peers should also learn about our ENR update. Subnet filters are also omitted
+	// because ENR publication is a global broadcast, not subnet-specific.
 	dvs.discover(ctx, func(e PeerEvent) {
 		_, err := dvs.dv5Listener.Ping(e.Node)
 		if err != nil {


### PR DESCRIPTION
Each discovery path serves a different purpose and intentionally uses a different set of peer filters. Add comments explaining the rationale for each filter set to prevent accidental "consistency" changes.