### PR TITLE
Synchronize access to current subnets

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -107,7 +108,8 @@ type p2pNetwork struct {
 	// these subnets should not be unsubscribed from even if all validators associated with them are removed
 	persistentSubnets commons.Subnets
 	// currentSubnets holds current subnets which depend on current active validators and committees
-	currentSubnets commons.Subnets
+	currentSubnets   commons.Subnets
+	currentSubnetsMu sync.RWMutex
 
 	libConnManager connmgrcore.ConnManager
 
@@ -325,13 +327,14 @@ func (n *p2pNetwork) peersTrimming() func() {
 		}
 
 		connectedPeers := n.host.Network().Peers()
+		currentSubnets := n.currentSubnetsSnapshot()
 
 		const maximumIrrelevantPeersToDisconnect = 3
 		disconnectedCnt = connMgr.DisconnectFromIrrelevantPeers(
 			maximumIrrelevantPeersToDisconnect,
 			n.host.Network(),
 			connectedPeers,
-			n.currentSubnets,
+			currentSubnets,
 		)
 		if disconnectedCnt > 0 {
 			// we can accept more peer connections now, no need to trim
@@ -526,7 +529,7 @@ func (n *p2pNetwork) UpdateSubnets() {
 		start := time.Now()
 
 		updatedSubnets := n.SubscribedSubnets()
-		n.currentSubnets = updatedSubnets
+		n.setCurrentSubnets(updatedSubnets)
 
 		// Compute the not yet registered subnets.
 		addedSubnets := make([]uint64, 0)
@@ -548,7 +551,7 @@ func (n *p2pNetwork) UpdateSubnets() {
 
 		if len(addedSubnets) > 0 || len(removedSubnets) > 0 {
 			n.idx.UpdateSelfRecord(func(self *records.NodeInfo) *records.NodeInfo {
-				self.Metadata.Subnets = n.currentSubnets.StringHex()
+				self.Metadata.Subnets = updatedSubnets.StringHex()
 				return self
 			})
 
@@ -586,7 +589,7 @@ func (n *p2pNetwork) UpdateSubnets() {
 				go n.disc.PublishENR()
 			}
 
-			subnetsList := commons.AllSubnets.SharedSubnets(n.currentSubnets)
+			subnetsList := commons.AllSubnets.SharedSubnets(updatedSubnets)
 			n.logger.Debug("updated subnets",
 				zap.Any("added", addedSubnets),
 				zap.Any("removed", removedSubnets),
@@ -604,6 +607,20 @@ func (n *p2pNetwork) UpdateSubnets() {
 		case <-ticker.C:
 		}
 	}
+}
+
+func (n *p2pNetwork) currentSubnetsSnapshot() commons.Subnets {
+	n.currentSubnetsMu.RLock()
+	defer n.currentSubnetsMu.RUnlock()
+
+	return n.currentSubnets
+}
+
+func (n *p2pNetwork) setCurrentSubnets(subnets commons.Subnets) {
+	n.currentSubnetsMu.Lock()
+	defer n.currentSubnetsMu.Unlock()
+
+	n.currentSubnets = subnets
 }
 
 // UpdateScoreParams updates the scoring parameters once per epoch through the call of n.topicsCtrl.UpdateScoreParams

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -98,14 +98,15 @@ func (n *p2pNetwork) SubscribeRandoms(numSubnets int) error {
 		numSubnets = commons.SubnetsCount
 	}
 
-	availableSubnetsCount := commons.SubnetsCount - n.currentSubnets.ActiveCount()
+	currentSubnets := n.currentSubnetsSnapshot()
+	availableSubnetsCount := commons.SubnetsCount - currentSubnets.ActiveCount()
 	if numSubnets > availableSubnetsCount {
 		return fmt.Errorf("not enough available subnets: requested %d, available %d", numSubnets, availableSubnetsCount)
 	}
 
 	availableSubnets := make([]uint64, 0, availableSubnetsCount)
 	for subnet := uint64(0); subnet < commons.SubnetsCount; subnet++ {
-		if !n.currentSubnets.IsSet(subnet) {
+		if !currentSubnets.IsSet(subnet) {
 			availableSubnets = append(availableSubnets, subnet)
 		}
 	}

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -257,7 +257,7 @@ func (n *p2pNetwork) setupPeerServices() error {
 }
 
 func (n *p2pNetwork) ActiveSubnets() p2pcommons.Subnets {
-	return n.currentSubnets
+	return n.currentSubnetsSnapshot()
 }
 
 func (n *p2pNetwork) FixedSubnets() p2pcommons.Subnets {

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -21,6 +21,7 @@ import (
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
 
 	"github.com/ssvlabs/ssv/network"
+	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/networkconfig"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -32,6 +33,38 @@ func TestGetMaxPeers(t *testing.T) {
 
 	require.Equal(t, 40, n.getMaxPeers(""))
 	require.Equal(t, 8, n.getMaxPeers("100"))
+}
+
+func TestCurrentSubnetsConcurrentAccess(t *testing.T) {
+	n := &p2pNetwork{}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := uint64(0); i < 5000; i++ {
+			subnets := commons.ZeroSubnets
+			subnets.Set(i % commons.SubnetsCount)
+			n.setCurrentSubnets(subnets)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 5000; i++ {
+			subnets := n.ActiveSubnets()
+			_ = subnets.ActiveCount()
+			_ = subnets.StringHex()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {


### PR DESCRIPTION
T-ssv-028 — Race Condition in UpdateSubnets

Original ticket summary:
- `network/p2p/p2p.go:466-551` updates `n.currentSubnets` without synchronization while `peersTrimming()` and `ActiveSubnets()` read it concurrently.
- Risk: torn reads of subnet state can lead to incorrect peer trimming or discovery registration.

Changes:
- synchronize reads and writes of `currentSubnets` with a dedicated lock
- use stable subnet snapshots in trim / active-subnet / random-subnet paths
- add a focused concurrent-access regression test

Fixes - Fixes ssvlabs/ssv-node-board#917
