### PR TITLE
tests: (p2p) TestBroadcaster is flaky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,7 @@ ssvsigner-boundary-lint:
 .PHONY: unit-test
 unit-test:
 	@echo "Running unit tests"
-	@go test -tags "blst_enabled lfs" -timeout 10m -race -covermode=atomic -coverprofile=coverage1.out -p 16 -parallel 256 `go list ./... | grep -ve "spectest\|ssv/scripts/\|/network/p2p"`
-	# running tests in `./network/p2p` separately because they get flaky when run concurrently with others for some reason
-	@go test -tags "blst_enabled lfs" -timeout 10m -race -covermode=atomic -coverprofile=coverage2.out -p 16 -parallel 256 ./network/p2p
-	@cat coverage1.out > coverage.out && tail -n +2 coverage2.out >> coverage.out
+	@go test -tags "blst_enabled lfs" -timeout 10m -race -covermode=atomic -coverprofile=coverage.out -p 16 -parallel 256 `go list ./... | grep -ve "spectest\|ssv/scripts/"`
 
 .PHONY: unit-test-all
 unit-test-all:

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,6 +1,10 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"runtime"
 	"time"
@@ -20,8 +24,8 @@ import (
 type Server struct {
 	logger *zap.Logger
 
-	addr       string
-	httpServer *http.Server
+	addr   string
+	router *chi.Mux
 }
 
 // New creates a new Server instance.
@@ -35,22 +39,10 @@ func New(
 ) *Server {
 	router := chi.NewRouter()
 
-	s := &Server{
-		logger: logger,
-		addr:   addr,
-		httpServer: &http.Server{
-			Addr:              addr,
-			Handler:           router,
-			ReadHeaderTimeout: 10 * time.Second,
-			ReadTimeout:       12 * time.Second,
-			WriteTimeout:      12 * time.Second,
-		},
-	}
-
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.Throttle(runtime.NumCPU() * 4))
 	router.Use(middleware.Compress(5, "application/json"))
-	router.Use(middlewareLogger(s.logger))
+	router.Use(middlewareLogger(logger))
 	router.Use(middlewareNodeVersion)
 
 	// @Summary Get node identity information
@@ -111,14 +103,49 @@ func New(
 		router.Post("/v1/exporter/decideds", api.Handler(exporter.Decideds))
 	}
 
-	return s
+	return &Server{
+		logger: logger,
+		addr:   addr,
+		router: router,
+	}
 }
 
-// Run starts the server and blocks until it's shut down.
-func (s *Server) Run() error {
-	s.logger.Info("Serving SSV API", zap.String("addr", s.addr))
+// Start binds a listener on the configured address and serves the HTTP API in
+// the background. It returns the bound address once the listener is ready (so
+// callers using a :0 port can discover the kernel-assigned one). The server
+// shuts down when ctx is canceled.
+func (s *Server) Start(ctx context.Context) (string, error) {
+	l, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return "", fmt.Errorf("listen on %s: %w", s.addr, err)
+	}
+	boundAddr := l.Addr().String()
 
-	return s.httpServer.ListenAndServe()
+	httpServer := &http.Server{
+		Handler:           s.router,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       12 * time.Second,
+		WriteTimeout:      12 * time.Second,
+	}
+
+	s.logger.Info("Serving SSV API", zap.String("addr", boundAddr))
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			s.logger.Error("shutdown failed", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("serve loop exited", zap.Error(err))
+		}
+	}()
+
+	return boundAddr, nil
 }
 
 func middlewareLogger(logger *zap.Logger) func(next http.Handler) http.Handler {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -2,21 +2,18 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/ssvlabs/ssv/api"
@@ -146,98 +143,81 @@ func TestNew(t *testing.T) {
 	require.Equal(t, ":8080", server.addr)
 }
 
-// TestRun_ActualExecution tests that the Run method starts a server.
-func TestRun_ActualExecution(t *testing.T) {
+// TestStart_ActualExecution verifies Start binds a listener, serves the API,
+// and shuts down cleanly when the context is canceled.
+func TestStart_ActualExecution(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := listener.Addr().String()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
-	logger := zaptest.NewLogger(t)
 	srv := New(
-		logger,
-		addr,
+		zaptest.NewLogger(t),
+		"127.0.0.1:0",
 		&hnode.Node{},
 		&hvalidators.Validators{},
 		&hexporter.Exporter{},
 		false,
 	)
 
-	errCh := make(chan error, 1)
-	go func() {
-		logger.Info("Serving SSV API", zap.String("addr", listener.Addr().String()))
-		errCh <- srv.httpServer.Serve(listener)
-	}()
+	addr, err := srv.Start(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, addr)
 
 	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	cancel()
 
-	if err := srv.httpServer.Shutdown(ctx); err != nil {
-		t.Logf("error shutting down server: %v", err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) && !strings.Contains(err.Error(), "closed") {
-			t.Logf("server exited with unexpected error: %v", err)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return true
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("server did not exit in time")
-	}
+		_ = conn.Close()
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "server did not stop accepting connections after ctx cancel")
 }
 
-// TestRun_ActualExecutionFullMode tests that the Run method starts a server in full exporter mode.
-func TestRun_ActualExecutionFullMode(t *testing.T) {
+// TestStart_ActualExecutionFullMode verifies Start works in full exporter mode.
+func TestStart_ActualExecutionFullMode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := listener.Addr().String()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
-	logger := zaptest.NewLogger(t)
 	srv := New(
-		logger,
-		addr,
+		zaptest.NewLogger(t),
+		"127.0.0.1:0",
 		&hnode.Node{},
 		&hvalidators.Validators{},
 		&hexporter.Exporter{},
 		true,
 	)
 
-	errCh := make(chan error, 1)
-	go func() {
-		logger.Info("Serving SSV API", zap.String("addr", listener.Addr().String()))
-		errCh <- srv.httpServer.Serve(listener)
-	}()
+	addr, err := srv.Start(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, addr)
 
 	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	cancel()
 
-	if err := srv.httpServer.Shutdown(ctx); err != nil {
-		t.Logf("error shutting down server: %v", err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) && !strings.Contains(err.Error(), "closed") {
-			t.Logf("server exited with unexpected error: %v", err)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return true
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("server did not exit in time")
-	}
+		_ = conn.Close()
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "server did not stop accepting connections after ctx cancel")
 }
 
 // TestMiddlewareLogger tests the logger middleware.

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/ssvlabs/ssv/api"
@@ -151,7 +152,9 @@ func TestRun_ActualExecution(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	addr := fmt.Sprintf("localhost:%d", reserveFreePort(t))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
 
 	logger := zaptest.NewLogger(t)
 	srv := New(
@@ -165,19 +168,12 @@ func TestRun_ActualExecution(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- srv.Run()
+		logger.Info("Serving SSV API", zap.String("addr", listener.Addr().String()))
+		errCh <- srv.httpServer.Serve(listener)
 	}()
 
-	var conn net.Conn
-	var connectErr error
-	for i := 0; i < 10; i++ {
-		conn, connectErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
-		if connectErr == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	require.NoError(t, connectErr, "failed to connect to server after multiple attempts")
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -203,7 +199,9 @@ func TestRun_ActualExecutionFullMode(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	addr := fmt.Sprintf("localhost:%d", reserveFreePort(t))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
 
 	logger := zaptest.NewLogger(t)
 	srv := New(
@@ -217,23 +215,13 @@ func TestRun_ActualExecutionFullMode(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- srv.Run()
+		logger.Info("Serving SSV API", zap.String("addr", listener.Addr().String()))
+		errCh <- srv.httpServer.Serve(listener)
 	}()
 
-	var conn net.Conn
-	var connectErr error
-
-	for range 10 {
-		conn, connectErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
-		if connectErr == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	require.NoError(t, connectErr, "failed to connect to server after multiple attempts")
-
-	conn.Close()
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
@@ -383,17 +371,4 @@ func TestRoutes(t *testing.T) {
 			route.validateBody(t, string(body))
 		})
 	}
-}
-
-// reserveFreePort asks the kernel for a free TCP port and releases it so the
-// caller can bind to it. A small TOCTOU window remains between the release
-// here and the bind by the server under test, but it's far narrower than
-// scanning random ports with a dial probe.
-func reserveFreePort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	require.NoError(t, l.Close())
-	return port
 }

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -151,15 +151,7 @@ func TestRun_ActualExecution(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	listener, err := net.Listen("tcp", "localhost:0")
-
-	require.NoError(t, err)
-
-	port := listener.Addr().(*net.TCPAddr).Port
-	addr := fmt.Sprintf("localhost:%d", port)
-
-	err = listener.Close()
-	require.NoError(t, err)
+	addr := fmt.Sprintf("localhost:%d", reserveFreePort(t))
 
 	logger := zaptest.NewLogger(t)
 	srv := New(
@@ -191,8 +183,7 @@ func TestRun_ActualExecution(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	err = srv.httpServer.Shutdown(ctx)
-	if err != nil {
+	if err := srv.httpServer.Shutdown(ctx); err != nil {
 		t.Logf("error shutting down server: %v", err)
 	}
 
@@ -212,15 +203,7 @@ func TestRun_ActualExecutionFullMode(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	listener, err := net.Listen("tcp", "localhost:0")
-
-	require.NoError(t, err)
-
-	port := listener.Addr().(*net.TCPAddr).Port
-	addr := fmt.Sprintf("localhost:%d", port)
-
-	err = listener.Close()
-	require.NoError(t, err)
+	addr := fmt.Sprintf("localhost:%d", reserveFreePort(t))
 
 	logger := zaptest.NewLogger(t)
 	srv := New(
@@ -255,8 +238,7 @@ func TestRun_ActualExecutionFullMode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	err = srv.httpServer.Shutdown(ctx)
-	if err != nil {
+	if err := srv.httpServer.Shutdown(ctx); err != nil {
 		t.Logf("error shutting down server: %v", err)
 	}
 
@@ -401,4 +383,17 @@ func TestRoutes(t *testing.T) {
 			route.validateBody(t, string(body))
 		})
 	}
+}
+
+// reserveFreePort asks the kernel for a free TCP port and releases it so the
+// caller can bind to it. A small TOCTOU window remains between the release
+// here and the bind by the server under test, but it's far narrower than
+// scanning random ports with a dial probe.
+func reserveFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -693,12 +693,9 @@ var StartNodeCmd = &cobra.Command{
 				hexporter.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore()),
 				cfg.ExporterOptions.Enabled && cfg.ExporterOptions.Mode == exporter.ModeArchive,
 			)
-			go func() {
-				err := apiServer.Run()
-				if err != nil {
-					logger.Fatal("failed to start API server", zap.Error(err))
-				}
-			}()
+			if _, err := apiServer.Start(cfg.SSVOptions.Context); err != nil {
+				logger.Fatal("failed to start API server", zap.Error(err))
+			}
 		}
 		if err := operatorNode.Start(cfg.SSVOptions.Context); err != nil {
 			logger.Fatal("failed to start SSV node", zap.Error(err))

--- a/exporter/api/broadcaster.go
+++ b/exporter/api/broadcaster.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"sync"
 
@@ -11,7 +12,7 @@ import (
 
 // Broadcaster is an interface broadcasting stream message across all available connections
 type Broadcaster interface {
-	FromFeed(feed *event.Feed) error
+	FromFeed(ctx context.Context, feed *event.Feed) error
 	Broadcast(msg Message) error
 	Register(conn broadcasted) bool
 	Deregister(conn broadcasted) bool
@@ -37,7 +38,9 @@ func newBroadcaster(logger *zap.Logger) Broadcaster {
 }
 
 // FromFeed subscribes to the given feed and broadcasts incoming messages
-func (b *broadcaster) FromFeed(msgFeed *event.Feed) error {
+// until ctx is canceled or the subscription errors. Returns nil on clean
+// ctx-driven shutdown.
+func (b *broadcaster) FromFeed(ctx context.Context, msgFeed *event.Feed) error {
 	cn := make(chan Message, 512)
 	sub := msgFeed.Subscribe(cn)
 	defer sub.Unsubscribe()
@@ -45,6 +48,8 @@ func (b *broadcaster) FromFeed(msgFeed *event.Feed) error {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case msg := <-cn:
 			go func(msg Message) {
 				if err := b.Broadcast(msg); err != nil {

--- a/exporter/api/broadcaster.go
+++ b/exporter/api/broadcaster.go
@@ -40,32 +40,23 @@ func newBroadcaster(logger *zap.Logger) Broadcaster {
 // FromFeed subscribes to the given feed synchronously so any subsequent Send
 // on the feed is guaranteed to reach this broadcaster, then spawns a pump
 // goroutine that forwards messages to registered connections until ctx is
-// canceled or the subscription errors.
+// canceled.
 func (b *broadcaster) FromFeed(ctx context.Context, msgFeed *event.Feed) {
-	cn := make(chan Message, 512)
-	sub := msgFeed.Subscribe(cn)
-	go b.pumpFeed(ctx, cn, sub)
-}
-
-func (b *broadcaster) pumpFeed(ctx context.Context, cn <-chan Message, sub event.Subscription) {
-	defer sub.Unsubscribe()
-	defer b.logger.Debug("done reading from feed")
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case msg := <-cn:
-			go func(msg Message) {
+	buffer := make(chan Message, 512)
+	sub := msgFeed.Subscribe(buffer)
+	go func() {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-buffer:
 				if err := b.Broadcast(msg); err != nil {
 					b.logger.Error("could not broadcast message", zap.Error(err))
 				}
-			}(msg)
-		case err := <-sub.Err():
-			b.logger.Warn("could not read messages from msgFeed", zap.Error(err))
-			return
+			}
 		}
-	}
+	}()
 }
 
 // Broadcast broadcasts a message to all available connections

--- a/exporter/api/broadcaster.go
+++ b/exporter/api/broadcaster.go
@@ -12,7 +12,7 @@ import (
 
 // Broadcaster is an interface broadcasting stream message across all available connections
 type Broadcaster interface {
-	FromFeed(ctx context.Context, feed *event.Feed) error
+	FromFeed(ctx context.Context, feed *event.Feed)
 	Broadcast(msg Message) error
 	Register(conn broadcasted) bool
 	Deregister(conn broadcasted) bool
@@ -37,19 +37,24 @@ func newBroadcaster(logger *zap.Logger) Broadcaster {
 	}
 }
 
-// FromFeed subscribes to the given feed and broadcasts incoming messages
-// until ctx is canceled or the subscription errors. Returns nil on clean
-// ctx-driven shutdown.
-func (b *broadcaster) FromFeed(ctx context.Context, msgFeed *event.Feed) error {
+// FromFeed subscribes to the given feed synchronously so any subsequent Send
+// on the feed is guaranteed to reach this broadcaster, then spawns a pump
+// goroutine that forwards messages to registered connections until ctx is
+// canceled or the subscription errors.
+func (b *broadcaster) FromFeed(ctx context.Context, msgFeed *event.Feed) {
 	cn := make(chan Message, 512)
 	sub := msgFeed.Subscribe(cn)
+	go b.pumpFeed(ctx, cn, sub)
+}
+
+func (b *broadcaster) pumpFeed(ctx context.Context, cn <-chan Message, sub event.Subscription) {
 	defer sub.Unsubscribe()
 	defer b.logger.Debug("done reading from feed")
 
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return
 		case msg := <-cn:
 			go func(msg Message) {
 				if err := b.Broadcast(msg); err != nil {
@@ -58,7 +63,7 @@ func (b *broadcaster) FromFeed(ctx context.Context, msgFeed *event.Feed) error {
 			}(msg)
 		case err := <-sub.Err():
 			b.logger.Warn("could not read messages from msgFeed", zap.Error(err))
-			return err
+			return
 		}
 	}
 }

--- a/exporter/api/broadcaster_test.go
+++ b/exporter/api/broadcaster_test.go
@@ -25,7 +25,7 @@ func TestBroadcaster(t *testing.T) {
 
 	feed := new(event.Feed)
 	go func() {
-		require.NoError(t, b.FromFeed(feed))
+		require.NoError(t, b.FromFeed(t.Context(), feed))
 	}()
 	bm1 := newBroadcastedMock("1")
 	bm2 := newBroadcastedMock("2")

--- a/exporter/api/broadcaster_test.go
+++ b/exporter/api/broadcaster_test.go
@@ -33,17 +33,23 @@ func TestBroadcaster(t *testing.T) {
 
 	require.True(t, b.Register(bm2))
 
-	go feed.Send(Message{Type: TypeValidator, Filter: MessageFilter{From: 0, To: 0}})
-	<-time.After(5 * time.Millisecond)
-	go b.Deregister(bm2)
-	<-time.After(5 * time.Millisecond)
-	go feed.Send(Message{Type: TypeValidator, Filter: MessageFilter{From: 0, To: 0}})
+	// Both subscribers are registered — both must receive msg1.
+	feed.Send(Message{Type: TypeValidator, Filter: MessageFilter{From: 0, To: 0}})
+	require.Eventually(t, func() bool {
+		return bm1.Size() == 1 && bm2.Size() == 1
+	}, time.Second, 5*time.Millisecond, "both subscribers should receive the first message")
 
-	// wait so messages will propagate
-	<-time.After(100 * time.Millisecond)
-	require.Equal(t, bm1.Size(), 2)
-	// the second broadcasted was deregistered after the first message
-	require.Equal(t, bm2.Size(), 1)
+	// Waiting above guarantees Broadcast(msg1) finished dispatching, so this
+	// Deregister lands before any Broadcast snapshot for msg2 can see bm2.
+	require.True(t, b.Deregister(bm2))
+
+	// Only bm1 is registered — only bm1 must receive msg2.
+	feed.Send(Message{Type: TypeValidator, Filter: MessageFilter{From: 0, To: 0}})
+	require.Eventually(t, func() bool {
+		return bm1.Size() == 2
+	}, time.Second, 5*time.Millisecond, "bm1 should receive the second message")
+
+	require.Equal(t, 1, bm2.Size(), "bm2 must not receive messages after deregister")
 }
 
 type broadcastedMock struct {

--- a/exporter/api/broadcaster_test.go
+++ b/exporter/api/broadcaster_test.go
@@ -24,9 +24,7 @@ func TestBroadcaster(t *testing.T) {
 	b := newBroadcaster(logger)
 
 	feed := new(event.Feed)
-	go func() {
-		require.NoError(t, b.FromFeed(t.Context(), feed))
-	}()
+	b.FromFeed(t.Context(), feed)
 	bm1 := newBroadcastedMock("1")
 	bm2 := newBroadcastedMock("2")
 
@@ -35,8 +33,6 @@ func TestBroadcaster(t *testing.T) {
 
 	require.True(t, b.Register(bm2))
 
-	// wait so setup will be finished
-	<-time.After(10 * time.Millisecond)
 	go feed.Send(Message{Type: TypeValidator, Filter: MessageFilter{From: 0, To: 0}})
 	<-time.After(5 * time.Millisecond)
 	go b.Deregister(bm2)

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -22,7 +22,11 @@ const (
 
 // WebSocketServer is responsible for managing all
 type WebSocketServer interface {
-	Start(addr string) error
+	// Start binds a listener on addr and begins serving in the background.
+	// It returns the bound address (useful when addr has a :0 port) once the
+	// listener is ready to accept connections. Serve-loop errors are logged,
+	// not returned.
+	Start(addr string) (string, error)
 	BroadcastFeed() *event.Feed
 	UseQueryHandler(handler QueryMessageHandler)
 }
@@ -44,9 +48,9 @@ type wsServer struct {
 }
 
 // NewWsServer creates a new instance. Handler routes are registered here so
-// that by the time Start/Serve is called the mux is ready and callers can
-// safely bind a listener and dial it without a setup race.
-func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool) WebSocketServer {
+// that by the time Start is called the mux is ready and callers can safely
+// dial the bound address without a setup race.
+func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool) *wsServer {
 	ws := wsServer{
 		ctx:         ctx,
 		logger:      logger.Named(log.NameWSServer),
@@ -65,42 +69,50 @@ func (ws *wsServer) UseQueryHandler(handler QueryMessageHandler) {
 	ws.handler = handler
 }
 
-// Start listens on addr and serves the websocket server. Blocks until the
-// server is shut down.
-func (ws *wsServer) Start(addr string) error {
+// Start binds a listener on addr and serves the websocket server in the
+// background. It returns the bound address once the listener is ready (so
+// callers using a :0 port can discover the kernel-assigned one). The server
+// shuts down when the ctx passed to NewWsServer is canceled
+func (ws *wsServer) Start(addr string) (string, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		ws.logger.Warn("could not listen", zap.Error(err))
-		return err
+		return "", err
 	}
-	return ws.Serve(l)
-}
 
-// Serve serves the websocket server on the given listener and blocks until
-// the server is shut down. Takes ownership of l — Shutdown/Close will close
-// it.
-func (ws *wsServer) Serve(l net.Listener) error {
-	go func() {
-		if err := ws.broadcaster.FromFeed(ws.out); err != nil {
-			ws.logger.Debug("failed to pull messages from feed")
-		}
-	}()
-
-	ws.logger.Info("starting", fields.Address(l.Addr().String()), zap.Strings("endPoints", []string{"/query", "/stream"}))
+	boundAddr := l.Addr().String()
 
 	const timeout = 3 * time.Second
-
 	ws.httpServer = &http.Server{
 		Handler:      ws.router,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	}
 
-	err := ws.httpServer.Serve(l)
-	if err != nil {
-		ws.logger.Warn("could not start", zap.Error(err))
-	}
-	return err
+	go func() {
+		if err := ws.broadcaster.FromFeed(ws.ctx, ws.out); err != nil {
+			ws.logger.Debug("failed to pull messages from feed")
+		}
+	}()
+
+	ws.logger.Info("starting", fields.Address(boundAddr), zap.Strings("endPoints", []string{"/query", "/stream"}))
+
+	go func() {
+		<-ws.ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := ws.httpServer.Shutdown(shutdownCtx); err != nil {
+			ws.logger.Warn("shutdown failed", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		if err := ws.httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
+			ws.logger.Warn("serve loop exited", zap.Error(err))
+		}
+	}()
+
+	return boundAddr, nil
 }
 
 // BroadcastFeed returns the feed for stream messages

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -38,13 +38,13 @@ type wsServer struct {
 	logger *zap.Logger
 	ctx    context.Context
 
+	router  *http.ServeMux
 	handler QueryMessageHandler
 
 	broadcaster Broadcaster
+	// outFeed is a subject for writing messages
+	outFeed *event.Feed
 
-	router     *http.ServeMux
-	// out is a subject for writing messages
-	out      *event.Feed
 	withPing bool
 }
 
@@ -56,7 +56,7 @@ func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHa
 		handler:     handler,
 		router:      mux,
 		broadcaster: newBroadcaster(logger),
-		out:         new(event.Feed),
+		outFeed:     new(event.Feed),
 		withPing:    withPing,
 	}
 	ws.RegisterHandler("query", "/query", ws.handleQuery)
@@ -88,7 +88,7 @@ func (ws *wsServer) Start(addr string) (string, error) {
 
 	ws.logger.Info("starting", fields.Address(boundAddr), zap.Strings("endPoints", []string{"/query", "/stream"}))
 
-	ws.broadcaster.FromFeed(ws.ctx, ws.out)
+	ws.broadcaster.FromFeed(ws.ctx, ws.outFeed)
 
 	go func() {
 		<-ws.ctx.Done()
@@ -110,7 +110,7 @@ func (ws *wsServer) Start(addr string) (string, error) {
 
 // BroadcastFeed returns the feed for stream messages
 func (ws *wsServer) BroadcastFeed() *event.Feed {
-	return ws.out
+	return ws.outFeed
 }
 
 // RegisterHandler registers an end point

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -35,13 +36,16 @@ type wsServer struct {
 
 	broadcaster Broadcaster
 
-	router *http.ServeMux
+	router     *http.ServeMux
+	httpServer *http.Server
 	// out is a subject for writing messages
 	out      *event.Feed
 	withPing bool
 }
 
-// NewWsServer creates a new instance
+// NewWsServer creates a new instance. Handler routes are registered here so
+// that by the time Start/Serve is called the mux is ready and callers can
+// safely bind a listener and dial it without a setup race.
 func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool) WebSocketServer {
 	ws := wsServer{
 		ctx:         ctx,
@@ -52,6 +56,8 @@ func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHa
 		out:         new(event.Feed),
 		withPing:    withPing,
 	}
+	ws.RegisterHandler("query", "/query", ws.handleQuery)
+	ws.RegisterHandler("stream", "/stream", ws.handleStream)
 	return &ws
 }
 
@@ -59,29 +65,38 @@ func (ws *wsServer) UseQueryHandler(handler QueryMessageHandler) {
 	ws.handler = handler
 }
 
-// Start starts the websocket server and the broadcaster
+// Start listens on addr and serves the websocket server. Blocks until the
+// server is shut down.
 func (ws *wsServer) Start(addr string) error {
-	ws.RegisterHandler("query", "/query", ws.handleQuery)
-	ws.RegisterHandler("stream", "/stream", ws.handleStream)
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		ws.logger.Warn("could not listen", zap.Error(err))
+		return err
+	}
+	return ws.Serve(l)
+}
 
+// Serve serves the websocket server on the given listener and blocks until
+// the server is shut down. Takes ownership of l — Shutdown/Close will close
+// it.
+func (ws *wsServer) Serve(l net.Listener) error {
 	go func() {
 		if err := ws.broadcaster.FromFeed(ws.out); err != nil {
 			ws.logger.Debug("failed to pull messages from feed")
 		}
 	}()
 
-	ws.logger.Info("starting", fields.Address(addr), zap.Strings("endPoints", []string{"/query", "/stream"}))
+	ws.logger.Info("starting", fields.Address(l.Addr().String()), zap.Strings("endPoints", []string{"/query", "/stream"}))
 
 	const timeout = 3 * time.Second
 
-	httpServer := &http.Server{
-		Addr:         addr,
+	ws.httpServer = &http.Server{
 		Handler:      ws.router,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	}
 
-	err := httpServer.ListenAndServe()
+	err := ws.httpServer.Serve(l)
 	if err != nil {
 		ws.logger.Warn("could not start", zap.Error(err))
 	}

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -41,15 +43,12 @@ type wsServer struct {
 	broadcaster Broadcaster
 
 	router     *http.ServeMux
-	httpServer *http.Server
 	// out is a subject for writing messages
 	out      *event.Feed
 	withPing bool
 }
 
-// NewWsServer creates a new instance. Handler routes are registered here so
-// that by the time Start is called the mux is ready and callers can safely
-// dial the bound address without a setup race.
+// NewWsServer creates a new instance.
 func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool) *wsServer {
 	ws := wsServer{
 		ctx:         ctx,
@@ -76,39 +75,33 @@ func (ws *wsServer) UseQueryHandler(handler QueryMessageHandler) {
 func (ws *wsServer) Start(addr string) (string, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		ws.logger.Warn("could not listen", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("listen on %s: %w", addr, err)
 	}
-
 	boundAddr := l.Addr().String()
 
 	const timeout = 3 * time.Second
-	ws.httpServer = &http.Server{
+	httpServer := &http.Server{
 		Handler:      ws.router,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	}
 
-	go func() {
-		if err := ws.broadcaster.FromFeed(ws.ctx, ws.out); err != nil {
-			ws.logger.Debug("failed to pull messages from feed")
-		}
-	}()
-
 	ws.logger.Info("starting", fields.Address(boundAddr), zap.Strings("endPoints", []string{"/query", "/stream"}))
+
+	ws.broadcaster.FromFeed(ws.ctx, ws.out)
 
 	go func() {
 		<-ws.ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := ws.httpServer.Shutdown(shutdownCtx); err != nil {
-			ws.logger.Warn("shutdown failed", zap.Error(err))
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			ws.logger.Error("shutdown failed", zap.Error(err))
 		}
 	}()
 
 	go func() {
-		if err := ws.httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
-			ws.logger.Warn("serve loop exited", zap.Error(err))
+		if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			ws.logger.Error("serve loop exited", zap.Error(err))
 		}
 	}()
 

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -156,7 +156,7 @@ func newTestMessage() Message {
 // reserveFreePort asks the kernel for a free TCP port and releases it so the
 // caller can bind to it. A small TOCTOU window remains between the release
 // here and the bind by the server under test, but it's far narrower than
-// scanning random ports with a dial probe. Matches api/server/server_test.go.
+// scanning random ports with a dial probe.
 func reserveFreePort(t *testing.T) int {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -25,13 +25,13 @@ func TestHandleQuery(t *testing.T) {
 			{PublicKey: fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From)},
 		}
 	}, mux, false).(*wsServer)
-	port := reserveFreePort(t)
-	addr := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
 	serverErrCh := make(chan error, 1)
 	go func() {
-		serverErrCh <- ws.Start(addr)
+		serverErrCh <- ws.Serve(listener)
 	}()
-	waitForCondition(t, 2*time.Second, func() bool { return checkPort(port) == nil })
 	select {
 	case err := <-serverErrCh:
 		require.NoError(t, err)
@@ -72,13 +72,13 @@ func TestHandleStream(t *testing.T) {
 	ctx := context.Background() // t.Context() breaks the test
 	mux := http.NewServeMux()
 	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false).(*wsServer)
-	port := reserveFreePort(t)
-	addr := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
 	serverErrCh := make(chan error, 1)
 	go func() {
-		serverErrCh <- ws.Start(addr)
+		serverErrCh <- ws.Serve(listener)
 	}()
-	waitForCondition(t, 2*time.Second, func() bool { return checkPort(port) == nil })
 	select {
 	case err := <-serverErrCh:
 		require.NoError(t, err)
@@ -151,26 +151,4 @@ func newTestMessage() Message {
 			{"PublicKey": "pubkey3"},
 		},
 	}
-}
-
-// reserveFreePort asks the kernel for a free TCP port and releases it so the
-// caller can bind to it. A small TOCTOU window remains between the release
-// here and the bind by the server under test, but it's far narrower than
-// scanning random ports with a dial probe.
-func reserveFreePort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	require.NoError(t, l.Close())
-	return port
-}
-
-func checkPort(port int) error {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf(":%d", port), 3*time.Second)
-	if err != nil {
-		return err
-	}
-	_ = conn.Close()
-	return nil
 }

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -87,18 +87,18 @@ func TestHandleStream(t *testing.T) {
 	}
 
 	// send 3 messages in the stream channel
-	ws.out.Send(newTestMessage())
+	ws.outFeed.Send(newTestMessage())
 
 	msg2 := newTestMessage()
 	msg2.Data = []registrystorage.OperatorData{
 		{PublicKey: "pubkey-operator"},
 	}
-	ws.out.Send(msg2)
+	ws.outFeed.Send(msg2)
 
 	msg3 := newTestMessage()
 	msg3.Type = TypeValidator
 	msg3.Data = map[string]string{"PublicKey": "pubkey3"}
-	ws.out.Send(msg3)
+	ws.outFeed.Send(msg3)
 
 	waitForCondition(t, 2*time.Second, func() bool { return client.MessageCount() == 3 })
 

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -24,20 +23,9 @@ func TestHandleQuery(t *testing.T) {
 		nm.Msg.Data = []registrystorage.OperatorData{
 			{PublicKey: fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From)},
 		}
-	}, mux, false).(*wsServer)
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	}, mux, false)
+	addr, err := ws.Start("127.0.0.1:0")
 	require.NoError(t, err)
-	addr := listener.Addr().String()
-	serverErrCh := make(chan error, 1)
-	go func() {
-		serverErrCh <- ws.Serve(listener)
-	}()
-	select {
-	case err := <-serverErrCh:
-		require.NoError(t, err)
-		t.Fatal("server exited unexpectedly")
-	default:
-	}
 
 	clientCtx, cancelClientCtx := context.WithCancel(ctx)
 	client := NewWSClient(clientCtx, logger)
@@ -69,22 +57,11 @@ func TestHandleQuery(t *testing.T) {
 
 func TestHandleStream(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	ctx := context.Background() // t.Context() breaks the test
+	ctx := t.Context()
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false).(*wsServer)
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false)
+	addr, err := ws.Start("127.0.0.1:0")
 	require.NoError(t, err)
-	addr := listener.Addr().String()
-	serverErrCh := make(chan error, 1)
-	go func() {
-		serverErrCh <- ws.Serve(listener)
-	}()
-	select {
-	case err := <-serverErrCh:
-		require.NoError(t, err)
-		t.Fatal("server exited unexpectedly")
-	default:
-	}
 
 	testCtx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"testing"
@@ -26,7 +25,7 @@ func TestHandleQuery(t *testing.T) {
 			{PublicKey: fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From)},
 		}
 	}, mux, false).(*wsServer)
-	port := getRandomPort(8001, 14000)
+	port := reserveFreePort(t)
 	addr := fmt.Sprintf(":%d", port)
 	serverErrCh := make(chan error, 1)
 	go func() {
@@ -73,7 +72,7 @@ func TestHandleStream(t *testing.T) {
 	ctx := context.Background() // t.Context() breaks the test
 	mux := http.NewServeMux()
 	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false).(*wsServer)
-	port := getRandomPort(8001, 14000)
+	port := reserveFreePort(t)
 	addr := fmt.Sprintf(":%d", port)
 	serverErrCh := make(chan error, 1)
 	go func() {
@@ -154,15 +153,17 @@ func newTestMessage() Message {
 	}
 }
 
-func getRandomPort(from, to int) int {
-	for {
-		port := rand.Intn(to-from) + from
-		if checkPort(port) == nil {
-			// port is taken
-			continue
-		}
-		return port
-	}
+// reserveFreePort asks the kernel for a free TCP port and releases it so the
+// caller can bind to it. A small TOCTOU window remains between the release
+// here and the bind by the server under test, but it's far narrower than
+// scanning random ports with a dial probe. Matches api/server/server_test.go.
+func reserveFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
 }
 
 func checkPort(port int) error {

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -82,7 +82,10 @@ type DiscV5Service struct {
 	publishLock chan struct{}
 }
 
-func newDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (*DiscV5Service, error) {
+func NewDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (*DiscV5Service, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithCancel(pctx)
 	dvs := DiscV5Service{
 		logger:              logger.Named(log.NameDiscoveryService),

--- a/network/discovery/local_service.go
+++ b/network/discovery/local_service.go
@@ -35,9 +35,15 @@ type localDiscovery struct {
 
 // NewLocalDiscovery creates an mDNS discovery service and attaches it to the libp2p Host.
 // This lets us automatically discover peers on the same LAN and connect to them.
-func NewLocalDiscovery(ctx context.Context, logger *zap.Logger, host host.Host) (Service, error) {
+// An empty serviceTag falls back to LocalDiscoveryServiceTag; tests use a unique tag
+// to isolate concurrently-running mDNS groups.
+func NewLocalDiscovery(ctx context.Context, logger *zap.Logger, host host.Host, serviceTag string) (Service, error) {
 	logger = logger.Named(log.NameDiscoveryService)
 	logger.Debug("configuring mdns")
+
+	if serviceTag == "" {
+		serviceTag = LocalDiscoveryServiceTag
+	}
 
 	routingDHT, disc, err := NewKadDHT(ctx, host, dht.ModeServer)
 	if err != nil {
@@ -49,7 +55,7 @@ func NewLocalDiscovery(ctx context.Context, logger *zap.Logger, host host.Host) 
 		host:       host,
 		routingTbl: routingDHT,
 		disc:       disc,
-		svc: mdnsDiscover.NewMdnsService(host, LocalDiscoveryServiceTag, &discoveryNotifee{
+		svc: mdnsDiscover.NewMdnsService(host, serviceTag, &discoveryNotifee{
 			handler: handle(host, func(e PeerEvent) {
 				err := host.Connect(ctx, e.AddrInfo)
 				if err != nil {

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -46,6 +46,12 @@ type Options struct {
 	SSVConfig           *networkconfig.SSV
 	DiscoveredPeersPool *ttl.Map[peer.ID, DiscoveredPeer]
 	TrimmedRecently     *ttl.Map[peer.ID, struct{}]
+
+	// MdnsServiceTag overrides the mDNS service tag when local (mdns) discovery
+	// is used. Empty falls back to LocalDiscoveryServiceTag. Tests set this to
+	// a unique value so concurrently-running test processes don't discover
+	// each other's peers.
+	MdnsServiceTag string
 }
 
 // Validate checks if the options are valid.
@@ -73,7 +79,7 @@ func NewService(ctx context.Context, logger *zap.Logger, opts Options) (Service,
 	}
 
 	if opts.DiscV5Opts == nil {
-		return NewLocalDiscovery(ctx, logger, opts.Host)
+		return NewLocalDiscovery(ctx, logger, opts.Host, opts.MdnsServiceTag)
 	}
 	return newDiscV5Service(ctx, logger, &opts)
 }

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"time"
@@ -10,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/discovery"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -35,7 +33,7 @@ type PeerEvent struct {
 // HandleNewPeer is the function interface for handling new peer
 type HandleNewPeer func(e PeerEvent)
 
-// Options represents the options passed to create a service
+// Options represents the options passed to create a discv5 discovery service.
 type Options struct {
 	Host                host.Host
 	DiscV5Opts          *DiscV5Options
@@ -46,12 +44,6 @@ type Options struct {
 	SSVConfig           *networkconfig.SSV
 	DiscoveredPeersPool *ttl.Map[peer.ID, DiscoveredPeer]
 	TrimmedRecently     *ttl.Map[peer.ID, struct{}]
-
-	// MdnsServiceTag overrides the mDNS service tag when local (mdns) discovery
-	// is used. Empty falls back to LocalDiscoveryServiceTag. Tests set this to
-	// a unique value so concurrently-running test processes don't discover
-	// each other's peers.
-	MdnsServiceTag string
 }
 
 // Validate checks if the options are valid.
@@ -70,18 +62,6 @@ type Service interface {
 	DeregisterSubnets(subnets ...uint64) (updated bool, err error)
 	Bootstrap(handler HandleNewPeer) error
 	PublishENR()
-}
-
-// NewService creates new discovery.Service
-func NewService(ctx context.Context, logger *zap.Logger, opts Options) (Service, error) {
-	if err := opts.Validate(); err != nil {
-		return nil, err
-	}
-
-	if opts.DiscV5Opts == nil {
-		return NewLocalDiscovery(ctx, logger, opts.Host, opts.MdnsServiceTag)
-	}
-	return newDiscV5Service(ctx, logger, &opts)
 }
 
 type DiscoveredPeer struct {

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -149,7 +149,7 @@ func TestDiscV5Service_PublishENR(t *testing.T) {
 	defer cancel()
 
 	opts := testingDiscoveryOptions(t, testNetConfig.SSV)
-	dvs, err := newDiscV5Service(ctx, testLogger, opts)
+	dvs, err := NewDiscV5Service(ctx, testLogger, opts)
 	require.NoError(t, err)
 
 	// Replace listener
@@ -176,7 +176,7 @@ func TestDiscV5Service_Bootstrap(t *testing.T) {
 
 	opts := testingDiscoveryOptions(t, testNetConfig.SSV)
 
-	dvs, err := newDiscV5Service(t.Context(), testLogger, opts)
+	dvs, err := NewDiscV5Service(t.Context(), testLogger, opts)
 	require.NoError(t, err)
 
 	// Replace listener
@@ -415,7 +415,7 @@ func TestServiceAddressConfiguration(t *testing.T) {
 			opts.HostAddress = tc.hostAddress
 			opts.HostDNS = tc.hostDNS
 
-			service, err := NewService(ctx, zap.NewNop(), *opts)
+			service, err := NewDiscV5Service(ctx, zap.NewNop(), opts)
 			if tc.expectError {
 				require.Error(t, err)
 
@@ -429,12 +429,8 @@ func TestServiceAddressConfiguration(t *testing.T) {
 				}
 			})
 
-			// verify we got the expected service type
-			dv5Service, ok := service.(*DiscV5Service)
-			require.True(t, ok)
-
 			// check that the node has the expected IP configuration
-			localNode := dv5Service.Self()
+			localNode := service.Self()
 			ip := localNode.Node().IP()
 
 			if tc.expectedResult != "" {

--- a/network/discovery/testutils.go
+++ b/network/discovery/testutils.go
@@ -68,5 +68,5 @@ func createBootnodeDiscovery(ctx context.Context, logger *zap.Logger, ssvConfig 
 			Bootnodes:  []string{},
 		},
 	}
-	return newDiscV5Service(ctx, logger, discOpts)
+	return NewDiscV5Service(ctx, logger, discOpts)
 }

--- a/network/discovery/util_test.go
+++ b/network/discovery/util_test.go
@@ -78,7 +78,7 @@ func testingDiscoveryOptions(t *testing.T, ssvConfig *networkconfig.SSV) *Option
 // Testing discovery service
 func testingDiscovery(t *testing.T) *DiscV5Service {
 	opts := testingDiscoveryOptions(t, testNetConfig.SSV)
-	dvs, err := newDiscV5Service(t.Context(), testLogger, opts)
+	dvs, err := NewDiscV5Service(t.Context(), testLogger, opts)
 	require.NoError(t, err)
 	require.NotNil(t, dvs)
 	return dvs

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -91,6 +91,11 @@ type Config struct {
 
 	// PeerScoreInspectorInterval is the interval at which the PeerScoreInspector is called.
 	PeerScoreInspectorInterval time.Duration
+
+	// MdnsDiscoveryTag overrides the mDNS service tag used by local discovery.
+	// Empty falls back to discovery.LocalDiscoveryServiceTag. Tests set this to
+	// a unique value so concurrent test processes don't cross-discover peers.
+	MdnsDiscoveryTag string
 }
 
 // Libp2pOptions creates options list for the libp2p host

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -280,6 +280,7 @@ func (n *p2pNetwork) setupDiscovery() error {
 		if err != nil {
 			return errors.Wrap(err, "could not get ip addr")
 		}
+
 		discV5Opts := &discovery.DiscV5Options{
 			IP:            ipAddr.String(),
 			BindIP:        net.IPv4zero.String(),
@@ -297,6 +298,7 @@ func (n *p2pNetwork) setupDiscovery() error {
 			zap.Strings("bootnodes", discV5Opts.Bootnodes),
 			zap.String("ip", discV5Opts.IP),
 		)
+
 		discOpts := &discovery.Options{
 			Host:                n.host,
 			DiscV5Opts:          discV5Opts,

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -303,6 +303,7 @@ func (n *p2pNetwork) setupDiscovery() error {
 		SSVConfig:           n.cfg.NetworkConfig.SSV,
 		DiscoveredPeersPool: n.discoveredPeersPool,
 		TrimmedRecently:     n.trimmedRecently,
+		MdnsServiceTag:      n.cfg.MdnsDiscoveryTag,
 	}
 	disc, err := discovery.NewService(n.ctx, logger, discOpts)
 	if err != nil {

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -267,13 +267,20 @@ func (n *p2pNetwork) FixedSubnets() p2pcommons.Subnets {
 func (n *p2pNetwork) setupDiscovery() error {
 	logger := n.logger
 
-	ipAddr, err := p2pcommons.IPAddr()
-	if err != nil {
-		return errors.Wrap(err, "could not get ip addr")
-	}
-	var discV5Opts *discovery.DiscV5Options
-	if n.cfg.Discovery != localDiscvery { // otherwise, we are in local scenario
-		discV5Opts = &discovery.DiscV5Options{
+	var disc discovery.Service
+	if n.cfg.Discovery == localDiscvery {
+		logger.Info("discovery: using mdns (local)")
+		var err error
+		disc, err = discovery.NewLocalDiscovery(n.ctx, logger, n.host, n.cfg.MdnsDiscoveryTag)
+		if err != nil {
+			return err
+		}
+	} else {
+		ipAddr, err := p2pcommons.IPAddr()
+		if err != nil {
+			return errors.Wrap(err, "could not get ip addr")
+		}
+		discV5Opts := &discovery.DiscV5Options{
 			IP:            ipAddr.String(),
 			BindIP:        net.IPv4zero.String(),
 			Port:          n.cfg.UDPPort,
@@ -290,24 +297,21 @@ func (n *p2pNetwork) setupDiscovery() error {
 			zap.Strings("bootnodes", discV5Opts.Bootnodes),
 			zap.String("ip", discV5Opts.IP),
 		)
-	} else {
-		logger.Info("discovery: using mdns (local)")
-	}
-	discOpts := discovery.Options{
-		Host:                n.host,
-		DiscV5Opts:          discV5Opts,
-		ConnIndex:           n.idx,
-		SubnetsIdx:          n.idx,
-		HostAddress:         n.cfg.HostAddress,
-		HostDNS:             n.cfg.HostDNS,
-		SSVConfig:           n.cfg.NetworkConfig.SSV,
-		DiscoveredPeersPool: n.discoveredPeersPool,
-		TrimmedRecently:     n.trimmedRecently,
-		MdnsServiceTag:      n.cfg.MdnsDiscoveryTag,
-	}
-	disc, err := discovery.NewService(n.ctx, logger, discOpts)
-	if err != nil {
-		return err
+		discOpts := &discovery.Options{
+			Host:                n.host,
+			DiscV5Opts:          discV5Opts,
+			ConnIndex:           n.idx,
+			SubnetsIdx:          n.idx,
+			HostAddress:         n.cfg.HostAddress,
+			HostDNS:             n.cfg.HostDNS,
+			SSVConfig:           n.cfg.NetworkConfig.SSV,
+			DiscoveredPeersPool: n.discoveredPeersPool,
+			TrimmedRecently:     n.trimmedRecently,
+		}
+		disc, err = discovery.NewDiscV5Service(n.ctx, logger, discOpts)
+		if err != nil {
+			return err
+		}
 	}
 	n.disc = disc
 

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -50,7 +50,6 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 	ln, routers, err := createNetworkAndSubscribe(t, ctx, LocalNetOptions{
 		Nodes:        n,
 		MinConnected: n/2 - 1,
-		UseDiscv5:    false,
 		Shares:       shares,
 	})
 	require.NoError(t, err)

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -340,7 +340,6 @@ func createVirtualNet(
 	ln, routers, err := createNetworkAndSubscribe(t, ctx, LocalNetOptions{
 		Nodes:                    nodes,
 		MinConnected:             nodes - 1,
-		UseDiscv5:                false,
 		TotalValidators:          1000,
 		ActiveValidators:         800,
 		MyValidators:             300,

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -196,14 +196,12 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	// Assert that the messages were distributed as expected.
 	time.Sleep(20 * time.Second)
 
-	interval := 100 * time.Millisecond
 	for i := 0; i < nodeCount; i++ {
 		// Messages from nodes broadcasting rejected role become rejected once score threshold is reached
 		if slices.Contains(messageTypesByNodeIndex[i], rejectedRole) {
 			continue
 		}
 
-		// better lock inside loop than wait interval locked
 		mtx.Lock()
 		var errors []error
 		if roleBroadcasts[acceptedRole] != messageValidators[i].TotalAccepted {
@@ -217,7 +215,6 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 		}
 		mtx.Unlock()
 		require.Empty(t, errors)
-		time.Sleep(interval)
 	}
 
 	// Assert that each node scores it's peers according to the following order:

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -113,15 +112,12 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			switch ssvMessage.MsgID.GetRoleType() {
 			case acceptedRole:
 				messageValidators[i].Accepted[p.Index]++
-				messageValidators[i].TotalAccepted++
 				validation = pubsub.ValidationAccept
 			case ignoredRole:
 				messageValidators[i].Ignored[p.Index]++
-				messageValidators[i].TotalIgnored++
 				validation = pubsub.ValidationIgnore
 			case rejectedRole:
 				messageValidators[i].Rejected[p.Index]++
-				messageValidators[i].TotalRejected++
 				validation = pubsub.ValidationReject
 			default:
 				panic("unsupported role")
@@ -151,16 +147,11 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 
 	// Prepare a pool of broadcasters.
 	height := atomic.Int64{}
-	roleBroadcasts := map[spectypes.RunnerRole]int{}
 	broadcasters := pool.New().WithErrors().WithContext(ctx)
 	broadcaster := func(node *VirtualNode, roles ...spectypes.RunnerRole) {
 		broadcasters.Go(func(ctx context.Context) error {
-			for i := 0; i < 30; i++ {
+			for i := 0; i < 12; i++ {
 				role := roles[i%len(roles)]
-
-				mtx.Lock()
-				roleBroadcasts[role]++
-				mtx.Unlock()
 
 				msgID, msg := dummyMsg(t, hex.EncodeToString(shares[rand.Intn(len(shares))].ValidatorPubKey[:]), int(height.Add(1)), role)
 				err := node.Broadcast(msgID, msg)
@@ -193,49 +184,27 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	err := broadcasters.Wait()
 	require.NoError(t, err)
 
-	// Assert that the messages were distributed as expected.
-	time.Sleep(20 * time.Second)
+	// Let peer scores settle after broadcasts.
+	time.Sleep(8 * time.Second)
 
-	for i := 0; i < nodeCount; i++ {
-		// Messages from nodes broadcasting rejected role become rejected once score threshold is reached
-		if slices.Contains(messageTypesByNodeIndex[i], rejectedRole) {
-			continue
-		}
-
-		mtx.Lock()
-		var errors []error
-		if roleBroadcasts[acceptedRole] != messageValidators[i].TotalAccepted {
-			errors = append(errors, fmt.Errorf("node %d accepted %d messages (expected %d)", i, messageValidators[i].TotalAccepted, roleBroadcasts[acceptedRole]))
-		}
-		if roleBroadcasts[ignoredRole] != messageValidators[i].TotalIgnored {
-			errors = append(errors, fmt.Errorf("node %d ignored %d messages (expected %d)", i, messageValidators[i].TotalIgnored, roleBroadcasts[ignoredRole]))
-		}
-		if roleBroadcasts[rejectedRole] != messageValidators[i].TotalRejected {
-			errors = append(errors, fmt.Errorf("node %d rejected %d messages (expected %d)", i, messageValidators[i].TotalRejected, roleBroadcasts[rejectedRole]))
-		}
-		mtx.Unlock()
-		require.Empty(t, errors)
-	}
-
-	// Assert that each node scores it's peers according to the following order:
-	// - node 0, (node 1 OR 3), (node 1 OR 3), node 2
-	// (after excluding itself from this list)
-	for _, node := range vNet.Nodes {
-		// Prepare the valid orders, excluding the node itself.
-		validOrders := [][]NodeIndex{
-			{0, 1, 3, 2},
-			{0, 3, 1, 2},
-		}
-		for i, validOrder := range validOrders {
-			for j, index := range validOrder {
-				if index == node.Index {
-					validOrders[i] = append(validOrders[i][:j], validOrders[i][j+1:]...)
-					break
-				}
+	// Compute each broadcaster's fraction of rejected-role messages. A higher
+	// rate should drive that broadcaster's score lower on every observer.
+	rejectedRate := map[NodeIndex]float64{}
+	for nodeIdx, roles := range messageTypesByNodeIndex {
+		rejected := 0
+		for _, r := range roles {
+			if r == rejectedRole {
+				rejected++
 			}
 		}
+		rejectedRate[NodeIndex(nodeIdx)] = float64(rejected) / float64(len(roles))
+	}
 
-		// Sort peers by their scores.
+	// Assert the peer-score ordering invariant: for any two peers, the one with
+	// a lower rejected-rate must not be ranked below the one with a higher
+	// rate. Peers sharing a rate (e.g. nodes 0 and 1, both at 0) may appear in
+	// any relative order — their scores fluctuate within scoring noise.
+	for _, node := range vNet.Nodes {
 		type peerScore struct {
 			index NodeIndex
 			score float64
@@ -269,33 +238,26 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			tbl.Render()
 		}()
 
-		// Assert that the peers are in one of the valid orders.
 		require.Equal(t, len(vNet.Nodes)-1, len(peers), "node %d", node.Index)
-		for i, validOrder := range validOrders {
-			valid := true
-			for j, peer := range peers {
-				if peer.index != validOrder[j] {
-					valid = false
-					break
+		for i := 0; i < len(peers); i++ {
+			for j := i + 1; j < len(peers); j++ {
+				if rejectedRate[peers[i].index] > rejectedRate[peers[j].index] {
+					require.Failf(t, "invalid order",
+						"observer %d: peer %d (rejected-rate=%.2f, score=%.2f) ranked above peer %d (rejected-rate=%.2f, score=%.2f)",
+						node.Index,
+						peers[i].index, rejectedRate[peers[i].index], peers[i].score,
+						peers[j].index, rejectedRate[peers[j].index], peers[j].score,
+					)
 				}
-			}
-			if valid {
-				break
-			}
-			if i == len(validOrders)-1 {
-				require.Fail(t, "invalid order", "node %d, peers %v", node.Index, peers)
 			}
 		}
 	}
 }
 
 type MockMessageValidator struct {
-	Accepted      []int
-	Ignored       []int
-	Rejected      []int
-	TotalAccepted int
-	TotalIgnored  int
-	TotalRejected int
+	Accepted []int
+	Ignored  []int
+	Rejected []int
 
 	ValidateFunc func(ctx context.Context, p peer.ID, pmsg *pubsub.Message) pubsub.ValidationResult
 }

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -155,7 +155,7 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	broadcasters := pool.New().WithErrors().WithContext(ctx)
 	broadcaster := func(node *VirtualNode, roles ...spectypes.RunnerRole) {
 		broadcasters.Go(func(ctx context.Context) error {
-			for i := 0; i < 12; i++ {
+			for i := 0; i < 30; i++ {
 				role := roles[i%len(roles)]
 
 				mtx.Lock()
@@ -194,7 +194,7 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert that the messages were distributed as expected.
-	time.Sleep(8 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	interval := 100 * time.Millisecond
 	for i := 0; i < nodeCount; i++ {

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -192,9 +192,8 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 	dutyStore := dutystore.New()
 	signatureVerifier := &mockSignatureVerifier{}
 
-	// Use TCP port 0 so the kernel picks a free port atomically at bind time,
-	// avoiding the TOCTOU gap in testing.RandomTCPPort. UDP port is unused for
-	// mDNS tests; leave it randomized for the (currently unused) discv5 path.
+	// Use TCP port 0 so the kernel picks a free port atomically at bind time. UDP port is unused for
+	// mDNS tests, leaving it randomized for the (currently unused) discv5 path.
 	cfg := NewNetConfig(keys, ln.Bootnode, 0, ln.udpRand.Next(13001, 13999), options.Nodes)
 	cfg.Ctx = ctx
 	cfg.MdnsDiscoveryTag = ln.mdnsTag

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -54,32 +54,6 @@ func randomMdnsTag() string {
 	return "ssv.test." + hex.EncodeToString(buf[:])
 }
 
-// WithBootnode adds a bootnode to the network
-func (ln *LocalNet) WithBootnode(ctx context.Context, logger *zap.Logger) error {
-	bnSk, err := testing.GenNetworkKey()
-	if err != nil {
-		return err
-	}
-	isk, err := p2pcommons.ECDSAPrivToInterface(bnSk)
-	if err != nil {
-		return err
-	}
-	b, err := isk.Raw()
-	if err != nil {
-		return err
-	}
-	bn, err := discovery.NewBootnode(ctx, logger, networkconfig.TestNetwork.SSV, &discovery.BootnodeOptions{
-		PrivateKey: hex.EncodeToString(b),
-		ExternalIP: "127.0.0.1",
-		Port:       ln.udpRand.Next(13001, 13999),
-	})
-	if err != nil {
-		return err
-	}
-	ln.Bootnode = bn
-	return nil
-}
-
 // CreateAndStartLocalNet creates a new local network and starts it
 // if any errors occurs during starting local network CreateAndStartLocalNet trying
 // to create and start local net one more time until pCtx is not Done()

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -259,7 +259,6 @@ type LocalNetOptions struct {
 	MessageValidatorProvider                        func(uint64) validation.MessageValidator
 	Nodes                                           int
 	MinConnected                                    int
-	UseDiscv5                                       bool
 	TotalValidators, ActiveValidators, MyValidators uint64
 	PeerScoreInspector                              func(selfPeer peer.ID, peerMap map[peer.ID]*pubsub.PeerScoreSnapshot)
 	PeerScoreInspectorInterval                      time.Duration
@@ -271,11 +270,6 @@ func NewLocalNet(ctx context.Context, logger *zap.Logger, options LocalNetOption
 	ln := &LocalNet{}
 	ln.udpRand = make(testing.UDPPortsRandomizer)
 	ln.mdnsTag = randomMdnsTag()
-	if options.UseDiscv5 {
-		if err := ln.WithBootnode(ctx, logger); err != nil {
-			return nil, err
-		}
-	}
 	nodes, keys, err := testing.NewLocalTestnet(ctx, options.Nodes, func(pctx context.Context, nodeIndex uint64, keys testing.NodeKeys) network.P2PNetwork {
 		logger := logger.Named(fmt.Sprintf("node-%d", nodeIndex))
 		p, err := ln.NewTestP2pNetwork(pctx, nodeIndex, keys, logger, options)

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -2,6 +2,7 @@ package p2pv1
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -38,6 +39,19 @@ type LocalNet struct {
 	Nodes    []network.P2PNetwork
 
 	udpRand testing.UDPPortsRandomizer
+
+	// mdnsTag is a per-LocalNet mDNS service tag so concurrently-running
+	// test processes don't discover each other's peers.
+	mdnsTag string
+}
+
+// randomMdnsTag returns a unique mDNS service tag for a test LocalNet.
+func randomMdnsTag() string {
+	var buf [8]byte
+	if _, err := cryptorand.Read(buf[:]); err != nil {
+		panic(fmt.Sprintf("read random bytes: %v", err))
+	}
+	return "ssv.test." + hex.EncodeToString(buf[:])
 }
 
 // WithBootnode adds a bootnode to the network
@@ -178,8 +192,12 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 	dutyStore := dutystore.New()
 	signatureVerifier := &mockSignatureVerifier{}
 
-	cfg := NewNetConfig(keys, ln.Bootnode, testing.RandomTCPPort(12001, 12999), ln.udpRand.Next(13001, 13999), options.Nodes)
+	// Use TCP port 0 so the kernel picks a free port atomically at bind time,
+	// avoiding the TOCTOU gap in testing.RandomTCPPort. UDP port is unused for
+	// mDNS tests; leave it randomized for the (currently unused) discv5 path.
+	cfg := NewNetConfig(keys, ln.Bootnode, 0, ln.udpRand.Next(13001, 13999), options.Nodes)
 	cfg.Ctx = ctx
+	cfg.MdnsDiscoveryTag = ln.mdnsTag
 	cfg.Subnets = "00000000000000000100000400000400" // calculated for topics 64, 90, 114; PAY ATTENTION for future test scenarios which use more than one eth-validator we need to make this field dynamically changing
 	cfg.NodeStorage = nodeStorage
 	cfg.MessageValidator = validation.New(
@@ -253,6 +271,7 @@ type LocalNetOptions struct {
 func NewLocalNet(ctx context.Context, logger *zap.Logger, options LocalNetOptions) (*LocalNet, error) {
 	ln := &LocalNet{}
 	ln.udpRand = make(testing.UDPPortsRandomizer)
+	ln.mdnsTag = randomMdnsTag()
 	if options.UseDiscv5 {
 		if err := ln.WithBootnode(ctx, logger); err != nil {
 			return nil, err

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -358,7 +358,7 @@ func (p *P) saveMsg(t string, msg *pubsub.Message) {
 func newPeers(ctx context.Context, logger *zap.Logger, t *testing.T, n int, msgValidator validation.MessageValidator, msgID bool, scoreInspector pubsub.ExtendedPeerScoreInspectFn) []*P {
 	peers := make([]*P, n)
 	for i := 0; i < n; i++ {
-		peers[i] = newPeer(ctx, logger, t, msgValidator, msgID, scoreInspector)
+		peers[i] = newPeer(t, ctx, logger, msgValidator, msgID, scoreInspector)
 	}
 	t.Logf("%d peers were created", n)
 	th := uint64(n/2) + uint64(n/4)
@@ -377,10 +377,10 @@ func newPeers(ctx context.Context, logger *zap.Logger, t *testing.T, n int, msgV
 	return peers
 }
 
-func newPeer(ctx context.Context, logger *zap.Logger, t *testing.T, msgValidator validation.MessageValidator, msgID bool, scoreInspector pubsub.ExtendedPeerScoreInspectFn) *P {
+func newPeer(t *testing.T, ctx context.Context, logger *zap.Logger, msgValidator validation.MessageValidator, msgID bool, scoreInspector pubsub.ExtendedPeerScoreInspectFn) *P {
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
-	ds, err := discovery.NewLocalDiscovery(ctx, logger, h, "")
+	ds, err := discovery.NewLocalDiscovery(ctx, logger, h, "ssv.test."+t.Name())
 	require.NoError(t, err)
 
 	var p *P

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -380,7 +380,7 @@ func newPeers(ctx context.Context, logger *zap.Logger, t *testing.T, n int, msgV
 func newPeer(ctx context.Context, logger *zap.Logger, t *testing.T, msgValidator validation.MessageValidator, msgID bool, scoreInspector pubsub.ExtendedPeerScoreInspectFn) *P {
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
-	ds, err := discovery.NewLocalDiscovery(ctx, logger, h)
+	ds, err := discovery.NewLocalDiscovery(ctx, logger, h, "")
 	require.NoError(t, err)
 
 	var p *P

--- a/operator/node.go
+++ b/operator/node.go
@@ -170,12 +170,9 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 func (n *Node) Start(ctx context.Context) error {
 	n.logger.Info("starting operator node")
 
-	go func() {
-		err := n.startWSServer()
-		if err != nil {
-			return
-		}
-	}()
+	if err := n.startWSServer(); err != nil {
+		return fmt.Errorf("start WS server: %w", err)
+	}
 
 	// Start the duty scheduler in modes that use it.
 	if n.dutyScheduler != nil {
@@ -440,7 +437,7 @@ func (n *Node) startWSServer() error {
 
 		n.ws.UseQueryHandler(n.handleQueryRequests)
 
-		if err := n.ws.Start(fmt.Sprintf(":%d", n.wsAPIPort)); err != nil {
+		if _, err := n.ws.Start(fmt.Sprintf(":%d", n.wsAPIPort)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Rebased onto https://github.com/ssvlabs/ssv/pull/2819 (only the latest commit here is new).

Resolves flaky pipeline https://github.com/ssvlabs/ssv/actions/runs/24669605966/job/72136402325?pr=2819
```
--- FAIL: TestBroadcaster (0.11s)
    broadcaster_test.go:46: 
        	Error Trace:	/home/runner/work/ssv/ssv/exporter/api/broadcaster_test.go:46
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestBroadcaster
```

Related to https://github.com/ssvlabs/ssv-node-board/issues/941 (discovered during investigation).