### PR TITLE
[F-ssv-131] Reduce overly aggressive discovery polling intervals

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	defaultDiscoveryInterval = time.Millisecond * 2
+	defaultDiscoveryInterval = 100 * time.Millisecond
+	publishENRInterval       = 500 * time.Millisecond
 	publishENRTimeout        = time.Minute
 )
 
@@ -528,7 +529,7 @@ func (dvs *DiscV5Service) PublishENR() {
 		}
 		pings++
 		peerIDs[e.AddrInfo.ID] = struct{}{}
-	}, time.Millisecond*100, dvs.ssvNodeFilter(), dvs.badNodeFilter())
+	}, publishENRInterval, dvs.ssvNodeFilter(), dvs.badNodeFilter())
 
 	// Log metrics.
 	dvs.logger.Debug("done publishing ENR",


### PR DESCRIPTION
## Ticket
- `F-ssv-131` — Discovery interval is extremely aggressive (`2ms`) in `network/discovery/dv5_service.go`, causing steady-state discovery filters to run hundreds of times per second and wasting CPU on constrained nodes.
- Fixes ssvlabs/ssv-node-board#687

## Changes
- increase the default background discovery interval from `2ms` to `100ms`
- add a dedicated `publishENRInterval` of `500ms` for ENR publication pings
- keep the on-demand `FindPeers` path unchanged

## Validation
- `go test ./network/discovery -run 'TestDiscV5Service_(PublishENR|Bootstrap)$' -count=1`
- `GOWORK=off go tool -modfile=tool.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run -v ./network/discovery/...`
