### PR TITLE
Replace flaky test sleeps with explicit waits - T-ssv-047

### DIFF
--- a/eth/ethtest/eth_e2e_test.go
+++ b/eth/ethtest/eth_e2e_test.go
@@ -229,7 +229,16 @@ func TestEthExecLayer(t *testing.T) {
 
 		// Step 4 Liquidate Cluster
 		{
-			taskExecutor.EXPECT().LiquidateCluster(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			liquidatedDone := make(chan struct{}, 1)
+			taskExecutor.EXPECT().LiquidateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ethcommon.Address, []uint64, []*ssvtypes.SSVShare) error {
+					select {
+					case liquidatedDone <- struct{}{}:
+					default:
+					}
+					return nil
+				},
+			).AnyTimes()
 
 			clusterLiquidate := NewTestClusterLiquidatedInput(common)
 			clusterLiquidate.prepare([]*ClusterLiquidatedEventInput{
@@ -244,18 +253,11 @@ func TestEthExecLayer(t *testing.T) {
 			testEnv.CloseFollowDistance(&blockNum)
 
 			clusterID := ssvtypes.ComputeClusterIDHash(testAddrAlice, []uint64{1, 2, 3, 4})
-			require.Eventually(t, func() bool {
-				shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
-				if len(shares) != 5 {
-					return false
-				}
-				for _, s := range shares {
-					if !s.Liquidated {
-						return false
-					}
-				}
-				return true
-			}, asyncWaitTimeout, asyncPollTick)
+			select {
+			case <-liquidatedDone:
+			case <-time.After(asyncWaitTimeout):
+				t.Fatal("timed out waiting for cluster liquidation task")
+			}
 
 			shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
 			require.NotEmpty(t, shares)
@@ -268,7 +270,16 @@ func TestEthExecLayer(t *testing.T) {
 
 		// Step 5 Reactivate Cluster
 		{
-			taskExecutor.EXPECT().ReactivateCluster(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			reactivatedDone := make(chan struct{}, 1)
+			taskExecutor.EXPECT().ReactivateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ethcommon.Address, []uint64, []*ssvtypes.SSVShare) error {
+					select {
+					case reactivatedDone <- struct{}{}:
+					default:
+					}
+					return nil
+				},
+			).AnyTimes()
 
 			clusterID := ssvtypes.ComputeClusterIDHash(testAddrAlice, []uint64{1, 2, 3, 4})
 
@@ -292,18 +303,11 @@ func TestEthExecLayer(t *testing.T) {
 			clusterReactivated.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			require.Eventually(t, func() bool {
-				clusterShares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
-				if len(clusterShares) != 5 {
-					return false
-				}
-				for _, s := range clusterShares {
-					if s.Liquidated {
-						return false
-					}
-				}
-				return true
-			}, asyncWaitTimeout, asyncPollTick)
+			select {
+			case <-reactivatedDone:
+			case <-time.After(asyncWaitTimeout):
+				t.Fatal("timed out waiting for cluster reactivation task")
+			}
 
 			shares = nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
 			require.NotEmpty(t, shares)

--- a/eth/ethtest/eth_e2e_test.go
+++ b/eth/ethtest/eth_e2e_test.go
@@ -1,6 +1,7 @@
 package ethtest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/big"
@@ -27,6 +28,11 @@ var (
 
 // E2E tests for ETH package
 func TestEthExecLayer(t *testing.T) {
+	const (
+		asyncWaitTimeout = 15 * time.Second
+		asyncPollTick    = 50 * time.Millisecond
+	)
+
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
@@ -125,23 +131,14 @@ func TestEthExecLayer(t *testing.T) {
 	// Main difference between "online" events handling and syncing the historical (old) events
 	// is that here we have to check that the controller was triggered
 	t.Run("SyncOngoing happy flow", func(t *testing.T) {
+		syncCtx, syncCancel := context.WithCancel(ctx)
+		syncOngoingErrCh := make(chan error, 1)
 		go func() {
-			err = eventSyncer.SyncOngoing(ctx, lastHandledBlockNum+1)
-			require.NoError(t, err)
+			syncOngoingErrCh <- eventSyncer.SyncOngoing(syncCtx, lastHandledBlockNum+1)
 		}()
-
-		stopChan := make(chan struct{})
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-stopChan:
-					return
-				default:
-					time.Sleep(100 * time.Millisecond)
-				}
-			}
+		defer func() {
+			syncCancel()
+			require.NoError(t, <-syncOngoingErrCh)
 		}()
 
 		// Step 1: Add more validators
@@ -156,8 +153,10 @@ func TestEthExecLayer(t *testing.T) {
 			valAddInput.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait until the state is changed
-			time.Sleep(time.Millisecond * 5000)
+			require.Eventually(t, func() bool {
+				nextNonce, err := nodeStorage.GetNextNonce(nil, testAddrAlice)
+				return err == nil && nextNonce == expectedNonce && len(nodeStorage.Shares().List(nil)) == 7
+			}, asyncWaitTimeout, asyncPollTick)
 
 			nonce, err = nodeStorage.GetNextNonce(nil, testAddrAlice)
 			require.NoError(t, err)
@@ -187,8 +186,9 @@ func TestEthExecLayer(t *testing.T) {
 			valExit.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait to make sure the state is not changed
-			time.Sleep(time.Millisecond * 500)
+			require.Never(t, func() bool {
+				return len(nodeStorage.Shares().List(nil)) != 7
+			}, 500*time.Millisecond, asyncPollTick)
 
 			shares = nodeStorage.Shares().List(nil)
 			require.Equal(t, 7, len(shares))
@@ -212,8 +212,9 @@ func TestEthExecLayer(t *testing.T) {
 			valRemove.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait until the state is changed
-			time.Sleep(time.Millisecond * 5000)
+			require.Eventually(t, func() bool {
+				return len(nodeStorage.Shares().List(nil)) == 5
+			}, asyncWaitTimeout, asyncPollTick)
 
 			shares = nodeStorage.Shares().List(nil)
 			require.Equal(t, 5, len(shares))
@@ -242,10 +243,19 @@ func TestEthExecLayer(t *testing.T) {
 			clusterLiquidate.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait until the state is changed
-			time.Sleep(time.Millisecond * 5000)
-
 			clusterID := ssvtypes.ComputeClusterIDHash(testAddrAlice, []uint64{1, 2, 3, 4})
+			require.Eventually(t, func() bool {
+				shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
+				if len(shares) != 5 {
+					return false
+				}
+				for _, s := range shares {
+					if !s.Liquidated {
+						return false
+					}
+				}
+				return true
+			}, asyncWaitTimeout, asyncPollTick)
 
 			shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
 			require.NotEmpty(t, shares)
@@ -282,8 +292,18 @@ func TestEthExecLayer(t *testing.T) {
 			clusterReactivated.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait until the state is changed
-			time.Sleep(time.Millisecond * 5000)
+			require.Eventually(t, func() bool {
+				clusterShares := nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
+				if len(clusterShares) != 5 {
+					return false
+				}
+				for _, s := range clusterShares {
+					if s.Liquidated {
+						return false
+					}
+				}
+				return true
+			}, asyncWaitTimeout, asyncPollTick)
 
 			shares = nodeStorage.Shares().List(nil, registrystorage.ByClusterIDHash(clusterID))
 			require.NotEmpty(t, shares)
@@ -319,14 +339,14 @@ func TestEthExecLayer(t *testing.T) {
 			setFeeRecipient.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Wait until the state is changed
-			time.Sleep(time.Millisecond * 5000)
+			require.Eventually(t, func() bool {
+				feeRecipient, err := nodeStorage.GetFeeRecipient(testAddrAlice)
+				return err == nil && bytes.Equal(testAddrBob.Bytes(), feeRecipient[:])
+			}, asyncWaitTimeout, asyncPollTick)
 
 			feeRecipient, err := nodeStorage.GetFeeRecipient(testAddrAlice)
 			require.NoError(t, err)
 			require.Equal(t, testAddrBob.Bytes(), feeRecipient[:])
 		}
-
-		stopChan <- struct{}{}
 	})
 }

--- a/eth/ethtest/eth_e2e_test.go
+++ b/eth/ethtest/eth_e2e_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -138,7 +140,7 @@ func TestEthExecLayer(t *testing.T) {
 		}()
 		defer func() {
 			syncCancel()
-			require.NoError(t, <-syncOngoingErrCh)
+			assert.NoError(t, <-syncOngoingErrCh)
 		}()
 
 		// Step 1: Add more validators
@@ -153,14 +155,17 @@ func TestEthExecLayer(t *testing.T) {
 			valAddInput.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
+			var syncedNonce registrystorage.Nonce
 			require.Eventually(t, func() bool {
 				nextNonce, err := nodeStorage.GetNextNonce(nil, testAddrAlice)
-				return err == nil && nextNonce == expectedNonce && len(nodeStorage.Shares().List(nil)) == 7
+				if err != nil || nextNonce != expectedNonce || len(nodeStorage.Shares().List(nil)) != 7 {
+					return false
+				}
+				syncedNonce = nextNonce
+				return true
 			}, asyncWaitTimeout, asyncPollTick)
 
-			nonce, err = nodeStorage.GetNextNonce(nil, testAddrAlice)
-			require.NoError(t, err)
-			require.Equal(t, expectedNonce, nonce)
+			require.Equal(t, expectedNonce, syncedNonce)
 
 			lastBlockNum, err := testEnv.sim.Client().BlockByNumber(ctx, nil)
 			require.NoError(t, err)
@@ -232,13 +237,10 @@ func TestEthExecLayer(t *testing.T) {
 			liquidatedDone := make(chan struct{}, 1)
 			taskExecutor.EXPECT().LiquidateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ethcommon.Address, []uint64, []*ssvtypes.SSVShare) error {
-					select {
-					case liquidatedDone <- struct{}{}:
-					default:
-					}
+					liquidatedDone <- struct{}{}
 					return nil
 				},
-			).AnyTimes()
+			).Times(1)
 
 			clusterLiquidate := NewTestClusterLiquidatedInput(common)
 			clusterLiquidate.prepare([]*ClusterLiquidatedEventInput{
@@ -273,13 +275,10 @@ func TestEthExecLayer(t *testing.T) {
 			reactivatedDone := make(chan struct{}, 1)
 			taskExecutor.EXPECT().ReactivateCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ethcommon.Address, []uint64, []*ssvtypes.SSVShare) error {
-					select {
-					case reactivatedDone <- struct{}{}:
-					default:
-					}
+					reactivatedDone <- struct{}{}
 					return nil
 				},
-			).AnyTimes()
+			).Times(1)
 
 			clusterID := ssvtypes.ComputeClusterIDHash(testAddrAlice, []uint64{1, 2, 3, 4})
 
@@ -343,14 +342,17 @@ func TestEthExecLayer(t *testing.T) {
 			setFeeRecipient.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
+			var updatedFeeRecipient bellatrix.ExecutionAddress
 			require.Eventually(t, func() bool {
 				feeRecipient, err := nodeStorage.GetFeeRecipient(testAddrAlice)
-				return err == nil && bytes.Equal(testAddrBob.Bytes(), feeRecipient[:])
+				if err != nil || !bytes.Equal(testAddrBob.Bytes(), feeRecipient[:]) {
+					return false
+				}
+				updatedFeeRecipient = feeRecipient
+				return true
 			}, asyncWaitTimeout, asyncPollTick)
 
-			feeRecipient, err := nodeStorage.GetFeeRecipient(testAddrAlice)
-			require.NoError(t, err)
-			require.Equal(t, testAddrBob.Bytes(), feeRecipient[:])
+			require.Equal(t, testAddrBob.Bytes(), updatedFeeRecipient[:])
 		}
 	})
 }

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -234,13 +234,15 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			}
 		}
 
+		var peers []peerScore
 		require.Eventually(t, func() bool {
-			peers, ok := sortedPeerScores(node)
-			return ok && peerScoresMatchAnyOrder(peers, validOrders)
+			snapshot, ok := sortedPeerScores(node)
+			if ok && peerScoresMatchAnyOrder(snapshot, validOrders) {
+				peers = snapshot
+				return true
+			}
+			return false
 		}, 15*time.Second, 100*time.Millisecond, "node %d", node.Index)
-
-		peers, ok := sortedPeerScores(node)
-		require.True(t, ok)
 
 		// Print a pretty table of each node's peers and their scores.
 		defer func() {
@@ -262,6 +264,7 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			tbl.Render()
 		}()
 
+		require.NotEmpty(t, peers)
 		require.True(t, peerScoresMatchAnyOrder(peers, validOrders), "node %d, peers %v", node.Index, peers)
 	}
 }

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -194,31 +194,27 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert that the messages were distributed as expected.
-	time.Sleep(8 * time.Second)
-
-	interval := 100 * time.Millisecond
-	for i := 0; i < nodeCount; i++ {
-		// Messages from nodes broadcasting rejected role become rejected once score threshold is reached
-		if slices.Contains(messageTypesByNodeIndex[i], rejectedRole) {
-			continue
-		}
-
-		// better lock inside loop than wait interval locked
+	require.Eventually(t, func() bool {
 		mtx.Lock()
-		var errors []error
-		if roleBroadcasts[acceptedRole] != messageValidators[i].TotalAccepted {
-			errors = append(errors, fmt.Errorf("node %d accepted %d messages (expected %d)", i, messageValidators[i].TotalAccepted, roleBroadcasts[acceptedRole]))
+		defer mtx.Unlock()
+
+		for i := 0; i < nodeCount; i++ {
+			// Messages from nodes broadcasting rejected role become rejected once score threshold is reached.
+			if slices.Contains(messageTypesByNodeIndex[i], rejectedRole) {
+				continue
+			}
+			if roleBroadcasts[acceptedRole] != messageValidators[i].TotalAccepted {
+				return false
+			}
+			if roleBroadcasts[ignoredRole] != messageValidators[i].TotalIgnored {
+				return false
+			}
+			if roleBroadcasts[rejectedRole] != messageValidators[i].TotalRejected {
+				return false
+			}
 		}
-		if roleBroadcasts[ignoredRole] != messageValidators[i].TotalIgnored {
-			errors = append(errors, fmt.Errorf("node %d ignored %d messages (expected %d)", i, messageValidators[i].TotalIgnored, roleBroadcasts[ignoredRole]))
-		}
-		if roleBroadcasts[rejectedRole] != messageValidators[i].TotalRejected {
-			errors = append(errors, fmt.Errorf("node %d rejected %d messages (expected %d)", i, messageValidators[i].TotalRejected, roleBroadcasts[rejectedRole]))
-		}
-		mtx.Unlock()
-		require.Empty(t, errors)
-		time.Sleep(interval)
-	}
+		return true
+	}, 15*time.Second, 100*time.Millisecond)
 
 	// Assert that each node scores it's peers according to the following order:
 	// - node 0, (node 1 OR 3), (node 1 OR 3), node 2
@@ -238,19 +234,13 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			}
 		}
 
-		// Sort peers by their scores.
-		type peerScore struct {
-			index NodeIndex
-			score float64
-		}
-		peerScores := *node.PeerScores.Load()
-		peers := make([]peerScore, 0, len(peerScores))
-		for index, snapshot := range peerScores {
-			peers = append(peers, peerScore{index, snapshot.Score})
-		}
-		sort.Slice(peers, func(i, j int) bool {
-			return peers[i].score > peers[j].score
-		})
+		require.Eventually(t, func() bool {
+			peers, ok := sortedPeerScores(node)
+			return ok && peerScoresMatchAnyOrder(peers, validOrders)
+		}, 15*time.Second, 100*time.Millisecond, "node %d", node.Index)
+
+		peers, ok := sortedPeerScores(node)
+		require.True(t, ok)
 
 		// Print a pretty table of each node's peers and their scores.
 		defer func() {
@@ -272,24 +262,51 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			tbl.Render()
 		}()
 
-		// Assert that the peers are in one of the valid orders.
-		require.Equal(t, len(vNet.Nodes)-1, len(peers), "node %d", node.Index)
-		for i, validOrder := range validOrders {
-			valid := true
-			for j, peer := range peers {
-				if peer.index != validOrder[j] {
-					valid = false
-					break
-				}
-			}
-			if valid {
+		require.True(t, peerScoresMatchAnyOrder(peers, validOrders), "node %d, peers %v", node.Index, peers)
+	}
+}
+
+type peerScore struct {
+	index NodeIndex
+	score float64
+}
+
+func sortedPeerScores(node *VirtualNode) ([]peerScore, bool) {
+	peerScores := node.PeerScores.Load()
+	if peerScores == nil {
+		return nil, false
+	}
+
+	peers := make([]peerScore, 0, len(*peerScores))
+	for index, snapshot := range *peerScores {
+		peers = append(peers, peerScore{index, snapshot.Score})
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		return peers[i].score > peers[j].score
+	})
+
+	return peers, len(peers) > 0
+}
+
+func peerScoresMatchAnyOrder(peers []peerScore, validOrders [][]NodeIndex) bool {
+	for _, validOrder := range validOrders {
+		if len(peers) != len(validOrder) {
+			continue
+		}
+
+		valid := true
+		for i, peer := range peers {
+			if peer.index != validOrder[i] {
+				valid = false
 				break
 			}
-			if i == len(validOrders)-1 {
-				require.Fail(t, "invalid order", "node %d, peers %v", node.Index, peers)
-			}
+		}
+		if valid {
+			return true
 		}
 	}
+
+	return false
 }
 
 type MockMessageValidator struct {

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -490,21 +491,30 @@ func TestIssue1682(t *testing.T) {
 
 			m := New[string, validatorStatus]()
 			var wg sync.WaitGroup
+			var attempted sync.WaitGroup
+			start := make(chan struct{})
+			releaseSubscribed := make(chan struct{})
 			for _, cmtID := range cmtIDs {
 				n := 50 + randSeed().Intn(200)
 				for j := 0; j < n; j++ {
 					wg.Add(1)
-					go func() {
+					attempted.Add(1)
+					go func(cmtID string) {
 						defer wg.Done()
-						time.Sleep(time.Duration(randSeed().Intn(2000)) * time.Millisecond)
+						<-start
 						_, found := m.GetOrSet(cmtID, validatorStatusSubscribing)
-						time.Sleep(time.Duration(randSeed().Intn(200)) * time.Millisecond)
+						attempted.Done()
 						if !found {
+							<-releaseSubscribed
+							runtime.Gosched()
 							m.Set(cmtID, validatorStatusSubscribed)
 						}
-					}()
+					}(cmtID)
 				}
 			}
+			close(start)
+			attempted.Wait()
+			close(releaseSubscribed)
 
 			done := make(chan struct{})
 			go func() {

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -503,6 +503,7 @@ func TestIssue1682(t *testing.T) {
 						defer wg.Done()
 						<-start
 						_, found := m.GetOrSet(cmtID, validatorStatusSubscribing)
+						// `attempted` tracks the "reached GetOrSet" barrier, while `wg` still tracks full goroutine completion.
 						attempted.Done()
 						if !found {
 							<-releaseSubscribed

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -502,9 +502,12 @@ func TestIssue1682(t *testing.T) {
 					go func(cmtID string) {
 						defer wg.Done()
 						<-start
-						_, found := m.GetOrSet(cmtID, validatorStatusSubscribing)
+						var found bool
+						func() {
+							defer attempted.Done()
+							_, found = m.GetOrSet(cmtID, validatorStatusSubscribing)
+						}()
 						// `attempted` tracks the "reached GetOrSet" barrier, while `wg` still tracks full goroutine completion.
-						attempted.Done()
 						if !found {
 							<-releaseSubscribed
 							runtime.Gosched()


### PR DESCRIPTION
T-ssv-047

Issue summary:
This ticket tracks flaky and unnecessarily slow tests caused by sleep-based synchronization in the `ssv` test suite. The main offenders were fixed-duration waits in the ETH E2E and P2P validation tests, plus randomized sleep-based interleaving in the hashmap concurrency test.

Changes:
- replaced fixed sleeps in `eth/ethtest/eth_e2e_test.go` with `require.Eventually` and `require.Never` checks against the actual state transitions under test
- replaced the fixed post-broadcast wait in `network/p2p/p2p_validation_test.go` with condition-based polling for validator counters and peer-score ordering
- removed randomized sleeps from `utils/hashmap/hashmap_test.go` and used explicit concurrency coordination instead

Validation:
- `go test ./utils/hashmap -run TestIssue1682 -count=1`
- `go test ./eth/ethtest -run TestEthExecLayer -count=1`
- `go test ./network/p2p -run TestGetMaxPeers -count=1`
- `GOWORK=off go tool -modfile=tool.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run -v ./network/p2p ./eth/ethtest ./utils/hashmap`
- `go test ./network/p2p -run TestP2pNetwork_MessageValidation -count=1 -v -timeout 2m` still times out locally in mDNS peer discovery during virtual network setup, before the edited assertions run

Fixes - Fixes ssvlabs/ssv-node-board#936
