### PR TITLE
Improve beacon mock error-path coverage - T-ssv-050

### DIFF
--- a/beacon/goclient/error_paths_test.go
+++ b/beacon/goclient/error_paths_test.go
@@ -1,6 +1,7 @@
 package goclient
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -18,10 +19,10 @@ func Test_specForClient_errorPaths(t *testing.T) {
 	t.Parallel()
 
 	tt := []struct {
-		name     string
-		response mocks.Response
-		wantErr  string
-		timeout  time.Duration
+		name           string
+		response       mocks.Response
+		wantErr        string
+		requestTimeout time.Duration
 	}{
 		{
 			name: "rate limited",
@@ -31,7 +32,6 @@ func Test_specForClient_errorPaths(t *testing.T) {
 				mocks.WithHeader("Retry-After", "1"),
 			),
 			wantErr: "GET failed with status 429",
-			timeout: 100 * time.Millisecond,
 		},
 		{
 			name: "internal server error",
@@ -40,7 +40,6 @@ func Test_specForClient_errorPaths(t *testing.T) {
 				mocks.WithStatusCode(http.StatusInternalServerError),
 			),
 			wantErr: "GET failed with status 500",
-			timeout: 100 * time.Millisecond,
 		},
 		{
 			name: "timeout",
@@ -48,8 +47,8 @@ func Test_specForClient_errorPaths(t *testing.T) {
 				nil,
 				mocks.WithDelay(200*time.Millisecond),
 			),
-			wantErr: "context deadline exceeded",
-			timeout: 50 * time.Millisecond,
+			wantErr:        "context deadline exceeded",
+			requestTimeout: 50 * time.Millisecond,
 		},
 	}
 
@@ -66,9 +65,16 @@ func Test_specForClient_errorPaths(t *testing.T) {
 			defer server.Close()
 
 			client := &GoClient{log: zap.NewNop()}
-			provider := newHTTPService(t, server.URL, tc.timeout)
+			provider := newHTTPService(t, server.URL)
 
-			_, err := client.specForClient(t.Context(), provider)
+			ctx := t.Context()
+			if tc.requestTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tc.requestTimeout)
+				defer cancel()
+			}
+
+			_, err := client.specForClient(ctx, provider)
 			require.ErrorContains(t, err, tc.wantErr)
 		})
 	}
@@ -86,23 +92,26 @@ func Test_genesisForClient_malformedJSON(t *testing.T) {
 	defer server.Close()
 
 	client := &GoClient{log: zap.NewNop()}
-	provider := newHTTPService(t, server.URL, 100*time.Millisecond)
+	provider := newHTTPService(t, server.URL)
 
 	_, err := client.genesisForClient(t.Context(), provider)
 	require.ErrorContains(t, err, "invalid character")
 }
 
-func newHTTPService(t *testing.T, addr string, timeout time.Duration) *eth2clienthttp.Service {
+func newHTTPService(t *testing.T, addr string) *eth2clienthttp.Service {
 	t.Helper()
 
 	service, err := eth2clienthttp.New(
 		t.Context(),
 		eth2clienthttp.WithAddress(addr),
 		eth2clienthttp.WithLogLevel(zerolog.Disabled),
-		eth2clienthttp.WithTimeout(timeout),
+		eth2clienthttp.WithTimeout(time.Second),
 		eth2clienthttp.WithReducedMemoryUsage(true),
 	)
 	require.NoError(t, err)
 
-	return service.(*eth2clienthttp.Service)
+	provider := service.(*eth2clienthttp.Service)
+	require.Eventually(t, provider.IsActive, time.Second, 10*time.Millisecond)
+
+	return provider
 }

--- a/beacon/goclient/error_paths_test.go
+++ b/beacon/goclient/error_paths_test.go
@@ -101,7 +101,6 @@ func newHTTPService(t *testing.T, addr string, timeout time.Duration) *eth2clien
 		eth2clienthttp.WithLogLevel(zerolog.Disabled),
 		eth2clienthttp.WithTimeout(timeout),
 		eth2clienthttp.WithReducedMemoryUsage(true),
-		eth2clienthttp.WithAllowDelayedStart(true),
 	)
 	require.NoError(t, err)
 

--- a/beacon/goclient/error_paths_test.go
+++ b/beacon/goclient/error_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2clienthttp "github.com/attestantio/go-eth2-client/http"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func Test_specForClient_errorPaths(t *testing.T) {
 	tt := []struct {
 		name           string
 		response       mocks.Response
-		wantErr        string
+		wantStatusCode int
 		requestTimeout time.Duration
 	}{
 		{
@@ -31,7 +32,15 @@ func Test_specForClient_errorPaths(t *testing.T) {
 				mocks.WithStatusCode(http.StatusTooManyRequests),
 				mocks.WithHeader("Retry-After", "1"),
 			),
-			wantErr: "GET failed with status 429",
+			wantStatusCode: http.StatusTooManyRequests,
+		},
+		{
+			name: "service unavailable",
+			response: mocks.NewResponse(
+				json.RawMessage(`{"message":"temporarily unavailable"}`),
+				mocks.WithStatusCode(http.StatusServiceUnavailable),
+			),
+			wantStatusCode: http.StatusServiceUnavailable,
 		},
 		{
 			name: "internal server error",
@@ -39,15 +48,15 @@ func Test_specForClient_errorPaths(t *testing.T) {
 				json.RawMessage(`{"message":"boom"}`),
 				mocks.WithStatusCode(http.StatusInternalServerError),
 			),
-			wantErr: "GET failed with status 500",
+			wantStatusCode: http.StatusInternalServerError,
 		},
 		{
 			name: "timeout",
 			response: mocks.NewResponse(
 				nil,
-				mocks.WithDelay(200*time.Millisecond),
+				mocks.WithDelay(400*time.Millisecond),
 			),
-			wantErr:        "context deadline exceeded",
+			wantStatusCode: 0,
 			requestTimeout: 50 * time.Millisecond,
 		},
 	}
@@ -75,7 +84,12 @@ func Test_specForClient_errorPaths(t *testing.T) {
 			}
 
 			_, err := client.specForClient(ctx, provider)
-			require.ErrorContains(t, err, tc.wantErr)
+			if tc.wantStatusCode == 0 {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				return
+			}
+
+			assertAPIErrorStatusCode(t, err, tc.wantStatusCode)
 		})
 	}
 }
@@ -106,6 +120,8 @@ func newHTTPService(t *testing.T, addr string) *eth2clienthttp.Service {
 		eth2clienthttp.WithAddress(addr),
 		eth2clienthttp.WithLogLevel(zerolog.Disabled),
 		eth2clienthttp.WithTimeout(time.Second),
+		// Reduced memory usage skips eager spec/genesis fetches, which keeps the
+		// cache cold so these tests exercise the mocked HTTP responses directly.
 		eth2clienthttp.WithReducedMemoryUsage(true),
 	)
 	require.NoError(t, err)
@@ -114,4 +130,12 @@ func newHTTPService(t *testing.T, addr string) *eth2clienthttp.Service {
 	require.Eventually(t, provider.IsActive, time.Second, 10*time.Millisecond)
 
 	return provider
+}
+
+func assertAPIErrorStatusCode(t *testing.T, err error, wantStatusCode int) {
+	t.Helper()
+
+	var apiErr *eth2api.Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, wantStatusCode, apiErr.StatusCode)
 }

--- a/beacon/goclient/error_paths_test.go
+++ b/beacon/goclient/error_paths_test.go
@@ -1,0 +1,109 @@
+package goclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	eth2clienthttp "github.com/attestantio/go-eth2-client/http"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/beacon/goclient/mocks"
+)
+
+func Test_specForClient_errorPaths(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		response mocks.Response
+		wantErr  string
+		timeout  time.Duration
+	}{
+		{
+			name: "rate limited",
+			response: mocks.NewResponse(
+				json.RawMessage(`{"message":"rate limited"}`),
+				mocks.WithStatusCode(http.StatusTooManyRequests),
+				mocks.WithHeader("Retry-After", "1"),
+			),
+			wantErr: "GET failed with status 429",
+			timeout: 100 * time.Millisecond,
+		},
+		{
+			name: "internal server error",
+			response: mocks.NewResponse(
+				json.RawMessage(`{"message":"boom"}`),
+				mocks.WithStatusCode(http.StatusInternalServerError),
+			),
+			wantErr: "GET failed with status 500",
+			timeout: 100 * time.Millisecond,
+		},
+		{
+			name: "timeout",
+			response: mocks.NewResponse(
+				nil,
+				mocks.WithDelay(200*time.Millisecond),
+			),
+			wantErr: "context deadline exceeded",
+			timeout: 50 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := mocks.NewServerWithHandler(func(r *http.Request, resp mocks.Response) (mocks.Response, error) {
+				if r.URL.Path == specPath {
+					return tc.response, nil
+				}
+				return resp, nil
+			})
+			defer server.Close()
+
+			client := &GoClient{log: zap.NewNop()}
+			provider := newHTTPService(t, server.URL, tc.timeout)
+
+			_, err := client.specForClient(t.Context(), provider)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func Test_genesisForClient_malformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := mocks.NewServerWithHandler(func(r *http.Request, resp mocks.Response) (mocks.Response, error) {
+		if r.URL.Path == genesisPath {
+			return mocks.NewResponse(json.RawMessage(`malformed`)), nil
+		}
+		return resp, nil
+	})
+	defer server.Close()
+
+	client := &GoClient{log: zap.NewNop()}
+	provider := newHTTPService(t, server.URL, 100*time.Millisecond)
+
+	_, err := client.genesisForClient(t.Context(), provider)
+	require.ErrorContains(t, err, "invalid character")
+}
+
+func newHTTPService(t *testing.T, addr string, timeout time.Duration) *eth2clienthttp.Service {
+	t.Helper()
+
+	service, err := eth2clienthttp.New(
+		t.Context(),
+		eth2clienthttp.WithAddress(addr),
+		eth2clienthttp.WithLogLevel(zerolog.Disabled),
+		eth2clienthttp.WithTimeout(timeout),
+		eth2clienthttp.WithReducedMemoryUsage(true),
+		eth2clienthttp.WithAllowDelayedStart(true),
+	)
+	require.NoError(t, err)
+
+	return service.(*eth2clienthttp.Service)
+}

--- a/beacon/goclient/genesis_test.go
+++ b/beacon/goclient/genesis_test.go
@@ -110,28 +110,4 @@ func Test_genesisForClient(t *testing.T) {
 		require.Contains(t, err.Error(), "timed out awaiting Beacon config initialization") // node cannot initialize if it cannot get genesis
 		require.Nil(t, client)
 	})
-
-	t.Run("error", func(t *testing.T) {
-		mockServer := mocks.NewServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
-			if r.URL.Path == genesisPath {
-				return json.RawMessage(`malformed`), nil
-			}
-			return resp, nil
-		})
-		defer mockServer.Close()
-
-		client, err := New(
-			ctx,
-			logger,
-			Options{
-				BeaconConfig:   networkconfig.TestNetwork.Beacon,
-				BeaconNodeAddr: mockServer.URL,
-				CommonTimeout:  400 * time.Millisecond,
-				LongTimeout:    500 * time.Millisecond,
-			},
-		)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "timed out awaiting Beacon config initialization") // node cannot initialize if it cannot get genesis
-		require.Nil(t, client)
-	})
 }

--- a/beacon/goclient/mocks/server.go
+++ b/beacon/goclient/mocks/server.go
@@ -6,44 +6,142 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"time"
 )
 
 type requestCallback = func(r *http.Request, resp json.RawMessage) (json.RawMessage, error)
+type requestHandler = func(r *http.Request, resp Response) (Response, error)
+
+type Response struct {
+	StatusCode int
+	Body       json.RawMessage
+	Headers    http.Header
+	Delay      time.Duration
+}
+
+type ResponseOption func(*Response)
+
+func NewResponse(body json.RawMessage, opts ...ResponseOption) Response {
+	resp := Response{
+		StatusCode: http.StatusOK,
+		Body:       body,
+		Headers:    make(http.Header),
+	}
+	for _, opt := range opts {
+		opt(&resp)
+	}
+
+	return resp
+}
+
+func WithStatusCode(statusCode int) ResponseOption {
+	return func(resp *Response) {
+		resp.StatusCode = statusCode
+	}
+}
+
+func WithHeader(key, value string) ResponseOption {
+	return func(resp *Response) {
+		if resp.Headers == nil {
+			resp.Headers = make(http.Header)
+		}
+		resp.Headers.Set(key, value)
+	}
+}
+
+func WithDelay(delay time.Duration) ResponseOption {
+	return func(resp *Response) {
+		resp.Delay = delay
+	}
+}
 
 func NewServer(onRequestFn requestCallback) *httptest.Server {
+	return NewServerWithHandler(func(r *http.Request, resp Response) (Response, error) {
+		if onRequestFn == nil {
+			return resp, nil
+		}
+
+		body, err := onRequestFn(r, resp.Body)
+		if err != nil {
+			return Response{}, err
+		}
+		resp.Body = body
+		return resp, nil
+	})
+}
+
+func NewServerWithHandler(onRequestFn requestHandler) *httptest.Server {
 	mockResponses := ServerResponses()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp, ok := mockResponses[r.URL.Path]
-		if !ok {
-			panic(fmt.Sprintf("unexpected request: %s", r.URL.Path))
-		}
+		resp := responseForPath(mockResponses, r.URL.Path)
 
 		var err error
 		if onRequestFn != nil {
 			resp, err = onRequestFn(r, resp)
 			if err != nil {
-				panic(fmt.Sprintf("onRequestFn returned error: %v", err))
+				http.Error(w, fmt.Sprintf("onRequestFn returned error: %v", err), http.StatusInternalServerError)
+				return
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write(resp); err != nil {
-			panic(fmt.Sprintf("got error writing response: %v", err))
+		if resp.Delay > 0 {
+			time.Sleep(resp.Delay)
 		}
+
+		writeResponse(w, resp)
 	}))
+}
+
+func responseForPath(mockResponses map[string]json.RawMessage, path string) Response {
+	if resp, ok := mockResponses[path]; ok {
+		return NewResponse(resp)
+	}
+
+	return NewResponse(
+		json.RawMessage(fmt.Sprintf(`{"error":"unexpected request","path":%q}`, path)),
+		WithStatusCode(http.StatusNotFound),
+	)
+}
+
+func writeResponse(w http.ResponseWriter, resp Response) {
+	for key, values := range resp.Headers {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+
+	statusCode := resp.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+
+	w.WriteHeader(statusCode)
+	if len(resp.Body) == 0 {
+		return
+	}
+
+	_, _ = w.Write(resp.Body)
 }
 
 func ServerResponses() map[string]json.RawMessage {
 	var responses map[string]json.RawMessage
+
 	f, err := os.Open("./mocks/mock-beacon-responses.json")
+	if err != nil {
+		f, err = os.Open("./mock-beacon-responses.json")
+	}
+	if err != nil {
+		panic(fmt.Sprintf("os.Open returned error: %v", err))
+	}
 	defer func() {
 		_ = f.Close()
 	}()
 
-	if err != nil {
-		panic(fmt.Sprintf("os.Open returned error: %v", err))
-	}
 	err = json.NewDecoder(f).Decode(&responses)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't decode json file: %v", err))

--- a/beacon/goclient/mocks/server.go
+++ b/beacon/goclient/mocks/server.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -42,9 +44,6 @@ func WithStatusCode(statusCode int) ResponseOption {
 
 func WithHeader(key, value string) ResponseOption {
 	return func(resp *Response) {
-		if resp.Headers == nil {
-			resp.Headers = make(http.Header)
-		}
 		resp.Headers.Set(key, value)
 	}
 }
@@ -101,8 +100,16 @@ func responseForPath(mockResponses map[string]json.RawMessage, path string) Resp
 		return NewResponse(resp)
 	}
 
+	body, err := json.Marshal(map[string]string{
+		"error": "unexpected request",
+		"path":  path,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("json.Marshal returned error: %v", err))
+	}
+
 	return NewResponse(
-		json.RawMessage(fmt.Sprintf(`{"error":"unexpected request","path":%q}`, path)),
+		body,
 		WithStatusCode(http.StatusNotFound),
 	)
 }
@@ -120,7 +127,7 @@ func writeResponse(w http.ResponseWriter, resp Response) {
 
 	statusCode := resp.StatusCode
 	if statusCode == 0 {
-		statusCode = http.StatusOK
+		panic("response status code must be set")
 	}
 
 	w.WriteHeader(statusCode)
@@ -134,10 +141,11 @@ func writeResponse(w http.ResponseWriter, resp Response) {
 func ServerResponses() map[string]json.RawMessage {
 	var responses map[string]json.RawMessage
 
-	f, err := os.Open("./mocks/mock-beacon-responses.json")
-	if err != nil {
-		f, err = os.Open("./mock-beacon-responses.json")
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller returned no caller information")
 	}
+	f, err := os.Open(filepath.Join(filepath.Dir(filename), "mock-beacon-responses.json"))
 	if err != nil {
 		panic(fmt.Sprintf("os.Open returned error: %v", err))
 	}

--- a/beacon/goclient/mocks/server.go
+++ b/beacon/goclient/mocks/server.go
@@ -86,7 +86,10 @@ func NewServerWithHandler(onRequestFn requestHandler) *httptest.Server {
 		}
 
 		if resp.Delay > 0 {
-			time.Sleep(resp.Delay)
+			select {
+			case <-time.After(resp.Delay):
+			case <-r.Context().Done():
+			}
 		}
 
 		writeResponse(w, resp)

--- a/beacon/goclient/mocks/server_test.go
+++ b/beacon/goclient/mocks/server_test.go
@@ -1,0 +1,75 @@
+package mocks
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerWithHandler(t *testing.T) {
+	t.Run("unexpected requests return not found", func(t *testing.T) {
+		server := NewServer(nil)
+		defer server.Close()
+
+		resp, err := http.Get(server.URL + "/unexpected")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		require.JSONEq(t, `{"error":"unexpected request","path":"/unexpected"}`, string(body))
+	})
+
+	t.Run("custom responses support status headers and delay", func(t *testing.T) {
+		server := NewServerWithHandler(func(r *http.Request, resp Response) (Response, error) {
+			if r.URL.Path == "/eth/v1/beacon/genesis" {
+				return NewResponse(
+					json.RawMessage(`malformed`),
+					WithStatusCode(http.StatusTooManyRequests),
+					WithHeader("Retry-After", "1"),
+					WithDelay(25*time.Millisecond),
+				), nil
+			}
+
+			return resp, nil
+		})
+		defer server.Close()
+
+		start := time.Now()
+		resp, err := http.Get(server.URL + "/eth/v1/beacon/genesis")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, time.Since(start), 25*time.Millisecond)
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+		require.Equal(t, "1", resp.Header.Get("Retry-After"))
+		require.Equal(t, "malformed", string(body))
+	})
+
+	t.Run("callback errors return internal server error", func(t *testing.T) {
+		server := NewServerWithHandler(func(r *http.Request, resp Response) (Response, error) {
+			return Response{}, errors.New("boom")
+		})
+		defer server.Close()
+
+		resp, err := http.Get(server.URL + "/eth/v1/config/spec")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Contains(t, string(body), "onRequestFn returned error: boom")
+	})
+}


### PR DESCRIPTION
T-ssv-050

Original ticket summary:
The shared beacon mock in `beacon/goclient/mocks/server.go` only returned happy-path JSON and panicked on unexpected requests, which left `429`, `500`, malformed JSON, and timeout handling effectively untested.

Changes:
- extended the shared beacon mock to support configurable status codes, headers, delayed responses, and deterministic error responses for unexpected paths
- added focused tests for the mock server itself and beacon client error paths covering `429`, `500`, malformed JSON, and timeout behavior

Fixes - Fixes ssvlabs/ssv-node-board#939
