### PR TITLE
Avoid calling test assertions from worker goroutines

### DIFF
--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -101,6 +101,12 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 	node1, node2 := ln.Nodes[1], ln.Nodes[2]
 
 	var wg sync.WaitGroup
+	broadcastErrCh := make(chan error, 12)
+	recordBroadcastErr := func(err error) {
+		if err != nil {
+			broadcastErrCh <- err
+		}
+	}
 	wg.Add(1)
 
 	go func() {
@@ -111,17 +117,17 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 		msgSyncCommitteeContribution := generateValidatorMsg(spectestingutils.Testing4SharesSet(), 5, spectypes.RoleSyncCommitteeContribution)
 		msgRoleVoluntaryExit := generateValidatorMsg(spectestingutils.Testing4SharesSet(), 6, spectypes.RoleVoluntaryExit)
 
-		require.NoError(t, node1.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
+		recordBroadcastErr(node1.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
 		<-time.After(time.Millisecond * 20)
-		require.NoError(t, node2.Broadcast(msgCommittee3.SSVMessage.GetID(), msgCommittee3))
+		recordBroadcastErr(node2.Broadcast(msgCommittee3.SSVMessage.GetID(), msgCommittee3))
 		<-time.After(time.Millisecond * 20)
-		require.NoError(t, node2.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
+		recordBroadcastErr(node2.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
 		<-time.After(time.Millisecond * 20)
-		require.NoError(t, node2.Broadcast(msgProposer.SSVMessage.GetID(), msgProposer))
+		recordBroadcastErr(node2.Broadcast(msgProposer.SSVMessage.GetID(), msgProposer))
 		<-time.After(time.Millisecond * 20)
-		require.NoError(t, node2.Broadcast(msgSyncCommitteeContribution.SSVMessage.GetID(), msgSyncCommitteeContribution))
+		recordBroadcastErr(node2.Broadcast(msgSyncCommitteeContribution.SSVMessage.GetID(), msgSyncCommitteeContribution))
 		<-time.After(time.Millisecond * 20)
-		require.NoError(t, node1.Broadcast(msgRoleVoluntaryExit.SSVMessage.GetID(), msgRoleVoluntaryExit))
+		recordBroadcastErr(node1.Broadcast(msgRoleVoluntaryExit.SSVMessage.GetID(), msgRoleVoluntaryExit))
 	}()
 
 	wg.Add(1)
@@ -136,20 +142,22 @@ func TestP2pNetwork_SubscribeBroadcast(t *testing.T) {
 		msgSyncCommitteeContribution := generateValidatorMsg(spectestingutils.Testing4SharesSet(), 5, spectypes.RoleSyncCommitteeContribution)
 		msgRoleVoluntaryExit := generateValidatorMsg(spectestingutils.Testing4SharesSet(), 6, spectypes.RoleVoluntaryExit)
 
-		require.NoError(t, err)
+		time.Sleep(time.Millisecond * 20)
+		recordBroadcastErr(node1.Broadcast(msgCommittee2.SSVMessage.GetID(), msgCommittee2))
 
 		time.Sleep(time.Millisecond * 20)
-		require.NoError(t, node1.Broadcast(msgCommittee2.SSVMessage.GetID(), msgCommittee2))
-
-		time.Sleep(time.Millisecond * 20)
-		require.NoError(t, node2.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
-		require.NoError(t, node1.Broadcast(msgCommittee3.SSVMessage.GetID(), msgCommittee3))
-		require.NoError(t, node1.Broadcast(msgProposer.SSVMessage.GetID(), msgProposer))
-		require.NoError(t, node1.Broadcast(msgSyncCommitteeContribution.SSVMessage.GetID(), msgSyncCommitteeContribution))
-		require.NoError(t, node2.Broadcast(msgRoleVoluntaryExit.SSVMessage.GetID(), msgRoleVoluntaryExit))
+		recordBroadcastErr(node2.Broadcast(msgCommittee1.SSVMessage.GetID(), msgCommittee1))
+		recordBroadcastErr(node1.Broadcast(msgCommittee3.SSVMessage.GetID(), msgCommittee3))
+		recordBroadcastErr(node1.Broadcast(msgProposer.SSVMessage.GetID(), msgProposer))
+		recordBroadcastErr(node1.Broadcast(msgSyncCommitteeContribution.SSVMessage.GetID(), msgSyncCommitteeContribution))
+		recordBroadcastErr(node2.Broadcast(msgRoleVoluntaryExit.SSVMessage.GetID(), msgRoleVoluntaryExit))
 	}()
 
 	wg.Wait()
+	close(broadcastErrCh)
+	for err := range broadcastErrCh {
+		require.NoError(t, err)
+	}
 
 	// waiting for messages
 	wg.Add(1)

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -209,17 +209,18 @@ func TestPriorityQueue_Pop_NothingThenSomething(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	require.Equal(t, 2, queue.Len())
 	expectedMsg := decodeAndPush(t, queue, mockConsensusMessage{Height: specqbft.Height(2), Type: specqbft.CommitMsgType}, state)
+	poppedCh := make(chan *SSVMessage, 1)
 
 	go func() {
 		defer wg.Done()
 		matchHeight2 := func(msg *SSVMessage) bool {
 			return msg.Body.(*specqbft.Message).Height == 2
 		}
-		popped := queue.Pop(t.Context(), NewMessagePrioritizer(state), matchHeight2)
-		require.Equal(t, expectedMsg, popped)
+		poppedCh <- queue.Pop(t.Context(), NewMessagePrioritizer(state), matchHeight2)
 	}()
 
 	wg.Wait()
+	require.Equal(t, expectedMsg, <-poppedCh)
 
 	// Ensure that the queue still contains the non-matching messages.
 	require.Equal(t, queue.Len(), 2)
@@ -231,6 +232,7 @@ func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+	poppedCh := make(chan *SSVMessage, 1)
 
 	state := &State{
 		HasRunningInstance: true,
@@ -243,14 +245,13 @@ func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.
 	// Pop in a separate goroutine. The first two pops should get the matching messages, and the third should return nil.
 	go func() {
 		defer wg.Done()
-		popped := queue.Pop(t.Context(), NewMessagePrioritizer(state), func(msg *SSVMessage) bool {
+		poppedCh <- queue.Pop(t.Context(), NewMessagePrioritizer(state), func(msg *SSVMessage) bool {
 			_, ok := msg.Body.(*specqbft.Message)
 			if !ok {
 				return true
 			}
 			return msg.Body.(*specqbft.Message).MsgType != specqbft.CommitMsgType
 		})
-		require.NotNil(t, popped)
 	}()
 
 	// Simulate delay before pushing messages.
@@ -266,6 +267,7 @@ func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.
 	decodeAndPush(t, queue, mockConsensusMessage{Height: specqbft.Height(1), Type: specqbft.CommitMsgType}, state)
 
 	wg.Wait()
+	require.NotNil(t, <-poppedCh)
 
 	// Ensure that the queue still contains the non-matching messages.
 	require.False(t, queue.Empty())
@@ -386,11 +388,12 @@ func benchmarkPriorityQueueParallel(b *testing.B, factory func() Queue, lossy bo
 		// Assert pushed messages.
 		var pushersAssertionWg sync.WaitGroup
 		pushersAssertionWg.Add(1)
+		pushedCountCh := make(chan int64, 1)
 		go func() {
 			pushersWg.Wait()
 			defer pushersAssertionWg.Done()
 			totalPushed += messageCount
-			require.Equal(b, int64(messageCount), pushedCount.Load())
+			pushedCountCh <- pushedCount.Load()
 		}()
 
 		// Pop all messages.
@@ -413,6 +416,7 @@ func benchmarkPriorityQueueParallel(b *testing.B, factory func() Queue, lossy bo
 
 		// Wait for pushed messages assertion.
 		pushersAssertionWg.Wait()
+		require.Equal(b, int64(messageCount), <-pushedCountCh)
 		stopPopping()
 
 		// Wait for poppers.


### PR DESCRIPTION
T-ssv-046

Original ticket summary:
The ticket flagged test code that called `require` from worker goroutines in `network/p2p/p2p_test.go` and `protocol/v2/ssv/queue/queue_test.go`, which is undefined behavior because those helpers may invoke `t.FailNow()` outside the main test goroutine.

Changes:
- route worker-goroutine results back to the parent test goroutine before asserting
- keep the existing test behavior and synchronization intact
- fix one additional same-pattern assertion in the queue benchmark while touching the file

Validation:
- `go test -tags "blst_enabled lfs" -timeout 10m ./exporter/api`
- `go test -tags "blst_enabled lfs" -timeout 10m ./protocol/v2/ssv/queue`
- `go test -tags "blst_enabled lfs" -run '^$' ./network/p2p`
- `GOWORK=off go tool -modfile=tool.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run -v ./exporter/api ./network/p2p ./protocol/v2/ssv/queue`

Fixes - Fixes ssvlabs/ssv-node-board#935
