### PR TITLE
refactor(runner): unification of runner ctor arguments

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -740,7 +740,7 @@ func (c *Controller) onShareInit(share *ssvtypes.SSVShare) (v *validator.Validat
 		// so that when the validator is stopped, the runners are stopped as well.
 		validatorCtx, validatorCancel := context.WithCancel(c.ctx)
 
-		dutyRunners, err := SetupRunners(validatorCtx, c.logger, share, operator, c.validatorRegistrationSubmitter, c.validatorStore, c.validatorCommonOpts)
+		dutyRunners, err := SetupRunners(validatorCtx, share, operator, c.validatorRegistrationSubmitter, c.validatorStore, c.validatorCommonOpts)
 		if err != nil {
 			validatorCancel()
 			return nil, true, fmt.Errorf("could not setup runners: %w", err)
@@ -1039,18 +1039,20 @@ func SetupCommitteeRunners(
 		attestingValidators []phase0.BLSPubKey,
 		dutyGuard runner.CommitteeDutyGuard,
 	) (*runner.CommitteeRunner, error) {
-		crunner, err := runner.NewCommitteeRunner(
-			options.NetworkConfig,
-			shares,
-			attestingValidators,
-			buildController(spectypes.RoleCommittee),
-			options.Beacon,
-			options.Network,
-			options.Signer,
-			options.OperatorSigner,
-			dutyGuard,
-			options.DoppelgangerHandler,
-		)
+		crunner, err := runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions: runner.BaseRunnerOptions{
+				NetworkConfig:  options.NetworkConfig,
+				Share:          shares,
+				Beacon:         options.Beacon,
+				Network:        options.Network,
+				Signer:         options.Signer,
+				OperatorSigner: options.OperatorSigner,
+			},
+			AttestingValidators: attestingValidators,
+			QBFTController:      buildController(spectypes.RoleCommittee),
+			DutyGuard:           dutyGuard,
+			DoppelgangerHandler: options.DoppelgangerHandler,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -1061,7 +1063,6 @@ func SetupCommitteeRunners(
 // SetupRunners initializes duty runners for the given validator
 func SetupRunners(
 	ctx context.Context,
-	logger *zap.Logger,
 	share *ssvtypes.SSVShare,
 	operator *spectypes.CommitteeMember,
 	validatorRegistrationSubmitter runner.ValidatorRegistrationSubmitter,
@@ -1097,26 +1098,57 @@ func SetupRunners(
 	shareMap := make(map[phase0.ValidatorIndex]*spectypes.Share)
 	shareMap[share.ValidatorIndex] = &share.Share
 
+	baseOpts := runner.BaseRunnerOptions{
+		NetworkConfig:  options.NetworkConfig,
+		Share:          shareMap,
+		Beacon:         options.Beacon,
+		Network:        options.Network,
+		Signer:         options.Signer,
+		OperatorSigner: options.OperatorSigner,
+	}
+
 	runners := runner.ValidatorDutyRunners{}
 	var err error
 	for _, role := range runnersType {
 		switch role {
 		case spectypes.RoleProposer:
 			proposedValueCheck := ssv.NewProposerChecker(options.Signer, options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex, phase0.BLSPubKey(share.SharePubKey))
-			qbftCtrl := buildController(spectypes.RoleProposer)
-			runners[role], err = runner.NewProposerRunner(logger, options.NetworkConfig, shareMap, qbftCtrl, options.Beacon, options.Network, options.Signer, options.OperatorSigner, options.DoppelgangerHandler, proposedValueCheck, 0, options.Graffiti, options.ProposerDelay)
+			runners[role], err = runner.NewProposerRunner(runner.ProposerRunnerOptions{
+				BaseRunnerOptions:   baseOpts,
+				QBFTController:      buildController(spectypes.RoleProposer),
+				DoppelgangerHandler: options.DoppelgangerHandler,
+				ValCheck:            proposedValueCheck,
+				HighestDecidedSlot:  0,
+				Graffiti:            options.Graffiti,
+				ProposerDelay:       options.ProposerDelay,
+			})
 		case spectypes.RoleAggregator:
 			aggregatorValueChecker := ssv.NewAggregatorChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
-			qbftCtrl := buildController(spectypes.RoleAggregator)
-			runners[role], err = runner.NewAggregatorRunner(options.NetworkConfig, shareMap, qbftCtrl, options.Beacon, options.Network, options.Signer, options.OperatorSigner, aggregatorValueChecker, 0)
+			runners[role], err = runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
+				BaseRunnerOptions:  baseOpts,
+				QBFTController:     buildController(spectypes.RoleAggregator),
+				ValCheck:           aggregatorValueChecker,
+				HighestDecidedSlot: 0,
+			})
 		case spectypes.RoleSyncCommitteeContribution:
 			syncCommitteeContributionValueChecker := ssv.NewSyncCommitteeContributionChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
-			qbftCtrl := buildController(spectypes.RoleSyncCommitteeContribution)
-			runners[role], err = runner.NewSyncCommitteeAggregatorRunner(options.NetworkConfig, shareMap, qbftCtrl, options.Beacon, options.Network, options.Signer, options.OperatorSigner, syncCommitteeContributionValueChecker, 0)
+			runners[role], err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{
+				BaseRunnerOptions:  baseOpts,
+				QBFTController:     buildController(spectypes.RoleSyncCommitteeContribution),
+				ValCheck:           syncCommitteeContributionValueChecker,
+				HighestDecidedSlot: 0,
+			})
 		case spectypes.RoleValidatorRegistration:
-			runners[role], err = runner.NewValidatorRegistrationRunner(options.NetworkConfig, shareMap, options.Beacon, options.Network, options.Signer, options.OperatorSigner, validatorRegistrationSubmitter, validatorStore, options.GasLimit)
+			runners[role], err = runner.NewValidatorRegistrationRunner(runner.ValidatorRegistrationRunnerOptions{
+				BaseRunnerOptions:              baseOpts,
+				ValidatorRegistrationSubmitter: validatorRegistrationSubmitter,
+				FeeRecipientProvider:           validatorStore,
+				GasLimit:                       options.GasLimit,
+			})
 		case spectypes.RoleVoluntaryExit:
-			runners[role], err = runner.NewVoluntaryExitRunner(options.NetworkConfig, shareMap, options.Beacon, options.Network, options.Signer, options.OperatorSigner)
+			runners[role], err = runner.NewVoluntaryExitRunner(runner.VoluntaryExitRunnerOptions{
+				BaseRunnerOptions: baseOpts,
+			})
 		default:
 			return nil, fmt.Errorf("unexpected duty runner type: %s", role)
 		}

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -60,35 +59,34 @@ type AggregatorRunner struct {
 
 var _ Runner = &AggregatorRunner{}
 
-func NewAggregatorRunner(
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	qbftController *controller.Controller,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-	valCheck ssv.ValueChecker,
-	highestDecidedSlot phase0.Slot,
-) (*AggregatorRunner, error) {
-	if len(share) != 1 {
+// AggregatorRunnerOptions bundles all dependencies required by NewAggregatorRunner.
+type AggregatorRunnerOptions struct {
+	BaseRunnerOptions
+
+	QBFTController     *controller.Controller
+	ValCheck           ssv.ValueChecker
+	HighestDecidedSlot phase0.Slot
+}
+
+func NewAggregatorRunner(opts AggregatorRunnerOptions) (*AggregatorRunner, error) {
+	if len(opts.Share) != 1 {
 		return nil, errors.New("must have one share")
 	}
 
 	return &AggregatorRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType:     spectypes.RoleAggregator,
-			NetworkConfig:      networkConfig,
-			Share:              share,
-			QBFTController:     qbftController,
-			highestDecidedSlot: highestDecidedSlot,
+			NetworkConfig:      opts.NetworkConfig,
+			Share:              opts.Share,
+			QBFTController:     opts.QBFTController,
+			highestDecidedSlot: opts.HighestDecidedSlot,
 		},
 
-		beacon:         beacon,
-		network:        network,
-		signer:         signer,
-		operatorSigner: operatorSigner,
-		ValCheck:       valCheck,
+		beacon:         opts.Beacon,
+		network:        opts.Network,
+		signer:         opts.Signer,
+		operatorSigner: opts.OperatorSigner,
+		ValCheck:       opts.ValCheck,
 		measurements:   newMeasurementsStore(),
 
 		IsAggregator: isAggregatorFn(),

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -68,7 +68,7 @@ type AggregatorRunnerOptions struct {
 	HighestDecidedSlot phase0.Slot
 }
 
-func NewAggregatorRunner(opts AggregatorRunnerOptions) (*AggregatorRunner, error) {
+func NewAggregatorRunner(opts AggregatorRunnerOptions) (Runner, error) {
 	if len(opts.Share) != 1 {
 		return nil, errors.New("must have one share")
 	}

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -61,39 +60,38 @@ type CommitteeRunner struct {
 	submittedDuties map[spectypes.BeaconRole]map[phase0.ValidatorIndex]struct{}
 }
 
-func NewCommitteeRunner(
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	attestingValidators []phase0.BLSPubKey,
-	qbftController *controller.Controller,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-	dutyGuard CommitteeDutyGuard,
-	doppelgangerHandler DoppelgangerProvider,
-) (Runner, error) {
-	if len(share) == 0 {
+// CommitteeRunnerOptions bundles all dependencies required by NewCommitteeRunner.
+type CommitteeRunnerOptions struct {
+	BaseRunnerOptions
+
+	AttestingValidators []phase0.BLSPubKey
+	QBFTController      *controller.Controller
+	DutyGuard           CommitteeDutyGuard
+	DoppelgangerHandler DoppelgangerProvider
+}
+
+func NewCommitteeRunner(opts CommitteeRunnerOptions) (Runner, error) {
+	if len(opts.Share) == 0 {
 		return nil, errors.New("no shares")
 	}
 
 	return &CommitteeRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType: spectypes.RoleCommittee,
-			NetworkConfig:  networkConfig,
-			Share:          share,
-			QBFTController: qbftController,
+			NetworkConfig:  opts.NetworkConfig,
+			Share:          opts.Share,
+			QBFTController: opts.QBFTController,
 		},
 
-		attestingValidators: attestingValidators,
+		attestingValidators: opts.AttestingValidators,
 
-		beacon:              beacon,
-		network:             network,
-		signer:              signer,
-		operatorSigner:      operatorSigner,
+		beacon:              opts.Beacon,
+		network:             opts.Network,
+		signer:              opts.Signer,
+		operatorSigner:      opts.OperatorSigner,
 		submittedDuties:     make(map[spectypes.BeaconRole]map[phase0.ValidatorIndex]struct{}),
-		DutyGuard:           dutyGuard,
-		doppelgangerHandler: doppelgangerHandler,
+		DutyGuard:           opts.DutyGuard,
+		doppelgangerHandler: opts.DoppelgangerHandler,
 		measurements:        newMeasurementsStore(),
 	}, nil
 }

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -129,18 +129,20 @@ func newCommitteeRunnerEnv(
 		doppelganger = &doppelgangerStub{}
 	}
 
-	runnerI, err := NewCommitteeRunner(
-		networkconfig.TestNetwork,
-		shareMap,
-		sharePubKeys,
-		controller,
-		beacon,
-		network,
-		signer,
-		spectestingutils.NewOperatorSigner(sampleKey, 1),
-		guard,
-		doppelganger,
-	)
+	runnerI, err := NewCommitteeRunner(CommitteeRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig:  networkconfig.TestNetwork,
+			Share:          shareMap,
+			Beacon:         beacon,
+			Network:        network,
+			Signer:         signer,
+			OperatorSigner: spectestingutils.NewOperatorSigner(sampleKey, 1),
+		},
+		AttestingValidators: sharePubKeys,
+		QBFTController:      controller,
+		DutyGuard:           guard,
+		DoppelgangerHandler: doppelganger,
+	})
 	require.NoError(t, err)
 
 	return &committeeRunnerEnv{

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -61,44 +60,45 @@ type ProposerRunner struct {
 	cachedBlindedBlockSSZ []byte
 }
 
-func NewProposerRunner(
-	logger *zap.Logger,
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	qbftController *controller.Controller,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-	doppelgangerHandler DoppelgangerProvider,
-	valCheck ssv.ValueChecker,
-	highestDecidedSlot phase0.Slot,
-	graffiti []byte,
-	proposerDelay time.Duration,
-) (Runner, error) {
-	if len(share) != 1 {
+// ProposerRunnerOptions bundles all dependencies required by NewProposerRunner.
+type ProposerRunnerOptions struct {
+	BaseRunnerOptions
+
+	QBFTController      *controller.Controller
+	DoppelgangerHandler DoppelgangerProvider
+	ValCheck            ssv.ValueChecker
+	HighestDecidedSlot  phase0.Slot
+	Graffiti            []byte
+	// ProposerDelay allows Operator to configure a delay to wait out before requesting Ethereum
+	// block to propose if this Operator is proposer-duty Leader. This allows Operator to extract
+	// higher MEV.
+	ProposerDelay time.Duration
+}
+
+func NewProposerRunner(opts ProposerRunnerOptions) (Runner, error) {
+	if len(opts.Share) != 1 {
 		return nil, errors.New("must have one share")
 	}
 
 	return &ProposerRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType:     spectypes.RoleProposer,
-			NetworkConfig:      networkConfig,
-			Share:              share,
-			QBFTController:     qbftController,
-			highestDecidedSlot: highestDecidedSlot,
+			NetworkConfig:      opts.NetworkConfig,
+			Share:              opts.Share,
+			QBFTController:     opts.QBFTController,
+			highestDecidedSlot: opts.HighestDecidedSlot,
 		},
 
-		beacon:              beacon,
-		network:             network,
-		signer:              signer,
-		operatorSigner:      operatorSigner,
-		doppelgangerHandler: doppelgangerHandler,
-		ValCheck:            valCheck,
+		beacon:              opts.Beacon,
+		network:             opts.Network,
+		signer:              opts.Signer,
+		operatorSigner:      opts.OperatorSigner,
+		doppelgangerHandler: opts.DoppelgangerHandler,
+		ValCheck:            opts.ValCheck,
 		measurements:        newMeasurementsStore(),
-		graffiti:            graffiti,
+		graffiti:            opts.Graffiti,
 
-		proposerDelay: proposerDelay,
+		proposerDelay: opts.ProposerDelay,
 	}, nil
 }
 

--- a/protocol/v2/ssv/runner/proposer_test.go
+++ b/protocol/v2/ssv/runner/proposer_test.go
@@ -401,21 +401,22 @@ func newProposerRunnerForTest(
 		share.ValidatorIndex: share,
 	}
 
-	runnerIface, err := NewProposerRunner(
-		logger,
-		cfg,
-		shareMap,
-		controller,
-		beacon,
-		network,
-		km,
-		operatorSigner,
-		dg,
-		valCheck,
-		0,
-		[]byte("graffiti"),
-		proposerDelay,
-	)
+	runnerIface, err := NewProposerRunner(ProposerRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig:  cfg,
+			Share:          shareMap,
+			Beacon:         beacon,
+			Network:        network,
+			Signer:         km,
+			OperatorSigner: operatorSigner,
+		},
+		QBFTController:      controller,
+		DoppelgangerHandler: dg,
+		ValCheck:            valCheck,
+		HighestDecidedSlot:  0,
+		Graffiti:            []byte("graffiti"),
+		ProposerDelay:       proposerDelay,
+	})
 	require.NoError(t, err)
 
 	return runnerIface.(*ProposerRunner), keySet, network

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -80,6 +80,17 @@ type DoppelgangerProvider interface {
 
 var _ Runner = new(CommitteeRunner)
 
+// BaseRunnerOptions holds fields shared across all runner constructors.
+// Each role-specific options struct embeds it.
+type BaseRunnerOptions struct {
+	NetworkConfig  *networkconfig.Network
+	Share          map[phase0.ValidatorIndex]*spectypes.Share
+	Beacon         beacon.BeaconNode
+	Network        specqbft.Network
+	Signer         ekm.BeaconSigner
+	OperatorSigner ssvtypes.OperatorSigner
+}
+
 type BaseRunner struct {
 	mtx            sync.RWMutex
 	State          *State

--- a/protocol/v2/ssv/runner/runner_decode_test.go
+++ b/protocol/v2/ssv/runner/runner_decode_test.go
@@ -7,7 +7,6 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 type dummyValueChecker struct{}
@@ -45,17 +44,14 @@ func TestAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
 	keySet := spectestingutils.Testing4SharesSet()
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
 
-	r, err := NewAggregatorRunner(
-		cloneTestNetworkConfig(),
-		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		dummyValueChecker{},
-		0,
-	)
+	r, err := NewAggregatorRunner(AggregatorRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig: cloneTestNetworkConfig(),
+			Share:         map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		},
+		ValCheck:           dummyValueChecker{},
+		HighestDecidedSlot: 0,
+	})
 	require.NoError(t, err)
 
 	beforeRoot, err := r.GetRoot()
@@ -85,21 +81,16 @@ func TestProposerRunnerDecodeIgnoresValCheck(t *testing.T) {
 	keySet := spectestingutils.Testing4SharesSet()
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
 
-	runnerIface, err := NewProposerRunner(
-		zap.NewNop(),
-		cloneTestNetworkConfig(),
-		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		dummyValueChecker{},
-		0,
-		nil,
-		0,
-	)
+	runnerIface, err := NewProposerRunner(ProposerRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig: cloneTestNetworkConfig(),
+			Share:         map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		},
+		ValCheck:           dummyValueChecker{},
+		HighestDecidedSlot: 0,
+		Graffiti:           nil,
+		ProposerDelay:      0,
+	})
 	require.NoError(t, err)
 
 	r := runnerIface.(*ProposerRunner)
@@ -130,17 +121,14 @@ func TestSyncCommitteeAggregatorRunnerDecodeIgnoresValCheck(t *testing.T) {
 	keySet := spectestingutils.Testing4SharesSet()
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
 
-	runnerIface, err := NewSyncCommitteeAggregatorRunner(
-		cloneTestNetworkConfig(),
-		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		dummyValueChecker{},
-		0,
-	)
+	runnerIface, err := NewSyncCommitteeAggregatorRunner(SyncCommitteeAggregatorRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig: cloneTestNetworkConfig(),
+			Share:         map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		},
+		ValCheck:           dummyValueChecker{},
+		HighestDecidedSlot: 0,
+	})
 	require.NoError(t, err)
 
 	r := runnerIface.(*SyncCommitteeAggregatorRunner)

--- a/protocol/v2/ssv/runner/runner_delegator_test.go
+++ b/protocol/v2/ssv/runner/runner_delegator_test.go
@@ -15,14 +15,12 @@ func TestVoluntaryExitRunnerDecodePreservesEmbeddedBaseRunnerMethods(t *testing.
 	keySet := spectestingutils.Testing4SharesSet()
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
 
-	runnerIface, err := NewVoluntaryExitRunner(
-		cloneTestNetworkConfig(),
-		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	runnerIface, err := NewVoluntaryExitRunner(VoluntaryExitRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig: cloneTestNetworkConfig(),
+			Share:         map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		},
+	})
 	require.NoError(t, err)
 
 	runner := runnerIface.(*VoluntaryExitRunner)
@@ -53,14 +51,12 @@ func TestVoluntaryExitRunnerUsesReplacedBaseRunner(t *testing.T) {
 	keySet := spectestingutils.Testing4SharesSet()
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
 
-	runnerIface, err := NewVoluntaryExitRunner(
-		cloneTestNetworkConfig(),
-		map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	runnerIface, err := NewVoluntaryExitRunner(VoluntaryExitRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig: cloneTestNetworkConfig(),
+			Share:         map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+		},
+	})
 	require.NoError(t, err)
 
 	runner := runnerIface.(*VoluntaryExitRunner)

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -44,35 +43,34 @@ type SyncCommitteeAggregatorRunner struct {
 	rootToSyncCommitteeIdx map[phase0.Root]phase0.ValidatorIndex
 }
 
-func NewSyncCommitteeAggregatorRunner(
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	qbftController *controller.Controller,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-	valCheck ssv.ValueChecker,
-	highestDecidedSlot phase0.Slot,
-) (Runner, error) {
-	if len(share) != 1 {
+// SyncCommitteeAggregatorRunnerOptions bundles all dependencies required by NewSyncCommitteeAggregatorRunner.
+type SyncCommitteeAggregatorRunnerOptions struct {
+	BaseRunnerOptions
+
+	QBFTController     *controller.Controller
+	ValCheck           ssv.ValueChecker
+	HighestDecidedSlot phase0.Slot
+}
+
+func NewSyncCommitteeAggregatorRunner(opts SyncCommitteeAggregatorRunnerOptions) (Runner, error) {
+	if len(opts.Share) != 1 {
 		return nil, errors.New("must have one share")
 	}
 
 	return &SyncCommitteeAggregatorRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType:     spectypes.RoleSyncCommitteeContribution,
-			NetworkConfig:      networkConfig,
-			Share:              share,
-			QBFTController:     qbftController,
-			highestDecidedSlot: highestDecidedSlot,
+			NetworkConfig:      opts.NetworkConfig,
+			Share:              opts.Share,
+			QBFTController:     opts.QBFTController,
+			highestDecidedSlot: opts.HighestDecidedSlot,
 		},
 
-		beacon:         beacon,
-		network:        network,
-		signer:         signer,
-		ValCheck:       valCheck,
-		operatorSigner: operatorSigner,
+		beacon:         opts.Beacon,
+		network:        opts.Network,
+		signer:         opts.Signer,
+		ValCheck:       opts.ValCheck,
+		operatorSigner: opts.OperatorSigner,
 		measurements:   *newMeasurementsStore(),
 	}, nil
 }

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -48,36 +48,35 @@ type ValidatorRegistrationRunner struct {
 	gasLimit uint64
 }
 
-func NewValidatorRegistrationRunner(
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-	validatorRegistrationSubmitter ValidatorRegistrationSubmitter,
-	feeRecipientProvider feeRecipientProvider,
-	gasLimit uint64,
-) (Runner, error) {
-	if len(share) != 1 {
+// ValidatorRegistrationRunnerOptions bundles all dependencies required by NewValidatorRegistrationRunner.
+type ValidatorRegistrationRunnerOptions struct {
+	BaseRunnerOptions
+
+	ValidatorRegistrationSubmitter ValidatorRegistrationSubmitter
+	FeeRecipientProvider           feeRecipientProvider
+	GasLimit                       uint64
+}
+
+func NewValidatorRegistrationRunner(opts ValidatorRegistrationRunnerOptions) (Runner, error) {
+	if len(opts.Share) != 1 {
 		return nil, fmt.Errorf("must have one share")
 	}
 
 	return &ValidatorRegistrationRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType: spectypes.RoleValidatorRegistration,
-			NetworkConfig:  networkConfig,
-			Share:          share,
+			NetworkConfig:  opts.NetworkConfig,
+			Share:          opts.Share,
 		},
 
-		beacon:                         beacon,
-		network:                        network,
-		signer:                         signer,
-		operatorSigner:                 operatorSigner,
-		validatorRegistrationSubmitter: validatorRegistrationSubmitter,
-		feeRecipientProvider:           feeRecipientProvider,
+		beacon:                         opts.Beacon,
+		network:                        opts.Network,
+		signer:                         opts.Signer,
+		operatorSigner:                 opts.OperatorSigner,
+		validatorRegistrationSubmitter: opts.ValidatorRegistrationSubmitter,
+		feeRecipientProvider:           opts.FeeRecipientProvider,
 
-		gasLimit: gasLimit,
+		gasLimit: opts.GasLimit,
 	}, nil
 }
 

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -38,29 +37,29 @@ type VoluntaryExitRunner struct {
 	voluntaryExit *phase0.VoluntaryExit
 }
 
-func NewVoluntaryExitRunner(
-	networkConfig *networkconfig.Network,
-	share map[phase0.ValidatorIndex]*spectypes.Share,
-	beacon beacon.BeaconNode,
-	network specqbft.Network,
-	signer ekm.BeaconSigner,
-	operatorSigner ssvtypes.OperatorSigner,
-) (Runner, error) {
-	if len(share) != 1 {
+// VoluntaryExitRunnerOptions bundles all dependencies required by NewVoluntaryExitRunner.
+// It currently only embeds BaseRunnerOptions since the runner has no role-specific fields,
+// but wrapping it keeps the constructor signature consistent with other runners.
+type VoluntaryExitRunnerOptions struct {
+	BaseRunnerOptions
+}
+
+func NewVoluntaryExitRunner(opts VoluntaryExitRunnerOptions) (Runner, error) {
+	if len(opts.Share) != 1 {
 		return nil, errors.New("must have one share")
 	}
 
 	return &VoluntaryExitRunner{
 		BaseRunner: &BaseRunner{
 			RunnerRoleType: spectypes.RoleVoluntaryExit,
-			NetworkConfig:  networkConfig,
-			Share:          share,
+			NetworkConfig:  opts.NetworkConfig,
+			Share:          opts.Share,
 		},
 
-		beacon:         beacon,
-		network:        network,
-		signer:         signer,
-		operatorSigner: operatorSigner,
+		beacon:         opts.Beacon,
+		network:        opts.Network,
+		signer:         opts.Signer,
+		operatorSigner: opts.OperatorSigner,
 	}, nil
 }
 

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -281,24 +281,26 @@ var baseCommitteeWithRunnerSample = func(
 		attestingValidators []phase0.BLSPubKey,
 		_ runner.CommitteeDutyGuard,
 	) (*runner.CommitteeRunner, error) {
-		r, err := runner.NewCommitteeRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			attestingValidators,
-			controller.NewController(
+		r, err := runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions: runner.BaseRunnerOptions{
+				NetworkConfig:  networkconfig.TestNetwork,
+				Share:          shareMap,
+				Beacon:         runnerSample.GetBeaconNode(),
+				Network:        runnerSample.GetNetwork(),
+				Signer:         runnerSample.GetSigner(),
+				OperatorSigner: runnerSample.GetOperatorSigner(),
+			},
+			AttestingValidators: attestingValidators,
+			QBFTController: controller.NewController(
 				runnerSample.QBFTController.Identifier,
 				runnerSample.QBFTController.CommitteeMember,
 				runnerSample.QBFTController.GetConfig(),
 				spectestingutils.TestingOperatorSigner(keySetSample),
 				false,
 			),
-			runnerSample.GetBeaconNode(),
-			runnerSample.GetNetwork(),
-			runnerSample.GetSigner(),
-			runnerSample.GetOperatorSigner(),
-			committeeDutyGuard,
-			runnerSample.GetDoppelgangerHandler(),
-		)
+			DutyGuard:           committeeDutyGuard,
+			DoppelgangerHandler: runnerSample.GetDoppelgangerHandler(),
+		})
 		return r.(*runner.CommitteeRunner), err
 	}
 

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -123,34 +123,34 @@ var ConstructBaseRunner = func(
 	shareMap[share.ValidatorIndex] = share
 	dutyGuard := validator.NewCommitteeDutyGuard()
 
+	beaconNode := protocoltesting.NewTestingBeaconNodeWrapped()
+	baseOpts := runner.BaseRunnerOptions{
+		NetworkConfig:  networkconfig.TestNetwork,
+		Share:          shareMap,
+		Beacon:         beaconNode,
+		Network:        net,
+		Signer:         km,
+		OperatorSigner: opSigner,
+	}
+
 	var r runner.Runner
 	var err error
 	switch role {
 	case spectypes.RoleCommittee:
-		r, err = runner.NewCommitteeRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)},
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dutyGuard,
-			dgHandler,
-		)
+		r, err = runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			AttestingValidators: []phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)},
+			QBFTController:      contr,
+			DutyGuard:           dutyGuard,
+			DoppelgangerHandler: dgHandler,
+		})
 	case spectypes.RoleAggregator:
-		rnr, err := runner.NewAggregatorRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			valCheck,
-			TestingHighestDecidedSlot,
-		)
+		rnr, err := runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
+			BaseRunnerOptions:  baseOpts,
+			QBFTController:     contr,
+			ValCheck:           valCheck,
+			HighestDecidedSlot: TestingHighestDecidedSlot,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -159,69 +159,42 @@ var ConstructBaseRunner = func(
 		}
 		r = rnr
 	case spectypes.RoleProposer:
-		r, err = runner.NewProposerRunner(
-			logger,
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dgHandler,
-			valCheck,
-			TestingHighestDecidedSlot,
-			[]byte("graffiti"),
-			0,
-		)
+		r, err = runner.NewProposerRunner(runner.ProposerRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			QBFTController:      contr,
+			DoppelgangerHandler: dgHandler,
+			ValCheck:            valCheck,
+			HighestDecidedSlot:  TestingHighestDecidedSlot,
+			Graffiti:            []byte("graffiti"),
+			ProposerDelay:       0,
+		})
 	case spectypes.RoleSyncCommitteeContribution:
-		r, err = runner.NewSyncCommitteeAggregatorRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			valCheck,
-			TestingHighestDecidedSlot,
-		)
+		r, err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{
+			BaseRunnerOptions:  baseOpts,
+			QBFTController:     contr,
+			ValCheck:           valCheck,
+			HighestDecidedSlot: TestingHighestDecidedSlot,
+		})
 	case spectypes.RoleValidatorRegistration:
-		beaconNode := protocoltesting.NewTestingBeaconNodeWrapped()
 		mockFeeProvider := &mocks.FeeRecipientProvider{}
-		r, err = runner.NewValidatorRegistrationRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			beaconNode,
-			net,
-			km,
-			opSigner,
-			mocks.NewValidatorRegistrationSubmitter(beaconNode),
-			mockFeeProvider,
-			spectypes.DefaultGasLimit,
-		)
+		r, err = runner.NewValidatorRegistrationRunner(runner.ValidatorRegistrationRunnerOptions{
+			BaseRunnerOptions:              baseOpts,
+			ValidatorRegistrationSubmitter: mocks.NewValidatorRegistrationSubmitter(beaconNode),
+			FeeRecipientProvider:           mockFeeProvider,
+			GasLimit:                       spectypes.DefaultGasLimit,
+		})
 	case spectypes.RoleVoluntaryExit:
-		r, err = runner.NewVoluntaryExitRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-		)
+		r, err = runner.NewVoluntaryExitRunner(runner.VoluntaryExitRunnerOptions{
+			BaseRunnerOptions: baseOpts,
+		})
 	case spectestingutils.UnknownDutyType:
-		r, err = runner.NewCommitteeRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)},
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dutyGuard,
-			dgHandler,
-		)
+		r, err = runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			AttestingValidators: []phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)},
+			QBFTController:      contr,
+			DutyGuard:           dutyGuard,
+			DoppelgangerHandler: dgHandler,
+		})
 		r.(*runner.CommitteeRunner).RunnerRoleType = spectestingutils.UnknownDutyType
 	default:
 		return nil, fmt.Errorf("unknown role type: %s", role)
@@ -319,34 +292,34 @@ var ConstructBaseRunnerWithShareMap = func(
 		)
 	}
 
+	beaconNode := protocoltesting.NewTestingBeaconNodeWrapped()
+	baseOpts := runner.BaseRunnerOptions{
+		NetworkConfig:  networkconfig.TestNetwork,
+		Share:          shareMap,
+		Beacon:         beaconNode,
+		Network:        net,
+		Signer:         km,
+		OperatorSigner: opSigner,
+	}
+
 	var r runner.Runner
 	var err error
 	switch role {
 	case spectypes.RoleCommittee:
-		r, err = runner.NewCommitteeRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			sharePubKeys,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dutyGuard,
-			dgHandler,
-		)
+		r, err = runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			AttestingValidators: sharePubKeys,
+			QBFTController:      contr,
+			DutyGuard:           dutyGuard,
+			DoppelgangerHandler: dgHandler,
+		})
 	case spectypes.RoleAggregator:
-		rnr, err := runner.NewAggregatorRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			valCheck,
-			TestingHighestDecidedSlot,
-		)
+		rnr, err := runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
+			BaseRunnerOptions:  baseOpts,
+			QBFTController:     contr,
+			ValCheck:           valCheck,
+			HighestDecidedSlot: TestingHighestDecidedSlot,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -355,69 +328,42 @@ var ConstructBaseRunnerWithShareMap = func(
 		}
 		r = rnr
 	case spectypes.RoleProposer:
-		r, err = runner.NewProposerRunner(
-			logger,
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dgHandler,
-			valCheck,
-			TestingHighestDecidedSlot,
-			[]byte("graffiti"),
-			0,
-		)
+		r, err = runner.NewProposerRunner(runner.ProposerRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			QBFTController:      contr,
+			DoppelgangerHandler: dgHandler,
+			ValCheck:            valCheck,
+			HighestDecidedSlot:  TestingHighestDecidedSlot,
+			Graffiti:            []byte("graffiti"),
+			ProposerDelay:       0,
+		})
 	case spectypes.RoleSyncCommitteeContribution:
-		r, err = runner.NewSyncCommitteeAggregatorRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			valCheck,
-			TestingHighestDecidedSlot,
-		)
+		r, err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{
+			BaseRunnerOptions:  baseOpts,
+			QBFTController:     contr,
+			ValCheck:           valCheck,
+			HighestDecidedSlot: TestingHighestDecidedSlot,
+		})
 	case spectypes.RoleValidatorRegistration:
-		beaconNode := protocoltesting.NewTestingBeaconNodeWrapped()
 		mockFeeProvider := &mocks.FeeRecipientProvider{}
-		r, err = runner.NewValidatorRegistrationRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			beaconNode,
-			net,
-			km,
-			opSigner,
-			mocks.NewValidatorRegistrationSubmitter(beaconNode),
-			mockFeeProvider,
-			spectypes.DefaultGasLimit,
-		)
+		r, err = runner.NewValidatorRegistrationRunner(runner.ValidatorRegistrationRunnerOptions{
+			BaseRunnerOptions:              baseOpts,
+			ValidatorRegistrationSubmitter: mocks.NewValidatorRegistrationSubmitter(beaconNode),
+			FeeRecipientProvider:           mockFeeProvider,
+			GasLimit:                       spectypes.DefaultGasLimit,
+		})
 	case spectypes.RoleVoluntaryExit:
-		r, err = runner.NewVoluntaryExitRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-		)
+		r, err = runner.NewVoluntaryExitRunner(runner.VoluntaryExitRunnerOptions{
+			BaseRunnerOptions: baseOpts,
+		})
 	case spectestingutils.UnknownDutyType:
-		r, err = runner.NewCommitteeRunner(
-			networkconfig.TestNetwork,
-			shareMap,
-			sharePubKeys,
-			contr,
-			protocoltesting.NewTestingBeaconNodeWrapped(),
-			net,
-			km,
-			opSigner,
-			dutyGuard,
-			dgHandler,
-		)
+		r, err = runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+			BaseRunnerOptions:   baseOpts,
+			AttestingValidators: sharePubKeys,
+			QBFTController:      contr,
+			DutyGuard:           dutyGuard,
+			DoppelgangerHandler: dgHandler,
+		})
 		if r != nil {
 			r.(*runner.CommitteeRunner).RunnerRoleType = spectestingutils.UnknownDutyType
 		}

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -154,7 +154,7 @@ var ConstructBaseRunner = func(
 		if err != nil {
 			return nil, err
 		}
-		rnr.IsAggregator = func(_ uint64, _ uint64, _ []byte) bool {
+		rnr.(*runner.AggregatorRunner).IsAggregator = func(_ uint64, _ uint64, _ []byte) bool {
 			return true
 		}
 		r = rnr
@@ -323,7 +323,7 @@ var ConstructBaseRunnerWithShareMap = func(
 		if err != nil {
 			return nil, err
 		}
-		rnr.IsAggregator = func(_ uint64, _ uint64, _ []byte) bool {
+		rnr.(*runner.AggregatorRunner).IsAggregator = func(_ uint64, _ uint64, _ []byte) bool {
 			return true
 		}
 		r = rnr


### PR DESCRIPTION
## Summary

Refactors all 6 runner constructors in `protocol/v2/ssv/runner/` to take a single options struct instead of positional arguments. Before this change, `NewProposerRunner` took 13 positional params and the others took 6–10.

Addresses ticket **CQ-7 / F-ssv-039** (`NewProposerRunner` has too many parameters). Expanded the scope to cover every runner since they share most dependencies.

Closes https://github.com/ssvlabs/ssv-node-board/issues/562

## Design

- **`BaseRunnerOptions`** (new, in `runner.go`) holds the 6 fields every runner needs: `NetworkConfig`, `Share`, `Beacon`, `Network`, `Signer`, `OperatorSigner`.
- **Per-role options structs** embed `BaseRunnerOptions` and add role-specific fields:
  - `ProposerRunnerOptions` — `QBFTController`, `DoppelgangerHandler`, `ValCheck`, `HighestDecidedSlot`, `Graffiti`, `ProposerDelay`
  - `AggregatorRunnerOptions` — `QBFTController`, `ValCheck`, `HighestDecidedSlot`
  - `SyncCommitteeAggregatorRunnerOptions` — `QBFTController`, `ValCheck`, `HighestDecidedSlot`
  - `CommitteeRunnerOptions` — `AttestingValidators`, `QBFTController`, `DutyGuard`, `DoppelgangerHandler`
  - `ValidatorRegistrationRunnerOptions` — `ValidatorRegistrationSubmitter`, `FeeRecipientProvider`, `GasLimit`
  - `VoluntaryExitRunnerOptions` — empty wrapper, kept for signature consistency
- Production caller `SetupRunners` constructs `baseOpts` once and reuses it across all cases.

## Drive-by cleanups

- Dropped the dead `logger *zap.Logger` parameter on `NewProposerRunner` — it was declared but never referenced.
- Dropped the now-unused `logger` parameter on `SetupRunners` (only caller updated in same change).
- Aligned `NewAggregatorRunner` with the other constructors: it now returns `(Runner, error)` instead of `(*AggregatorRunner, error)`. The two test-only sites that mutate the `IsAggregator` hook type-assert to `*AggregatorRunner`. (Separate commit.)