### PR TITLE
Refactor DutyHandler's Setup() method parameters

### DIFF
--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -12,21 +12,22 @@ import (
 
 //go:generate go tool -modfile=../../tool.mod mockgen -package=duties -destination=./base_handler_mock.go -source=./base_handler.go
 
+type SetupOptions struct {
+	Name                string
+	Logger              *zap.Logger
+	BeaconNode          BeaconNode
+	ExecutionClient     ExecutionClient
+	BeaconConfig        *networkconfig.Beacon
+	ValidatorProvider   ValidatorProvider
+	ValidatorController ValidatorController
+	DutiesExecutor      DutiesExecutor
+	SlotTickerProvider  slotticker.Provider
+	ReorgEvents         chan ReorgEvent
+	IndicesChange       chan struct{}
+}
+
 type dutyHandler interface {
-	Setup(
-		ctx context.Context,
-		name string,
-		logger *zap.Logger,
-		beaconNode BeaconNode,
-		executionClient ExecutionClient,
-		beaconConfig *networkconfig.Beacon,
-		validatorProvider ValidatorProvider,
-		validatorController ValidatorController,
-		dutiesExecutor DutiesExecutor,
-		slotTickerProvider slotticker.Provider,
-		reorgEvents chan ReorgEvent,
-		indicesChange chan struct{},
-	)
+	Setup(ctx context.Context, opts SetupOptions)
 	HandleDuties(context.Context)
 	HandleInitialDuties(context.Context)
 	Name() string
@@ -53,31 +54,18 @@ type baseHandler struct {
 	indicesChanged bool
 }
 
-func (h *baseHandler) Setup(
-	ctx context.Context,
-	name string,
-	logger *zap.Logger,
-	beaconNode BeaconNode,
-	executionClient ExecutionClient,
-	beaconConfig *networkconfig.Beacon,
-	validatorProvider ValidatorProvider,
-	validatorController ValidatorController,
-	dutiesExecutor DutiesExecutor,
-	slotTickerProvider slotticker.Provider,
-	reorgEvents chan ReorgEvent,
-	indicesChange chan struct{},
-) {
-	h.logger = logger.With(zap.String("handler", name))
+func (h *baseHandler) Setup(ctx context.Context, opts SetupOptions) {
+	h.logger = opts.Logger.With(zap.String("handler", opts.Name))
 	h.ctx = ctx
-	h.beaconNode = beaconNode
-	h.executionClient = executionClient
-	h.beaconConfig = beaconConfig
-	h.validatorProvider = validatorProvider
-	h.validatorController = validatorController
-	h.dutiesExecutor = dutiesExecutor
-	h.ticker = slotTickerProvider()
-	h.reorg = reorgEvents
-	h.indicesChange = indicesChange
+	h.beaconNode = opts.BeaconNode
+	h.executionClient = opts.ExecutionClient
+	h.beaconConfig = opts.BeaconConfig
+	h.validatorProvider = opts.ValidatorProvider
+	h.validatorController = opts.ValidatorController
+	h.dutiesExecutor = opts.DutiesExecutor
+	h.ticker = opts.SlotTickerProvider()
+	h.reorg = opts.ReorgEvents
+	h.indicesChange = opts.IndicesChange
 }
 
 func (h *baseHandler) warnMisalignedSlotAndDuty(dutyType string) {

--- a/operator/duties/base_handler_mock.go
+++ b/operator/duties/base_handler_mock.go
@@ -13,10 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	networkconfig "github.com/ssvlabs/ssv/networkconfig"
-	slotticker "github.com/ssvlabs/ssv/operator/slotticker"
 	gomock "go.uber.org/mock/gomock"
-	zap "go.uber.org/zap"
 )
 
 // MockdutyHandler is a mock of dutyHandler interface.
@@ -82,15 +79,15 @@ func (mr *MockdutyHandlerMockRecorder) Name() *gomock.Call {
 }
 
 // Setup mocks base method.
-func (m *MockdutyHandler) Setup(ctx context.Context, name string, logger *zap.Logger, beaconNode BeaconNode, executionClient ExecutionClient, beaconConfig *networkconfig.Beacon, validatorProvider ValidatorProvider, validatorController ValidatorController, dutiesExecutor DutiesExecutor, slotTickerProvider slotticker.Provider, reorgEvents chan ReorgEvent, indicesChange chan struct{}) {
+func (m *MockdutyHandler) Setup(ctx context.Context, opts SetupOptions) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Setup", ctx, name, logger, beaconNode, executionClient, beaconConfig, validatorProvider, validatorController, dutiesExecutor, slotTickerProvider, reorgEvents, indicesChange)
+	m.ctrl.Call(m, "Setup", ctx, opts)
 }
 
 // Setup indicates an expected call of Setup.
-func (mr *MockdutyHandlerMockRecorder) Setup(ctx, name, logger, beaconNode, executionClient, beaconConfig, validatorProvider, validatorController, dutiesExecutor, slotTickerProvider, reorgEvents, indicesChange any) *gomock.Call {
+func (mr *MockdutyHandlerMockRecorder) Setup(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockdutyHandler)(nil).Setup), ctx, name, logger, beaconNode, executionClient, beaconConfig, validatorProvider, validatorController, dutiesExecutor, slotTickerProvider, reorgEvents, indicesChange)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockdutyHandler)(nil).Setup), ctx, opts)
 }
 
 // WaitShutdown mocks base method.

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -203,20 +203,19 @@ func (s *Scheduler) Start(ctx context.Context) error {
 		reorgCh := make(chan ReorgEvent)
 		reorgFeed.Subscribe(reorgCh)
 
-		handler.Setup(
-			ctx,
-			handler.Name(),
-			s.logger,
-			s.beaconNode,
-			s.executionClient,
-			s.beaconConfig,
-			s.validatorProvider,
-			s.validatorController,
-			s,
-			s.slotTickerProvider,
-			reorgCh,
-			indicesChangeCh,
-		)
+		handler.Setup(ctx, SetupOptions{
+			Name:                handler.Name(),
+			Logger:              s.logger,
+			BeaconNode:          s.beaconNode,
+			ExecutionClient:     s.executionClient,
+			BeaconConfig:        s.beaconConfig,
+			ValidatorProvider:   s.validatorProvider,
+			ValidatorController: s.validatorController,
+			DutiesExecutor:      s,
+			SlotTickerProvider:  s.slotTickerProvider,
+			ReorgEvents:         reorgCh,
+			IndicesChange:       indicesChangeCh,
+		})
 
 		// This call is blocking.
 		handler.HandleInitialDuties(s.ctx)

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -452,7 +452,7 @@ func TestScheduler_Run(t *testing.T) {
 
 		// setup mock duty handler expectations
 		for _, mockDutyHandler := range s.handlers {
-			mockDutyHandler.(*MockdutyHandler).EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockDutyHandler.(*MockdutyHandler).EXPECT().Setup(gomock.Any(), gomock.Any()).Times(1)
 			mockDutyHandler.(*MockdutyHandler).EXPECT().HandleDuties(gomock.Any()).
 				DoAndReturn(func(ctx context.Context) {
 					<-ctx.Done()


### PR DESCRIPTION
## Summary

Replace the 12-parameter `dutyHandler.Setup` signature with a `SetupOptions` struct, eliminating the positional-argument hazard at the (single) call site.

## Motivation

`baseHandler.Setup` accepted 12 positional parameters, including two `chan` arguments (`chan ReorgEvent`, `chan struct{}`) that were silently swappable, and five interfaces (`BeaconNode`, `ExecutionClient`, `ValidatorProvider`, `ValidatorController`, `DutiesExecutor`) any two of which could be misordered without a compile error if their method sets overlapped. Named struct fields at the call site make the dependency wiring self-documenting and future-proof against adding more dependencies.

## Changes

- `operator/duties/base_handler.go` — introduce `SetupOptions` struct; `dutyHandler.Setup` now takes `(ctx, opts SetupOptions)`
- `operator/duties/scheduler.go` — update the single production call site to named-field struct literal
- `operator/duties/base_handler_mock.go` — regenerated via `go generate`
- `operator/duties/scheduler_test.go` — update mock expectation from 12 `gomock.Any()` args to 2

`ctx` remains a separate parameter per Go convention.

Closes https://github.com/ssvlabs/ssv-node-board/issues/561
