### PR TITLE
operator: add exporter network key regression tests

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -239,10 +239,34 @@ var StartNodeCmd = &cobra.Command{
 			logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))
 			logger.Info("using ssv-signer for signing")
 
-			ssvSignerClient, err = newSSVSignerClient(logger)
-			if err != nil {
-				logger.Fatal("failed to initialize ssv-signer client", zap.Error(err))
+			if _, err := url.ParseRequestURI(cfg.SSVSigner.Endpoint); err != nil {
+				logger.Fatal("invalid ssv signer endpoint format", zap.Error(err))
 			}
+
+			ssvSignerOptions := []ssvsigner.ClientOption{
+				ssvsigner.WithLogger(logger),
+				ssvsigner.WithRequestTimeout(cfg.SSVSigner.RequestTimeout),
+			}
+
+			if cfg.SSVSigner.KeystoreFile != "" || cfg.SSVSigner.ServerCertFile != "" {
+				tlsConfig := &ssvsignertls.Config{
+					ClientKeystoreFile:         cfg.SSVSigner.KeystoreFile,
+					ClientKeystorePasswordFile: cfg.SSVSigner.KeystorePasswordFile,
+					ClientServerCertFile:       cfg.SSVSigner.ServerCertFile,
+				}
+
+				clientConfig, err := tlsConfig.LoadClientTLSConfig()
+				if err != nil {
+					logger.Fatal("failed to load ssv-signer TLS config", zap.Error(err))
+				}
+
+				ssvSignerOptions = append(ssvSignerOptions, ssvsigner.WithTLSConfig(clientConfig))
+			}
+
+			ssvSignerClient = ssvsigner.NewClient(
+				cfg.SSVSigner.Endpoint,
+				ssvSignerOptions...,
+			)
 
 			operatorPubKeyString, err := ssvSignerClient.OperatorIdentity(cmd.Context())
 			if err != nil {
@@ -262,9 +286,25 @@ var StartNodeCmd = &cobra.Command{
 				logger.Fatal("could not get operator public key base64", zap.Error(err))
 			}
 		} else {
-			operatorPrivKey, operatorPrivKeyPEM, err = resolveLocalOperatorPrivateKey(logger, usingKeystore, usingPrivKey)
-			if err != nil {
-				logger.Fatal("could not resolve operator private key", zap.Error(err))
+			if usingKeystore {
+				logger.Info("getting operator private key from keystore")
+
+				var decryptedKeystore []byte
+				operatorPrivKey, decryptedKeystore, err = privateKeyFromKeystore(cfg.KeyStore.PrivateKeyFile, cfg.KeyStore.PasswordFile)
+				if err != nil {
+					logger.Fatal("could not extract private key from keystore", zap.Error(err))
+				}
+
+				operatorPrivKeyPEM = base64.StdEncoding.EncodeToString(decryptedKeystore)
+			} else if usingPrivKey {
+				logger.Info("getting operator private key from args")
+
+				operatorPrivKey, err = keys.PrivateKeyFromString(cfg.OperatorPrivateKey)
+				if err != nil {
+					logger.Fatal("could not decode operator private key", zap.Error(err))
+				}
+
+				operatorPrivKeyPEM = cfg.OperatorPrivateKey
 			}
 
 			operatorPubKeyBase64, err = operatorPrivKey.Public().Base64()
@@ -743,60 +783,6 @@ func privateKeyFromKeystore(privKeyFile, passwordFile string) (keys.OperatorPriv
 	}
 
 	return operatorPrivKey, operatorPrivKeyBytes, nil
-}
-
-func resolveLocalOperatorPrivateKey(logger *zap.Logger, usingKeystore, usingPrivKey bool) (keys.OperatorPrivateKey, string, error) {
-	if usingKeystore {
-		logger.Info("getting operator private key from keystore")
-
-		operatorPrivKey, decryptedKeystore, err := privateKeyFromKeystore(cfg.KeyStore.PrivateKeyFile, cfg.KeyStore.PasswordFile)
-		if err != nil {
-			return nil, "", err
-		}
-
-		return operatorPrivKey, base64.StdEncoding.EncodeToString(decryptedKeystore), nil
-	}
-
-	if usingPrivKey {
-		logger.Info("getting operator private key from args")
-
-		operatorPrivKey, err := keys.PrivateKeyFromString(cfg.OperatorPrivateKey)
-		if err != nil {
-			return nil, "", fmt.Errorf("could not decode operator private key: %w", err)
-		}
-
-		return operatorPrivKey, cfg.OperatorPrivateKey, nil
-	}
-
-	return nil, "", nil
-}
-
-func newSSVSignerClient(logger *zap.Logger) (*ssvsigner.Client, error) {
-	if _, err := url.ParseRequestURI(cfg.SSVSigner.Endpoint); err != nil {
-		return nil, fmt.Errorf("invalid ssv signer endpoint format: %w", err)
-	}
-
-	ssvSignerOptions := []ssvsigner.ClientOption{
-		ssvsigner.WithLogger(logger),
-		ssvsigner.WithRequestTimeout(cfg.SSVSigner.RequestTimeout),
-	}
-
-	if cfg.SSVSigner.KeystoreFile != "" || cfg.SSVSigner.ServerCertFile != "" {
-		tlsConfig := &ssvsignertls.Config{
-			ClientKeystoreFile:         cfg.SSVSigner.KeystoreFile,
-			ClientKeystorePasswordFile: cfg.SSVSigner.KeystorePasswordFile,
-			ClientServerCertFile:       cfg.SSVSigner.ServerCertFile,
-		}
-
-		clientConfig, err := tlsConfig.LoadClientTLSConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load ssv-signer TLS config: %w", err)
-		}
-
-		ssvSignerOptions = append(ssvSignerOptions, ssvsigner.WithTLSConfig(clientConfig))
-	}
-
-	return ssvsigner.NewClient(cfg.SSVSigner.Endpoint, ssvSignerOptions...), nil
 }
 
 func assertSigningConfig(logger *zap.Logger) (usingSSVSigner, usingKeystore, usingPrivKey bool) {

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -805,7 +805,9 @@ func newSSVSignerClient(logger *zap.Logger) (*ssvsigner.Client, error) {
 }
 
 func resolveExporterP2PNetworkKeyProtector(ctx context.Context, logger *zap.Logger) (keys.OperatorPrivateKey, *ssvsigner.Client, error) {
-	usingSSVSigner, usingKeystore, usingPrivKey := assertSigningConfig(logger)
+	usingSSVSigner := cfg.SSVSigner.Endpoint != ""
+	usingKeystore := cfg.KeyStore.PrivateKeyFile != "" && cfg.KeyStore.PasswordFile != ""
+	usingPrivKey := cfg.OperatorPrivateKey != ""
 
 	if usingSSVSigner {
 		logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -236,7 +236,7 @@ var StartNodeCmd = &cobra.Command{
 		if cfg.ExporterOptions.Enabled {
 			logger.Info("exporter mode: skipping operator signing and key manager services")
 
-			operatorPrivKey, ssvSignerClient, err = resolveExporterP2PNetworkKeyProtector(cmd.Context(), logger)
+			operatorPrivKey, ssvSignerClient, err = resolveExporterP2PNetworkKeyProtector(logger)
 			if err != nil {
 				logger.Fatal("failed to initialize exporter p2p network key protector", zap.Error(err))
 			}
@@ -804,7 +804,7 @@ func newSSVSignerClient(logger *zap.Logger) (*ssvsigner.Client, error) {
 	return ssvsigner.NewClient(cfg.SSVSigner.Endpoint, ssvSignerOptions...), nil
 }
 
-func resolveExporterP2PNetworkKeyProtector(ctx context.Context, logger *zap.Logger) (keys.OperatorPrivateKey, *ssvsigner.Client, error) {
+func resolveExporterP2PNetworkKeyProtector(logger *zap.Logger) (keys.OperatorPrivateKey, *ssvsigner.Client, error) {
 	usingSSVSigner := cfg.SSVSigner.Endpoint != ""
 	usingKeystore := cfg.KeyStore.PrivateKeyFile != "" && cfg.KeyStore.PasswordFile != ""
 	usingPrivKey := cfg.OperatorPrivateKey != ""

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -458,7 +458,7 @@ var StartNodeCmd = &cobra.Command{
 		cfg.P2pNetworkConfig.MessageValidator = messageValidator
 		cfg.SSVOptions.ValidatorOptions.MessageValidator = messageValidator
 
-		p2pNetwork := setupP2P(cmd.Context(), logger, db, operatorPrivKey, ssvSignerClient)
+		p2pNetwork := setupP2P(cmd.Context(), logger, db, cfg.ExporterOptions.Enabled, operatorPrivKey, ssvSignerClient)
 
 		cfg.SSVOptions.Context = cmd.Context()
 		cfg.SSVOptions.DB = db
@@ -1118,42 +1118,10 @@ func setupSSVNetwork(logger *zap.Logger) (*networkconfig.SSV, error) {
 	return ssvConfig, nil
 }
 
-func setupP2P(ctx context.Context, logger *zap.Logger, db basedb.Database, operatorPrivKey keys.OperatorPrivateKey, signerClient *ssvsigner.Client) network.P2PNetwork {
-	var protectFn func(context.Context, []byte) ([]byte, error)
-	var unprotectFn func(context.Context, []byte) ([]byte, error)
-
-	// The configured startup mode determines how the persisted P2P network key is protected.
-	if operatorPrivKey != nil {
-		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
-		if err != nil {
-			logger.Fatal("failed to derive operator-based network key protection secret", zap.Error(err))
-		}
-		protectFn = func(_ context.Context, plaintext []byte) ([]byte, error) {
-			return keys.EncryptPayload(encryptionKey, plaintext)
-		}
-		unprotectFn = func(_ context.Context, protectedValue []byte) ([]byte, error) {
-			return keys.DecryptPayload(encryptionKey, protectedValue)
-		}
-	} else if signerClient != nil {
-		err := probeRemoteNetworkKeyProtector(ctx, signerClient)
-		if err == nil {
-			protectFn = signerClient.OperatorEncrypt
-			unprotectFn = signerClient.OperatorDecrypt
-		} else if !errors.Is(err, ssvsigner.ErrOperatorDataProtectionUnsupported) {
-			logger.Fatal("failed to probe ssv-signer p2p network key protection", zap.Error(err))
-		} else {
-			hasEncryptedKey, hasEncryptedKeyErr := ssv_identity.HasEncryptedNetworkKey(db)
-			if hasEncryptedKeyErr != nil {
-				logger.Fatal("failed to inspect stored p2p network private key format", zap.Error(hasEncryptedKeyErr))
-			}
-			if hasEncryptedKey {
-				logger.Fatal("existing database contains an encrypted p2p network private key, but the configured ssv-signer cannot encrypt or decrypt it. Upgrade ssv-signer to a version that supports /v1/operator/encrypt and /v1/operator/decrypt, or restore the operator key and signing mode that originally encrypted this database", zap.Error(err))
-			}
-
-			logger.Warn("ssv-signer does not support remote p2p network key protection, falling back to local compatibility mode",
-				zap.Error(err),
-			)
-		}
+func setupP2P(ctx context.Context, logger *zap.Logger, db basedb.Database, exporterEnabled bool, operatorPrivKey keys.OperatorPrivateKey, signerClient *ssvsigner.Client) network.P2PNetwork {
+	protectFn, unprotectFn, err := decideNetworkKeyProtectors(ctx, logger, db, exporterEnabled, operatorPrivKey, signerClient)
+	if err != nil {
+		logger.Fatal("failed to decide p2p network key protection", zap.Error(err))
 	}
 
 	istore := ssv_identity.NewIdentityStore(logger, db, protectFn, unprotectFn)
@@ -1168,6 +1136,61 @@ func setupP2P(ctx context.Context, logger *zap.Logger, db basedb.Database, opera
 		logger.Fatal("failed to setup p2p network", zap.Error(err))
 	}
 	return n
+}
+
+func decideNetworkKeyProtectors(
+	ctx context.Context,
+	logger *zap.Logger,
+	db basedb.Database,
+	exporterEnabled bool,
+	operatorPrivKey keys.OperatorPrivateKey,
+	signerClient *ssvsigner.Client,
+) (
+	func(context.Context, []byte) ([]byte, error),
+	func(context.Context, []byte) ([]byte, error),
+	error,
+) {
+	if exporterEnabled {
+		return nil, nil, nil
+	}
+
+	if operatorPrivKey != nil {
+		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
+		if err != nil {
+			return nil, nil, fmt.Errorf("derive operator-based network key protection secret: %w", err)
+		}
+		protectFn := func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(encryptionKey, plaintext)
+		}
+		unprotectFn := func(_ context.Context, protectedValue []byte) ([]byte, error) {
+			return keys.DecryptPayload(encryptionKey, protectedValue)
+		}
+		return protectFn, unprotectFn, nil
+	}
+
+	if signerClient != nil {
+		err := probeRemoteNetworkKeyProtector(ctx, signerClient)
+		if err == nil {
+			return signerClient.OperatorEncrypt, signerClient.OperatorDecrypt, nil
+		}
+		if !errors.Is(err, ssvsigner.ErrOperatorDataProtectionUnsupported) {
+			return nil, nil, fmt.Errorf("probe ssv-signer p2p network key protection: %w", err)
+		}
+
+		hasEncryptedKey, hasEncryptedKeyErr := ssv_identity.HasEncryptedNetworkKey(db)
+		if hasEncryptedKeyErr != nil {
+			return nil, nil, fmt.Errorf("inspect stored p2p network private key format: %w", hasEncryptedKeyErr)
+		}
+		if hasEncryptedKey {
+			return nil, nil, fmt.Errorf("existing database contains an encrypted p2p network private key, but the configured ssv-signer cannot encrypt or decrypt it. Upgrade ssv-signer to a version that supports /v1/operator/encrypt and /v1/operator/decrypt, or restore the operator key and signing mode that originally encrypted this database: %w", err)
+		}
+
+		logger.Warn("ssv-signer does not support remote p2p network key protection, falling back to local compatibility mode",
+			zap.Error(err),
+		)
+	}
+
+	return nil, nil, nil
 }
 
 func probeRemoteNetworkKeyProtector(

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -235,11 +235,6 @@ var StartNodeCmd = &cobra.Command{
 
 		if cfg.ExporterOptions.Enabled {
 			logger.Info("exporter mode: skipping operator signing and key manager services")
-
-			operatorPrivKey, ssvSignerClient, err = resolveExporterP2PNetworkKeyProtector(logger)
-			if err != nil {
-				logger.Fatal("failed to initialize exporter p2p network key protector", zap.Error(err))
-			}
 		} else if usingSSVSigner {
 			logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))
 			logger.Info("using ssv-signer for signing")
@@ -804,37 +799,6 @@ func newSSVSignerClient(logger *zap.Logger) (*ssvsigner.Client, error) {
 	return ssvsigner.NewClient(cfg.SSVSigner.Endpoint, ssvSignerOptions...), nil
 }
 
-func resolveExporterP2PNetworkKeyProtector(logger *zap.Logger) (keys.OperatorPrivateKey, *ssvsigner.Client, error) {
-	usingSSVSigner := cfg.SSVSigner.Endpoint != ""
-	usingKeystore := cfg.KeyStore.PrivateKeyFile != "" && cfg.KeyStore.PasswordFile != ""
-	usingPrivKey := cfg.OperatorPrivateKey != ""
-
-	if usingSSVSigner {
-		logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))
-		logger.Info("exporter mode: using ssv-signer only for p2p network-key protection")
-
-		ssvSignerClient, err := newSSVSignerClient(logger)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return nil, ssvSignerClient, nil
-	}
-
-	if usingKeystore || usingPrivKey {
-		logger.Info("exporter mode: using local operator key only for p2p network-key protection")
-
-		operatorPrivKey, _, err := resolveLocalOperatorPrivateKey(logger, usingKeystore, usingPrivKey)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return operatorPrivKey, nil, nil
-	}
-
-	return nil, nil, nil
-}
-
 func assertSigningConfig(logger *zap.Logger) (usingSSVSigner, usingKeystore, usingPrivKey bool) {
 	if cfg.SSVSigner.Endpoint != "" {
 		usingSSVSigner = true
@@ -877,7 +841,7 @@ func warnIfExporterSigningConfigProvided(logger *zap.Logger) {
 	}
 
 	logger.Warn(
-		"exporter mode skips operator signing services; configured signer or operator key will only be used for persisted p2p network-key protection",
+		"exporter mode ignores operator signing configuration",
 		zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint),
 		zap.String("ssv_signer_keystore_file", cfg.SSVSigner.KeystoreFile),
 		zap.String("ssv_signer_keystore_password_file", cfg.SSVSigner.KeystorePasswordFile),

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -234,39 +234,20 @@ var StartNodeCmd = &cobra.Command{
 		var operatorPubKeyBase64 string
 
 		if cfg.ExporterOptions.Enabled {
-			logger.Info("exporter mode: running without operator signing key and key manager")
+			logger.Info("exporter mode: skipping operator signing and key manager services")
+
+			operatorPrivKey, ssvSignerClient, err = resolveExporterP2PNetworkKeyProtector(cmd.Context(), logger)
+			if err != nil {
+				logger.Fatal("failed to initialize exporter p2p network key protector", zap.Error(err))
+			}
 		} else if usingSSVSigner {
 			logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))
 			logger.Info("using ssv-signer for signing")
 
-			if _, err := url.ParseRequestURI(cfg.SSVSigner.Endpoint); err != nil {
-				logger.Fatal("invalid ssv signer endpoint format", zap.Error(err))
+			ssvSignerClient, err = newSSVSignerClient(logger)
+			if err != nil {
+				logger.Fatal("failed to initialize ssv-signer client", zap.Error(err))
 			}
-
-			ssvSignerOptions := []ssvsigner.ClientOption{
-				ssvsigner.WithLogger(logger),
-				ssvsigner.WithRequestTimeout(cfg.SSVSigner.RequestTimeout),
-			}
-
-			if cfg.SSVSigner.KeystoreFile != "" || cfg.SSVSigner.ServerCertFile != "" {
-				tlsConfig := &ssvsignertls.Config{
-					ClientKeystoreFile:         cfg.SSVSigner.KeystoreFile,
-					ClientKeystorePasswordFile: cfg.SSVSigner.KeystorePasswordFile,
-					ClientServerCertFile:       cfg.SSVSigner.ServerCertFile,
-				}
-
-				clientConfig, err := tlsConfig.LoadClientTLSConfig()
-				if err != nil {
-					logger.Fatal("failed to load ssv-signer TLS config", zap.Error(err))
-				}
-
-				ssvSignerOptions = append(ssvSignerOptions, ssvsigner.WithTLSConfig(clientConfig))
-			}
-
-			ssvSignerClient = ssvsigner.NewClient(
-				cfg.SSVSigner.Endpoint,
-				ssvSignerOptions...,
-			)
 
 			operatorPubKeyString, err := ssvSignerClient.OperatorIdentity(cmd.Context())
 			if err != nil {
@@ -286,25 +267,9 @@ var StartNodeCmd = &cobra.Command{
 				logger.Fatal("could not get operator public key base64", zap.Error(err))
 			}
 		} else {
-			if usingKeystore {
-				logger.Info("getting operator private key from keystore")
-
-				var decryptedKeystore []byte
-				operatorPrivKey, decryptedKeystore, err = privateKeyFromKeystore(cfg.KeyStore.PrivateKeyFile, cfg.KeyStore.PasswordFile)
-				if err != nil {
-					logger.Fatal("could not extract private key from keystore", zap.Error(err))
-				}
-
-				operatorPrivKeyPEM = base64.StdEncoding.EncodeToString(decryptedKeystore)
-			} else if usingPrivKey {
-				logger.Info("getting operator private key from args")
-
-				operatorPrivKey, err = keys.PrivateKeyFromString(cfg.OperatorPrivateKey)
-				if err != nil {
-					logger.Fatal("could not decode operator private key", zap.Error(err))
-				}
-
-				operatorPrivKeyPEM = cfg.OperatorPrivateKey
+			operatorPrivKey, operatorPrivKeyPEM, err = resolveLocalOperatorPrivateKey(logger, usingKeystore, usingPrivKey)
+			if err != nil {
+				logger.Fatal("could not resolve operator private key", zap.Error(err))
 			}
 
 			operatorPubKeyBase64, err = operatorPrivKey.Public().Base64()
@@ -785,6 +750,89 @@ func privateKeyFromKeystore(privKeyFile, passwordFile string) (keys.OperatorPriv
 	return operatorPrivKey, operatorPrivKeyBytes, nil
 }
 
+func resolveLocalOperatorPrivateKey(logger *zap.Logger, usingKeystore, usingPrivKey bool) (keys.OperatorPrivateKey, string, error) {
+	if usingKeystore {
+		logger.Info("getting operator private key from keystore")
+
+		operatorPrivKey, decryptedKeystore, err := privateKeyFromKeystore(cfg.KeyStore.PrivateKeyFile, cfg.KeyStore.PasswordFile)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return operatorPrivKey, base64.StdEncoding.EncodeToString(decryptedKeystore), nil
+	}
+
+	if usingPrivKey {
+		logger.Info("getting operator private key from args")
+
+		operatorPrivKey, err := keys.PrivateKeyFromString(cfg.OperatorPrivateKey)
+		if err != nil {
+			return nil, "", fmt.Errorf("could not decode operator private key: %w", err)
+		}
+
+		return operatorPrivKey, cfg.OperatorPrivateKey, nil
+	}
+
+	return nil, "", nil
+}
+
+func newSSVSignerClient(logger *zap.Logger) (*ssvsigner.Client, error) {
+	if _, err := url.ParseRequestURI(cfg.SSVSigner.Endpoint); err != nil {
+		return nil, fmt.Errorf("invalid ssv signer endpoint format: %w", err)
+	}
+
+	ssvSignerOptions := []ssvsigner.ClientOption{
+		ssvsigner.WithLogger(logger),
+		ssvsigner.WithRequestTimeout(cfg.SSVSigner.RequestTimeout),
+	}
+
+	if cfg.SSVSigner.KeystoreFile != "" || cfg.SSVSigner.ServerCertFile != "" {
+		tlsConfig := &ssvsignertls.Config{
+			ClientKeystoreFile:         cfg.SSVSigner.KeystoreFile,
+			ClientKeystorePasswordFile: cfg.SSVSigner.KeystorePasswordFile,
+			ClientServerCertFile:       cfg.SSVSigner.ServerCertFile,
+		}
+
+		clientConfig, err := tlsConfig.LoadClientTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load ssv-signer TLS config: %w", err)
+		}
+
+		ssvSignerOptions = append(ssvSignerOptions, ssvsigner.WithTLSConfig(clientConfig))
+	}
+
+	return ssvsigner.NewClient(cfg.SSVSigner.Endpoint, ssvSignerOptions...), nil
+}
+
+func resolveExporterP2PNetworkKeyProtector(ctx context.Context, logger *zap.Logger) (keys.OperatorPrivateKey, *ssvsigner.Client, error) {
+	usingSSVSigner, usingKeystore, usingPrivKey := assertSigningConfig(logger)
+
+	if usingSSVSigner {
+		logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint))
+		logger.Info("exporter mode: using ssv-signer only for p2p network-key protection")
+
+		ssvSignerClient, err := newSSVSignerClient(logger)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, ssvSignerClient, nil
+	}
+
+	if usingKeystore || usingPrivKey {
+		logger.Info("exporter mode: using local operator key only for p2p network-key protection")
+
+		operatorPrivKey, _, err := resolveLocalOperatorPrivateKey(logger, usingKeystore, usingPrivKey)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return operatorPrivKey, nil, nil
+	}
+
+	return nil, nil, nil
+}
+
 func assertSigningConfig(logger *zap.Logger) (usingSSVSigner, usingKeystore, usingPrivKey bool) {
 	if cfg.SSVSigner.Endpoint != "" {
 		usingSSVSigner = true
@@ -827,7 +875,7 @@ func warnIfExporterSigningConfigProvided(logger *zap.Logger) {
 	}
 
 	logger.Warn(
-		"exporter mode ignores operator signing configuration",
+		"exporter mode skips operator signing services; configured signer or operator key will only be used for persisted p2p network-key protection",
 		zap.String("ssv_signer_endpoint", cfg.SSVSigner.Endpoint),
 		zap.String("ssv_signer_keystore_file", cfg.SSVSigner.KeystoreFile),
 		zap.String("ssv_signer_keystore_password_file", cfg.SSVSigner.KeystorePasswordFile),

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -63,6 +63,58 @@ func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
 	})
 }
 
+func Test_warnIfExporterSigningConfigProvided(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() { cfg = originalCfg })
+
+	t.Run("does not warn when exporter has no signing config", func(t *testing.T) {
+		cfg = config{}
+
+		core, recorded := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+
+		warnIfExporterSigningConfigProvided(logger)
+
+		require.Len(t, recorded.All(), 0)
+	})
+
+	t.Run("warns when exporter is given operator key", func(t *testing.T) {
+		cfg = config{
+			OperatorPrivateKey: "operator-key",
+		}
+
+		core, recorded := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+
+		warnIfExporterSigningConfigProvided(logger)
+
+		logs := recorded.All()
+		require.Len(t, logs, 1)
+		require.Equal(t, zapcore.WarnLevel, logs[0].Level)
+		require.Equal(t, "exporter mode ignores operator signing configuration", logs[0].Message)
+		require.EqualValues(t, len(cfg.OperatorPrivateKey), logs[0].ContextMap()["operator_private_key_len"])
+	})
+
+	t.Run("warns when exporter is given ssv-signer config", func(t *testing.T) {
+		cfg = config{
+			SSVSigner: SSVSignerConfig{
+				Endpoint: "https://signer.example",
+			},
+		}
+
+		core, recorded := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+
+		warnIfExporterSigningConfigProvided(logger)
+
+		logs := recorded.All()
+		require.Len(t, logs, 1)
+		require.Equal(t, zapcore.WarnLevel, logs[0].Level)
+		require.Equal(t, "exporter mode ignores operator signing configuration", logs[0].Message)
+		require.Equal(t, cfg.SSVSigner.Endpoint, logs[0].ContextMap()["ssv_signer_endpoint"])
+	})
+}
+
 func Test_ssvAPIListenAddress(t *testing.T) {
 	t.Parallel()
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -471,18 +471,64 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 		require.Len(t, encryptionKey, 32)
 	})
 
+	t.Run("ignores incomplete keystore config when operator key is available", func(t *testing.T) {
+		privateKey, err := keys.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		cfg = config{
+			KeyStore: KeyStore{
+				PrivateKeyFile: "/tmp/exporter-keystore.json",
+			},
+			OperatorPrivateKey: privateKey.Base64(),
+		}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.NotNil(t, operatorPrivKey)
+		require.Nil(t, signerClient)
+	})
+
+	t.Run("ignores incomplete keystore config when no other protector source exists", func(t *testing.T) {
+		cfg = config{
+			KeyStore: KeyStore{
+				PrivateKeyFile: "/tmp/exporter-keystore.json",
+			},
+		}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.Nil(t, operatorPrivKey)
+		require.Nil(t, signerClient)
+	})
+
 	t.Run("loads ssv-signer client for exporter p2p protection", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, ssvsigner.PathOperatorIdentity, r.URL.Path)
-			_, err := w.Write([]byte("exporter-identity"))
-			require.NoError(t, err)
-		}))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		t.Cleanup(server.Close)
 
 		cfg = config{
 			SSVSigner: SSVSignerConfig{
 				Endpoint: server.URL,
 			},
+		}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.Nil(t, operatorPrivKey)
+		require.NotNil(t, signerClient)
+	})
+
+	t.Run("prefers ssv-signer when both local and remote configs are present", func(t *testing.T) {
+		privateKey, err := keys.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		t.Cleanup(server.Close)
+
+		cfg = config{
+			SSVSigner: SSVSignerConfig{
+				Endpoint: server.URL,
+			},
+			OperatorPrivateKey: privateKey.Base64(),
 		}
 
 		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
-	ssv_identity "github.com/ssvlabs/ssv/identity"
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/ssvsigner"
@@ -65,115 +64,74 @@ func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
 	})
 }
 
-func TestExporterNetworkKeyStorage(t *testing.T) {
-	originalCfg := cfg
-	t.Cleanup(func() { cfg = originalCfg })
-
-	t.Run("fresh exporter db stays plaintext", func(t *testing.T) {
-		logger := zap.NewNop()
-		ctx := context.Background()
-
-		cfg = config{}
-		cfg.DBOptions.Path = t.TempDir() + "/db"
-		cfg.DBOptions.Ctx = ctx
-
-		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, db.Close()) })
-
-		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
-		_, err = store.SetupNetworkKey(ctx, "")
-		require.NoError(t, err)
-
-		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
-		require.NoError(t, err)
-		require.False(t, encrypted)
-	})
-
-	t.Run("exporter ignores operator key and still stores plaintext", func(t *testing.T) {
-		logger := zap.NewNop()
-		ctx := context.Background()
-
+func TestDecideNetworkKeyProtectors(t *testing.T) {
+	t.Run("exporter ignores operator key", func(t *testing.T) {
 		operatorPrivKey, err := keys.GeneratePrivateKey()
 		require.NoError(t, err)
 
-		cfg = config{
-			OperatorPrivateKey: operatorPrivKey.Base64(),
-		}
-		cfg.DBOptions.Path = t.TempDir() + "/db"
-		cfg.DBOptions.Ctx = ctx
-
-		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		protectFn, unprotectFn, err := decideNetworkKeyProtectors(context.Background(), zap.NewNop(), nil, true, operatorPrivKey, nil)
 		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, db.Close()) })
-
-		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
-		_, err = store.SetupNetworkKey(ctx, "")
-		require.NoError(t, err)
-
-		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
-		require.NoError(t, err)
-		require.False(t, encrypted)
+		require.Nil(t, protectFn)
+		require.Nil(t, unprotectFn)
 	})
 
-	t.Run("exporter ignores ssv-signer config and still stores plaintext", func(t *testing.T) {
-		logger := zap.NewNop()
-		ctx := context.Background()
+	t.Run("exporter ignores ssv-signer config", func(t *testing.T) {
+		client := newTestSSVSignerClient(t, nil)
 
-		cfg = config{
-			SSVSigner: SSVSignerConfig{
-				Endpoint: "https://signer.example",
-			},
-		}
-		cfg.DBOptions.Path = t.TempDir() + "/db"
-		cfg.DBOptions.Ctx = ctx
-
-		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		protectFn, unprotectFn, err := decideNetworkKeyProtectors(context.Background(), zap.NewNop(), nil, true, nil, client)
 		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, db.Close()) })
-
-		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
-		_, err = store.SetupNetworkKey(ctx, "")
-		require.NoError(t, err)
-
-		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
-		require.NoError(t, err)
-		require.False(t, encrypted)
+		require.Nil(t, protectFn)
+		require.Nil(t, unprotectFn)
 	})
 
-	t.Run("exporter fails clearly on encrypted db key", func(t *testing.T) {
-		logger := zap.NewNop()
-		ctx := context.Background()
-
-		cfg = config{}
-		cfg.DBOptions.Path = t.TempDir() + "/db"
-		cfg.DBOptions.Ctx = ctx
-
-		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, db.Close()) })
-
+	t.Run("non-exporter keeps local operator key", func(t *testing.T) {
 		operatorPrivKey, err := keys.GeneratePrivateKey()
 		require.NoError(t, err)
-		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
-		require.NoError(t, err)
 
-		encryptingStore := ssv_identity.NewIdentityStore(
-			logger,
-			db,
-			func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(encryptionKey, plaintext)
-			},
-			func(_ context.Context, protectedValue []byte) ([]byte, error) {
-				return keys.DecryptPayload(encryptionKey, protectedValue)
-			},
-		)
-		_, err = encryptingStore.SetupNetworkKey(ctx, "")
+		protectFn, unprotectFn, err := decideNetworkKeyProtectors(context.Background(), zap.NewNop(), nil, false, operatorPrivKey, nil)
 		require.NoError(t, err)
+		require.NotNil(t, protectFn)
+		require.NotNil(t, unprotectFn)
 
-		exporterStore := ssv_identity.NewIdentityStore(logger, db, nil, nil)
-		_, err = exporterStore.SetupNetworkKey(ctx, "")
-		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
+		plaintext := []byte("local-protected-payload")
+		protectedValue, err := protectFn(context.Background(), plaintext)
+		require.NoError(t, err)
+		require.NotEqual(t, plaintext, protectedValue)
+
+		decryptedValue, err := unprotectFn(context.Background(), protectedValue)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, decryptedValue)
+	})
+
+	t.Run("non-exporter keeps ssv-signer client", func(t *testing.T) {
+		probeClient := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathOperatorEncrypt, func(w http.ResponseWriter, r *http.Request) {
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				_, err = w.Write(append([]byte("encrypted:"), payload...))
+				require.NoError(t, err)
+			})
+			mux.HandleFunc(ssvsigner.PathOperatorDecrypt, func(w http.ResponseWriter, r *http.Request) {
+				payload, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				_, err = w.Write(bytes.TrimPrefix(payload, []byte("encrypted:")))
+				require.NoError(t, err)
+			})
+		})
+
+		protectFn, unprotectFn, err := decideNetworkKeyProtectors(context.Background(), zap.NewNop(), nil, false, nil, probeClient)
+		require.NoError(t, err)
+		require.NotNil(t, protectFn)
+		require.NotNil(t, unprotectFn)
+
+		plaintext := []byte("remote-protected-payload")
+		protectedValue, err := protectFn(context.Background(), plaintext)
+		require.NoError(t, err)
+		require.Equal(t, []byte("encrypted:"+string(plaintext)), protectedValue)
+
+		decryptedValue, err := unprotectFn(context.Background(), protectedValue)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, decryptedValue)
 	})
 }
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/ssvsigner"
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
@@ -436,5 +437,57 @@ func Test_probeRemoteNetworkKeyProtector(t *testing.T) {
 		err := probeRemoteNetworkKeyProtector(context.Background(), client)
 		require.ErrorContains(t, err, "probe remote data protector encrypt")
 		require.ErrorContains(t, err, "unexpected status: 500")
+	})
+}
+
+func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() { cfg = originalCfg })
+
+	t.Run("returns nil when exporter has no protection config", func(t *testing.T) {
+		cfg = config{}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.Nil(t, operatorPrivKey)
+		require.Nil(t, signerClient)
+	})
+
+	t.Run("loads local operator key for exporter p2p protection", func(t *testing.T) {
+		privateKey, err := keys.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		cfg = config{
+			OperatorPrivateKey: privateKey.Base64(),
+		}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.NotNil(t, operatorPrivKey)
+		require.Nil(t, signerClient)
+
+		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
+		require.NoError(t, err)
+		require.Len(t, encryptionKey, 32)
+	})
+
+	t.Run("loads ssv-signer client for exporter p2p protection", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, ssvsigner.PathOperatorIdentity, r.URL.Path)
+			_, err := w.Write([]byte("exporter-identity"))
+			require.NoError(t, err)
+		}))
+		t.Cleanup(server.Close)
+
+		cfg = config{
+			SSVSigner: SSVSignerConfig{
+				Endpoint: server.URL,
+			},
+		}
+
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		require.NoError(t, err)
+		require.Nil(t, operatorPrivKey)
+		require.NotNil(t, signerClient)
 	})
 }

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/ssvsigner"
-	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
@@ -437,103 +436,5 @@ func Test_probeRemoteNetworkKeyProtector(t *testing.T) {
 		err := probeRemoteNetworkKeyProtector(context.Background(), client)
 		require.ErrorContains(t, err, "probe remote data protector encrypt")
 		require.ErrorContains(t, err, "unexpected status: 500")
-	})
-}
-
-func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
-	originalCfg := cfg
-	t.Cleanup(func() { cfg = originalCfg })
-
-	t.Run("returns nil when exporter has no protection config", func(t *testing.T) {
-		cfg = config{}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.Nil(t, operatorPrivKey)
-		require.Nil(t, signerClient)
-	})
-
-	t.Run("loads local operator key for exporter p2p protection", func(t *testing.T) {
-		privateKey, err := keys.GeneratePrivateKey()
-		require.NoError(t, err)
-
-		cfg = config{
-			OperatorPrivateKey: privateKey.Base64(),
-		}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.NotNil(t, operatorPrivKey)
-		require.Nil(t, signerClient)
-
-		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
-		require.NoError(t, err)
-		require.Len(t, encryptionKey, 32)
-	})
-
-	t.Run("ignores incomplete keystore config when operator key is available", func(t *testing.T) {
-		privateKey, err := keys.GeneratePrivateKey()
-		require.NoError(t, err)
-
-		cfg = config{
-			KeyStore: KeyStore{
-				PrivateKeyFile: "/tmp/exporter-keystore.json",
-			},
-			OperatorPrivateKey: privateKey.Base64(),
-		}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.NotNil(t, operatorPrivKey)
-		require.Nil(t, signerClient)
-	})
-
-	t.Run("ignores incomplete keystore config when no other protector source exists", func(t *testing.T) {
-		cfg = config{
-			KeyStore: KeyStore{
-				PrivateKeyFile: "/tmp/exporter-keystore.json",
-			},
-		}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.Nil(t, operatorPrivKey)
-		require.Nil(t, signerClient)
-	})
-
-	t.Run("loads ssv-signer client for exporter p2p protection", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		t.Cleanup(server.Close)
-
-		cfg = config{
-			SSVSigner: SSVSignerConfig{
-				Endpoint: server.URL,
-			},
-		}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.Nil(t, operatorPrivKey)
-		require.NotNil(t, signerClient)
-	})
-
-	t.Run("prefers ssv-signer when both local and remote configs are present", func(t *testing.T) {
-		privateKey, err := keys.GeneratePrivateKey()
-		require.NoError(t, err)
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		t.Cleanup(server.Close)
-
-		cfg = config{
-			SSVSigner: SSVSignerConfig{
-				Endpoint: server.URL,
-			},
-			OperatorPrivateKey: privateKey.Base64(),
-		}
-
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
-		require.NoError(t, err)
-		require.Nil(t, operatorPrivKey)
-		require.NotNil(t, signerClient)
 	})
 }

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -16,9 +16,11 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	ssv_identity "github.com/ssvlabs/ssv/identity"
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/ssvsigner"
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
@@ -63,55 +65,115 @@ func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
 	})
 }
 
-func Test_warnIfExporterSigningConfigProvided(t *testing.T) {
+func TestExporterNetworkKeyStorage(t *testing.T) {
 	originalCfg := cfg
 	t.Cleanup(func() { cfg = originalCfg })
 
-	t.Run("does not warn when exporter has no signing config", func(t *testing.T) {
+	t.Run("fresh exporter db stays plaintext", func(t *testing.T) {
+		logger := zap.NewNop()
+		ctx := context.Background()
+
 		cfg = config{}
+		cfg.DBOptions.Path = t.TempDir() + "/db"
+		cfg.DBOptions.Ctx = ctx
 
-		core, recorded := observer.New(zapcore.WarnLevel)
-		logger := zap.New(core)
+		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-		warnIfExporterSigningConfigProvided(logger)
+		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
+		_, err = store.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
 
-		require.Len(t, recorded.All(), 0)
+		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.False(t, encrypted)
 	})
 
-	t.Run("warns when exporter is given operator key", func(t *testing.T) {
+	t.Run("exporter ignores operator key and still stores plaintext", func(t *testing.T) {
+		logger := zap.NewNop()
+		ctx := context.Background()
+
+		operatorPrivKey, err := keys.GeneratePrivateKey()
+		require.NoError(t, err)
+
 		cfg = config{
-			OperatorPrivateKey: "operator-key",
+			OperatorPrivateKey: operatorPrivKey.Base64(),
 		}
+		cfg.DBOptions.Path = t.TempDir() + "/db"
+		cfg.DBOptions.Ctx = ctx
 
-		core, recorded := observer.New(zapcore.WarnLevel)
-		logger := zap.New(core)
+		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-		warnIfExporterSigningConfigProvided(logger)
+		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
+		_, err = store.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
 
-		logs := recorded.All()
-		require.Len(t, logs, 1)
-		require.Equal(t, zapcore.WarnLevel, logs[0].Level)
-		require.Equal(t, "exporter mode ignores operator signing configuration", logs[0].Message)
-		require.EqualValues(t, len(cfg.OperatorPrivateKey), logs[0].ContextMap()["operator_private_key_len"])
+		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.False(t, encrypted)
 	})
 
-	t.Run("warns when exporter is given ssv-signer config", func(t *testing.T) {
+	t.Run("exporter ignores ssv-signer config and still stores plaintext", func(t *testing.T) {
+		logger := zap.NewNop()
+		ctx := context.Background()
+
 		cfg = config{
 			SSVSigner: SSVSignerConfig{
 				Endpoint: "https://signer.example",
 			},
 		}
+		cfg.DBOptions.Path = t.TempDir() + "/db"
+		cfg.DBOptions.Ctx = ctx
 
-		core, recorded := observer.New(zapcore.WarnLevel)
-		logger := zap.New(core)
+		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-		warnIfExporterSigningConfigProvided(logger)
+		store := ssv_identity.NewIdentityStore(logger, db, nil, nil)
+		_, err = store.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
 
-		logs := recorded.All()
-		require.Len(t, logs, 1)
-		require.Equal(t, zapcore.WarnLevel, logs[0].Level)
-		require.Equal(t, "exporter mode ignores operator signing configuration", logs[0].Message)
-		require.Equal(t, cfg.SSVSigner.Endpoint, logs[0].ContextMap()["ssv_signer_endpoint"])
+		encrypted, err := ssv_identity.HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.False(t, encrypted)
+	})
+
+	t.Run("exporter fails clearly on encrypted db key", func(t *testing.T) {
+		logger := zap.NewNop()
+		ctx := context.Background()
+
+		cfg = config{}
+		cfg.DBOptions.Path = t.TempDir() + "/db"
+		cfg.DBOptions.Ctx = ctx
+
+		db, err := setupPebbleDB(logger, networkconfig.TestNetwork.Beacon, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+		operatorPrivKey, err := keys.GeneratePrivateKey()
+		require.NoError(t, err)
+		encryptionKey, err := operatorPrivKey.EKMEncryptionKey()
+		require.NoError(t, err)
+
+		encryptingStore := ssv_identity.NewIdentityStore(
+			logger,
+			db,
+			func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(encryptionKey, plaintext)
+			},
+			func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(encryptionKey, protectedValue)
+			},
+		)
+		_, err = encryptingStore.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+
+		exporterStore := ssv_identity.NewIdentityStore(logger, db, nil, nil)
+		_, err = exporterStore.SetupNetworkKey(ctx, "")
+		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
 	})
 }
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -447,7 +447,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 	t.Run("returns nil when exporter has no protection config", func(t *testing.T) {
 		cfg = config{}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.Nil(t, operatorPrivKey)
 		require.Nil(t, signerClient)
@@ -461,7 +461,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 			OperatorPrivateKey: privateKey.Base64(),
 		}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.NotNil(t, operatorPrivKey)
 		require.Nil(t, signerClient)
@@ -482,7 +482,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 			OperatorPrivateKey: privateKey.Base64(),
 		}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.NotNil(t, operatorPrivKey)
 		require.Nil(t, signerClient)
@@ -495,7 +495,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 			},
 		}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.Nil(t, operatorPrivKey)
 		require.Nil(t, signerClient)
@@ -511,7 +511,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 			},
 		}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.Nil(t, operatorPrivKey)
 		require.NotNil(t, signerClient)
@@ -531,7 +531,7 @@ func Test_resolveExporterP2PNetworkKeyProtector(t *testing.T) {
 			OperatorPrivateKey: privateKey.Base64(),
 		}
 
-		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(context.Background(), zap.NewNop())
+		operatorPrivKey, signerClient, err := resolveExporterP2PNetworkKeyProtector(zap.NewNop())
 		require.NoError(t, err)
 		require.Nil(t, operatorPrivKey)
 		require.NotNil(t, signerClient)

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -157,6 +157,25 @@ func TestSetupPrivateKey(t *testing.T) {
 		})
 	}
 
+	t.Run("generates and stores plaintext key when encryption secret is missing", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
+		require.NoError(t, err)
+		require.False(t, hasEncryptedKey)
+	})
+
 	t.Run("migrates legacy plaintext key to encrypted storage", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
@@ -426,6 +445,34 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		}
 
 		_, _, err = storeWithoutProtector.GetNetworkKey(ctx)
+		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
+	})
+
+	t.Run("errors clearly when encrypted key cannot be decrypted via SetupNetworkKey", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		require.NoError(t, err)
+
+		storeWithoutProtector := identityStore{
+			db:     db,
+			logger: logger,
+		}
+
+		_, err = storeWithoutProtector.SetupNetworkKey(ctx, "")
 		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
 	})
 


### PR DESCRIPTION
Fixes https://github.com/ssvlabs/ssv-node-board/issues/1008.

## Summary

Add regression tests for the intended exporter behavior around persisted P2P network keys.

## What changed

- add tests that verify exporter keeps the persisted network key plaintext on a fresh DB
- add tests that verify exporter still keeps it plaintext even if `OPERATOR_KEY` is passed
- add tests that verify exporter still keeps it plaintext even if `SSVSigner.Endpoint` is passed
- add a test that verifies exporter fails clearly if it encounters an already-encrypted persisted network key without a protector

## Why

Exporter is not supposed to use signing config. These tests lock in that contract so we do not accidentally reintroduce exporter-side network key encryption again.

## Operational note

This does not recover already-encrypted exporter DBs. Those still require operational cleanup:
- wipe/reset the DB