### PR TITLE
queue: address inline-review feedback on #2812

### DIFF
--- a/operator/validator/observability.go
+++ b/operator/validator/observability.go
@@ -81,9 +81,3 @@ func recordValidatorStatus(ctx context.Context, count uint32, status validatorSt
 		metric.WithAttributes(validatorStatusAttribute(status)),
 	)
 }
-
-func recordRouterMessageDrop(ctx context.Context, reason string) {
-	routerDroppedMessagesCounter.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("ssv.validator.router.drop_reason", reason)),
-	)
-}

--- a/operator/validator/router.go
+++ b/operator/validator/router.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync/atomic"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network"
@@ -14,9 +16,17 @@ const bufSize = 65536
 const bufferFillSampleRate = 64
 
 func newMessageRouter(logger *zap.Logger) *messageRouter {
+	return newMessageRouterWithMetrics(logger, routerDroppedMessagesCounter, routerBufferFillGauge)
+}
+
+// newMessageRouterWithMetrics builds a router with injected metrics — used by tests
+// to assert on counter/gauge values without depending on global OTel state.
+func newMessageRouterWithMetrics(logger *zap.Logger, droppedCounter metric.Int64Counter, bufferFillGauge metric.Int64Gauge) *messageRouter {
 	return &messageRouter{
-		logger: logger,
-		ch:     make(chan network.DecodedSSVMessage, bufSize),
+		logger:          logger,
+		ch:              make(chan network.DecodedSSVMessage, bufSize),
+		droppedCounter:  droppedCounter,
+		bufferFillGauge: bufferFillGauge,
 	}
 }
 
@@ -24,6 +34,8 @@ type messageRouter struct {
 	logger               *zap.Logger
 	ch                   chan network.DecodedSSVMessage
 	bufferFillSampleTick atomic.Uint64
+	droppedCounter       metric.Int64Counter
+	bufferFillGauge      metric.Int64Gauge
 }
 
 func (r *messageRouter) Route(ctx context.Context, message network.DecodedSSVMessage) {
@@ -33,7 +45,7 @@ func (r *messageRouter) Route(ctx context.Context, message network.DecodedSSVMes
 func (r *messageRouter) route(ctx context.Context, message network.DecodedSSVMessage) bool {
 	select {
 	case <-ctx.Done():
-		recordRouterMessageDrop(context.Background(), routerDropReasonContextCanceled)
+		r.recordDrop(context.Background(), routerDropReasonContextCanceled)
 		r.logger.Debug("context canceled, dropping message")
 		return false
 	default:
@@ -44,7 +56,7 @@ func (r *messageRouter) route(ctx context.Context, message network.DecodedSSVMes
 		r.recordBufferFill(ctx)
 		return true
 	default:
-		recordRouterMessageDrop(ctx, routerDropReasonBufferFull)
+		r.recordDrop(ctx, routerDropReasonBufferFull)
 		r.recordBufferFill(ctx)
 		r.logger.Warn("message router buffer is full, dropping message")
 		return false
@@ -65,9 +77,15 @@ func (r *messageRouter) Len() int {
 	return len(r.ch)
 }
 
+func (r *messageRouter) recordDrop(ctx context.Context, reason string) {
+	r.droppedCounter.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("ssv.validator.router.drop_reason", reason)),
+	)
+}
+
 func (r *messageRouter) recordBufferFill(ctx context.Context) {
 	if r.bufferFillSampleTick.Add(1)%bufferFillSampleRate != 0 {
 		return
 	}
-	routerBufferFillGauge.Record(ctx, int64(len(r.ch)))
+	r.bufferFillGauge.Record(ctx, int64(len(r.ch)))
 }

--- a/operator/validator/router.go
+++ b/operator/validator/router.go
@@ -23,10 +23,28 @@ func newMessageRouter(logger *zap.Logger) *messageRouter {
 // to assert on counter/gauge values without depending on global OTel state.
 func newMessageRouterWithMetrics(logger *zap.Logger, droppedCounter metric.Int64Counter, bufferFillGauge metric.Int64Gauge) *messageRouter {
 	return &messageRouter{
-		logger:          logger,
-		ch:              make(chan network.DecodedSSVMessage, bufSize),
-		droppedCounter:  droppedCounter,
-		bufferFillGauge: bufferFillGauge,
+		logger:             logger,
+		ch:                 make(chan network.DecodedSSVMessage, bufSize),
+		droppedCounter:     droppedCounter,
+		bufferFillGauge:    bufferFillGauge,
+		dropAddOpsByReason: routerDropAddOpsByReason(),
+	}
+}
+
+// routerDropAddOpsByReason builds the pre-allocated AddOptions for each known
+// drop reason so recordDrop doesn't allocate attributes on the hot path.
+func routerDropAddOpsByReason() map[string][]metric.AddOption {
+	return map[string][]metric.AddOption{
+		routerDropReasonContextCanceled: {
+			metric.WithAttributeSet(attribute.NewSet(
+				attribute.String("ssv.validator.router.drop_reason", routerDropReasonContextCanceled),
+			)),
+		},
+		routerDropReasonBufferFull: {
+			metric.WithAttributeSet(attribute.NewSet(
+				attribute.String("ssv.validator.router.drop_reason", routerDropReasonBufferFull),
+			)),
+		},
 	}
 }
 
@@ -36,6 +54,7 @@ type messageRouter struct {
 	bufferFillSampleTick atomic.Uint64
 	droppedCounter       metric.Int64Counter
 	bufferFillGauge      metric.Int64Gauge
+	dropAddOpsByReason   map[string][]metric.AddOption
 }
 
 func (r *messageRouter) Route(ctx context.Context, message network.DecodedSSVMessage) {
@@ -78,6 +97,13 @@ func (r *messageRouter) Len() int {
 }
 
 func (r *messageRouter) recordDrop(ctx context.Context, reason string) {
+	if ops, ok := r.dropAddOpsByReason[reason]; ok {
+		r.droppedCounter.Add(ctx, 1, ops...)
+		return
+	}
+	// Unregistered reason — fall back to per-call allocation so the metric
+	// still records (no silent miss). Adding a new reason should also extend
+	// routerDropAddOpsByReason to keep the hot path zero-alloc.
 	r.droppedCounter.Add(ctx, 1,
 		metric.WithAttributes(attribute.String("ssv.validator.router.drop_reason", reason)),
 	)

--- a/operator/validator/router_test.go
+++ b/operator/validator/router_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
@@ -66,8 +69,8 @@ func TestRouter(t *testing.T) {
 func TestRouter_DropsWhenContextCanceled(t *testing.T) {
 	t.Parallel()
 
-	logger := log.TestLogger(t)
-	router := newMessageRouter(logger)
+	reader, droppedCounter, bufferFillGauge := newRouterTestMetrics(t)
+	router := newMessageRouterWithMetrics(log.TestLogger(t), droppedCounter, bufferFillGauge)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -83,13 +86,14 @@ func TestRouter_DropsWhenContextCanceled(t *testing.T) {
 	router.Route(ctx, msg)
 
 	require.Zero(t, router.Len())
+	requireRouterDropCounter(t, reader, routerDropReasonContextCanceled, 1)
 }
 
 func TestRouter_DropsWhenBufferFull(t *testing.T) {
 	t.Parallel()
 
-	logger := log.TestLogger(t)
-	router := newMessageRouter(logger)
+	reader, droppedCounter, bufferFillGauge := newRouterTestMetrics(t)
+	router := newMessageRouterWithMetrics(log.TestLogger(t), droppedCounter, bufferFillGauge)
 
 	msg := &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
@@ -106,4 +110,48 @@ func TestRouter_DropsWhenBufferFull(t *testing.T) {
 	router.Route(context.Background(), msg)
 
 	require.Equal(t, bufSize, router.Len())
+	requireRouterDropCounter(t, reader, routerDropReasonBufferFull, 1)
+}
+
+func newRouterTestMetrics(t *testing.T) (*metric.ManualReader, otelmetric.Int64Counter, otelmetric.Int64Gauge) {
+	t.Helper()
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	testMeter := provider.Meter("test")
+
+	counter, err := testMeter.Int64Counter("test_router_dropped")
+	require.NoError(t, err)
+
+	gauge, err := testMeter.Int64Gauge("test_router_buffer_fill")
+	require.NoError(t, err)
+
+	return reader, counter, gauge
+}
+
+// requireRouterDropCounter asserts that the test counter recorded `expected`
+// for the given drop reason attribute.
+func requireRouterDropCounter(t *testing.T, reader *metric.ManualReader, reason string, expected int64) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "test_router_dropped" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "expected counter, got %T", m.Data)
+			for _, dp := range sum.DataPoints {
+				v, ok := dp.Attributes.Value("ssv.validator.router.drop_reason")
+				if !ok || v.AsString() != reason {
+					continue
+				}
+				require.Equal(t, expected, dp.Value)
+				return
+			}
+		}
+	}
+	t.Fatalf("no drop counter data point found for reason=%q", reason)
 }

--- a/protocol/v2/ssv/queue/observability.go
+++ b/protocol/v2/ssv/queue/observability.go
@@ -1,13 +1,11 @@
 package queue
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/ssvlabs/ssv/observability"
@@ -47,8 +45,7 @@ const (
 	ValidatorQueueMetricType = "validator"
 	CommitteeQueueMetricType = "committee"
 
-	DropReasonBufferFull      = "buffer_full"
-	DropReasonContextCanceled = "context_canceled"
+	DropReasonBufferFull = "buffer_full"
 )
 
 // ValidatorMetricID returns a queue identifier to differentiate validator-related queues (in metrics).
@@ -63,16 +60,4 @@ func ValidatorMetricID(runnerRole spectypes.RunnerRole) string {
 func CommitteeMetricID(slot phase0.Slot) string {
 	slotInEpoch := slot % 32
 	return fmt.Sprintf("%d", slotInEpoch)
-}
-
-func recordDroppedMessage(queueType, queueID, reason string) {
-	droppedMessagesMetric.Add(
-		context.Background(),
-		1,
-		metric.WithAttributes(
-			attribute.String("ssv.queue.type", queueType),
-			attribute.String("ssv.queue.id", queueID),
-			attribute.String("ssv.queue.drop_reason", reason),
-		),
-	)
 }

--- a/protocol/v2/ssv/queue/queue_observer.go
+++ b/protocol/v2/ssv/queue/queue_observer.go
@@ -25,6 +25,8 @@ func (noopQueueObserver) recordDrop(string) {}
 type metricsQueueObserver struct {
 	inboxSizeMetric    metric.Int64Gauge
 	inboxSizeRecordOps []metric.RecordOption
+	queueType          string
+	queueID            string
 	// dropAddOpsByReason holds pre-built AddOptions per known drop reason so
 	// the hot path doesn't allocate attributes on every dropped message.
 	dropAddOpsByReason map[string][]metric.AddOption
@@ -37,21 +39,22 @@ func WithQueueMetrics(inboxSizeMetric metric.Int64Gauge, queueType, queueID stri
 		attribute.String("ssv.queue.id", queueID),
 	)
 
-	dropAddOpsByReason := make(map[string][]metric.AddOption, 1)
-	for _, reason := range []string{DropReasonBufferFull} {
-		dropAddOpsByReason[reason] = []metric.AddOption{
+	dropAddOpsByReason := map[string][]metric.AddOption{
+		DropReasonBufferFull: {
 			metric.WithAttributeSet(attribute.NewSet(
 				attribute.String("ssv.queue.type", queueType),
 				attribute.String("ssv.queue.id", queueID),
-				attribute.String("ssv.queue.drop_reason", reason),
+				attribute.String("ssv.queue.drop_reason", DropReasonBufferFull),
 			)),
-		}
+		},
 	}
 
 	return func(q *priorityQueue) {
 		q.observer = metricsQueueObserver{
 			inboxSizeMetric:    inboxSizeMetric,
 			inboxSizeRecordOps: []metric.RecordOption{metric.WithAttributeSet(queueAttrSet)},
+			queueType:          queueType,
+			queueID:            queueID,
 			dropAddOpsByReason: dropAddOpsByReason,
 		}
 	}
@@ -69,9 +72,20 @@ func (o metricsQueueObserver) recordInboxSize(inboxSize int64) {
 }
 
 func (o metricsQueueObserver) recordDrop(reason string) {
-	ops, ok := o.dropAddOpsByReason[reason]
-	if !ok {
+	if ops, ok := o.dropAddOpsByReason[reason]; ok {
+		droppedMessagesMetric.Add(context.Background(), 1, ops...)
 		return
 	}
-	droppedMessagesMetric.Add(context.Background(), 1, ops...)
+	// Unregistered reason — fall back to per-call allocation so the metric
+	// still records (no silent miss). Adding a new reason should also extend
+	// the pre-built map above to keep the hot path zero-alloc.
+	droppedMessagesMetric.Add(
+		context.Background(),
+		1,
+		metric.WithAttributes(
+			attribute.String("ssv.queue.type", o.queueType),
+			attribute.String("ssv.queue.id", o.queueID),
+			attribute.String("ssv.queue.drop_reason", reason),
+		),
+	)
 }

--- a/protocol/v2/ssv/queue/queue_observer.go
+++ b/protocol/v2/ssv/queue/queue_observer.go
@@ -25,23 +25,34 @@ func (noopQueueObserver) recordDrop(string) {}
 type metricsQueueObserver struct {
 	inboxSizeMetric    metric.Int64Gauge
 	inboxSizeRecordOps []metric.RecordOption
-	queueType          string
-	queueID            string
+	// dropAddOpsByReason holds pre-built AddOptions per known drop reason so
+	// the hot path doesn't allocate attributes on every dropped message.
+	dropAddOpsByReason map[string][]metric.AddOption
 }
 
-// WithInboxSizeMetric configures queue-level observability for inbox size and dropped messages.
-func WithInboxSizeMetric(inboxSizeMetric metric.Int64Gauge, queueType, queueID string) Option {
-	attrSet := attribute.NewSet(
+// WithQueueMetrics configures queue-level observability for inbox size and dropped messages.
+func WithQueueMetrics(inboxSizeMetric metric.Int64Gauge, queueType, queueID string) Option {
+	queueAttrSet := attribute.NewSet(
 		attribute.String("ssv.queue.type", queueType),
 		attribute.String("ssv.queue.id", queueID),
 	)
 
+	dropAddOpsByReason := make(map[string][]metric.AddOption, 1)
+	for _, reason := range []string{DropReasonBufferFull} {
+		dropAddOpsByReason[reason] = []metric.AddOption{
+			metric.WithAttributeSet(attribute.NewSet(
+				attribute.String("ssv.queue.type", queueType),
+				attribute.String("ssv.queue.id", queueID),
+				attribute.String("ssv.queue.drop_reason", reason),
+			)),
+		}
+	}
+
 	return func(q *priorityQueue) {
 		q.observer = metricsQueueObserver{
 			inboxSizeMetric:    inboxSizeMetric,
-			inboxSizeRecordOps: []metric.RecordOption{metric.WithAttributeSet(attrSet)},
-			queueType:          queueType,
-			queueID:            queueID,
+			inboxSizeRecordOps: []metric.RecordOption{metric.WithAttributeSet(queueAttrSet)},
+			dropAddOpsByReason: dropAddOpsByReason,
 		}
 	}
 }
@@ -58,5 +69,9 @@ func (o metricsQueueObserver) recordInboxSize(inboxSize int64) {
 }
 
 func (o metricsQueueObserver) recordDrop(reason string) {
-	recordDroppedMessage(o.queueType, o.queueID, reason)
+	ops, ok := o.dropAddOpsByReason[reason]
+	if !ok {
+		return
+	}
+	droppedMessagesMetric.Add(context.Background(), 1, ops...)
 }

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -283,7 +283,7 @@ func TestPriorityQueue_InboxSizeMetricAttributes(t *testing.T) {
 		queueID   = "attester"
 	)
 
-	queue := New(log.TestLogger(t), 4, WithInboxSizeMetric(gauge, queueType, queueID))
+	queue := New(log.TestLogger(t), 4, WithQueueMetrics(gauge, queueType, queueID))
 	decodeAndPush(t, queue, mockConsensusMessage{Height: 100, Type: specqbft.PrepareMsgType}, mockState)
 
 	var rm metricdata.ResourceMetrics
@@ -323,7 +323,7 @@ func TestPriorityQueue_TryPushInboxSizeMetricDoesNotExceedCapacityOnDrop(t *test
 		queueID   = "attester"
 	)
 
-	queue := New(log.TestLogger(t), 1, WithInboxSizeMetric(gauge, queueType, queueID))
+	queue := New(log.TestLogger(t), 1, WithQueueMetrics(gauge, queueType, queueID))
 	msg, err := DecodeSignedSSVMessage(mockConsensusMessage{Height: 100, Type: specqbft.PrepareMsgType}.ssvMessage(mockState))
 	require.NoError(t, err)
 

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -172,7 +172,7 @@ func (c *Committee) getQueue(logger *zap.Logger, slot phase0.Slot) queue.Queue {
 		q = queue.New(
 			logger,
 			defaultValidatorQueueSize,
-			queue.WithInboxSizeMetric(
+			queue.WithQueueMetrics(
 				queue.InboxSizeMetric,
 				queue.CommitteeQueueMetricType,
 				queue.CommitteeMetricID(slot),

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -83,7 +83,7 @@ func NewValidator(ctx context.Context, cancel func(), logger *zap.Logger, option
 		v.Queues[role] = queue.New(
 			logger,
 			options.QueueSize,
-			queue.WithInboxSizeMetric(
+			queue.WithQueueMetrics(
 				queue.InboxSizeMetric,
 				queue.ValidatorQueueMetricType,
 				queue.ValidatorMetricID(role),


### PR DESCRIPTION
Suggested follow-up to address the inline review comments on #2812.

Targets the `queue-pressure` branch so it stacks on top — merging this folds the changes into PR #2812.

## Changes

| Feedback | Fix |
|---|---|
| Unused exported constant `DropReasonContextCanceled` ([review comment](https://github.com/ssvlabs/ssv/pull/2812#discussion_r3193976247)) | Remove it. No caller after the admission descope; the router uses its own private `routerDropReasonContextCanceled`. |
| `WithInboxSizeMetric` name now misleading ([review comment](https://github.com/ssvlabs/ssv/pull/2812#discussion_r3193976258)) | Rename to `WithQueueMetrics` (matches iurii's [suggestion branch](https://github.com/ssvlabs/ssv/compare/queue-pressure...queue-pressure-iurii-suggestions)). Update 4 callers. |
| Per-call attribute allocation in `recordDroppedMessage` ([review comment](https://github.com/ssvlabs/ssv/pull/2812#discussion_r3193976260)) | Pre-build drop `AddOption`s per known reason at observer construction; hot path becomes a map lookup. Inline `recordDroppedMessage` into the observer. |
| Router drop tests don't verify the metric ([review comment](https://github.com/ssvlabs/ssv/pull/2812#discussion_r3193976252)) | Add `droppedCounter` / `bufferFillGauge` fields to `messageRouter` plus a test-only constructor `newMessageRouterWithMetrics`. Tests use `metric.NewManualReader` to assert counter values per drop reason — same pattern as `TestPriorityQueue_TryPushInboxSizeMetricDoesNotExceedCapacityOnDrop`. |

## Test plan

- [x] `go build ./...`
- [x] `go test ./operator/validator/... ./protocol/v2/ssv/queue/... ./protocol/v2/ssv/validator/...`
- [x] `go vet ./...`
- [x] New `TestRouter_DropsWhenContextCanceled` / `TestRouter_DropsWhenBufferFull` run cleanly with `-count=3` (parallel-safe via DI).