### PR TITLE
Fix SetupRunners call site after logger removal

### DIFF
--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -116,7 +116,6 @@ func TestSetupValidatorsExporter(t *testing.T) {
 func TestSetupRunnersExporter(t *testing.T) {
 	runners, err := SetupRunners(
 		t.Context(),
-		log.TestLogger(t),
 		&types.SSVShare{},
 		nil,
 		nil,


### PR DESCRIPTION
## Summary
- #2804 dropped `*zap.Logger` from `SetupRunners` but left the `TestSetupRunnersExporter` call site in `operator/validator/controller_test.go` unchanged.
- Lint has been failing on `stage` since that merge (`too many arguments in call to SetupRunners`).
- One-line deletion of the leftover `log.TestLogger(t),` arg.

## Test plan
- [x] `go build ./operator/validator/...`
- [x] CI lint job green