### PR TITLE
chore(cleanup) - remove unused public methods and types

### DIFF
--- a/networkconfig/beacon.go
+++ b/networkconfig/beacon.go
@@ -46,11 +46,6 @@ func (b *Beacon) SlotStartTime(slot phase0.Slot) time.Time {
 	return start
 }
 
-// SlotEndTime returns the end time for the given slot
-func (b *Beacon) SlotEndTime(slot phase0.Slot) time.Time {
-	return b.SlotStartTime(slot + 1)
-}
-
 // EstimatedCurrentSlot returns the estimation of the current slot
 func (b *Beacon) EstimatedCurrentSlot() phase0.Slot {
 	return b.EstimatedSlotAtTime(time.Now())

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -56,9 +56,6 @@ const (
 	networkRouterConcurrency = 2048
 )
 
-// ShareEventHandlerFunc is a function that handles event in an extended mode
-type ShareEventHandlerFunc func(share *ssvtypes.SSVShare)
-
 // ControllerOptions for creating a validator controller
 type ControllerOptions struct {
 	Context                        context.Context
@@ -93,8 +90,6 @@ type ControllerOptions struct {
 	QueueBufferSize int    `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Size of message worker queue buffer"`
 	GasLimit        uint64 `yaml:"ExperimentalGasLimit" env:"EXPERIMENTAL_GAS_LIMIT" env-description:"Gas limit for MEV block proposals (must match across committee, otherwise MEV fails). Do not change unless you know what you're doing"`
 }
-
-type Nonce uint16
 
 type SharesStorage interface {
 	Get(txn basedb.Reader, pubKey []byte) (*ssvtypes.SSVShare, bool)

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -205,11 +205,6 @@ func (b *BaseRunner) MarshalJSON() ([]byte, error) {
 	return byts, err
 }
 
-// SetHighestDecidedSlot set highestDecidedSlot for base runner
-func (b *BaseRunner) SetHighestDecidedSlot(slot phase0.Slot) {
-	b.highestDecidedSlot = slot
-}
-
 // baseSetupForNewDuty is sets the runner for a new duty
 func (b *BaseRunner) baseSetupForNewDuty(duty spectypes.Duty, quorum uint64) {
 	// start new state


### PR DESCRIPTION
## Summary

Delete 4 unused exported symbols (subset of finding F-ssv-025 ). Three of the originally flagged items (`ValidatorsMap.ForEachCommittee`, `ValidatorsMap.GetAllCommittees`, `Beacon.EstimatedTimeIntoSlot`) are kept — see "Kept" section for rationale.

## Motivation

Dead public API surface adds maintenance noise and can mislead future contributors into assuming the symbol is wired up to something. One of the deletions (`validator.Nonce`) is more than unused — it silently shadows `registrystorage.Nonce`, which is the real type used across `eth/eventhandler/...`. Removing the shadow reduces a readability trap.

Not all symbols flagged as "dead" are equally safe to delete. Symbols that *complete an API pattern already in active use*, that *round out a natural set of accessors on a collection type*, or that *name a conceptually meaningful query* over other active methods, are worth preserving because adding them back requires re-establishing the surrounding context (locking strategy, intent). The kept items below meet that bar; the deleted ones do not.

## Deleted

- `operator/validator/controller.go:59-60` — `ShareEventHandlerFunc` type (never instantiated; pure type alias with no semantic weight).
- `operator/validator/controller.go:97` — `Nonce uint16` type (unused shadow of `registrystorage.Nonce`; actively harmful, not just dead).
- `protocol/v2/ssv/runner/runner.go:208-211` — `BaseRunner.SetHighestDecidedSlot` method (pure setter, no invariants; field is set directly at `runner.go:336`; zero external callers).
- `networkconfig/beacon.go:49-52` — `Beacon.SlotEndTime` method. The inlined rewrite `SlotStartTime(slot+1)` is trivially obvious at call sites, so naming the concept adds little.

Total: 15 lines deleted, 0 added.

## Kept (and why)

- **`ValidatorsMap.ForEachCommittee`** (+ the `committeeIterator` helper type). `ForEachValidator` is actively used at `operator/validator/task_executor.go:102`. The two methods form a deliberate validator/committee mirror; completing a pattern that is itself load-bearing is different from inventing one for nobody.
- **`ValidatorsMap.GetAllCommittees`**. Rounds out the natural accessor set on a map-backed collection type (`ForEach*`, `Get*`, `GetAll*`, `Put*`, `Remove*`, `Size*`). Unlike `ForEach*` which is for traversal with early-return, `GetAll*` supports the distinct snapshot use case (holding / returning / passing the slice around) that a `ForEach`+accumulator construction handles more awkwardly. Kept for cheap API completeness on the collection type.
- **`Beacon.EstimatedTimeIntoSlot`**. Names a genuinely useful concept ("how far into the current slot are we?") that composes two heavily-used methods (`EstimatedCurrentSlot`, `TimeAtSlot`). Inlining the 3-call expression at every call site is more error-prone (slot/epoch/time confusion) and loses the intent encoded in the name.

Closes https://github.com/ssvlabs/ssv-node-board/issues/548