### PR TITLE
beacon/goclient: tolerate transient CL inactivity at multi-client init

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -205,6 +205,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}
 
+	// First error stops the loop on purpose - a malformed CL address must surface to the operator, not be silently skipped.
 	for _, beaconAddr := range beaconAddrList {
 		if err := client.addSingleClient(ctx, beaconAddr); err != nil {
 			return nil, err
@@ -300,6 +301,8 @@ func (gc *GoClient) initMultiClient(ctx context.Context) error {
 		eth2clientmulti.WithClients(services),
 		eth2clientmulti.WithLogLevel(zerolog.DebugLevel),
 		eth2clientmulti.WithTimeout(gc.commonTimeout),
+		// Mirrors WithAllowDelayedStart on individual CL clients - avoids ErrNotActive on transient CL outages at startup.
+		eth2clientmulti.WithAllowDelayedStart(true),
 	)
 	if err != nil {
 		return fmt.Errorf("create multi client: %w", err)

--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -193,18 +193,22 @@ func TestTimeouts(t *testing.T) {
 		mockServerEpoch = 132502
 	)
 
-	// Too slow to dial.
+	// CLs unresponsive at startup: New must wait under ctx, not fatal eagerly with "client is not active".
 	{
 		undialableServer := mocks.NewServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			time.Sleep(commonTimeout + timeoutMargin)
 			return resp, nil
 		})
-		_, err := New(t.Context(), zap.NewNop(), Options{
+		ctx, cancel := context.WithTimeout(t.Context(), commonTimeout+timeoutMargin)
+		defer cancel()
+		_, err := New(ctx, zap.NewNop(), Options{
 			BeaconNodeAddr: undialableServer.URL,
 			CommonTimeout:  commonTimeout,
 			LongTimeout:    longTimeout,
 		})
-		require.ErrorContains(t, err, "client is not active")
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "client is not active")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	}
 
 	// Too slow to respond to the Validators request.


### PR DESCRIPTION
## Summary
- Mirrors `WithAllowDelayedStart(true)` on the multi-client constructor (single CL clients already had it). Without this flag the constructor returned `ErrNotActive` immediately on transient CL inactivity at startup, killing the SSV node before the existing 60s `longTimeout`-bounded `beaconConfigInit` wait could even run.
- Adds a clarifying comment on the `addSingleClient` loop documenting that bailing on the first error is intentional - a malformed CL address must surface to the operator rather than be silently skipped.
- Updates `TestTimeouts` "Too slow to dial" sub-block to assert the new behavior: the wait now times out via `longTimeout` rather than via eager `ErrNotActive`.

## Why
On mainnet, committee 1-2-3-4 hit a startup-time fatal during a transient CL outage: nodes 2 and 4 restarted while all CLs were briefly inactive, and the multi-client constructor immediately returned `ErrNotActive` (`create multi client: client is not active`), exiting the process before the 60s wait window could absorb the blip. With this fix the multi-client tolerates delayed-start clients; transient CL inactivity is absorbed within the existing `longTimeout` budget, prolonged outages still fatal so supervisors restart.

Closes https://github.com/ssvlabs/ssv-node-board/issues/1042

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./beacon/goclient/...` clean
- [x] `go test -count=1 ./beacon/goclient/...` passes (including updated `TestTimeouts`)
- [ ] Manual: start an SSV node against a CL that's down for <60s - verify it tolerates and continues without restart
- [ ] Manual: leave all CLs unreachable indefinitely - verify the existing 60s `longTimeout` fatal still kicks in