### PR TITLE
identity/store: rollback p2p network key storage to plaintext

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -1119,12 +1119,12 @@ func setupSSVNetwork(logger *zap.Logger) (*networkconfig.SSV, error) {
 }
 
 func setupP2P(ctx context.Context, logger *zap.Logger, db basedb.Database, exporterEnabled bool, operatorPrivKey keys.OperatorPrivateKey, signerClient *ssvsigner.Client) network.P2PNetwork {
-	protectFn, unprotectFn, err := decideNetworkKeyProtectors(ctx, logger, db, exporterEnabled, operatorPrivKey, signerClient)
+	_, unprotectFn, err := decideNetworkKeyProtectors(ctx, logger, db, exporterEnabled, operatorPrivKey, signerClient)
 	if err != nil {
 		logger.Fatal("failed to decide p2p network key protection", zap.Error(err))
 	}
 
-	istore := ssv_identity.NewIdentityStore(logger, db, protectFn, unprotectFn)
+	istore := ssv_identity.NewIdentityStore(logger, db, unprotectFn)
 	netPrivKey, err := istore.SetupNetworkKey(ctx, cfg.NetworkPrivateKey)
 	if err != nil {
 		logger.Fatal("failed to setup network private key", zap.Error(err))

--- a/identity/store.go
+++ b/identity/store.go
@@ -37,7 +37,6 @@ type Store interface {
 type identityStore struct {
 	logger      *zap.Logger
 	db          basedb.Database
-	protectFn   func(ctx context.Context, plaintext []byte) ([]byte, error)
 	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error)
 }
 
@@ -45,13 +44,12 @@ type identityStore struct {
 func NewIdentityStore(
 	logger *zap.Logger,
 	db basedb.Database,
-	protectFn func(ctx context.Context, plaintext []byte) ([]byte, error),
+	_ func(ctx context.Context, plaintext []byte) ([]byte, error),
 	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error),
 ) Store {
 	es := identityStore{
 		logger:      logger.Named(log.NameP2PStorage),
 		db:          db,
-		protectFn:   protectFn,
 		unprotectFn: unprotectFn,
 	}
 	return &es
@@ -112,17 +110,6 @@ func (s identityStore) SetupNetworkKey(ctx context.Context, skEncoded string) (*
 	return privateKey, s.saveNetworkKeyPlaintext(privateKey)
 }
 
-func (s identityStore) saveNetworkKey(ctx context.Context, privateKey *ecdsa.PrivateKey) error {
-	protectedValue, err := encodeNetworkKey(ctx, privateKey, s.protectFn)
-	if err != nil {
-		return fmt.Errorf("failed to protect private key: %w", err)
-	}
-	if err := s.db.Set(prefix, netKeyPrefix, protectedValue); err != nil {
-		return fmt.Errorf("failed to save to db: %w", err)
-	}
-	return nil
-}
-
 func (s identityStore) saveNetworkKeyPlaintext(privateKey *ecdsa.PrivateKey) error {
 	if err := s.db.Set(prefix, netKeyPrefix, gcrypto.FromECDSA(privateKey)); err != nil {
 		return fmt.Errorf("failed to save to db: %w", err)
@@ -139,25 +126,6 @@ func HasEncryptedNetworkKey(db basedb.Database) (bool, error) {
 	}
 
 	return bytes.HasPrefix(obj.Value, encryptedPrefix), nil
-}
-
-func encodeNetworkKey(
-	ctx context.Context,
-	privateKey *ecdsa.PrivateKey,
-	protectFn func(ctx context.Context, plaintext []byte) ([]byte, error),
-) ([]byte, error) {
-	plaintext := gcrypto.FromECDSA(privateKey)
-	if protectFn == nil {
-		return nil, errors.New("network key protector is required")
-	}
-	protectedValue, err := protectFn(ctx, plaintext)
-	if err != nil {
-		return nil, err
-	}
-	storedValue := make([]byte, 0, len(encryptedPrefix)+len(protectedValue))
-	storedValue = append(storedValue, encryptedPrefix...)
-	storedValue = append(storedValue, protectedValue...)
-	return storedValue, nil
 }
 
 func decodeNetworkKey(

--- a/identity/store.go
+++ b/identity/store.go
@@ -44,7 +44,6 @@ type identityStore struct {
 func NewIdentityStore(
 	logger *zap.Logger,
 	db basedb.Database,
-	_ func(ctx context.Context, plaintext []byte) ([]byte, error),
 	unprotectFn func(ctx context.Context, protectedValue []byte) ([]byte, error),
 ) Store {
 	es := identityStore{

--- a/identity/store.go
+++ b/identity/store.go
@@ -95,14 +95,10 @@ func (s identityStore) SetupNetworkKey(ctx context.Context, skEncoded string) (*
 		}
 	}
 	if skEncoded == "" && found && privateKey != nil {
-		if !encrypted {
-			if s.hasProtectedStorage() {
-				s.logger.Info("migrating plaintext p2p network private key to encrypted storage")
-				if err := s.saveNetworkKey(ctx, privateKey); err != nil {
-					return nil, err
-				}
-			} else {
-				s.logger.Warn("using legacy plaintext p2p network private key from storage; configure a local operator key or use an ssv-signer deployment that supports remote network-key protection to encrypt it at rest")
+		if encrypted {
+			s.logger.Info("migrating encrypted p2p network private key back to plaintext storage for rollback compatibility")
+			if err := s.saveNetworkKeyPlaintext(privateKey); err != nil {
+				return nil, err
 			}
 		}
 		s.logger.Debug("using p2p network privateKey from storage")
@@ -113,12 +109,7 @@ func (s identityStore) SetupNetworkKey(ctx context.Context, skEncoded string) (*
 		return nil, fmt.Errorf("failed to generate private key: %w", err)
 	}
 
-	if !s.hasProtectedStorage() {
-		s.logger.Warn("persisting p2p network private key in legacy plaintext storage because no network key encryption secret is configured; configure a local operator key or use an ssv-signer deployment that supports remote network-key protection to encrypt it at rest")
-		return privateKey, s.saveNetworkKeyPlaintext(privateKey)
-	}
-
-	return privateKey, s.saveNetworkKey(ctx, privateKey)
+	return privateKey, s.saveNetworkKeyPlaintext(privateKey)
 }
 
 func (s identityStore) saveNetworkKey(ctx context.Context, privateKey *ecdsa.PrivateKey) error {
@@ -130,10 +121,6 @@ func (s identityStore) saveNetworkKey(ctx context.Context, privateKey *ecdsa.Pri
 		return fmt.Errorf("failed to save to db: %w", err)
 	}
 	return nil
-}
-
-func (s identityStore) hasProtectedStorage() bool {
-	return s.protectFn != nil && s.unprotectFn != nil
 }
 
 func (s identityStore) saveNetworkKeyPlaintext(privateKey *ecdsa.PrivateKey) error {

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -65,6 +66,23 @@ func (db getOverrideDB) Get(prefix []byte, key []byte) (basedb.Obj, bool, error)
 	return db.Database.Get(prefix, key)
 }
 
+func storeEncryptedNetworkKey(
+	ctx context.Context,
+	db basedb.Database,
+	privateKey *ecdsa.PrivateKey,
+	protectFn func(context.Context, []byte) ([]byte, error),
+) error {
+	protectedValue, err := protectFn(ctx, gcrypto.FromECDSA(privateKey))
+	if err != nil {
+		return err
+	}
+
+	storedValue := make([]byte, 0, len(encryptedPrefix)+len(protectedValue))
+	storedValue = append(storedValue, encryptedPrefix...)
+	storedValue = append(storedValue, protectedValue...)
+	return db.Set(prefix, netKeyPrefix, storedValue)
+}
+
 func TestSetupPrivateKey(t *testing.T) {
 	logger := log.TestLogger(t)
 	ctx := context.Background()
@@ -105,9 +123,6 @@ func TestSetupPrivateKey(t *testing.T) {
 			p2pStorage := identityStore{
 				db:     db,
 				logger: logger,
-				protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-					return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-				},
 				unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
 					return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
 				},
@@ -116,7 +131,9 @@ func TestSetupPrivateKey(t *testing.T) {
 			if test.existKey != "" { // mock exist key
 				privKey, err := gcrypto.HexToECDSA(test.existKey)
 				require.NoError(t, err)
-				require.NoError(t, p2pStorage.saveNetworkKey(ctx, privKey))
+				require.NoError(t, storeEncryptedNetworkKey(ctx, db, privKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+					return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+				}))
 				sk, found, err := p2pStorage.GetNetworkKey(ctx)
 				require.True(t, found)
 				require.NoError(t, err)
@@ -184,9 +201,6 @@ func TestSetupPrivateKey(t *testing.T) {
 		p2pStorage := identityStore{
 			db:     db,
 			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
 			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
 				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
 			},
@@ -214,9 +228,6 @@ func TestSetupPrivateKey(t *testing.T) {
 		p2pStorage := identityStore{
 			db:     db,
 			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
 			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
 				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
 			},
@@ -333,15 +344,14 @@ func TestSetupPrivateKey(t *testing.T) {
 		p2pStorage := identityStore{
 			db:     db,
 			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
 			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
 				return bytes.Repeat([]byte{0xff}, 32), nil
 			},
 		}
 
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+		}))
 
 		_, err = p2pStorage.SetupNetworkKey(ctx, "")
 		require.ErrorContains(t, err, "decode network key")
@@ -392,9 +402,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		p2pStorage := identityStore{
 			db:     db,
 			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
 			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
 				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
 			},
@@ -402,7 +409,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+		}))
 
 		storedBefore, found, err := db.Get(prefix, netKeyPrefix)
 		require.NoError(t, err)
@@ -435,20 +444,11 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		p2pStorage := identityStore{
-			db:     db,
-			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
-			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
-				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
-			},
-		}
-
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+		}))
 		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
@@ -461,20 +461,11 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		p2pStorage := identityStore{
-			db:     db,
-			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
-			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
-				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
-			},
-		}
-
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+		}))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
@@ -491,20 +482,11 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		p2pStorage := identityStore{
-			db:     db,
-			logger: logger,
-			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
-			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
-				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
-			},
-		}
-
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
+			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+		}))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
@@ -525,13 +507,11 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		p2pStorage := identityStore{
 			db:          db,
 			logger:      logger,
-			protectFn:   signerClient.OperatorEncrypt,
 			unprotectFn: signerClient.OperatorDecrypt,
 		}
-
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, signerClient.OperatorEncrypt))
 
 		storedBefore, found, err := db.Get(prefix, netKeyPrefix)
 		require.NoError(t, err)
@@ -559,16 +539,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		defer db.Close()
 
 		signerClient := newTestSSVSignerClient(t)
-		p2pStorage := identityStore{
-			db:          db,
-			logger:      logger,
-			protectFn:   signerClient.OperatorEncrypt,
-			unprotectFn: signerClient.OperatorDecrypt,
-		}
-
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, signerClient.OperatorEncrypt))
 		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
@@ -582,16 +555,10 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		defer db.Close()
 
 		signerClient := newTestSSVSignerClient(t)
-		p2pStorage := identityStore{
-			db:          db,
-			logger:      logger,
-			protectFn:   signerClient.OperatorEncrypt,
-			unprotectFn: signerClient.OperatorDecrypt,
-		}
 
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
-		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, signerClient.OperatorEncrypt))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -446,7 +446,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
 			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
 		}))
-		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
 		require.NoError(t, err)
@@ -463,7 +462,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
 			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
 		}))
-		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
 			db:     db,
@@ -484,7 +482,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, func(_ context.Context, plaintext []byte) ([]byte, error) {
 			return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
 		}))
-		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
 			db:     db,
@@ -539,7 +536,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
 		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, signerClient.OperatorEncrypt))
-		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
 		require.NoError(t, err)
@@ -556,7 +552,6 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		privateKey, err := gcrypto.HexToECDSA(sk)
 		require.NoError(t, err)
 		require.NoError(t, storeEncryptedNetworkKey(ctx, db, privateKey, signerClient.OperatorEncrypt))
-		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
 			db:     db,

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -365,9 +365,6 @@ func TestSetupPrivateKey(t *testing.T) {
 		p2pStorage := NewIdentityStore(
 			logger,
 			db,
-			func(_ context.Context, plaintext []byte) ([]byte, error) {
-				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
-			},
 			func(_ context.Context, protectedValue []byte) ([]byte, error) {
 				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
 			},

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -176,7 +176,33 @@ func TestSetupPrivateKey(t *testing.T) {
 		require.False(t, hasEncryptedKey)
 	})
 
-	t.Run("migrates legacy plaintext key to encrypted storage", func(t *testing.T) {
+	t.Run("generates and stores plaintext key even when encryption secret exists", func(t *testing.T) {
+		db, err := kv.NewInMemory(logger, basedb.Options{})
+		require.NoError(t, err)
+		defer db.Close()
+
+		p2pStorage := identityStore{
+			db:     db,
+			logger: logger,
+			protectFn: func(_ context.Context, plaintext []byte) ([]byte, error) {
+				return keys.EncryptPayload(networkKeyEncryptionKey, plaintext)
+			},
+			unprotectFn: func(_ context.Context, protectedValue []byte) ([]byte, error) {
+				return keys.DecryptPayload(networkKeyEncryptionKey, protectedValue)
+			},
+		}
+
+		privateKey, err := p2pStorage.SetupNetworkKey(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, gcrypto.FromECDSA(privateKey), storedAfter.Value)
+	})
+
+	t.Run("keeps legacy plaintext key in plaintext storage even when decryptor exists", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
@@ -208,11 +234,10 @@ func TestSetupPrivateKey(t *testing.T) {
 		storedAfter, found, err := db.Get(prefix, netKeyPrefix)
 		require.NoError(t, err)
 		require.True(t, found)
-		require.True(t, bytes.HasPrefix(storedAfter.Value, encryptedPrefix))
-		require.NotEqual(t, gcrypto.FromECDSA(privKey), storedAfter.Value)
+		require.Equal(t, gcrypto.FromECDSA(privKey), storedAfter.Value)
 	})
 
-	t.Run("persists configured key in legacy plaintext when encryption secret is missing", func(t *testing.T) {
+	t.Run("persists configured key in plaintext storage", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
@@ -359,7 +384,7 @@ func TestEncryptedNetworkKey(t *testing.T) {
 	logger := log.TestLogger(t)
 	ctx := context.Background()
 
-	t.Run("stores and loads encrypted network key", func(t *testing.T) {
+	t.Run("loads encrypted network key and downgrades it to plaintext", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
@@ -375,14 +400,23 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			},
 		}
 
-		privateKey, err := p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+
+		storedBefore, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, bytes.HasPrefix(storedBefore.Value, encryptedPrefix))
+
+		privateKey, err = p2pStorage.SetupNetworkKey(ctx, "")
 		require.NoError(t, err)
 		require.NotNil(t, privateKey)
 
 		storedObj, found, err := db.Get(prefix, netKeyPrefix)
 		require.NoError(t, err)
 		require.True(t, found)
-		require.True(t, bytes.HasPrefix(storedObj.Value, encryptedPrefix))
+		require.Equal(t, gcrypto.FromECDSA(privateKey), storedObj.Value)
 
 		loadedKey, found, err := p2pStorage.GetNetworkKey(ctx)
 		require.NoError(t, err)
@@ -412,7 +446,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			},
 		}
 
-		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
 		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
@@ -436,7 +472,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			},
 		}
 
-		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
@@ -464,7 +502,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			},
 		}
 
-		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{
@@ -476,7 +516,7 @@ func TestEncryptedNetworkKey(t *testing.T) {
 		require.ErrorContains(t, err, "network key is encrypted but no compatible network key protector is configured")
 	})
 
-	t.Run("stores and loads remotely protected network key using encrypted format", func(t *testing.T) {
+	t.Run("loads remotely protected network key and downgrades it to plaintext", func(t *testing.T) {
 		db, err := kv.NewInMemory(logger, basedb.Options{})
 		require.NoError(t, err)
 		defer db.Close()
@@ -489,14 +529,23 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			unprotectFn: signerClient.OperatorDecrypt,
 		}
 
-		privateKey, err := p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
+
+		storedBefore, found, err := db.Get(prefix, netKeyPrefix)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, bytes.HasPrefix(storedBefore.Value, encryptedPrefix))
+
+		privateKey, err = p2pStorage.SetupNetworkKey(ctx, "")
 		require.NoError(t, err)
 		require.NotNil(t, privateKey)
 
 		storedObj, found, err := db.Get(prefix, netKeyPrefix)
 		require.NoError(t, err)
 		require.True(t, found)
-		require.True(t, bytes.HasPrefix(storedObj.Value, encryptedPrefix))
+		require.Equal(t, gcrypto.FromECDSA(privateKey), storedObj.Value)
 
 		loadedKey, found, err := p2pStorage.GetNetworkKey(ctx)
 		require.NoError(t, err)
@@ -517,7 +566,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			unprotectFn: signerClient.OperatorDecrypt,
 		}
 
-		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
 		require.NoError(t, err)
 
 		hasEncryptedKey, err := HasEncryptedNetworkKey(db)
@@ -538,7 +589,9 @@ func TestEncryptedNetworkKey(t *testing.T) {
 			unprotectFn: signerClient.OperatorDecrypt,
 		}
 
-		_, err = p2pStorage.SetupNetworkKey(ctx, sk)
+		privateKey, err := gcrypto.HexToECDSA(sk)
+		require.NoError(t, err)
+		require.NoError(t, p2pStorage.saveNetworkKey(ctx, privateKey))
 		require.NoError(t, err)
 
 		storeWithoutProtector := identityStore{


### PR DESCRIPTION
## Summary

Roll back persisted P2P network key storage to plaintext for stage rollback safety.

Closes https://github.com/ssvlabs/ssv-node-board/issues/1038

## What changed

- keep support for reading encrypted persisted P2P network keys
- when an encrypted key is successfully read during `SetupNetworkKey`, rewrite it back to plaintext in DB
- stop migrating plaintext keys to encrypted storage
- stop writing new persisted P2P network keys in encrypted format
- keep the decrypt path in place temporarily so already-migrated stage DBs can be downgraded safely before the actual revert

## Why

PR [#2765](https://github.com/ssvlabs/ssv/pull/2765) was already merged into `stage`, so some stage nodes may already have persisted P2P keys stored as `enc:` in DB.

A direct revert would be unsafe for those nodes. This bridge PR downgrades stored keys back to plaintext first, so the later revert can happen without breaking nodes that already migrated their DB.

## Scope

- this PR is intentionally a temporary rollback bridge
- exporter behavior is unchanged
- the follow-up step is to let this deploy and rewrite DBs, then revert the original encryption change

## Testing

- `go test ./cli/operator ./identity`