### PR TITLE
operator/duties: fix late voluntary exit scheduling

### DIFF
--- a/eth/ethtest/common_test.go
+++ b/eth/ethtest/common_test.go
@@ -51,20 +51,19 @@ func NewCommonTestInput(
 }
 
 type TestEnv struct {
-	eventSyncer    *eventsyncer.EventSyncer
-	validators     []*testValidatorData
-	ops            []*testOperator
-	nodeStorage    storage.Storage
-	sim            *simulator.Backend
-	boundContract  *simcontract.Simcontract
-	auth           *bind.TransactOpts
-	shares         [][]byte
-	execClient     *executionclient.ExecutionClient
-	rpcServer      *rpc.Server
-	httpSrv        *httptest.Server
-	taskExecutor   *mocks.MockTaskExecutor
-	mockCtrl       *gomock.Controller
-	followDistance *uint64
+	eventSyncer   *eventsyncer.EventSyncer
+	validators    []*testValidatorData
+	ops           []*testOperator
+	nodeStorage   storage.Storage
+	sim           *simulator.Backend
+	boundContract *simcontract.Simcontract
+	auth          *bind.TransactOpts
+	shares        [][]byte
+	execClient    *executionclient.ExecutionClient
+	rpcServer     *rpc.Server
+	httpSrv       *httptest.Server
+	taskExecutor  *mocks.MockTaskExecutor
+	mockCtrl      *gomock.Controller
 }
 
 func (e *TestEnv) shutdown() {
@@ -89,9 +88,6 @@ func (e *TestEnv) setup(
 	validatorsCount uint64,
 	operatorsCount uint64,
 ) error {
-	if e.followDistance == nil {
-		e.SetDefaultFollowDistance()
-	}
 	logger := zaptest.NewLogger(t)
 
 	// Create operators RSA keys
@@ -173,7 +169,6 @@ func (e *TestEnv) setup(
 		addr,
 		contractAddr,
 		executionclient.WithLogger(logger),
-		executionclient.WithFollowDistance(*e.followDistance),
 	)
 	if err != nil {
 		return err
@@ -206,14 +201,10 @@ func (e *TestEnv) setup(
 	return nil
 }
 
-func (e *TestEnv) SetDefaultFollowDistance() {
-	// 8 is current production offset
-	value := uint64(8)
-	e.followDistance = &value
-}
-
+// CloseFollowDistance advances the simulator past the EL follow-distance
+// window so that events committed before it become visible to log streaming.
 func (e *TestEnv) CloseFollowDistance(blockNum *uint64) {
-	for i := uint64(0); i < *e.followDistance; i++ {
+	for i := uint64(0); i < executionclient.FollowDistance; i++ {
 		commitBlock(e.sim, blockNum)
 	}
 }

--- a/eth/ethtest/eth_e2e_test.go
+++ b/eth/ethtest/eth_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/eth/simulator/simcontract"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
@@ -53,7 +54,6 @@ func TestEthExecLayer(t *testing.T) {
 	expectedNonce := registrystorage.Nonce(0)
 
 	testEnv := TestEnv{}
-	testEnv.SetDefaultFollowDistance()
 
 	defer testEnv.shutdown()
 	err := testEnv.setup(t, ctx, testAddresses, 7, 4)
@@ -111,7 +111,7 @@ func TestEthExecLayer(t *testing.T) {
 			require.NoError(t, err)
 
 			//check all the events were handled correctly and block number was increased
-			require.Equal(t, blockNum-*testEnv.followDistance, lastHandledBlockNum)
+			require.Equal(t, blockNum-executionclient.FollowDistance, lastHandledBlockNum)
 			fmt.Println("lastHandledBlockNum", lastHandledBlockNum)
 
 			// Check that operators were successfully registered

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -118,7 +119,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 	require.NotEmpty(t, contractCode)
 
 	// Create a client and connect to the simulator
-	client, err := executionclient.New(ctx, addr, contractAddr, executionclient.WithLogger(logger), executionclient.WithFollowDistance(0))
+	client, err := executionclient.New(ctx, addr, contractAddr, executionclient.WithLogger(logger))
 	require.NoError(t, err)
 
 	contractFilterer, err := client.Filterer()
@@ -127,7 +128,28 @@ func TestHandleBlockEventsStream(t *testing.T) {
 	err = client.Healthy(ctx)
 	require.NoError(t, err)
 
-	logs := client.StreamLogs(ctx, 0)
+	// nextEventBlock returns the logs from the most recently committed block as
+	// a BlockLogs ready to feed into HandleBlockEventsStream. It bypasses the EL
+	// log stream (FollowDistance lag, websocket round-trips) — this test
+	// exercises the handler, not streaming, and the original WithFollowDistance(0)
+	// shortcut had the same effect. Going direct also keeps the test
+	// wall-clock tight so the slot-equality assertions further down don't race
+	// past slot boundaries.
+	nextEventBlock := func() executionclient.BlockLogs {
+		header, err := client.HeaderByNumber(ctx, nil)
+		require.NoError(t, err)
+		blockNumber := header.Number.Uint64()
+		blockLogs, err := client.FilterLogs(ctx, ethereum.FilterQuery{
+			Addresses: []ethcommon.Address{contractAddr},
+			FromBlock: new(big.Int).SetUint64(blockNumber),
+			ToBlock:   new(big.Int).SetUint64(blockNumber),
+		})
+		require.NoError(t, err)
+		return executionclient.BlockLogs{
+			BlockNumber: blockNumber,
+			Logs:        blockLogs,
+		}
+	}
 
 	boundContract, err := simcontract.NewSimcontract(contractAddr, sim.Client())
 	require.NoError(t, err)
@@ -163,8 +185,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		}
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -285,8 +306,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -336,8 +356,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)
@@ -386,8 +405,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)
@@ -441,8 +459,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)
@@ -490,8 +507,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)
@@ -540,8 +556,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)
@@ -583,8 +598,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xb4b20ffb2eb1f020be3df600b2287914f50c07003526d3a9d89a9dd12351828c"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -610,8 +624,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xb4b20ffb2eb1f020be3df600b2287914f50c07003526d3a9d89a9dd12351828c"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -650,8 +663,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xb4b20ffb2eb1f020be3df600b2287914f50c07003526d3a9d89a9dd12351828c"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -695,8 +707,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xccf4370403e5fbbde0cd3f13426479dcd8a5916b05db424b7a2c04978cf8ce6e"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -733,8 +744,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xccf4370403e5fbbde0cd3f13426479dcd8a5916b05db424b7a2c04978cf8ce6e"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -779,8 +789,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xccf4370403e5fbbde0cd3f13426479dcd8a5916b05db424b7a2c04978cf8ce6e"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -821,8 +830,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0x1fce24c373e07f89214e9187598635036111dbb363e99f4ce498488cdc66e688"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -882,8 +890,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0xc803f8c01343fcdaf32068f4c283951623ef2b3fa0c547551931356f456b6859"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -932,8 +939,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0x1fce24c373e07f89214e9187598635036111dbb363e99f4ce498488cdc66e688"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -966,8 +972,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0xc803f8c01343fcdaf32068f4c283951623ef2b3fa0c547551931356f456b6859"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -1020,8 +1025,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
+		block := nextEventBlock()
 		require.Equal(t, ethcommon.HexToHash("0x259235c230d57def1521657e7c7951d3b385e76193378bc87ef6b56bc2ec3548"), block.Logs[0].Topics[0])
 
 		eventsCh := make(chan executionclient.BlockLogs)
@@ -1069,8 +1073,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
 			require.Equal(t, ethcommon.HexToHash("0x0e0ba6c2b04de36d6d509ec5bd155c43a9fe862f8052096dd54f3902a74cca3e"), block.Logs[1].Topics[0])
 
@@ -1147,8 +1150,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 			require.Equal(t, ethcommon.HexToHash("0xccf4370403e5fbbde0cd3f13426479dcd8a5916b05db424b7a2c04978cf8ce6e"), block.Logs[1].Topics[0])
 
@@ -1211,8 +1213,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x1fce24c373e07f89214e9187598635036111dbb363e99f4ce498488cdc66e688"), block.Logs[0].Topics[0])
 			require.Equal(t, ethcommon.HexToHash("0xc803f8c01343fcdaf32068f4c283951623ef2b3fa0c547551931356f456b6859"), block.Logs[1].Topics[0])
 
@@ -1242,8 +1243,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x0e0ba6c2b04de36d6d509ec5bd155c43a9fe862f8052096dd54f3902a74cca3e"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -1287,8 +1287,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 
 			sim.Commit()
 
-			block := <-logs
-			require.NotEmpty(t, block.Logs)
+			block := nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
 
 			eventsCh := make(chan executionclient.BlockLogs)
@@ -1318,8 +1317,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.NoError(t, err)
 			sim.Commit()
 
-			block = <-logs
-			require.NotEmpty(t, block.Logs)
+			block = nextEventBlock()
 			require.Equal(t, ethcommon.HexToHash("0x0e0ba6c2b04de36d6d509ec5bd155c43a9fe862f8052096dd54f3902a74cca3e"), block.Logs[0].Topics[0])
 
 			eventsCh = make(chan executionclient.BlockLogs)

--- a/eth/executionclient/bloom_test.go
+++ b/eth/executionclient/bloom_test.go
@@ -97,7 +97,6 @@ func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 
 	client, err := New(t.Context(), srv.URL, env.contractAddr,
 		WithLogger(logger),
-		WithFollowDistance(0),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
@@ -139,7 +138,6 @@ func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
 	// No proxy tricks — use the real backend directly.
 	err = env.createClient(
 		WithLogger(logger),
-		WithFollowDistance(0),
 	)
 	require.NoError(t, err)
 
@@ -174,7 +172,6 @@ func TestVerifyLogsWithBloom_EmptyRange(t *testing.T) {
 
 	err = env.createClient(
 		WithLogger(logger),
-		WithFollowDistance(0),
 	)
 	require.NoError(t, err)
 
@@ -269,7 +266,6 @@ func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
 
 	client, err := New(t.Context(), srv.URL, contractAddr,
 		WithLogger(logger),
-		WithFollowDistance(0),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
@@ -324,7 +320,6 @@ func TestVerifyLogsWithBloom_BlocksWithExistingLogs(t *testing.T) {
 
 	client, err := New(t.Context(), srv.URL, env.contractAddr,
 		WithLogger(logger),
-		WithFollowDistance(0),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })

--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -8,7 +8,20 @@ const (
 	DefaultReqTimeout    = 10 * time.Second
 	DefaultReqRetryDelay = 10 * time.Second
 
-	DefaultFollowDistance = 8
+	// FollowDistance is the offset (in blocks) into the past from the chain head
+	// at which a block is considered very likely finalized. The EL log stream
+	// only surfaces events from blocks at this depth or deeper, trading some
+	// latency for reorg-safety (SSV cares strongly: surfacing an event from a
+	// later-reorged block could lead to slashing).
+	//
+	// This value is a network-wide invariant rather than an operator-tunable
+	// knob: duty-scheduling logic in operator/duties derives slot offsets from
+	// it (see voluntaryExitSlotsToPostpone) so that operators agree on the same
+	// scheduled slot deterministically. If operators ran with different values,
+	// some would schedule duties in the past on receipt and broadcast pre-
+	// consensus messages with diverging slot/epoch values, breaking partial-
+	// signature aggregation.
+	FollowDistance = 8
 
 	DefaultHealthInvalidationInterval = 10 * time.Second
 

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -55,10 +55,6 @@ type ExecutionClient struct {
 	reqTimeout    time.Duration
 	reqRetryDelay time.Duration
 
-	// followDistance defines an offset into the past from the head block such that the block
-	// at this offset will be considered as very likely finalized.
-	followDistance uint64 // TODO: consider reading the finalized checkpoint from consensus layer
-
 	syncDistanceTolerance uint64
 	// syncProgressFn is a struct-field so it can be overwritten for testing
 	syncProgressFn func(context.Context) (*ethereum.SyncProgress, error)
@@ -79,7 +75,6 @@ func New(ctx context.Context, nodeAddr string, contractAddr ethcommon.Address, o
 		logger:                     zap.NewNop(),
 		reqTimeout:                 DefaultReqTimeout,
 		reqRetryDelay:              DefaultReqRetryDelay,
-		followDistance:             DefaultFollowDistance,
 		healthInvalidationInterval: DefaultHealthInvalidationInterval,
 		syncDistanceTolerance:      DefaultSyncDistanceTolerance,
 		closed:                     make(chan struct{}),
@@ -137,10 +132,10 @@ func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock ui
 	if err != nil {
 		return nil, nil, ec.errSingleClient(fmt.Errorf("get current block: %w", err), "eth_blockNumber")
 	}
-	if currentBlock < ec.followDistance {
+	if currentBlock < FollowDistance {
 		return nil, nil, ErrNothingToSync
 	}
-	toBlock := currentBlock - ec.followDistance
+	toBlock := currentBlock - FollowDistance
 	if toBlock < fromBlock {
 		return nil, nil, ErrNothingToSync
 	}
@@ -500,10 +495,10 @@ func (ec *ExecutionClient) streamLogsToChan(
 			return lastBlock, progressed, fmt.Errorf("subscription error: %w", err)
 
 		case header := <-heads:
-			if header.Number.Uint64() < ec.followDistance {
+			if header.Number.Uint64() < FollowDistance {
 				continue
 			}
-			toBlock := header.Number.Uint64() - ec.followDistance
+			toBlock := header.Number.Uint64() - FollowDistance
 			if toBlock < fromBlock {
 				continue
 			}

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -168,10 +168,8 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a client and connect to the simulator
-		const followDistance = 8
 		err = env.createClient(
 			WithLogger(logger),
-			WithFollowDistance(followDistance),
 			WithReqTimeout(2*time.Second),
 		)
 		require.NoError(t, err)
@@ -190,7 +188,7 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		}
 		require.NotEmpty(t, fetchedLogs)
 
-		expectedSeenLogs := blocksWithLogsLength - followDistance
+		expectedSeenLogs := blocksWithLogsLength - FollowDistance
 		require.Equal(t, expectedSeenLogs, len(fetchedLogs))
 
 		select {
@@ -201,21 +199,20 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		}
 	})
 
-	t.Run("error when currentBlock < followDistance", func(t *testing.T) {
+	t.Run("error when currentBlock < FollowDistance", func(t *testing.T) {
 		env := setupTestEnv(t, 5*time.Second)
 		_, err := env.deployCallableContract()
 		require.NoError(t, err)
 
-		// Create a client with a large followDistance
-		const followDistance = 100 // Much larger than the current block number
+		// Create a client. The simulator is at block 1 after deployCallableContract,
+		// which is below FollowDistance (=8) so FetchHistoricalLogs should bail out
+		// with ErrNothingToSync.
 		err = env.createClient(
 			WithLogger(logger),
-			WithFollowDistance(followDistance),
 			WithReqTimeout(2*time.Second),
 		)
 		require.NoError(t, err)
 
-		// Fetch logs - should fail because the currentBlock < followDistance
 		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, 0)
 		require.ErrorIs(t, err, ErrNothingToSync)
 		require.Nil(t, logs)
@@ -228,10 +225,8 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a client
-		const followDistance = 8
 		err = env.createClient(
 			WithLogger(logger),
-			WithFollowDistance(followDistance),
 			WithReqTimeout(2*time.Second),
 		)
 		require.NoError(t, err)
@@ -244,8 +239,8 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		currentBlock, err := env.client.client.BlockNumber(env.ctx)
 		require.NoError(t, err)
 
-		// Set fromBlock to a value greater than the currentBlock - followDistance
-		fromBlock := currentBlock - followDistance + 10
+		// Set fromBlock to a value greater than the currentBlock - FollowDistance
+		fromBlock := currentBlock - FollowDistance + 10
 
 		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, fromBlock)
 		require.ErrorIs(t, err, ErrNothingToSync)
@@ -261,7 +256,6 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		// Create a client - connection should succeed initially
 		err = env.createClient(
 			WithLogger(logger),
-			WithFollowDistance(8),
 			WithReqTimeout(200*time.Millisecond),
 		)
 		require.NoError(t, err) // Connection is established initially
@@ -379,19 +373,20 @@ func TestFetchHistoricalLogs_Subdivide(t *testing.T) {
 			srv := httptest.NewServer(wrapped)
 			t.Cleanup(srv.Close)
 
-			opts := []Option{WithFollowDistance(0)}
-
 			client, err := New(t.Context(),
 				srv.URL,
 				env.contractAddr,
-				opts...,
 			)
 			require.NoError(t, err)
 
 			t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-			logsCh, errCh, err := client.FetchHistoricalLogs(t.Context(), 0)
+			// Bypass the FetchHistoricalLogs follow-distance window so the
+			// subdivision algorithm operates on the full mined range and the
+			// per-case eth_getLogs call counts remain meaningful.
+			currentBlock, err := client.client.BlockNumber(t.Context())
 			require.NoError(t, err)
+			logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, false)
 
 			all := make([]ethtypes.Log, 0, tc.wantLogs)
 			for blk := range logsCh {
@@ -425,8 +420,7 @@ func TestStreamLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a client and connect to the simulator
-		const followDistance = 2
-		err = env.createClient(WithLogger(logger), WithFollowDistance(followDistance))
+		err = env.createClient(WithLogger(logger))
 		require.NoError(t, err)
 
 		logs := env.client.StreamLogs(env.ctx, 0)
@@ -445,22 +439,22 @@ func TestStreamLogs(t *testing.T) {
 		err = env.createBlocksWithLogs(contract, blocksWithLogsLength, delay)
 		require.NoError(t, err)
 
-		// Wait for blocksWithLogsLength-followDistance blocks to be streamed.
+		// Wait for blocksWithLogsLength-FollowDistance blocks to be streamed.
 	Wait1:
 		for {
 			select {
 			case <-env.ctx.Done():
 				require.Failf(t, "timed out", "err: %v, streamedLogsCount: %d", env.ctx.Err(), streamedLogsCount.Load())
 			case <-time.After(time.Millisecond * 5):
-				if streamedLogsCount.Load() == int64(blocksWithLogsLength-followDistance) {
+				if streamedLogsCount.Load() == int64(blocksWithLogsLength-FollowDistance) {
 					break Wait1
 				}
 			}
 		}
 
 		// Create empty blocks with no transactions to advance the chain
-		// followDistance blocks ahead.
-		for i := 0; i < followDistance; i++ {
+		// FollowDistance blocks ahead.
+		for i := 0; i < FollowDistance; i++ {
 			env.sim.Commit()
 			time.Sleep(delay)
 		}
@@ -723,7 +717,7 @@ func TestChainReorganizationLogs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := New(ctx, srv.URL, contractAddr, WithLogger(zaptest.NewLogger(t)), WithFollowDistance(0))
+	client, err := New(ctx, srv.URL, contractAddr, WithLogger(zaptest.NewLogger(t)))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, client.Close()) }()
 
@@ -783,35 +777,50 @@ func TestSimSSV(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a client and connect to the simulator
-	err = env.createClient(WithLogger(logger), WithFollowDistance(0))
+	err = env.createClient(WithLogger(logger))
 	require.NoError(t, err)
 
 	logs := env.client.StreamLogs(env.ctx, 0)
 
+	// commitAndAdvance commits the supplied transaction and then mines FollowDistance
+	// empty blocks so the tx block clears the EL log stream's follow-distance window.
+	commitAndAdvance := func(t *testing.T, tx *ethtypes.Transaction) {
+		env.sim.Commit()
+		receipt, err := env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
+		require.NoError(t, err, "get receipt")
+		require.Equal(t, uint64(0x1), receipt.Status)
+		for i := 0; i < FollowDistance; i++ {
+			env.sim.Commit()
+		}
+	}
+	// nextEventBlock drains empty progression markers and returns the next block
+	// carrying actual logs from the stream.
+	nextEventBlock := func(t *testing.T) BlockLogs {
+		for {
+			select {
+			case block, ok := <-logs:
+				require.True(t, ok, "logs channel closed unexpectedly")
+				if len(block.Logs) > 0 {
+					return block
+				}
+			case <-env.ctx.Done():
+				t.Fatalf("timed out waiting for event: %v", env.ctx.Err())
+			}
+		}
+	}
+
 	// Emit event OperatorAdded
 	tx, err := boundContract.RegisterOperator(env.auth, ethcommon.Hex2Bytes("0xb24454393691331ee6eba4ffa2dbb2600b9859f908c3e648b6c6de9e1dea3e9329866015d08355c8d451427762b913d1"), big.NewInt(100_000_000))
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err := env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block := <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block := nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
 
 	// Emit event OperatorRemoved
 	tx, err = boundContract.RemoveOperator(env.auth, 1)
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0x0e0ba6c2b04de36d6d509ec5bd155c43a9fe862f8052096dd54f3902a74cca3e"), block.Logs[0].Topics[0])
 
 	// Emit event ValidatorAdded
@@ -828,14 +837,8 @@ func TestSimSSV(t *testing.T) {
 			Balance:         big.NewInt(100_000_000),
 		})
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0x48a3ea0796746043948f6341d17ff8200937b99262a0b48c2663b951ed7114e5"), block.Logs[0].Topics[0])
 
 	// Emit event ValidatorRemoved
@@ -851,14 +854,8 @@ func TestSimSSV(t *testing.T) {
 			Balance:         big.NewInt(100_000_000),
 		})
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0xccf4370403e5fbbde0cd3f13426479dcd8a5916b05db424b7a2c04978cf8ce6e"), block.Logs[0].Topics[0])
 
 	// Emit event ClusterLiquidated
@@ -874,14 +871,8 @@ func TestSimSSV(t *testing.T) {
 			Balance:         big.NewInt(100_000_000),
 		})
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0x1fce24c373e07f89214e9187598635036111dbb363e99f4ce498488cdc66e688"), block.Logs[0].Topics[0])
 
 	// Emit event ClusterReactivated
@@ -897,14 +888,8 @@ func TestSimSSV(t *testing.T) {
 			Balance:         big.NewInt(100_000_000),
 		})
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0xc803f8c01343fcdaf32068f4c283951623ef2b3fa0c547551931356f456b6859"), block.Logs[0].Topics[0])
 
 	// Emit event FeeRecipientAddressUpdated
@@ -913,14 +898,8 @@ func TestSimSSV(t *testing.T) {
 		ethcommon.HexToAddress("0x1"),
 	)
 	require.NoError(t, err)
-	env.sim.Commit()
-	receipt, err = env.sim.Client().TransactionReceipt(env.ctx, tx.Hash())
-	if err != nil {
-		t.Errorf("get receipt: %v", err)
-	}
-	require.Equal(t, uint64(0x1), receipt.Status)
-	block = <-logs
-	require.NotEmpty(t, block.Logs)
+	commitAndAdvance(t, tx)
+	block = nextEventBlock(t)
 	require.Equal(t, ethcommon.HexToHash("0x259235c230d57def1521657e7c7951d3b385e76193378bc87ef6b56bc2ec3548"), block.Logs[0].Topics[0])
 }
 

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -55,10 +55,6 @@ type MultiClient struct {
 	reqTimeout    time.Duration
 	reqRetryDelay time.Duration
 
-	// followDistance defines an offset into the past from the head block such that the block
-	// at this offset will be considered as very likely finalized.
-	followDistance uint64 // TODO: consider reading the finalized checkpoint from consensus layer
-
 	healthInvalidationInterval time.Duration
 
 	syncDistanceTolerance uint64
@@ -88,7 +84,6 @@ func NewMulti(ctx context.Context, nodeAddrs []string, contractAddr ethcommon.Ad
 		logger:                     zap.NewNop(),
 		reqTimeout:                 DefaultReqTimeout,
 		reqRetryDelay:              DefaultReqRetryDelay,
-		followDistance:             DefaultFollowDistance,
 		healthInvalidationInterval: DefaultHealthInvalidationInterval,
 		syncDistanceTolerance:      DefaultSyncDistanceTolerance,
 	}
@@ -147,7 +142,6 @@ func (mc *MultiClient) connect(ctx context.Context, clientAddr string) (*Executi
 		clientAddr,
 		mc.contractAddress,
 		WithLogger(mc.logger),
-		WithFollowDistance(mc.followDistance),
 		WithReqTimeout(mc.reqTimeout),
 		WithHealthInvalidationInterval(mc.healthInvalidationInterval),
 		WithSyncDistanceTolerance(mc.syncDistanceTolerance),

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -47,7 +47,6 @@ func TestNewMulti(t *testing.T) {
 		require.Equal(t, zap.NewNop(), mc.logger)
 		require.EqualValues(t, DefaultReqTimeout, mc.reqTimeout)
 		require.EqualValues(t, DefaultReqRetryDelay, mc.reqRetryDelay)
-		require.EqualValues(t, DefaultFollowDistance, mc.followDistance)
 		require.EqualValues(t, DefaultHealthInvalidationInterval, mc.healthInvalidationInterval)
 		require.EqualValues(t, DefaultSyncDistanceTolerance, mc.syncDistanceTolerance)
 	})

--- a/eth/executionclient/options.go
+++ b/eth/executionclient/options.go
@@ -28,14 +28,6 @@ func WithLoggerMulti(logger *zap.Logger) OptionMulti {
 	}
 }
 
-// WithFollowDistance sets finalization offset (a block at this offset into the past
-// from the head block will be considered as very likely finalized).
-func WithFollowDistance(offset uint64) Option {
-	return func(s *ExecutionClient) {
-		s.followDistance = offset
-	}
-}
-
 // WithReqTimeout sets timeout for RPC requests to eth1 node.
 // The timeout must be positive, otherwise the default value will be used.
 func WithReqTimeout(timeout time.Duration) Option {

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -12,14 +12,22 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
+	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 )
 
-// voluntaryExitSlotsToPostpone defines how many slots we want to wait out before
-// executing voluntary exit duty.
-const voluntaryExitSlotsToPostpone = phase0.Slot(4)
+const (
+	// voluntaryExitSchedulingSlack keeps a few slots of buffer after the execution-layer
+	// follow distance so the duty is still in the future when the event is finally observed
+	// and picked up on the next slot tick.
+	voluntaryExitSchedulingSlack = phase0.Slot(4)
+
+	// voluntaryExitSlotsToPostpone defines how many slots we want to wait out before
+	// executing voluntary exit duty.
+	voluntaryExitSlotsToPostpone = phase0.Slot(executionclient.DefaultFollowDistance) + voluntaryExitSchedulingSlack
+)
 
 type ExitDescriptor struct {
 	OwnValidator   bool
@@ -86,9 +94,9 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 			}
 
 			// Calculate duty slot in a deterministic manner to ensure every Operator will have the same
-			// slot value for this duty. Additionally, add validatorRegistrationSlotsToPostpone slots on
-			// top to ensure the duty is scheduled with a slot number never in the past since several slots
-			// might have passed by the time we are processing this event here.
+			// slot value for this duty. Additionally, add voluntaryExitSlotsToPostpone slots on
+			// top to ensure the duty is scheduled with a slot number still in the future once the
+			// event clears the execution-layer follow distance and reaches this handler.
 			blockSlot, err := h.blockSlot(ctx, exitDescriptor.BlockNumber)
 			if err != nil {
 				h.logger.Warn(

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -19,14 +19,26 @@ import (
 )
 
 const (
-	// voluntaryExitSchedulingSlack keeps a few slots of buffer after the execution-layer
-	// follow distance so the duty is still in the future when the event is finally observed
-	// and picked up on the next slot tick.
+	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an
+	// exit event clears the execution-layer follow distance. Different operators
+	// observe the event at slightly different wall-clock times due to EL client
+	// differences, head-subscription latency, FilterLogs round-trip, and the
+	// phase of the local slot ticker relative to event delivery. The slack gives
+	// every operator enough time to compute the same dutySlot and have it still
+	// be in the future when their scheduler picks it up, so they all execute on
+	// the same target slot rather than firing on the next tick after receipt.
 	voluntaryExitSchedulingSlack = phase0.Slot(4)
 
-	// voluntaryExitSlotsToPostpone defines how many slots we want to wait out before
-	// executing voluntary exit duty.
-	voluntaryExitSlotsToPostpone = phase0.Slot(executionclient.DefaultFollowDistance) + voluntaryExitSchedulingSlack
+	// voluntaryExitSlotsToPostpone is the offset added to an exit event's block
+	// slot to derive the scheduled duty slot. It must exceed the EL streaming
+	// pipeline's worst-case latency from event production to handler delivery,
+	// which is dominated by executionclient.FollowDistance (the EL log stream
+	// only surfaces an event once the chain head reaches blockSlot+FollowDistance);
+	// the remainder is the slack above. If this value were smaller than any
+	// operator's effective EL streaming lag, that operator would schedule the
+	// duty in the past on receipt and fire immediately, defeating the cross-
+	// operator coordination that downstream pre-consensus signing depends on.
+	voluntaryExitSlotsToPostpone = phase0.Slot(executionclient.FollowDistance) + voluntaryExitSchedulingSlack
 )
 
 type ExitDescriptor struct {
@@ -93,10 +105,17 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				return
 			}
 
-			// Calculate duty slot in a deterministic manner to ensure every Operator will have the same
-			// slot value for this duty. Additionally, add voluntaryExitSlotsToPostpone slots on
-			// top to ensure the duty is scheduled with a slot number still in the future once the
-			// event clears the execution-layer follow distance and reaches this handler.
+			// Derive dutySlot deterministically from the EL event's block slot so
+			// every operator arrives at the same value regardless of when they
+			// personally received the event. This matters because the runner
+			// derives VoluntaryExit.Epoch from dutySlot (see
+			// VoluntaryExitRunner.calculateVoluntaryExit), and operators sign over
+			// the resulting VoluntaryExit object — divergent slots would produce
+			// different epochs near an epoch boundary, breaking BLS partial-
+			// signature aggregation and silently failing the exit.
+			//
+			// voluntaryExitSlotsToPostpone keeps that shared slot in the future
+			// for every operator: see its docstring for the breakdown.
 			blockSlot, err := h.blockSlot(ctx, exitDescriptor.BlockNumber)
 			if err != nil {
 				h.logger.Warn(

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -81,27 +81,27 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 	require.EqualValues(t, 1, blockByNumberCalls.Load())
 	exitCh <- normalExit
 
-	t.Run("slot = 0, block = 1 - no execution", func(t *testing.T) {
+	t.Run("slot = 0, block = 1 - no execution before block slot", func(t *testing.T) {
 		ticker.Send(phase0.Slot(0))
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = 1, block = 1 - no execution", func(t *testing.T) {
+	t.Run("slot = 1, block = 1 - no execution at block slot", func(t *testing.T) {
 		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber))
 		ticker.Send(phase0.Slot(normalExit.BlockNumber))
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = 4, block = 1 - no execution", func(t *testing.T) {
+	t.Run("slot = block + postpone - 1, block = 1 - no execution", func(t *testing.T) {
 		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitSlotsToPostpone-1)
 		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitSlotsToPostpone - 1)
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = 5, block = 1 - executing duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + postpone, block = 1 - executing duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
@@ -112,7 +112,7 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 
 	exitCh <- sameBlockExit
 
-	t.Run("slot = 5, block = 1 - executing another duty, no block number fetch", func(t *testing.T) {
+	t.Run("slot = block + postpone, block = 1 - executing another duty, no block number fetch", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
@@ -123,14 +123,14 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 
 	exitCh <- newBlockExit
 
-	t.Run("slot = 5, block = 2 - no execution", func(t *testing.T) {
+	t.Run("slot = block + postpone, block = 2 - no execution", func(t *testing.T) {
 		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitSlotsToPostpone)
 		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitSlotsToPostpone)
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 3, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = 6, block = 1 - executing new duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + postpone, block = 2 - executing new duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
@@ -141,7 +141,7 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 
 	exitCh <- pastBlockExit
 
-	t.Run("slot = 10, block = 5 - executing past duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + postpone + 1, block = 5 - executing past duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -178,7 +178,7 @@ func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistan
 		ValidatorIndex: phase0.ValidatorIndex(3),
 		BlockNumber:    blockNumber,
 	}
-	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.DefaultFollowDistance)
+	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.FollowDistance)
 	expectedDuty := []*spectypes.ValidatorDuty{{
 		Type:           spectypes.BNRoleVoluntaryExit,
 		PubKey:         lateObservedExit.PubKey,

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -14,6 +14,7 @@ import (
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 )
 
@@ -147,6 +148,59 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 		ticker.Send(phase0.Slot(pastBlockExit.BlockNumber) + voluntaryExitSlotsToPostpone + 1)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuties[3:4])
 		require.EqualValues(t, 4, blockByNumberCalls.Load())
+	})
+
+	cancel()
+	close(exitCh)
+	require.NoError(t, scheduler.Wait())
+	ticker.WaitShutdown()
+}
+
+func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistance(t *testing.T) {
+	t.Parallel()
+
+	exitCh := make(chan ExitDescriptor)
+	handler := NewVoluntaryExitHandler(dutystore.NewVoluntaryExit(), exitCh)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+
+	scheduler, ticker := setupSchedulerAndMocksWithParams(ctx, t, []dutyHandler{handler}, time.Unix(0, 0), time.Second)
+
+	require.NoError(t, scheduler.Start(ctx))
+
+	create1to1BlockSlotMapping(scheduler)
+
+	const blockNumber = uint64(1)
+
+	lateObservedExit := ExitDescriptor{
+		OwnValidator:   true,
+		PubKey:         phase0.BLSPubKey{7, 8, 9},
+		ValidatorIndex: phase0.ValidatorIndex(3),
+		BlockNumber:    blockNumber,
+	}
+	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.DefaultFollowDistance)
+	expectedDuty := []*spectypes.ValidatorDuty{{
+		Type:           spectypes.BNRoleVoluntaryExit,
+		PubKey:         lateObservedExit.PubKey,
+		Slot:           phase0.Slot(blockNumber) + voluntaryExitSlotsToPostpone,
+		ValidatorIndex: lateObservedExit.ValidatorIndex,
+	}}
+
+	executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
+	setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
+
+	waitForSlotN(scheduler.beaconConfig, lateObservationSlot)
+	exitCh <- lateObservedExit
+
+	t.Run("slot = block + followDistance - no execution", func(t *testing.T) {
+		ticker.Send(lateObservationSlot)
+		waitForNoAction(t, nil, executeDutiesCall, noActionTimeout)
+	})
+
+	t.Run("slot = block + postponed exit slot - execute", func(t *testing.T) {
+		waitForSlotN(scheduler.beaconConfig, phase0.Slot(blockNumber)+voluntaryExitSlotsToPostpone)
+		ticker.Send(phase0.Slot(blockNumber) + voluntaryExitSlotsToPostpone)
+		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuty)
 	})
 
 	cancel()


### PR DESCRIPTION
## What changed
- schedule voluntary exit duties after the execution-layer follow distance instead of using a fixed `blockSlot + 4`
- keep a small deterministic slack so the duty is still in the future when the event reaches the handler
- add a regression test covering late observation of an exit event after the EL follow-distance window

+ includes https://github.com/ssvlabs/ssv/pull/2852 as a clarifying refactor (to remove all related foot-guns).

## Why
Voluntary exit duties were derived from the EL event block slot with only a 4-slot delay, while EL log streaming only exposed events after an 8-block follow distance. That allowed duties to enter the queue already stale and execute immediately as late duties.

## Impact
- voluntary exits observed through the EL event stream are scheduled far enough ahead to avoid deterministic lateness
- no operator configuration change is required
- coverage now includes the reproduced late-observation path

## Verification
- `go test ./operator/duties -count=1`

Resolves https://github.com/ssvlabs/ssv-node-board/issues/1066