### PR TITLE
boole: p2p discovery, handle lossy topics->subnets mapping

### DIFF
--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -41,22 +41,22 @@ func (s Subnet) BooleTopic(networkName string) string {
 }
 
 // ParseTopicSubnet extracts the subnet number from a full topic name.
-func ParseTopicSubnet(topicName string) (Subnet, error) {
+func ParseTopicSubnet(topicName string) (s Subnet, boole bool, err error) {
 	if strings.HasPrefix(topicName, alanTopicPrefix+".") {
 		trimmed := strings.TrimPrefix(topicName, alanTopicPrefix+".")
 		subnet, err := strconv.ParseUint(trimmed, 10, 64)
-		return Subnet(subnet), err
+		return Subnet(subnet), false, err
 	}
 	if strings.HasPrefix(topicName, topicRoot+"/") {
 		remainder := strings.TrimPrefix(topicName, topicRoot+"/")
 		parts := strings.SplitN(remainder, "/", 3)
 		if len(parts) != 3 || parts[1] != booleTopicFork || parts[2] == "" {
-			return 0, fmt.Errorf("invalid topic format: %s", topicName)
+			return 0, false, fmt.Errorf("invalid topic format: %s", topicName)
 		}
 		subnet, err := strconv.ParseUint(parts[2], 10, 64)
-		return Subnet(subnet), err
+		return Subnet(subnet), true, err
 	}
-	return 0, fmt.Errorf("invalid topic format: %s", topicName)
+	return 0, false, fmt.Errorf("invalid topic format: %s", topicName)
 }
 
 // BooleCommitteeSubnet returns the subnet for the given committee calculated as (lowestHash % bigIntSubnetsCount).

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -112,6 +112,64 @@ func TestAlanCommitteeSubnet(t *testing.T) {
 	}
 }
 
+func TestParseTopicSubnet(t *testing.T) {
+	tests := []struct {
+		name           string
+		topic          string
+		expectedSubnet Subnet
+		expectedBoole  bool
+		expectedErr    bool
+	}{
+		{
+			name:           "alan topic",
+			topic:          Subnet(12).AlanTopic(),
+			expectedSubnet: 12,
+			expectedBoole:  false,
+		},
+		{
+			name:           "boole topic",
+			topic:          Subnet(42).BooleTopic("mainnet"),
+			expectedSubnet: 42,
+			expectedBoole:  true,
+		},
+		{
+			name:        "invalid alan subnet",
+			topic:       "ssv.v2.not-a-subnet",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid boole fork segment",
+			topic:       "/ssv/mainnet/alan/42",
+			expectedErr: true,
+		},
+		{
+			name:        "missing boole subnet",
+			topic:       "/ssv/mainnet/boole/",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid topic root",
+			topic:       "/other/mainnet/boole/42",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subnet, boole, err := ParseTopicSubnet(test.topic)
+			if test.expectedErr {
+				require.Error(t, err)
+				require.False(t, boole)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expectedSubnet, subnet)
+			require.Equal(t, test.expectedBoole, boole)
+		})
+	}
+}
+
 func TestSubnetsParsing(t *testing.T) {
 	subtests := []struct {
 		name        string
@@ -129,7 +187,7 @@ func TestSubnetsParsing(t *testing.T) {
 			false,
 		},
 		{
-			"wrong size",
+			"without 0x prefix",
 			"57b080fffd743d9878dc41a184ab1600",
 			false,
 		},

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -759,117 +759,178 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 // for the given peers.
 //
 // The peer-scores are calculated based on:
-//   - ownSubnets is the desired set of subnets we want to be connected to
-//   - ownSubnetPeers is our own currently connected peer count per subnet across all
-//     peers in our topic mesh
-//   - peerSubnets tracks all the subnets each of our peers is connected to
+//   - ownAlanSubnets / ownBooleSubnets: subnets we're subscribed to, per-fork.
+//     During the Boole-fork transition both sets may be populated.
+//   - ownSubnetPeers: our currently connected peer count per (fork, subnet) across
+//     all peers in our topic mesh. Alan-N and Boole-N are tracked separately since
+//     they are distinct gossipsub topics even though they share the subnet index.
+//   - peerObservedSubnets: each peer's observed Alan/Boole participation from our
+//     own topic mesh (precise, unlike the ENR bitfield).
 //
 // Algo:
-//   - calculate (take snapshot of) ownSubnets, ownSubnetPeers, peerSubnets
-//   - for each candidate peer we need to score:
-//   - calculate subnetPeersExcluding (currently connected subnets IF that candidate peer is excluded/disconnected)
-//   - use SubnetPeers.Score to calculate the final peer-score for each peer (based on: subnetPeersExcluding, desired
-//     set of subnets, subnets this peer is connected to)
+//   - snapshot ownAlanSubnets, ownBooleSubnets, ownSubnetPeers, peerObservedSubnets
+//   - for each candidate peer:
+//   - build subnetPeersExcluding by decrementing the (fork, subnet) slots the peer actually serves
+//   - Score the peer against the excluding-counts
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
-	ownSubnets := n.SubscribedSubnets()
+	ownAlanSubnets, ownBooleSubnets := n.subscribedSubnetsForCurrentEpoch()
 	ownSubnetPeers := newSubnetPeers()
-	peerSubnets := make(map[peer.ID]commons.Subnets)
+
+	// peerPresence tracks a peer's observed Alan/Boole participation from our own
+	// topic mesh. Unlike the ENR subnet bitfield (a union of Alan and Boole that
+	// can't be disambiguated), this is precise — we know which topics we've seen
+	// the peer on.
+	type peerPresence struct {
+		alan  commons.Subnets
+		boole commons.Subnets
+	}
+	peerObservedSubnets := make(map[peer.ID]peerPresence)
 
 	for topic, peers := range n.PeersByTopic() {
-		subnet, ok := n.topicSubnet(topic)
-		if !ok {
+		subnet, isBoole, err := n.topicSubnet(topic)
+		if err != nil {
+			n.logger.Error("failed to convert topic to subnet",
+				zap.String("topic", topic),
+				zap.Error(err),
+			)
 			continue
 		}
 
-		ownSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
+		if isBoole {
+			ownSubnetPeers.boole[subnet] = uint16(len(peers)) //nolint: gosec
+		} else {
+			ownSubnetPeers.alan[subnet] = uint16(len(peers)) //nolint: gosec
+		}
+
 		for _, peerID := range peers {
-			peerContribution := peerSubnets[peerID]
-			peerContribution.Set(subnet)
-			peerSubnets[peerID] = peerContribution
+			presence := peerObservedSubnets[peerID]
+			if isBoole {
+				presence.boole.Set(subnet)
+			} else {
+				presence.alan.Set(subnet)
+			}
+			peerObservedSubnets[peerID] = presence
 		}
 	}
 
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
-		pSubnets := peerSubnets[peerID]
+		presence := peerObservedSubnets[peerID]
 		subnetPeersExcluding := ownSubnetPeers
-		for subnet := range ownSubnetPeers {
-			if pSubnets.IsSet(commons.Subnet(subnet)) { //nolint: gosec
-				// This subtraction here should never result into an underflow in practice (by construction),
-				// clamp to zero just in case that invariant is ever broken by a future change.
-				if subnetPeersExcluding[subnet] >= 1 {
-					subnetPeersExcluding[subnet] -= 1
-				}
+		for subnet := commons.Subnet(0); subnet < commons.Subnet(commons.SubnetsCount); subnet++ {
+			// Clamp to zero just in case the invariant "peer-observed implies count >= 1"
+			// is ever broken by a future change.
+			if presence.alan.IsSet(subnet) && subnetPeersExcluding.alan[subnet] >= 1 {
+				subnetPeersExcluding.alan[subnet] -= 1
+			}
+			if presence.boole.IsSet(subnet) && subnetPeersExcluding.boole[subnet] >= 1 {
+				subnetPeersExcluding.boole[subnet] -= 1
 			}
 		}
 
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
+		scores[peerID] = subnetPeersExcluding.Score(ownAlanSubnets, ownBooleSubnets, presence.alan, presence.boole)
 	}
 	return scores
 }
 
 // topicSubnet parses a topic name into a subnet index and logs malformed topics.
-func (n *p2pNetwork) topicSubnet(topic string) (commons.Subnet, bool) {
-	subnet, err := commons.ParseTopicSubnet(topic)
+func (n *p2pNetwork) topicSubnet(topic string) (s commons.Subnet, boole bool, err error) {
+	s, boole, err = commons.ParseTopicSubnet(topic)
 	if err != nil {
-		n.logger.Error("failed to parse topic",
-			zap.String("topic", topic),
-			zap.Error(err))
-		return 0, false
+		return 0, false, fmt.Errorf("parse topic subnet: %w", err)
 	}
-	if subnet >= commons.SubnetsCount {
-		n.logger.Error("invalid topic",
-			zap.String("topic", topic),
-			fields.Subnet(subnet))
-		return 0, false
+	if s >= commons.SubnetsCount {
+		return 0, false, fmt.Errorf("subnet must be in range [0, %d], got subnet: %d", commons.SubnetsCount, s)
 	}
-	return subnet, true
+	return s, boole, nil
 }
 
-// SubnetPeers maps subnets to the number of peers connected to each of those subnets.
-type SubnetPeers [commons.SubnetsCount]uint16
+// SubnetPeers tracks peer counts per (fork, subnet) across our gossipsub topic mesh.
+//
+// During the Boole-fork transition the same subnet index (0..127) maps to two
+// distinct gossipsub topics — Alan (ssv.v2.N) and Boole (/ssv/<net>/boole/N) —
+// which have independent peer populations. Merging the counts (as a prior
+// implementation did via `+=`) hides a dead Alan-N behind a healthy Boole-N (or
+// vice versa) and misguides scoring. Tracking per-fork lets `Score` credit
+// each (fork, subnet) we care about separately. After the transition the Alan
+// side naturally stays zero for all new peers.
+type SubnetPeers struct {
+	alan  [commons.SubnetsCount]uint16
+	boole [commons.SubnetsCount]uint16
+}
 
 func newSubnetPeers() SubnetPeers {
 	return SubnetPeers{}
 }
 
-func newSubnetPeersFromSubnets(s commons.Subnets) SubnetPeers {
+// newSubnetPeersFromPeerENR builds the optimistic contribution a newly-connected
+// peer would make, given their advertised ENR subnet bitfield. The ENR is a union
+// of the peer's Alan and Boole subnets (indistinguishable), so for each bit set
+// we bump exactly the sides we are subscribed to — the peer might help with
+// either or both, and we only ever track topics we actually care about.
+func newSubnetPeersFromPeerENR(peerENR, ourAlan, ourBoole commons.Subnets) SubnetPeers {
 	var result SubnetPeers
-	for _, subnet := range s.SubnetList() {
-		result[subnet] = 1
+	for _, subnet := range peerENR.SubnetList() {
+		if ourAlan.IsSet(subnet) {
+			result.alan[subnet] = 1
+		}
+		if ourBoole.IsSet(subnet) {
+			result.boole[subnet] = 1
+		}
 	}
 	return result
 }
 
 func (a SubnetPeers) Add(b SubnetPeers) SubnetPeers {
 	var sum SubnetPeers
-	for i := range a {
-		sum[i] = a[i] + b[i]
+	for i := range a.alan {
+		sum.alan[i] = a.alan[i] + b.alan[i]
+		sum.boole[i] = a.boole[i] + b.boole[i]
 	}
 	return sum
 }
 
-// Score estimates how many valuable subnets the given peer would contribute.
-// Param ours defines subnets we are interested in.
-// Param theirs defines subnets given peer has to offer.
-func (a SubnetPeers) Score(ours, theirs commons.Subnets) float64 {
+// Score estimates the value of a peer's (potential or observed) contribution to
+// our topic mesh, summed across every (fork, subnet) pair we are subscribed to
+// and the peer participates in.
+//
+// Parameters:
+//   - ourAlan, ourBoole: subnets we are subscribed to, per-fork.
+//   - theirAlan, theirBoole: the peer's participation per-fork.
+//     For discovery (ENR-based scoring) pass the ENR bitfield for both sides —
+//     a bit set in the ENR means the peer could be on Alan-N, Boole-N, or both,
+//     so we credit every side we care about.
+//     For trim scoring pass the peer's actually-observed Alan/Boole presence —
+//     this credits the peer precisely for the topics they serve.
+//
+// For each (fork, subnet) pair we are subscribed to AND the peer participates in,
+// the priority is based on how many other peers we have on that specific topic:
+// dead (0) > solo (1) > duo (2) > healthy (3+). Summed across pairs.
+func (a SubnetPeers) Score(ourAlan, ourBoole, theirAlan, theirBoole commons.Subnets) float64 {
 	const (
 		duoSubnetPriority  = 1
 		soloSubnetPriority = 4
 		deadSubnetPriority = 16
 	)
-	score := float64(0)
+	priority := func(count uint16) float64 {
+		switch count {
+		case 0:
+			return deadSubnetPriority
+		case 1:
+			return soloSubnetPriority
+		case 2:
+			return duoSubnetPriority
+		}
+		return 0
+	}
 
+	score := float64(0)
 	for subnet := commons.Subnet(0); subnet < commons.Subnet(commons.SubnetsCount); subnet++ {
-		if ours.IsSet(subnet) && theirs.IsSet(subnet) {
-			switch a[subnet] {
-			case 0:
-				score += deadSubnetPriority
-			case 1:
-				score += soloSubnetPriority
-			case 2:
-				score += duoSubnetPriority
-			}
+		if ourAlan.IsSet(subnet) && theirAlan.IsSet(subnet) {
+			score += priority(a.alan[subnet])
+		}
+		if ourBoole.IsSet(subnet) && theirBoole.IsSet(subnet) {
+			score += priority(a.boole[subnet])
 		}
 	}
 	return score
@@ -877,10 +938,11 @@ func (a SubnetPeers) Score(ours, theirs commons.Subnets) float64 {
 
 func (a SubnetPeers) String() string {
 	var result strings.Builder
-	for i, v := range a {
-		if v > 0 {
-			_, _ = fmt.Fprintf(&result, "%d:%d ", i, v)
+	for i := range a.alan {
+		if a.alan[i] == 0 && a.boole[i] == 0 {
+			continue
 		}
+		_, _ = fmt.Fprintf(&result, "%d:%d/%d ", i, a.alan[i], a.boole[i])
 	}
 	return strings.TrimSuffix(result.String(), " ")
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -730,117 +730,178 @@ func (n *p2pNetwork) getMaxPeers(topic string) int {
 // for the given peers.
 //
 // The peer-scores are calculated based on:
-//   - ownSubnets is the desired set of subnets we want to be connected to
-//   - ownSubnetPeers is our own currently connected peer count per subnet across all
-//     peers in our topic mesh
-//   - peerSubnets tracks all the subnets each of our peers is connected to
+//   - ownAlanSubnets / ownBooleSubnets: subnets we're subscribed to, per-fork.
+//     During the Boole-fork transition both sets may be populated.
+//   - ownSubnetPeers: our currently connected peer count per (fork, subnet) across
+//     all peers in our topic mesh. Alan-N and Boole-N are tracked separately since
+//     they are distinct gossipsub topics even though they share the subnet index.
+//   - peerObservedSubnets: each peer's observed Alan/Boole participation from our
+//     own topic mesh (precise, unlike the ENR bitfield).
 //
 // Algo:
-//   - calculate (take snapshot of) ownSubnets, ownSubnetPeers, peerSubnets
-//   - for each candidate peer we need to score:
-//   - calculate subnetPeersExcluding (currently connected subnets IF that candidate peer is excluded/disconnected)
-//   - use SubnetPeers.Score to calculate the final peer-score for each peer (based on: subnetPeersExcluding, desired
-//     set of subnets, subnets this peer is connected to)
+//   - snapshot ownAlanSubnets, ownBooleSubnets, ownSubnetPeers, peerObservedSubnets
+//   - for each candidate peer:
+//   - build subnetPeersExcluding by decrementing the (fork, subnet) slots the peer actually serves
+//   - Score the peer against the excluding-counts
 func (n *p2pNetwork) buildPeerTrimScores(peerIDs []peer.ID) map[peer.ID]float64 {
-	ownSubnets := n.SubscribedSubnets()
+	ownAlanSubnets, ownBooleSubnets := n.subscribedSubnetsForCurrentEpoch()
 	ownSubnetPeers := newSubnetPeers()
-	peerSubnets := make(map[peer.ID]commons.Subnets)
+
+	// peerPresence tracks a peer's observed Alan/Boole participation from our own
+	// topic mesh. Unlike the ENR subnet bitfield (a union of Alan and Boole that
+	// can't be disambiguated), this is precise — we know which topics we've seen
+	// the peer on.
+	type peerPresence struct {
+		alan  commons.Subnets
+		boole commons.Subnets
+	}
+	peerObservedSubnets := make(map[peer.ID]peerPresence)
 
 	for topic, peers := range n.PeersByTopic() {
-		subnet, ok := n.topicSubnet(topic)
-		if !ok {
+		subnet, isBoole, err := n.topicSubnet(topic)
+		if err != nil {
+			n.logger.Error("failed to convert topic to subnet",
+				zap.String("topic", topic),
+				zap.Error(err),
+			)
 			continue
 		}
 
-		ownSubnetPeers[subnet] = uint16(len(peers)) //nolint: gosec
+		if isBoole {
+			ownSubnetPeers.boole[subnet] = uint16(len(peers)) //nolint: gosec
+		} else {
+			ownSubnetPeers.alan[subnet] = uint16(len(peers)) //nolint: gosec
+		}
+
 		for _, peerID := range peers {
-			peerContribution := peerSubnets[peerID]
-			peerContribution.Set(subnet)
-			peerSubnets[peerID] = peerContribution
+			presence := peerObservedSubnets[peerID]
+			if isBoole {
+				presence.boole.Set(subnet)
+			} else {
+				presence.alan.Set(subnet)
+			}
+			peerObservedSubnets[peerID] = presence
 		}
 	}
 
 	scores := make(map[peer.ID]float64, len(peerIDs))
 	for _, peerID := range peerIDs {
-		pSubnets := peerSubnets[peerID]
+		presence := peerObservedSubnets[peerID]
 		subnetPeersExcluding := ownSubnetPeers
-		for subnet := range ownSubnetPeers {
-			if pSubnets.IsSet(commons.Subnet(subnet)) { //nolint: gosec
-				// This subtraction here should never result into an underflow in practice (by construction),
-				// clamp to zero just in case that invariant is ever broken by a future change.
-				if subnetPeersExcluding[subnet] >= 1 {
-					subnetPeersExcluding[subnet] -= 1
-				}
+		for subnet := commons.Subnet(0); subnet < commons.Subnet(commons.SubnetsCount); subnet++ {
+			// Clamp to zero just in case the invariant "peer-observed implies count >= 1"
+			// is ever broken by a future change.
+			if presence.alan.IsSet(subnet) && subnetPeersExcluding.alan[subnet] >= 1 {
+				subnetPeersExcluding.alan[subnet] -= 1
+			}
+			if presence.boole.IsSet(subnet) && subnetPeersExcluding.boole[subnet] >= 1 {
+				subnetPeersExcluding.boole[subnet] -= 1
 			}
 		}
 
-		scores[peerID] = subnetPeersExcluding.Score(ownSubnets, pSubnets)
+		scores[peerID] = subnetPeersExcluding.Score(ownAlanSubnets, ownBooleSubnets, presence.alan, presence.boole)
 	}
 	return scores
 }
 
 // topicSubnet parses a topic name into a subnet index and logs malformed topics.
-func (n *p2pNetwork) topicSubnet(topic string) (commons.Subnet, bool) {
-	subnet, err := commons.ParseTopicSubnet(topic)
+func (n *p2pNetwork) topicSubnet(topic string) (s commons.Subnet, boole bool, err error) {
+	s, boole, err = commons.ParseTopicSubnet(topic)
 	if err != nil {
-		n.logger.Error("failed to parse topic",
-			zap.String("topic", topic),
-			zap.Error(err))
-		return 0, false
+		return 0, false, fmt.Errorf("parse topic subnet: %w", err)
 	}
-	if subnet >= commons.SubnetsCount {
-		n.logger.Error("invalid topic",
-			zap.String("topic", topic),
-			fields.Subnet(subnet))
-		return 0, false
+	if s >= commons.SubnetsCount {
+		return 0, false, fmt.Errorf("subnet must be in range [0, %d], got subnet: %d", commons.SubnetsCount, s)
 	}
-	return subnet, true
+	return s, boole, nil
 }
 
-// SubnetPeers maps subnets to the number of peers connected to each of those subnets.
-type SubnetPeers [commons.SubnetsCount]uint16
+// SubnetPeers tracks peer counts per (fork, subnet) across our gossipsub topic mesh.
+//
+// During the Boole-fork transition the same subnet index (0..127) maps to two
+// distinct gossipsub topics — Alan (ssv.v2.N) and Boole (/ssv/<net>/boole/N) —
+// which have independent peer populations. Merging the counts (as a prior
+// implementation did via `+=`) hides a dead Alan-N behind a healthy Boole-N (or
+// vice versa) and misguides scoring. Tracking per-fork lets `Score` credit
+// each (fork, subnet) we care about separately. After the transition the Alan
+// side naturally stays zero for all new peers.
+type SubnetPeers struct {
+	alan  [commons.SubnetsCount]uint16
+	boole [commons.SubnetsCount]uint16
+}
 
 func newSubnetPeers() SubnetPeers {
 	return SubnetPeers{}
 }
 
-func newSubnetPeersFromSubnets(s commons.Subnets) SubnetPeers {
+// newSubnetPeersFromPeerENR builds the optimistic contribution a newly-connected
+// peer would make, given their advertised ENR subnet bitfield. The ENR is a union
+// of the peer's Alan and Boole subnets (indistinguishable), so for each bit set
+// we bump exactly the sides we are subscribed to — the peer might help with
+// either or both, and we only ever track topics we actually care about.
+func newSubnetPeersFromPeerENR(peerENR, ourAlan, ourBoole commons.Subnets) SubnetPeers {
 	var result SubnetPeers
-	for _, subnet := range s.SubnetList() {
-		result[subnet] = 1
+	for _, subnet := range peerENR.SubnetList() {
+		if ourAlan.IsSet(subnet) {
+			result.alan[subnet] = 1
+		}
+		if ourBoole.IsSet(subnet) {
+			result.boole[subnet] = 1
+		}
 	}
 	return result
 }
 
 func (a SubnetPeers) Add(b SubnetPeers) SubnetPeers {
 	var sum SubnetPeers
-	for i := range a {
-		sum[i] = a[i] + b[i]
+	for i := range a.alan {
+		sum.alan[i] = a.alan[i] + b.alan[i]
+		sum.boole[i] = a.boole[i] + b.boole[i]
 	}
 	return sum
 }
 
-// Score estimates how many valuable subnets the given peer would contribute.
-// Param ours defines subnets we are interested in.
-// Param theirs defines subnets given peer has to offer.
-func (a SubnetPeers) Score(ours, theirs commons.Subnets) float64 {
+// Score estimates the value of a peer's (potential or observed) contribution to
+// our topic mesh, summed across every (fork, subnet) pair we are subscribed to
+// and the peer participates in.
+//
+// Parameters:
+//   - ourAlan, ourBoole: subnets we are subscribed to, per-fork.
+//   - theirAlan, theirBoole: the peer's participation per-fork.
+//     For discovery (ENR-based scoring) pass the ENR bitfield for both sides —
+//     a bit set in the ENR means the peer could be on Alan-N, Boole-N, or both,
+//     so we credit every side we care about.
+//     For trim scoring pass the peer's actually-observed Alan/Boole presence —
+//     this credits the peer precisely for the topics they serve.
+//
+// For each (fork, subnet) pair we are subscribed to AND the peer participates in,
+// the priority is based on how many other peers we have on that specific topic:
+// dead (0) > solo (1) > duo (2) > healthy (3+). Summed across pairs.
+func (a SubnetPeers) Score(ourAlan, ourBoole, theirAlan, theirBoole commons.Subnets) float64 {
 	const (
 		duoSubnetPriority  = 1
 		soloSubnetPriority = 4
 		deadSubnetPriority = 16
 	)
-	score := float64(0)
+	priority := func(count uint16) float64 {
+		switch count {
+		case 0:
+			return deadSubnetPriority
+		case 1:
+			return soloSubnetPriority
+		case 2:
+			return duoSubnetPriority
+		}
+		return 0
+	}
 
+	score := float64(0)
 	for subnet := commons.Subnet(0); subnet < commons.Subnet(commons.SubnetsCount); subnet++ {
-		if ours.IsSet(subnet) && theirs.IsSet(subnet) {
-			switch a[subnet] {
-			case 0:
-				score += deadSubnetPriority
-			case 1:
-				score += soloSubnetPriority
-			case 2:
-				score += duoSubnetPriority
-			}
+		if ourAlan.IsSet(subnet) && theirAlan.IsSet(subnet) {
+			score += priority(a.alan[subnet])
+		}
+		if ourBoole.IsSet(subnet) && theirBoole.IsSet(subnet) {
+			score += priority(a.boole[subnet])
 		}
 	}
 	return score
@@ -848,10 +909,11 @@ func (a SubnetPeers) Score(ours, theirs commons.Subnets) float64 {
 
 func (a SubnetPeers) String() string {
 	var result strings.Builder
-	for i, v := range a {
-		if v > 0 {
-			_, _ = fmt.Fprintf(&result, "%d:%d ", i, v)
+	for i := range a.alan {
+		if a.alan[i] == 0 && a.boole[i] == 0 {
+			continue
 		}
+		_, _ = fmt.Fprintf(&result, "%d:%d/%d ", i, a.alan[i], a.boole[i])
 	}
 	return strings.TrimSuffix(result.String(), " ")
 }

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -86,18 +86,30 @@ func (n *p2pNetwork) startDiscovery() error {
 			return
 		}
 
-		// Compute the number of peers we're connected to for each subnet.
-		ownSubnets := n.SubscribedSubnets()
+		// Compute the number of peers we're connected to per (fork, subnet).
+		// During the Boole-fork transition window Alan and Boole topics coexist for
+		// the same subnet index but have independent peer populations, so we track
+		// them separately to avoid a dead Alan-N topic hiding behind a healthy
+		// Boole-N (or vice versa).
+		ownAlanSubnets, ownBooleSubnets := n.subscribedSubnetsForCurrentEpoch()
 		currentSubnetPeers := newSubnetPeers()
 		for topic, peers := range n.PeersByTopic() {
-			subnet, ok := n.topicSubnet(topic)
-			if !ok {
+			subnet, isBoole, err := n.topicSubnet(topic)
+			if err != nil {
+				n.logger.Error("failed to convert topic to subnet",
+					zap.String("topic", topic),
+					zap.Error(err),
+				)
 				continue
 			}
-			currentSubnetPeers[uint64(subnet)] = uint16(len(peers)) //nolint: gosec
+			if isBoole {
+				currentSubnetPeers.boole[subnet] = uint16(len(peers)) //nolint: gosec
+			} else {
+				currentSubnetPeers.alan[subnet] = uint16(len(peers)) //nolint: gosec
+			}
 		}
 
-		poolStats := n.peerSelectionPoolStats(ownSubnets, currentSubnetPeers)
+		poolStats := n.peerSelectionPoolStats(ownAlanSubnets, ownBooleSubnets, currentSubnetPeers)
 
 		n.logger.Debug("selecting discovered peers", append([]zap.Field{
 			zap.Int("trimmed_recently_size", n.trimmedRecently.SlowLen()),
@@ -127,7 +139,14 @@ func (n *p2pNetwork) startDiscovery() error {
 				// - the more a peer has been tried, the less relevant it is (cooldown grows)
 				// - the more time has passed since the last connect attempt the more relevant peer is (waited grows)
 				peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-				peerScore, ready := peerSelectionScore(now, discoveredPeer, optimisticSubnetPeers, ownSubnets, peerSubnets)
+				peerScore, ready := peerSelectionScore(
+					now,
+					discoveredPeer,
+					optimisticSubnetPeers,
+					ownAlanSubnets,
+					ownBooleSubnets,
+					peerSubnets,
+				)
 				if !ready {
 					return true
 				}
@@ -147,7 +166,7 @@ func (n *p2pNetwork) startDiscovery() error {
 
 			// Add the selected(best) peer's subnets to pendingSubnetPeers to be used on the next iteration.
 			bestPeerSubnets, _ := n.PeersIndex().GetPeerSubnets(bestPeer.ID)
-			bestSubnetPeers := newSubnetPeersFromSubnets(bestPeerSubnets)
+			bestSubnetPeers := newSubnetPeersFromPeerENR(bestPeerSubnets, ownAlanSubnets, ownBooleSubnets)
 			pendingSubnetPeers = pendingSubnetPeers.Add(bestSubnetPeers)
 			peersToConnect[bestPeer.ID] = bestPeer
 
@@ -185,14 +204,19 @@ func (n *p2pNetwork) startDiscovery() error {
 	return nil
 }
 
+// peerSelectionScore scores a discovered peer for outbound-connection selection.
+// The peer's ENR bitfield is the union of their Alan and Boole subnets, so we pass
+// it as both sides to SubnetPeers.Score — a bit set in the peer's ENR means the
+// peer could be serving Alan-N, Boole-N, or both, and we credit them for each
+// side we ourselves care about.
 func peerSelectionScore(
 	now time.Time,
 	discoveredPeer discovery.DiscoveredPeer,
 	currentSubnetPeers SubnetPeers,
-	ownSubnets commons.Subnets,
+	ownAlanSubnets, ownBooleSubnets commons.Subnets,
 	peerSubnets commons.Subnets,
 ) (float64, bool) {
-	peerScore := currentSubnetPeers.Score(ownSubnets, peerSubnets)
+	peerScore := currentSubnetPeers.Score(ownAlanSubnets, ownBooleSubnets, peerSubnets, peerSubnets)
 	if discoveredPeer.Tries == 0 {
 		return peerScore, true
 	}
@@ -207,14 +231,14 @@ func peerSelectionScore(
 	return peerScore * peerRelevance * peerRelevance, true
 }
 
-func (n *p2pNetwork) peerSelectionPoolStats(ownSubnets commons.Subnets, currentSubnetPeers SubnetPeers) peerSelectionPoolStats {
+func (n *p2pNetwork) peerSelectionPoolStats(ownAlanSubnets, ownBooleSubnets commons.Subnets, currentSubnetPeers SubnetPeers) peerSelectionPoolStats {
 	var stats peerSelectionPoolStats
 	now := time.Now()
 	n.discoveredPeersPool.Range(func(peerID peer.ID, discoveredPeer discovery.DiscoveredPeer) bool {
 		stats.poolSize++
 
 		peerSubnets, _ := n.PeersIndex().GetPeerSubnets(peerID)
-		peerScore, ready := peerSelectionScore(now, discoveredPeer, currentSubnetPeers, ownSubnets, peerSubnets)
+		peerScore, ready := peerSelectionScore(now, discoveredPeer, currentSubnetPeers, ownAlanSubnets, ownBooleSubnets, peerSubnets)
 		if !ready {
 			stats.cooldownBlockedCandidates++
 			return true

--- a/network/p2p/p2p_discovery_test.go
+++ b/network/p2p/p2p_discovery_test.go
@@ -21,15 +21,35 @@ func createSubnets(activeSubnets ...commons.Subnet) commons.Subnets {
 	return subnets
 }
 
-// createSubnetPeers creates a SubnetPeers with the specified number of peers for each subnet
+// createSubnetPeers creates a SubnetPeers with the specified number of peers on the
+// Alan side of each subnet. Boole side stays zero. Use createBooleSubnetPeers or
+// createMixedSubnetPeers to populate the Boole side.
 func createSubnetPeers(peerCounts map[int]uint16) SubnetPeers {
 	var peers SubnetPeers
 	for subnet, count := range peerCounts {
 		if subnet >= 0 && subnet < commons.SubnetsCount {
-			peers[subnet] = count
+			peers.alan[subnet] = count
 		}
 	}
 	return peers
+}
+
+// createBooleSubnetPeers is the Boole-side counterpart to createSubnetPeers.
+func createBooleSubnetPeers(peerCounts map[int]uint16) SubnetPeers {
+	var peers SubnetPeers
+	for subnet, count := range peerCounts {
+		if subnet >= 0 && subnet < commons.SubnetsCount {
+			peers.boole[subnet] = count
+		}
+	}
+	return peers
+}
+
+// scoreAlanOnly helps legacy tests that were written pre-Boole: it treats the given
+// ours/theirs as Alan subnets only, which matches the semantic of the original
+// single-bitfield SubnetPeers.Score(ours, theirs) method.
+func scoreAlanOnly(a SubnetPeers, ours, theirs commons.Subnets) float64 {
+	return a.Score(ours, commons.ZeroSubnets, theirs, commons.ZeroSubnets)
 }
 
 func TestSubnetPeers_Add(t *testing.T) {
@@ -146,7 +166,7 @@ func TestSubnetPeers_Score_DeadSubnets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			score := ourSubnetPeers.Score(ourSubnets, tt.theirSubnets)
+			score := scoreAlanOnly(ourSubnetPeers, ourSubnets, tt.theirSubnets)
 			require.Equal(t, tt.expectedScore, score, tt.description)
 		})
 	}
@@ -227,7 +247,7 @@ func TestSubnetPeers_Score_MixedSubnets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			score := ourSubnetPeers.Score(ourSubnets, tt.theirSubnets)
+			score := scoreAlanOnly(ourSubnetPeers, ourSubnets, tt.theirSubnets)
 			require.Equal(t, tt.expectedScore, score, tt.description)
 		})
 	}
@@ -253,14 +273,14 @@ func TestSubnetPeers_Score_PeerSelection(t *testing.T) {
 	peerH := createSubnets(3, 4, 5) // Shares no subnets
 
 	// Calculate scores for each peer
-	scoreA := ourSubnetPeers.Score(ourSubnets, peerA)
-	scoreB := ourSubnetPeers.Score(ourSubnets, peerB)
-	scoreC := ourSubnetPeers.Score(ourSubnets, peerC)
-	scoreD := ourSubnetPeers.Score(ourSubnets, peerD)
-	scoreE := ourSubnetPeers.Score(ourSubnets, peerE)
-	scoreF := ourSubnetPeers.Score(ourSubnets, peerF)
-	scoreG := ourSubnetPeers.Score(ourSubnets, peerG)
-	scoreH := ourSubnetPeers.Score(ourSubnets, peerH)
+	scoreA := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerA)
+	scoreB := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerB)
+	scoreC := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerC)
+	scoreD := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerD)
+	scoreE := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerE)
+	scoreF := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerF)
+	scoreG := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerG)
+	scoreH := scoreAlanOnly(ourSubnetPeers, ourSubnets, peerH)
 
 	// Verify the peer selection priority
 	// Expected order: D/G (dead+solo) > E (dead+duo) > A (dead) > F (solo+duo) > B (solo) > C (duo) > H (none)
@@ -289,6 +309,8 @@ func TestSubnetPeers_Score_PeerSelection(t *testing.T) {
 }
 
 func TestSubnetPeers_String(t *testing.T) {
+	// Format: "subnet:alan/boole", printed for every subnet index that has a non-zero
+	// count on either side.
 	tests := []struct {
 		name     string
 		peers    SubnetPeers
@@ -300,19 +322,24 @@ func TestSubnetPeers_String(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "single subnet",
+			name:     "single subnet alan side",
 			peers:    createSubnetPeers(map[int]uint16{5: 3}),
-			expected: "5:3",
+			expected: "5:3/0",
 		},
 		{
-			name:     "multiple subnets",
+			name:     "multiple subnets alan side",
 			peers:    createSubnetPeers(map[int]uint16{1: 1, 5: 3, 10: 2}),
-			expected: "1:1 5:3 10:2",
+			expected: "1:1/0 5:3/0 10:2/0",
 		},
 		{
 			name:     "zero value subnets are not included",
 			peers:    createSubnetPeers(map[int]uint16{1: 0, 5: 3, 10: 0}),
-			expected: "5:3",
+			expected: "5:3/0",
+		},
+		{
+			name:     "mixed alan and boole",
+			peers:    createSubnetPeers(map[int]uint16{1: 2}).Add(createBooleSubnetPeers(map[int]uint16{1: 3, 5: 1})),
+			expected: "1:2/3 5:0/1",
 		},
 	}
 
@@ -324,8 +351,62 @@ func TestSubnetPeers_String(t *testing.T) {
 	}
 }
 
+// TestSubnetPeers_Score_BooleTransition covers the fork-transition case where
+// Alan-N and Boole-N share the subnet index but are independent gossipsub topics.
+// Before this refactor the two sides were summed, which hid a dead side behind a
+// healthy side and mis-scored peers.
+func TestSubnetPeers_Score_BooleTransition(t *testing.T) {
+	// We're in the prior window: subscribed to Alan-5, Alan-7, Boole-5, Boole-42.
+	ourAlan := createSubnets(5, 7)
+	ourBoole := createSubnets(5, 42)
+
+	// Alan-5 is dead (0 peers) while Boole-5 has 10 peers.
+	// Alan-7 has 1 peer; Boole-42 is dead.
+	peers := createSubnetPeers(map[int]uint16{5: 0, 7: 1}).
+		Add(createBooleSubnetPeers(map[int]uint16{5: 10, 42: 0}))
+
+	t.Run("peer advertising bit 5 is credited for dead Alan-5 even though Boole-5 is healthy", func(t *testing.T) {
+		// Peer ENR: bit 5. Could be Alan-5, Boole-5, or both.
+		peerENR := createSubnets(5)
+		// Credit: Alan-5 dead (+16) + Boole-5 healthy (0). Pre-refactor: sum=10 → no credit.
+		got := peers.Score(ourAlan, ourBoole, peerENR, peerENR)
+		require.Equal(t, 16.0, got, "dead Alan-5 must not be hidden by healthy Boole-5")
+	})
+
+	t.Run("peer advertising bit 42 is credited for dead Boole-42", func(t *testing.T) {
+		peerENR := createSubnets(42)
+		// Credit: Alan-42 not subscribed → skip; Boole-42 dead (+16).
+		got := peers.Score(ourAlan, ourBoole, peerENR, peerENR)
+		require.Equal(t, 16.0, got)
+	})
+
+	t.Run("peer advertising bit 7 is credited for solo Alan-7", func(t *testing.T) {
+		peerENR := createSubnets(7)
+		// Credit: Alan-7 solo (+4); Boole-7 not subscribed → skip.
+		got := peers.Score(ourAlan, ourBoole, peerENR, peerENR)
+		require.Equal(t, 4.0, got)
+	})
+
+	t.Run("peer covering multiple bits sums per-fork credits", func(t *testing.T) {
+		peerENR := createSubnets(5, 7, 42)
+		// 16 (Alan-5 dead) + 0 (Boole-5 healthy) + 4 (Alan-7 solo) + 16 (Boole-42 dead) = 36.
+		got := peers.Score(ourAlan, ourBoole, peerENR, peerENR)
+		require.Equal(t, 36.0, got)
+	})
+
+	t.Run("observed trim-side scoring credits only actually-served forks", func(t *testing.T) {
+		// Peer is observed on Alan-5 only (not Boole-5). Trim-scoring uses the precise
+		// observed participation rather than the ENR union — so we credit only Alan-5.
+		observedAlan := createSubnets(5)
+		observedBoole := commons.ZeroSubnets
+		got := peers.Score(ourAlan, ourBoole, observedAlan, observedBoole)
+		require.Equal(t, 16.0, got, "peer only on Alan-5 should not be credited for Boole-5")
+	})
+}
+
 func TestPeerSelectionScore(t *testing.T) {
-	ownSubnets := createSubnets(1)
+	ownAlanSubnets := createSubnets(1)
+	ownBooleSubnets := commons.ZeroSubnets
 	currentSubnetPeers := createSubnetPeers(map[int]uint16{1: 0})
 	peerSubnets := createSubnets(1)
 	now := time.Now()
@@ -334,7 +415,7 @@ func TestPeerSelectionScore(t *testing.T) {
 		score, ready := peerSelectionScore(now, discovery.DiscoveredPeer{
 			Tries:   1,
 			LastTry: now.Add(-peerSelectionRetryCooldownMin / 2),
-		}, currentSubnetPeers, ownSubnets, peerSubnets)
+		}, currentSubnetPeers, ownAlanSubnets, ownBooleSubnets, peerSubnets)
 		require.False(t, ready)
 		require.Zero(t, score)
 	})
@@ -343,7 +424,7 @@ func TestPeerSelectionScore(t *testing.T) {
 		score, ready := peerSelectionScore(now, discovery.DiscoveredPeer{
 			Tries:   2,
 			LastTry: now.Add(-45 * time.Second),
-		}, currentSubnetPeers, ownSubnets, peerSubnets)
+		}, currentSubnetPeers, ownAlanSubnets, ownBooleSubnets, peerSubnets)
 		require.True(t, ready)
 		require.Equal(t, 9.0, score)
 	})

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -278,7 +278,7 @@ func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.
 		}
 		if topicsCtrl != nil {
 			for _, topic := range topicsCtrl.Topics() {
-				subnet, err := commons.ParseTopicSubnet(topic)
+				subnet, _, err := commons.ParseTopicSubnet(topic)
 				if err != nil || subnet >= commons.SubnetsCount {
 					continue
 				}

--- a/network/peers/connections/conn_handler.go
+++ b/network/peers/connections/conn_handler.go
@@ -145,7 +145,7 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 				}
 			}
 
-			if !ch.sharesEnoughSubnets(conn) {
+			if !ch.inboundSharesEnoughSubnets(conn) {
 				return errors.New("peer doesn't share enough subnets")
 			}
 
@@ -232,7 +232,7 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 	}
 }
 
-func (ch *connHandler) sharesEnoughSubnets(conn libp2pnetwork.Conn) bool {
+func (ch *connHandler) inboundSharesEnoughSubnets(conn libp2pnetwork.Conn) bool {
 	pid := conn.RemotePeer()
 
 	peerSubnets, ok := ch.subnetsIndex.GetPeerSubnets(pid)
@@ -251,5 +251,13 @@ func (ch *connHandler) sharesEnoughSubnets(conn libp2pnetwork.Conn) bool {
 		zap.String("peer_subnets", peerSubnets.StringHumanReadable()),
 	)
 
+	// TODO: remove this comment as irrelevant past Boole-fork
+	// During Boole-fork transition period we are connected to Alan-topics and Boole-topics some of which can map
+	// onto the same subnet (by construction). This means we might be accepting inbound connections when we shouldn't
+	// be - it's not a big deal in practice since SSV nodes typically run well below their configured MaxPeers limit
+	// (meaning SSV nodes can afford connecting a bunch of extra useless peers). Exporter node running at MaxPeers
+	// limit might be affected by this to a higher extent, but it is not mission-critical to warrant a dedicated
+	// handling due to the Alan->Boole transition period lasting for ~1 epoch, and honest peers will stop participating
+	// in Alan topics after that - eventually the 1:1 mapping between Boole topic <-> subnet gets established.
 	return len(mySubnets.SharedSubnetsN(peerSubnets, 1)) == 1
 }

--- a/network/peers/connections/conn_handler_test.go
+++ b/network/peers/connections/conn_handler_test.go
@@ -373,19 +373,19 @@ func TestConnHandlerSharesEnoughSubnets(t *testing.T) {
 	}
 	conn := &testConn{remotePeer: pid}
 
-	require.False(t, handler.sharesEnoughSubnets(conn))
+	require.False(t, handler.inboundSharesEnoughSubnets(conn))
 
 	peerSubnets := commons.ZeroSubnets
 	peerSubnets.Set(2)
 	subnetsIndex.UpdatePeerSubnets(pid, peerSubnets)
-	require.True(t, handler.sharesEnoughSubnets(conn))
+	require.True(t, handler.inboundSharesEnoughSubnets(conn))
 
 	mySubnets := commons.ZeroSubnets
 	mySubnets.Set(3)
 	handler.subnetsProvider = func() commons.Subnets { return mySubnets }
-	require.False(t, handler.sharesEnoughSubnets(conn))
+	require.False(t, handler.inboundSharesEnoughSubnets(conn))
 
 	mySubnets.Set(2)
 	handler.subnetsProvider = func() commons.Subnets { return mySubnets }
-	require.True(t, handler.sharesEnoughSubnets(conn))
+	require.True(t, handler.inboundSharesEnoughSubnets(conn))
 }

--- a/network/topics/scoring.go
+++ b/network/topics/scoring.go
@@ -261,7 +261,7 @@ func formatInvalidMessageStats(filtered []*topicScoreSnapshot) string {
 			b.WriteString(" ")
 		}
 		label := snapshot.topic
-		if subnet, err := commons.ParseTopicSubnet(snapshot.topic); err == nil {
+		if subnet, _, err := commons.ParseTopicSubnet(snapshot.topic); err == nil {
 			label = strconv.FormatUint(uint64(subnet), 10)
 		}
 		fmt.Fprintf(


### PR DESCRIPTION
`SubnetPeers` was split to track Alan and Boole topic peer counts independently, using the `boole bool` from `topicSubnet` and `subscribedSubnetsForCurrentEpoch`'s split return.

**Key design decision — per-fork sum when scoring:**
For each ENR bit N the peer advertises, we credit them independently for *every side* of our subscription — Alan-N (if we care) plus Boole-N (if we care). Rationale:
- Per-fork sum: honest reflection that Alan-N and Boole-N are two distinct topics we need peers for. A peer advertising bit 5 *could* help either side; if both our sides are hungry, reward them for both.
- `min` would over-reward peers for help they might not deliver.

**Trim-side asymmetry:**
For trim scoring we have *precise* info (we observed the peer on specific topics), so we pass `(observedAlan, observedBoole)` separately — no over-crediting. For discovery-based scoring where ENR is ambiguous, we pass the same ENR bitfield as both sides.

Resolves https://github.com/ssvlabs/ssv-node-board/issues/959 / https://github.com/ssvlabs/ssv/issues/2740