### PR TITLE
Prevent msg ID handler overflows from dropping peers

### DIFF
--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -27,7 +27,7 @@ const (
 )
 
 const (
-	msgIDHandlerBufferSize = 32
+	msgIDHandlerBufferSize = 1024
 )
 
 // MsgPeersResolver will resolve the sending peers of the given message
@@ -157,7 +157,8 @@ func (handler *msgIDHandler) GetPeers(msg []byte) []peer.ID {
 }
 
 // Add adds the given pair of msg id + peer id
-// it uses channel to avoid blocking
+// it uses a buffered channel to reduce lock contention and falls back to a
+// synchronous insert when the buffer is full to avoid losing associations.
 func (handler *msgIDHandler) Add(msgID string, pi peer.ID) {
 	select {
 	case handler.added <- addedEvent{
@@ -165,6 +166,8 @@ func (handler *msgIDHandler) Add(msgID string, pi peer.ID) {
 		pid: pi,
 	}:
 	default:
+		msgIDHandlerBufferFallbackCounter.Add(handler.ctx, 1)
+		handler.add(msgID, pi)
 	}
 }
 

--- a/network/topics/msg_id_test.go
+++ b/network/topics/msg_id_test.go
@@ -1,0 +1,59 @@
+package topics
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgIDHandlerStartProcessesQueuedEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	handler := &msgIDHandler{
+		ctx:    ctx,
+		added:  make(chan addedEvent, 1),
+		ids:    make(map[string]*msgIDEntry),
+		locker: &sync.Mutex{},
+		ttl:    time.Minute,
+	}
+
+	handler.Add("queued", peer.ID("peer-1"))
+	go handler.Start()
+
+	require.Eventually(t, func() bool {
+		handler.locker.Lock()
+		defer handler.locker.Unlock()
+
+		entry, ok := handler.ids["queued"]
+		return ok && len(entry.peers) == 1 && entry.peers[0] == peer.ID("peer-1")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMsgIDHandlerAddFallsBackWhenBufferFull(t *testing.T) {
+	t.Parallel()
+
+	handler := &msgIDHandler{
+		ctx:    context.Background(),
+		added:  make(chan addedEvent, 1),
+		ids:    make(map[string]*msgIDEntry),
+		locker: &sync.Mutex{},
+		ttl:    time.Minute,
+	}
+
+	handler.added <- addedEvent{mid: "queued", pid: peer.ID("peer-0")}
+	handler.Add("fallback", peer.ID("peer-1"))
+
+	handler.locker.Lock()
+	defer handler.locker.Unlock()
+
+	entry, ok := handler.ids["fallback"]
+	require.True(t, ok)
+	require.Equal(t, []peer.ID{peer.ID("peer-1")}, entry.peers)
+}

--- a/network/topics/msg_id_test.go
+++ b/network/topics/msg_id_test.go
@@ -13,11 +13,8 @@ import (
 func TestMsgIDHandlerStartProcessesQueuedEvents(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	handler := &msgIDHandler{
-		ctx:    ctx,
+		ctx:    t.Context(),
 		added:  make(chan addedEvent, 1),
 		ids:    make(map[string]*msgIDEntry),
 		locker: &sync.Mutex{},

--- a/network/topics/observability.go
+++ b/network/topics/observability.go
@@ -28,6 +28,12 @@ var (
 			observability.InstrumentName(observabilityNamespace, "out"),
 			metric.WithUnit("{message}"),
 			metric.WithDescription("total number of outbound(broadcasted) messages")))
+
+	msgIDHandlerBufferFallbackCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "msg_id_buffer_fallback"),
+			metric.WithUnit("{event}"),
+			metric.WithDescription("total number of msg_id add operations processed synchronously because the async buffer was full")))
 )
 
 func messageTopicAttribute(value string) attribute.KeyValue {


### PR DESCRIPTION
## Ticket
- `[F-ssv-132] #688 — MsgIDHandler.Add silently drops events when buffer is full`
- Under load, `MsgIDHandler.Add` could silently drop peer-to-message associations once its async buffer filled, weakening deduplication and peer scoring.

## Changes
- increased the async msg-id buffer from `32` to `1024` to absorb larger bursts
- changed the full-buffer path to fall back to a synchronous insert instead of dropping the mapping
- added a `msg_id_buffer_fallback` metric to make overload visible
- added focused tests for queued processing and the full-buffer fallback path

## Validation
- `go test ./network/topics -run 'TestMsgIDHandler' -count=1`
- `GOWORK=off go tool -modfile=tool.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run -v ./network/topics/...`

Fixes - Fixes ssvlabs/ssv-node-board#688
