### PR TITLE
queue: cover test gaps for dropped-message metric and concurrent drops

### DIFF
--- a/operator/validator/router_test.go
+++ b/operator/validator/router_test.go
@@ -155,3 +155,48 @@ func requireRouterDropCounter(t *testing.T, reader *metric.ManualReader, reason 
 	}
 	t.Fatalf("no drop counter data point found for reason=%q", reason)
 }
+
+func TestMessageRouter_RecordDrop_FallbackForUnregisteredReason(t *testing.T) {
+	t.Parallel()
+
+	reader, droppedCounter, bufferFillGauge := newRouterTestMetrics(t)
+	router := newMessageRouterWithMetrics(log.TestLogger(t), droppedCounter, bufferFillGauge)
+
+	const reason = "synthetic_unregistered_reason"
+	router.recordDrop(t.Context(), reason)
+
+	requireRouterDropCounter(t, reader, reason, 1)
+}
+
+func TestRouter_ConcurrentRoute_RecordsAllBufferFullDrops(t *testing.T) {
+	t.Parallel()
+
+	reader, droppedCounter, bufferFillGauge := newRouterTestMetrics(t)
+	router := newMessageRouterWithMetrics(log.TestLogger(t), droppedCounter, bufferFillGauge)
+
+	msg := &queue.SSVMessage{
+		SSVMessage: &spectypes.SSVMessage{
+			MsgType: spectypes.SSVConsensusMsgType,
+			MsgID:   spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, []byte{1, 1, 1, 1, 1}, spectypes.RoleCommittee),
+			Data:    []byte("data"),
+		},
+	}
+
+	for range bufSize {
+		router.ch <- msg
+	}
+
+	const callers = 64
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			router.Route(context.Background(), msg)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, bufSize, router.Len(), "buffer must not grow past capacity under contention")
+	requireRouterDropCounter(t, reader, routerDropReasonBufferFull, callers)
+}

--- a/protocol/v2/ssv/queue/main_test.go
+++ b/protocol/v2/ssv/queue/main_test.go
@@ -1,0 +1,22 @@
+package queue
+
+import (
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// pkgTestMetricReader exposes the package-global counters created at init time
+// (e.g. droppedMessagesMetric) for tests that need to assert on them. Because
+// otel.Meter() returns a delegating proxy, calling otel.SetMeterProvider before
+// tests run is enough to make the package-globals forward to this reader.
+var pkgTestMetricReader *sdkmetric.ManualReader
+
+func TestMain(m *testing.M) {
+	pkgTestMetricReader = sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(pkgTestMetricReader))
+	otel.SetMeterProvider(provider)
+	os.Exit(m.Run())
+}

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -271,8 +273,8 @@ func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.
 }
 
 func TestPriorityQueue_InboxSizeMetricAttributes(t *testing.T) {
-	reader := metric.NewManualReader()
-	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	testMeter := provider.Meter("test")
 
 	gauge, err := testMeter.Int64Gauge("test_inbox_size")
@@ -311,8 +313,8 @@ func TestPriorityQueue_InboxSizeMetricAttributes(t *testing.T) {
 }
 
 func TestPriorityQueue_TryPushInboxSizeMetricDoesNotExceedCapacityOnDrop(t *testing.T) {
-	reader := metric.NewManualReader()
-	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	testMeter := provider.Meter("test")
 
 	gauge, err := testMeter.Int64Gauge("test_inbox_size")
@@ -560,6 +562,132 @@ func BenchmarkPriorityQueue_Concurrent(b *testing.B) {
 
 	b.Logf("popped %d messages", popped)
 	b.Logf("pushed %d messages", pushed.Load())
+}
+
+// requireQueueDropCounter asserts that the package-global droppedMessagesMetric
+// (read via pkgTestMetricReader) has a data point matching queueType/queueID/reason
+// with the expected value. Fatals if no matching data point exists, so a missing
+// data point shows up as a clear "no data point found for …" failure rather than
+// a confusing "expected N, got -1" comparison.
+func requireQueueDropCounter(t *testing.T, queueType, queueID, reason string, expected int64) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, pkgTestMetricReader.Collect(t.Context(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "ssv.queue.messages.dropped" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "expected Sum[int64], got %T", m.Data)
+			for _, dp := range sum.DataPoints {
+				if !attrEquals(dp.Attributes, "ssv.queue.type", queueType) {
+					continue
+				}
+				if !attrEquals(dp.Attributes, "ssv.queue.id", queueID) {
+					continue
+				}
+				if !attrEquals(dp.Attributes, "ssv.queue.drop_reason", reason) {
+					continue
+				}
+				require.Equal(t, expected, dp.Value)
+				return
+			}
+		}
+	}
+	t.Fatalf("no drop counter data point found for queueType=%q queueID=%q reason=%q", queueType, queueID, reason)
+}
+
+func attrEquals(set attribute.Set, key, expected string) bool {
+	v, ok := set.Value(attribute.Key(key))
+	return ok && v.AsString() == expected
+}
+
+func TestPriorityQueue_TryPushDropMetric_RecordsAttributes(t *testing.T) {
+	t.Parallel()
+
+	gauge := newTestGauge(t)
+	const queueType = ValidatorQueueMetricType
+	queueID := uniqueQueueID(t)
+
+	q := New(log.TestLogger(t), 1, WithQueueMetrics(gauge, queueType, queueID))
+	msg, err := DecodeSignedSSVMessage(mockConsensusMessage{Height: 100, Type: specqbft.PrepareMsgType}.ssvMessage(mockState))
+	require.NoError(t, err)
+
+	require.True(t, q.TryPush(msg))
+	require.False(t, q.TryPush(msg))
+	require.False(t, q.TryPush(msg))
+
+	requireQueueDropCounter(t, queueType, queueID, DropReasonBufferFull, 2)
+}
+
+func TestMetricsQueueObserver_RecordDrop_FallbackForUnregisteredReason(t *testing.T) {
+	t.Parallel()
+
+	gauge := newTestGauge(t)
+	const (
+		queueType = ValidatorQueueMetricType
+		reason    = "synthetic_unregistered_reason"
+	)
+	queueID := uniqueQueueID(t)
+
+	q := New(log.TestLogger(t), 1, WithQueueMetrics(gauge, queueType, queueID)).(*priorityQueue)
+	q.observer.recordDrop(reason)
+
+	requireQueueDropCounter(t, queueType, queueID, reason, 1)
+}
+
+func TestPriorityQueue_ConcurrentTryPush_RecordsAllDrops(t *testing.T) {
+	t.Parallel()
+
+	gauge := newTestGauge(t)
+	const (
+		queueType = ValidatorQueueMetricType
+		pushers   = 64
+	)
+	queueID := uniqueQueueID(t)
+
+	q := New(log.TestLogger(t), 1, WithQueueMetrics(gauge, queueType, queueID))
+	msg, err := DecodeSignedSSVMessage(mockConsensusMessage{Height: 100, Type: specqbft.PrepareMsgType}.ssvMessage(mockState))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var pushed atomic.Int64
+	wg.Add(pushers)
+	for i := 0; i < pushers; i++ {
+		go func() {
+			defer wg.Done()
+			if q.TryPush(msg) {
+				pushed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// With cap=1 and no consumer, exactly one TryPush succeeds; the rest drop.
+	require.Equal(t, int64(1), pushed.Load(), "exactly one push should succeed for cap=1 with no consumer")
+	requireQueueDropCounter(t, queueType, queueID, DropReasonBufferFull, pushers-1)
+}
+
+// uniqueQueueID builds a queueID that's stable within a test invocation but
+// differs across re-runs (e.g. `go test -count=N`). Necessary because the
+// queue-side drop counter is a package-global that accumulates across runs.
+func uniqueQueueID(t *testing.T) string {
+	return fmt.Sprintf("%s/%d", t.Name(), time.Now().UnixNano())
+}
+
+// newTestGauge returns a gauge backed by a fresh provider/reader, isolated
+// from the package-global pkgTestMetricReader. It's used wherever a test only
+// needs to satisfy WithQueueMetrics' gauge parameter without asserting on the
+// gauge itself.
+func newTestGauge(t *testing.T) otelmetric.Int64Gauge {
+	t.Helper()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader()))
+	gauge, err := provider.Meter("test").Int64Gauge("test_inbox_size")
+	require.NoError(t, err)
+	return gauge
 }
 
 func decodeAndPush(t require.TestingT, queue Queue, msg mockMessage, state *State) *SSVMessage {


### PR DESCRIPTION
Stacks on top of #2812 to fill the test-coverage gaps identified in the post-merge audit. Targets `queue-pressure` so merging this folds the new tests into PR #2812.

Closes https://github.com/ssvlabs/ssv-node-board/issues/1065

## Coverage added

**Queue side** (uses a `TestMain` that sets a global OTel provider so tests can read the package-global `droppedMessagesMetric`):

| Test | What it pins down |
|---|---|
| `TestPriorityQueue_TryPushDropMetric_RecordsAttributes` | Drop counter increments with `(queue_type, queue_id, drop_reason)` attributes when `TryPush` fails — previously asserted nowhere on the queue side. |
| `TestMetricsQueueObserver_RecordDrop_FallbackForUnregisteredReason` | The unregistered-reason fallback path (added in #2842 in response to greptile's "silent miss" comment) actually records a data point. Without this, the fallback could silently regress — exactly the bug it was meant to prevent. |
| `TestPriorityQueue_ConcurrentTryPush_RecordsAllDrops` | 64 goroutines hit a cap=1 queue with no consumer; asserts exactly 1 success and `pushers-1` counter increments. Pins down behaviour under contention that previously was only exercised by `BenchmarkPriorityQueue_Parallel_Lossy` (which `make unit-test` doesn't run). |

**Router side** (per-test isolated `ManualReader` via the existing `newRouterTestMetrics` helper):

| Test | What it pins down |
|---|---|
| `TestMessageRouter_RecordDrop_FallbackForUnregisteredReason` | Mirror of the queue-side fallback test for the router's `recordDrop`. |
| `TestRouter_ConcurrentRoute_RecordsAllBufferFullDrops` | 64 concurrent `Route` calls into a pre-filled buffer; asserts buffer doesn't grow past capacity and counter equals caller count. |

## Notes

- Each queue-side test uses `uniqueQueueID(t)` = `t.Name() + "-" + UnixNano` so attribute sets are unique across `go test -count=N` re-runs (the queue-side counter is a package-global that accumulates across runs).
- All new tests use `t.Parallel()`. Queue-side tests rely on unique IDs for isolation; router-side tests use isolated readers.

## Test plan

- [x] `go test -race -count=5 ./protocol/v2/ssv/queue/ ./operator/validator/`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean