### PR TITLE
operator/duties: decouple voluntary-exit wire slot from local execution gate

### DIFF
--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -11,18 +11,15 @@ const (
 	// FollowDistance is the offset (in blocks) into the past from the chain head
 	// at which a block is considered very likely finalized. The EL log stream
 	// only surfaces events from blocks at this depth or deeper, trading some
-	// latency for reorg-safety (SSV cares strongly: surfacing an event from a
-	// later-reorged block could lead to slashing).
+	// latency for reorg-safety: surfacing an event from a block that the
+	// canonical chain may yet rewrite would let operators act on stale
+	// validator-share or cluster-membership state, corrupting slashing-
+	// protection records (see eth/eventhandler/handlers.go for the EKM bumping
+	// logic that this depth protects).
 	//
-	// This value is a network-wide invariant rather than an operator-tunable
-	// knob. It is load-bearing for the voluntary-exit broadcast gate in
-	// operator/duties (voluntaryExitExecutionSlotsToPostpone is derived from
-	// it): every operator uses it to size the worst-case EL-streaming lag
-	// before broadcasting their own partial-sig. If operators ran with
-	// different values, fast-EL operators with smaller FollowDistance would
-	// broadcast before slower peers had received the EL event, dropping the
-	// partial-sig at the receiver's dutyCount validation check and reopening
-	// the race that PR #2851 was meant to close.
+	// This is a network-wide invariant, not an operator-tunable knob —
+	// downstream duty-scheduling logic assumes every operator uses the same
+	// value. Treat any change as a coordinated network-wide upgrade.
 	FollowDistance = 8
 
 	DefaultHealthInvalidationInterval = 10 * time.Second

--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -15,12 +15,14 @@ const (
 	// later-reorged block could lead to slashing).
 	//
 	// This value is a network-wide invariant rather than an operator-tunable
-	// knob: duty-scheduling logic in operator/duties derives slot offsets from
-	// it (see voluntaryExitSlotsToPostpone) so that operators agree on the same
-	// scheduled slot deterministically. If operators ran with different values,
-	// some would schedule duties in the past on receipt and broadcast pre-
-	// consensus messages with diverging slot/epoch values, breaking partial-
-	// signature aggregation.
+	// knob. It is load-bearing for the voluntary-exit broadcast gate in
+	// operator/duties (voluntaryExitExecutionSlotsToPostpone is derived from
+	// it): every operator uses it to size the worst-case EL-streaming lag
+	// before broadcasting their own partial-sig. If operators ran with
+	// different values, fast-EL operators with smaller FollowDistance would
+	// broadcast before slower peers had received the EL event, dropping the
+	// partial-sig at the receiver's dutyCount validation check and reopening
+	// the race that PR #2851 was meant to close.
 	FollowDistance = 8
 
 	DefaultHealthInvalidationInterval = 10 * time.Second

--- a/operator/duties/observability.go
+++ b/operator/duties/observability.go
@@ -35,19 +35,24 @@ var (
 			metric.WithDescription("total number of duties scheduled for execution")))
 )
 
+// recordDutyScheduled bumps the per-role scheduled-duty counter and, when
+// meaningful, records a slot-delay histogram point. For wire-slot roles
+// (see usesWireSlot), the caller's slotDelay is intentionally large and
+// does not reflect operator lateness, so the histogram point is skipped;
+// the counter still ticks.
 func recordDutyScheduled(ctx context.Context, role types.RunnerRole, slotDelay time.Duration) {
 	runnerRoleAttr := metric.WithAttributes(observability.RunnerRoleAttribute(role))
 	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
-	slotDelayHistogram.Record(ctx, slotDelay.Seconds(), runnerRoleAttr)
+	if !usesWireSlot(role) {
+		slotDelayHistogram.Record(ctx, slotDelay.Seconds(), runnerRoleAttr)
+	}
 }
 
-// recordDutyScheduledNoDelay increments the scheduled-duty counter without
-// touching the slot-delay histogram. Use this when the duty's Slot field does
-// not represent the intended firing time (e.g. voluntary-exit, where duty.Slot
-// is a wire/coordination slot kept deliberately in the past) — recording the
-// computed "delay" against such a slot would pollute the histogram with
-// values that don't reflect operator lateness.
-func recordDutyScheduledNoDelay(ctx context.Context, role types.RunnerRole) {
-	runnerRoleAttr := metric.WithAttributes(observability.RunnerRoleAttribute(role))
-	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
+// usesWireSlot reports whether duty.Slot for the given role is a wire /
+// coordination slot intentionally kept in the past (rather than the
+// wall-clock firing slot). For such roles, "lateness" relative to duty.Slot
+// is meaningless — see voluntaryExitWireSlotsToPostpone for the canonical
+// rationale.
+func usesWireSlot(role types.RunnerRole) bool {
+	return role == types.RoleVoluntaryExit
 }

--- a/operator/duties/observability.go
+++ b/operator/duties/observability.go
@@ -36,23 +36,24 @@ var (
 )
 
 // recordDutyScheduled bumps the per-role scheduled-duty counter and, when
-// meaningful, records a slot-delay histogram point. For wire-slot roles
-// (see usesWireSlot), the caller's slotDelay is intentionally large and
-// does not reflect operator lateness, so the histogram point is skipped;
-// the counter still ticks.
+// meaningful, records a slot-delay histogram point. For roles where
+// duty.Slot is not the intended firing slot (see dutySlotIsFiringSlot), the
+// caller's slotDelay does not reflect operator lateness, so the histogram
+// point is skipped; the counter still ticks.
 func recordDutyScheduled(ctx context.Context, role types.RunnerRole, slotDelay time.Duration) {
 	runnerRoleAttr := metric.WithAttributes(observability.RunnerRoleAttribute(role))
 	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
-	if !usesWireSlot(role) {
+	if dutySlotIsFiringSlot(role) {
 		slotDelayHistogram.Record(ctx, slotDelay.Seconds(), runnerRoleAttr)
 	}
 }
 
-// usesWireSlot reports whether duty.Slot for the given role is a wire /
-// coordination slot intentionally kept in the past (rather than the
-// wall-clock firing slot). For such roles, "lateness" relative to duty.Slot
-// is meaningless — see voluntaryExitWireSlotsToPostpone for the canonical
-// rationale.
-func usesWireSlot(role types.RunnerRole) bool {
-	return role == types.RoleVoluntaryExit
+// dutySlotIsFiringSlot reports whether duty.Slot for the given role
+// represents the wall-clock slot at which this operator intends to fire its
+// duty. True for most roles (attester, proposer, etc.); false for roles where
+// duty.Slot is a shared coordination point intentionally held in the past
+// (the operator fires later than duty.Slot) — see
+// voluntaryExitDutySlotsToPostpone for the canonical rationale.
+func dutySlotIsFiringSlot(role types.RunnerRole) bool {
+	return role != types.RoleVoluntaryExit
 }

--- a/operator/duties/observability.go
+++ b/operator/duties/observability.go
@@ -37,23 +37,23 @@ var (
 
 // recordDutyScheduled bumps the per-role scheduled-duty counter and, when
 // meaningful, records a slot-delay histogram point. For roles where
-// duty.Slot is not the intended firing slot (see dutySlotIsFiringSlot), the
-// caller's slotDelay does not reflect operator lateness, so the histogram
+// duty.Slot is not the intended execution slot (see dutySlotIsExecutionSlot),
+// the caller's slotDelay does not reflect operator lateness, so the histogram
 // point is skipped; the counter still ticks.
 func recordDutyScheduled(ctx context.Context, role types.RunnerRole, slotDelay time.Duration) {
 	runnerRoleAttr := metric.WithAttributes(observability.RunnerRoleAttribute(role))
 	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
-	if dutySlotIsFiringSlot(role) {
+	if dutySlotIsExecutionSlot(role) {
 		slotDelayHistogram.Record(ctx, slotDelay.Seconds(), runnerRoleAttr)
 	}
 }
 
-// dutySlotIsFiringSlot reports whether duty.Slot for the given role
-// represents the wall-clock slot at which this operator intends to fire its
-// duty. True for most roles (attester, proposer, etc.); false for roles where
-// duty.Slot is a shared coordination point intentionally held in the past
-// (the operator fires later than duty.Slot) — see
+// dutySlotIsExecutionSlot reports whether duty.Slot for the given role
+// represents the wall-clock slot at which this operator intends to execute
+// its duty. True for most roles (attester, proposer, etc.); false for roles
+// where duty.Slot is a shared coordination point intentionally held in the
+// past (the operator executes later than duty.Slot) — see
 // voluntaryExitDutySlotsToPostpone for the canonical rationale.
-func dutySlotIsFiringSlot(role types.RunnerRole) bool {
+func dutySlotIsExecutionSlot(role types.RunnerRole) bool {
 	return role != types.RoleVoluntaryExit
 }

--- a/operator/duties/observability.go
+++ b/operator/duties/observability.go
@@ -40,3 +40,14 @@ func recordDutyScheduled(ctx context.Context, role types.RunnerRole, slotDelay t
 	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
 	slotDelayHistogram.Record(ctx, slotDelay.Seconds(), runnerRoleAttr)
 }
+
+// recordDutyScheduledNoDelay increments the scheduled-duty counter without
+// touching the slot-delay histogram. Use this when the duty's Slot field does
+// not represent the intended firing time (e.g. voluntary-exit, where duty.Slot
+// is a wire/coordination slot kept deliberately in the past) — recording the
+// computed "delay" against such a slot would pollute the histogram with
+// values that don't reflect operator lateness.
+func recordDutyScheduledNoDelay(ctx context.Context, role types.RunnerRole) {
+	runnerRoleAttr := metric.WithAttributes(observability.RunnerRoleAttribute(role))
+	dutiesScheduledCounter.Add(ctx, 1, runnerRoleAttr)
+}

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -476,24 +476,22 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 		logger.Debug(eventMsg)
 		span.AddEvent(eventMsg)
 
-		// For voluntary-exit, duty.Slot is the wire/coordination slot, not the
-		// intended firing slot (see voluntaryExitWireSlotsToPostpone). Lateness
-		// metrics against it would be misleading, so skip them; the counter
-		// still ticks.
-		if duty.RunnerRole() == spectypes.RoleVoluntaryExit {
-			recordDutyScheduledNoDelay(ctx, duty.RunnerRole())
-		} else {
-			slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
-			if slotDelay >= 100*time.Millisecond {
-				const eventMsg = "⚠️ late duty execution"
-				logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
-				span.AddEvent(eventMsg, trace.WithAttributes(
-					attribute.Int64("ssv.beacon.slot_delay_ms", slotDelay.Milliseconds()),
-					observability.BeaconRoleAttribute(duty.Type),
-					observability.RunnerRoleAttribute(duty.RunnerRole())))
-			}
-			recordDutyScheduled(ctx, duty.RunnerRole(), slotDelay)
+		role := duty.RunnerRole()
+		slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
+
+		// For wire-slot roles (see usesWireSlot), duty.Slot is a
+		// coordination slot held in the past — slotDelay against it is
+		// meaningless. Skip the warning; recordDutyScheduled handles the
+		// histogram side. The counter still ticks for both kinds.
+		if !usesWireSlot(role) && slotDelay >= 100*time.Millisecond {
+			const eventMsg = "⚠️ late duty execution"
+			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
+			span.AddEvent(eventMsg, trace.WithAttributes(
+				attribute.Int64("ssv.beacon.slot_delay_ms", slotDelay.Milliseconds()),
+				observability.BeaconRoleAttribute(duty.Type),
+				observability.RunnerRoleAttribute(role)))
 		}
+		recordDutyScheduled(ctx, role, slotDelay)
 
 		s.backgroundTasks.Add(1)
 		go func() {

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -476,14 +476,10 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 		logger.Debug(eventMsg)
 		span.AddEvent(eventMsg)
 
-		// duty.Slot represents the intended wall-clock firing slot for most
-		// duties, but for voluntary-exit it carries the wire/duty slot — a
-		// coordination point kept deliberately in the past relative to actual
-		// broadcast time (see voluntaryExitWireSlotsToPostpone vs
-		// voluntaryExitExecutionSlotsToPostpone). Measuring "lateness" relative
-		// to that slot is meaningless and would fire the warning + pollute the
-		// histogram on every exit, so we skip both for the voluntary-exit role
-		// while still incrementing the scheduled-duty counter.
+		// For voluntary-exit, duty.Slot is the wire/coordination slot, not the
+		// intended firing slot (see voluntaryExitWireSlotsToPostpone). Lateness
+		// metrics against it would be misleading, so skip them; the counter
+		// still ticks.
 		if duty.RunnerRole() == spectypes.RoleVoluntaryExit {
 			recordDutyScheduledNoDelay(ctx, duty.RunnerRole())
 		} else {

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -476,17 +476,28 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 		logger.Debug(eventMsg)
 		span.AddEvent(eventMsg)
 
-		slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
-		if slotDelay >= 100*time.Millisecond {
-			const eventMsg = "⚠️ late duty execution"
-			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
-			span.AddEvent(eventMsg, trace.WithAttributes(
-				attribute.Int64("ssv.beacon.slot_delay_ms", slotDelay.Milliseconds()),
-				observability.BeaconRoleAttribute(duty.Type),
-				observability.RunnerRoleAttribute(duty.RunnerRole())))
+		// duty.Slot represents the intended wall-clock firing slot for most
+		// duties, but for voluntary-exit it carries the wire/duty slot — a
+		// coordination point kept deliberately in the past relative to actual
+		// broadcast time (see voluntaryExitWireSlotsToPostpone vs
+		// voluntaryExitExecutionSlotsToPostpone). Measuring "lateness" relative
+		// to that slot is meaningless and would fire the warning + pollute the
+		// histogram on every exit, so we skip both for the voluntary-exit role
+		// while still incrementing the scheduled-duty counter.
+		if duty.RunnerRole() == spectypes.RoleVoluntaryExit {
+			recordDutyScheduledNoDelay(ctx, duty.RunnerRole())
+		} else {
+			slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
+			if slotDelay >= 100*time.Millisecond {
+				const eventMsg = "⚠️ late duty execution"
+				logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
+				span.AddEvent(eventMsg, trace.WithAttributes(
+					attribute.Int64("ssv.beacon.slot_delay_ms", slotDelay.Milliseconds()),
+					observability.BeaconRoleAttribute(duty.Type),
+					observability.RunnerRoleAttribute(duty.RunnerRole())))
+			}
+			recordDutyScheduled(ctx, duty.RunnerRole(), slotDelay)
 		}
-
-		recordDutyScheduled(ctx, duty.RunnerRole(), slotDelay)
 
 		s.backgroundTasks.Add(1)
 		go func() {

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -481,8 +481,7 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 
 		// For roles where duty.Slot is a shared coordination point rather
 		// than the execution target (see dutySlotIsExecutionSlot), slotDelay
-		// against it is meaningless. Skip the warning; recordDutyScheduled
-		// handles the histogram side. The counter still ticks for both kinds.
+		// against it is meaningless.
 		if dutySlotIsExecutionSlot(role) && slotDelay >= 100*time.Millisecond {
 			const eventMsg = "⚠️ late duty execution"
 			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -479,11 +479,11 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 		role := duty.RunnerRole()
 		slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
 
-		// For wire-slot roles (see usesWireSlot), duty.Slot is a
-		// coordination slot held in the past — slotDelay against it is
-		// meaningless. Skip the warning; recordDutyScheduled handles the
-		// histogram side. The counter still ticks for both kinds.
-		if !usesWireSlot(role) && slotDelay >= 100*time.Millisecond {
+		// For roles where duty.Slot is a shared coordination point rather
+		// than the firing target (see dutySlotIsFiringSlot), slotDelay
+		// against it is meaningless. Skip the warning; recordDutyScheduled
+		// handles the histogram side. The counter still ticks for both kinds.
+		if dutySlotIsFiringSlot(role) && slotDelay >= 100*time.Millisecond {
 			const eventMsg = "⚠️ late duty execution"
 			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
 			span.AddEvent(eventMsg, trace.WithAttributes(

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -480,10 +480,10 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, duties []*spectypes.Valid
 		slotDelay := time.Since(s.beaconConfig.SlotStartTime(duty.Slot))
 
 		// For roles where duty.Slot is a shared coordination point rather
-		// than the firing target (see dutySlotIsFiringSlot), slotDelay
+		// than the execution target (see dutySlotIsExecutionSlot), slotDelay
 		// against it is meaningless. Skip the warning; recordDutyScheduled
 		// handles the histogram side. The counter still ticks for both kinds.
-		if dutySlotIsFiringSlot(role) && slotDelay >= 100*time.Millisecond {
+		if dutySlotIsExecutionSlot(role) && slotDelay >= 100*time.Millisecond {
 			const eventMsg = "⚠️ late duty execution"
 			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
 			span.AddEvent(eventMsg, trace.WithAttributes(

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -222,7 +222,7 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 	defer span.End()
 
 	// Preallocate both with a non-nil, zero-length slice so that the queue
-	// retains the same "initialised, empty" shape as set up by the constructor
+	// retains the same "initialized, empty" shape as set up by the constructor
 	// even on ticks where every queued exit clears the gate.
 	dutiesForExecution := make([]*spectypes.ValidatorDuty, 0, len(h.dutyQueue))
 	pendingItems := make([]*queuedExit, 0, len(h.dutyQueue))

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -221,9 +221,6 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 		trace.WithAttributes(observability.BeaconSlotAttribute(slot)))
 	defer span.End()
 
-	// Preallocate both with a non-nil, zero-length slice so that the queue
-	// retains the same "initialized, empty" shape as set up by the constructor
-	// even on ticks where every queued exit clears the gate.
 	dutiesForExecution := make([]*spectypes.ValidatorDuty, 0, len(h.dutyQueue))
 	pendingItems := make([]*queuedExit, 0, len(h.dutyQueue))
 

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	// voluntaryExitWireSlotsToPostpone is the offset added to an exit event's
-	// block slot to derive the *duty slot* — the slot that every operator in
-	// the cluster must agree on regardless of code version. It feeds three
-	// things on the wire:
+	// voluntaryExitDutySlotsToPostpone is the offset added to an exit event's
+	// block slot to derive the *duty slot* — the slot stored in duty.Slot and
+	// shared across the cluster regardless of code version. It feeds three
+	// downstream uses:
 	//   1. The dutyStore key (AddDuty / GetDutyCount), used by inbound
 	//      message-validation's dutyCount check.
 	//   2. The Slot field of the outbound PartialSignatureMessages envelope,
@@ -43,9 +43,9 @@ const (
 	//
 	// Note: this constant happens to share its numeric value (4) with
 	// voluntaryExitSchedulingSlack below, but the two are independent — one
-	// governs the wire/coordination slot, the other the local execution
-	// timing budget. Do not assume they should track each other.
-	voluntaryExitWireSlotsToPostpone = phase0.Slot(4)
+	// defines the shared duty slot, the other the local execution timing
+	// budget. Do not assume they should track each other.
+	voluntaryExitDutySlotsToPostpone = phase0.Slot(4)
 
 	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an
 	// exit event clears the execution-layer follow distance. Different operators
@@ -57,7 +57,7 @@ const (
 	// time to receive the EL event and register the duty in its local dutyStore
 	// — which the inbound message-validation path checks via dutyCount.
 	//
-	// Independent of voluntaryExitWireSlotsToPostpone despite happening to
+	// Independent of voluntaryExitDutySlotsToPostpone despite happening to
 	// share the same numeric value (4); see the note on that constant.
 	voluntaryExitSchedulingSlack = phase0.Slot(4)
 
@@ -86,12 +86,12 @@ type ExitDescriptor struct {
 
 // queuedExit holds an own-validator exit duty awaiting local broadcast.
 //
-// duty.Slot carries the deterministic wire/duty slot (blockSlot +
-// voluntaryExitWireSlotsToPostpone) — used in the dutyStore, on the wire, and
+// duty.Slot carries the deterministic shared duty slot (blockSlot +
+// voluntaryExitDutySlotsToPostpone) — used in the dutyStore, on the wire, and
 // to derive the signed VoluntaryExit.Epoch. earliestExecutionSlot is the
 // purely-local gate that defers our own partial-sig broadcast until peers'
 // EL streaming pipelines have plausibly caught up; see the docstrings of
-// voluntaryExitWireSlotsToPostpone and voluntaryExitExecutionSlotsToPostpone
+// voluntaryExitDutySlotsToPostpone and voluntaryExitExecutionSlotsToPostpone
 // for the breakdown.
 type queuedExit struct {
 	duty                  *spectypes.ValidatorDuty
@@ -179,7 +179,7 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				)
 				continue
 			}
-			dutySlot := blockSlot + voluntaryExitWireSlotsToPostpone
+			dutySlot := blockSlot + voluntaryExitDutySlotsToPostpone
 			earliestExecutionSlot := blockSlot + voluntaryExitExecutionSlotsToPostpone
 
 			duty := &spectypes.ValidatorDuty{
@@ -226,7 +226,7 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 
 	for _, item := range h.dutyQueue {
 		// Gate on earliestExecutionSlot, not duty.Slot: the duty's Slot is the
-		// wire/duty slot (kept low for cross-version interop), while
+		// shared duty slot (kept low for cross-version interop), while
 		// earliestExecutionSlot is the local-only "no earlier than" trigger.
 		if item.earliestExecutionSlot <= slot {
 			dutiesForExecution = append(dutiesForExecution, item.duty)
@@ -280,9 +280,9 @@ func (h *VoluntaryExitHandler) blockSlot(ctx context.Context, blockNumber uint64
 
 func (h *VoluntaryExitHandler) dutyExecutionDeadline(slot phase0.Slot) time.Time {
 	// slot is the firing slot (the current ticker slot at dispatch), not
-	// duty.Slot — which for voluntary-exit is the wire/coordination slot held
-	// in the past. 1 wall-clock slot from firing should be sufficient for
-	// this duty-type.
+	// duty.Slot — which for voluntary-exit is the shared duty slot held in the
+	// past for cross-operator coordination. 1 wall-clock slot from firing
+	// should be sufficient for this duty-type.
 	dutyDeadline := h.beaconConfig.SlotStartTime(slot + 1)
 	return dutyDeadline
 }

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -279,7 +279,10 @@ func (h *VoluntaryExitHandler) blockSlot(ctx context.Context, blockNumber uint64
 }
 
 func (h *VoluntaryExitHandler) dutyExecutionDeadline(slot phase0.Slot) time.Time {
-	// 1 slot of time since the target slot should be sufficient for this duty-type.
+	// slot is the firing slot (the current ticker slot at dispatch), not
+	// duty.Slot — which for voluntary-exit is the wire/coordination slot held
+	// in the past. 1 wall-clock slot from firing should be sufficient for
+	// this duty-type.
 	dutyDeadline := h.beaconConfig.SlotStartTime(slot + 1)
 	return dutyDeadline
 }

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -19,26 +19,54 @@ import (
 )
 
 const (
+	// voluntaryExitWireSlotsToPostpone is the offset added to an exit event's
+	// block slot to derive the *duty slot* — the slot that every operator in
+	// the cluster must agree on regardless of code version. It feeds three
+	// things on the wire:
+	//   1. The dutyStore key (AddDuty / GetDutyCount), used by inbound
+	//      message-validation's dutyCount check.
+	//   2. The Slot field of the outbound PartialSignatureMessages envelope,
+	//      which peers feed into step 1 against their own dutyStore.
+	//   3. The slot fed into NetworkConfig.EstimatedEpochAtSlot when
+	//      constructing the VoluntaryExit object that gets BLS-signed (see
+	//      VoluntaryExitRunner.calculateVoluntaryExit).
+	//
+	// Because items 1–3 must agree across every operator for partial-sigs to
+	// validate, route, and aggregate, the numeric value is part of the wire
+	// format. It is intentionally kept at 4 — the value used by operators
+	// running pre-#2851 code — so that nodes upgraded to the post-#2851
+	// scheduling logic remain backwards-compatible in mixed clusters. Do NOT
+	// change it without a coordinated network-wide upgrade.
+	//
+	// This is NOT when this operator broadcasts its own partial-sig; see
+	// voluntaryExitExecutionSlotsToPostpone for that.
+	voluntaryExitWireSlotsToPostpone = phase0.Slot(4)
+
 	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an
 	// exit event clears the execution-layer follow distance. Different operators
 	// observe the event at slightly different wall-clock times due to EL client
 	// differences, head-subscription latency, FilterLogs round-trip, and the
-	// phase of the local slot ticker relative to event delivery. The slack gives
-	// every operator enough time to compute the same dutySlot and have it still
-	// be in the future when their scheduler picks it up, so they all execute on
-	// the same target slot rather than firing on the next tick after receipt.
+	// phase of the local slot ticker relative to event delivery. The slack
+	// ensures that by the time the earliest operator broadcasts its partial-sig
+	// (at voluntaryExitExecutionSlotsToPostpone), every other operator has had
+	// time to receive the EL event and register the duty in its local dutyStore
+	// — which the inbound message-validation path checks via dutyCount.
 	voluntaryExitSchedulingSlack = phase0.Slot(4)
 
-	// voluntaryExitSlotsToPostpone is the offset added to an exit event's block
-	// slot to derive the scheduled duty slot. It must exceed the EL streaming
-	// pipeline's worst-case latency from event production to handler delivery,
-	// which is dominated by executionclient.FollowDistance (the EL log stream
-	// only surfaces an event once the chain head reaches blockSlot+FollowDistance);
-	// the remainder is the slack above. If this value were smaller than any
-	// operator's effective EL streaming lag, that operator would schedule the
-	// duty in the past on receipt and fire immediately, defeating the cross-
-	// operator coordination that downstream pre-consensus signing depends on.
-	voluntaryExitSlotsToPostpone = phase0.Slot(executionclient.FollowDistance) + voluntaryExitSchedulingSlack
+	// voluntaryExitExecutionSlotsToPostpone is the earliest slot, expressed as
+	// an offset from the exit event's block slot, at which this operator may
+	// broadcast its own partial-sig. It is a *local-only* scheduling decision:
+	// it does not appear on the wire and need not match across operators.
+	//
+	// The value must exceed the worst-case EL streaming latency from event
+	// production to handler delivery, which is dominated by
+	// executionclient.FollowDistance (the EL log stream only surfaces an event
+	// once the chain head reaches blockSlot + FollowDistance); the remainder is
+	// voluntaryExitSchedulingSlack. Broadcasting earlier than this risks racing
+	// peers whose EL streaming pipeline hasn't yet delivered the event: their
+	// dutyStore returns 0 for the (slot, pk) key, so the dutyCount check fails
+	// and our message is dropped (ValidationIgnore on ErrTooManyDutiesPerEpoch).
+	voluntaryExitExecutionSlotsToPostpone = phase0.Slot(executionclient.FollowDistance) + voluntaryExitSchedulingSlack
 )
 
 type ExitDescriptor struct {
@@ -48,11 +76,25 @@ type ExitDescriptor struct {
 	BlockNumber    uint64
 }
 
+// queuedExit holds an own-validator exit duty awaiting local broadcast.
+//
+// duty.Slot carries the deterministic wire/duty slot (blockSlot +
+// voluntaryExitWireSlotsToPostpone) — used in the dutyStore, on the wire, and
+// to derive the signed VoluntaryExit.Epoch. earliestExecutionSlot is the
+// purely-local gate that defers our own partial-sig broadcast until peers'
+// EL streaming pipelines have plausibly caught up; see the docstrings of
+// voluntaryExitWireSlotsToPostpone and voluntaryExitExecutionSlotsToPostpone
+// for the breakdown.
+type queuedExit struct {
+	duty                  *spectypes.ValidatorDuty
+	earliestExecutionSlot phase0.Slot
+}
+
 type VoluntaryExitHandler struct {
 	baseHandler
 	duties          *dutystore.VoluntaryExitDuties
 	validatorExitCh <-chan ExitDescriptor
-	dutyQueue       []*spectypes.ValidatorDuty
+	dutyQueue       []*queuedExit
 	blockSlots      map[uint64]phase0.Slot
 }
 
@@ -60,7 +102,7 @@ func NewVoluntaryExitHandler(duties *dutystore.VoluntaryExitDuties, validatorExi
 	return &VoluntaryExitHandler{
 		duties:          duties,
 		validatorExitCh: validatorExitCh,
-		dutyQueue:       make([]*spectypes.ValidatorDuty, 0),
+		dutyQueue:       make([]*queuedExit, 0),
 		blockSlots:      map[uint64]phase0.Slot{},
 	}
 }
@@ -105,17 +147,22 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				return
 			}
 
-			// Derive dutySlot deterministically from the EL event's block slot so
-			// every operator arrives at the same value regardless of when they
-			// personally received the event. This matters because the runner
-			// derives VoluntaryExit.Epoch from dutySlot (see
-			// VoluntaryExitRunner.calculateVoluntaryExit), and operators sign over
-			// the resulting VoluntaryExit object — divergent slots would produce
-			// different epochs near an epoch boundary, breaking BLS partial-
-			// signature aggregation and silently failing the exit.
+			// Derive dutySlot deterministically from the EL event's block slot
+			// so every operator arrives at the same value regardless of when
+			// they personally received the event, and regardless of code version.
+			// This matters because dutySlot feeds dutyStore (used by inbound
+			// message-validation's dutyCount check), the outbound partial-sig
+			// envelope's Slot field, and VoluntaryExit.Epoch via
+			// EstimatedEpochAtSlot (see VoluntaryExitRunner.calculateVoluntaryExit).
+			// Divergent slots — across operators or across versions — would
+			// either drop messages at validation or break BLS partial-signature
+			// aggregation near epoch boundaries, silently failing the exit.
 			//
-			// voluntaryExitSlotsToPostpone keeps that shared slot in the future
-			// for every operator: see its docstring for the breakdown.
+			// earliestExecutionSlot is a separate, local-only gate that defers
+			// our own broadcast until peers' EL streaming pipelines have
+			// plausibly caught up. The two slots are deliberately decoupled so
+			// this operator's wire behavior stays interoperable with pre-#2851
+			// operators in mixed clusters.
 			blockSlot, err := h.blockSlot(ctx, exitDescriptor.BlockNumber)
 			if err != nil {
 				h.logger.Warn(
@@ -124,7 +171,8 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				)
 				continue
 			}
-			dutySlot := blockSlot + voluntaryExitSlotsToPostpone
+			dutySlot := blockSlot + voluntaryExitWireSlotsToPostpone
+			earliestExecutionSlot := blockSlot + voluntaryExitExecutionSlotsToPostpone
 
 			duty := &spectypes.ValidatorDuty{
 				Type:           spectypes.BNRoleVoluntaryExit,
@@ -138,11 +186,15 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				continue
 			}
 
-			h.dutyQueue = append(h.dutyQueue, duty)
+			h.dutyQueue = append(h.dutyQueue, &queuedExit{
+				duty:                  duty,
+				earliestExecutionSlot: earliestExecutionSlot,
+			})
 
 			h.logger.Debug("🛠 scheduled duty for execution",
 				zap.Uint64("block_slot", uint64(blockSlot)),
 				zap.Uint64("duty_slot", uint64(dutySlot)),
+				zap.Uint64("earliest_execution_slot", uint64(earliestExecutionSlot)),
 				fields.BlockNumber(exitDescriptor.BlockNumber),
 			)
 
@@ -161,17 +213,21 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 		trace.WithAttributes(observability.BeaconSlotAttribute(slot)))
 	defer span.End()
 
-	var dutiesForExecution, pendingDuties []*spectypes.ValidatorDuty
+	var dutiesForExecution []*spectypes.ValidatorDuty
+	var pendingItems []*queuedExit
 
-	for _, duty := range h.dutyQueue {
-		if duty.Slot <= slot {
-			dutiesForExecution = append(dutiesForExecution, duty)
+	for _, item := range h.dutyQueue {
+		// Gate on earliestExecutionSlot, not duty.Slot: the duty's Slot is the
+		// wire/duty slot (kept low for cross-version interop), while
+		// earliestExecutionSlot is the local-only "no earlier than" trigger.
+		if item.earliestExecutionSlot <= slot {
+			dutiesForExecution = append(dutiesForExecution, item.duty)
 		} else {
-			pendingDuties = append(pendingDuties, duty)
+			pendingItems = append(pendingItems, item)
 		}
 	}
 
-	h.dutyQueue = pendingDuties
+	h.dutyQueue = pendingItems
 	h.duties.RemoveSlot(slot - phase0.Slot(h.beaconConfig.SlotsPerEpoch))
 
 	span.SetAttributes(observability.DutyCountAttribute(len(dutiesForExecution)))

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -75,15 +75,10 @@ type ExitDescriptor struct {
 	BlockNumber    uint64
 }
 
-// queuedExit holds an own-validator exit duty awaiting local broadcast.
-//
-// duty.Slot carries the deterministic shared duty slot (blockSlot +
-// voluntaryExitDutySlotsToPostpone) — used in the dutyStore, on the wire, and
-// to derive the signed VoluntaryExit.Epoch. earliestExecutionSlot is the
-// purely-local gate that defers our own partial-sig broadcast until peers'
-// EL streaming pipelines have plausibly caught up; see the docstrings of
-// voluntaryExitDutySlotsToPostpone and voluntaryExitExecutionSlotsToPostpone
-// for the breakdown.
+// queuedExit holds an own-validator exit duty awaiting its local execution
+// gate. duty.Slot is the shared duty slot (voluntaryExitDutySlotsToPostpone);
+// earliestExecutionSlot is when this operator may broadcast its partial-sig
+// (voluntaryExitExecutionSlotsToPostpone).
 type queuedExit struct {
 	duty                  *spectypes.ValidatorDuty
 	earliestExecutionSlot phase0.Slot
@@ -216,9 +211,6 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 	pendingItems := make([]*queuedExit, 0, len(h.dutyQueue))
 
 	for _, item := range h.dutyQueue {
-		// Gate on earliestExecutionSlot, not duty.Slot: the duty's Slot is the
-		// shared duty slot (kept low for cross-version interop), while
-		// earliestExecutionSlot is the local-only "no earlier than" trigger.
 		if item.earliestExecutionSlot <= slot {
 			dutiesForExecution = append(dutiesForExecution, item.duty)
 		} else {
@@ -270,10 +262,7 @@ func (h *VoluntaryExitHandler) blockSlot(ctx context.Context, blockNumber uint64
 }
 
 func (h *VoluntaryExitHandler) dutyExecutionDeadline(slot phase0.Slot) time.Time {
-	// slot is the execution slot (the current ticker slot at dispatch), not
-	// duty.Slot — which for voluntary-exit is the shared duty slot held in the
-	// past for cross-operator coordination. 1 wall-clock slot from execution
-	// should be sufficient for this duty-type.
+	// 1 wall-clock slot from execution should be sufficient for this duty-type.
 	dutyDeadline := h.beaconConfig.SlotStartTime(slot + 1)
 	return dutyDeadline
 }

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -40,6 +40,11 @@ const (
 	//
 	// This is NOT when this operator broadcasts its own partial-sig; see
 	// voluntaryExitExecutionSlotsToPostpone for that.
+	//
+	// Note: this constant happens to share its numeric value (4) with
+	// voluntaryExitSchedulingSlack below, but the two are independent — one
+	// governs the wire/coordination slot, the other the local execution
+	// timing budget. Do not assume they should track each other.
 	voluntaryExitWireSlotsToPostpone = phase0.Slot(4)
 
 	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an
@@ -51,6 +56,9 @@ const (
 	// (at voluntaryExitExecutionSlotsToPostpone), every other operator has had
 	// time to receive the EL event and register the duty in its local dutyStore
 	// — which the inbound message-validation path checks via dutyCount.
+	//
+	// Independent of voluntaryExitWireSlotsToPostpone despite happening to
+	// share the same numeric value (4); see the note on that constant.
 	voluntaryExitSchedulingSlack = phase0.Slot(4)
 
 	// voluntaryExitExecutionSlotsToPostpone is the earliest slot, expressed as
@@ -213,8 +221,11 @@ func (h *VoluntaryExitHandler) processExecution(ctx context.Context, slot phase0
 		trace.WithAttributes(observability.BeaconSlotAttribute(slot)))
 	defer span.End()
 
-	var dutiesForExecution []*spectypes.ValidatorDuty
-	var pendingItems []*queuedExit
+	// Preallocate both with a non-nil, zero-length slice so that the queue
+	// retains the same "initialised, empty" shape as set up by the constructor
+	// even on ticks where every queued exit clears the gate.
+	dutiesForExecution := make([]*spectypes.ValidatorDuty, 0, len(h.dutyQueue))
+	pendingItems := make([]*queuedExit, 0, len(h.dutyQueue))
 
 	for _, item := range h.dutyQueue {
 		// Gate on earliestExecutionSlot, not duty.Slot: the duty's Slot is the

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -20,31 +20,22 @@ import (
 
 const (
 	// voluntaryExitDutySlotsToPostpone is the offset added to an exit event's
-	// block slot to derive the *duty slot* — the slot stored in duty.Slot and
-	// shared across the cluster regardless of code version. It feeds three
-	// downstream uses:
-	//   1. The dutyStore key (AddDuty / GetDutyCount), used by inbound
-	//      message-validation's dutyCount check.
-	//   2. The Slot field of the outbound PartialSignatureMessages envelope,
-	//      which peers feed into step 1 against their own dutyStore.
-	//   3. The slot fed into NetworkConfig.EstimatedEpochAtSlot when
-	//      constructing the VoluntaryExit object that gets BLS-signed (see
-	//      VoluntaryExitRunner.calculateVoluntaryExit).
+	// block slot to derive duty.Slot — the shared coordination slot used as
+	// the dutyStore key (inbound dutyCount validation), as the outbound
+	// partial-sig envelope Slot, and as input to the signed VoluntaryExit.Epoch
+	// (see VoluntaryExitRunner.calculateVoluntaryExit). Every operator must
+	// compute the same value for partial-sigs to validate, route, and
+	// aggregate, so it's part of the wire format.
 	//
-	// Because items 1–3 must agree across every operator for partial-sigs to
-	// validate, route, and aggregate, the numeric value is part of the wire
-	// format. It is intentionally kept at 4 — the value used by operators
-	// running pre-#2851 code — so that nodes upgraded to the post-#2851
-	// scheduling logic remain backwards-compatible in mixed clusters. Do NOT
-	// change it without a coordinated network-wide upgrade.
+	// Kept at 4 — the value used by pre-#2851 operators — so upgraded nodes
+	// remain backwards-compatible in mixed clusters. Do NOT change it without
+	// a coordinated network-wide upgrade.
 	//
 	// This is NOT when this operator broadcasts its own partial-sig; see
 	// voluntaryExitExecutionSlotsToPostpone for that.
 	//
-	// Note: this constant happens to share its numeric value (4) with
-	// voluntaryExitSchedulingSlack below, but the two are independent — one
-	// defines the shared duty slot, the other the local execution timing
-	// budget. Do not assume they should track each other.
+	// Note: shares its numeric value (4) with voluntaryExitSchedulingSlack
+	// below by coincidence — the two are independent.
 	voluntaryExitDutySlotsToPostpone = 4
 
 	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -45,7 +45,7 @@ const (
 	// voluntaryExitSchedulingSlack below, but the two are independent — one
 	// defines the shared duty slot, the other the local execution timing
 	// budget. Do not assume they should track each other.
-	voluntaryExitDutySlotsToPostpone = phase0.Slot(4)
+	voluntaryExitDutySlotsToPostpone = 4
 
 	// voluntaryExitSchedulingSlack absorbs per-operator timing variance once an
 	// exit event clears the execution-layer follow distance. Different operators
@@ -59,7 +59,7 @@ const (
 	//
 	// Independent of voluntaryExitDutySlotsToPostpone despite happening to
 	// share the same numeric value (4); see the note on that constant.
-	voluntaryExitSchedulingSlack = phase0.Slot(4)
+	voluntaryExitSchedulingSlack = 4
 
 	// voluntaryExitExecutionSlotsToPostpone is the earliest slot, expressed as
 	// an offset from the exit event's block slot, at which this operator may
@@ -74,7 +74,7 @@ const (
 	// peers whose EL streaming pipeline hasn't yet delivered the event: their
 	// dutyStore returns 0 for the (slot, pk) key, so the dutyCount check fails
 	// and our message is dropped (ValidationIgnore on ErrTooManyDutiesPerEpoch).
-	voluntaryExitExecutionSlotsToPostpone = phase0.Slot(executionclient.FollowDistance) + voluntaryExitSchedulingSlack
+	voluntaryExitExecutionSlotsToPostpone = executionclient.FollowDistance + voluntaryExitSchedulingSlack
 )
 
 type ExitDescriptor struct {

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -279,9 +279,9 @@ func (h *VoluntaryExitHandler) blockSlot(ctx context.Context, blockNumber uint64
 }
 
 func (h *VoluntaryExitHandler) dutyExecutionDeadline(slot phase0.Slot) time.Time {
-	// slot is the firing slot (the current ticker slot at dispatch), not
+	// slot is the execution slot (the current ticker slot at dispatch), not
 	// duty.Slot — which for voluntary-exit is the shared duty slot held in the
-	// past for cross-operator coordination. 1 wall-clock slot from firing
+	// past for cross-operator coordination. 1 wall-clock slot from execution
 	// should be sufficient for this duty-type.
 	dutyDeadline := h.beaconConfig.SlotStartTime(slot + 1)
 	return dutyDeadline

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -18,14 +18,14 @@ import (
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 )
 
-// TestVoluntaryExitWireSlotPinned guards a wire-format invariant: pre-#2851
+// TestVoluntaryExitDutySlotPinned guards a wire-format invariant: pre-#2851
 // peers compute and validate against blockSlot + 4, so this operator must
 // emit the same value for cross-version interop. Bumping the constant is a
 // coordinated network-wide upgrade, not a code-cleanup change — this test
 // turns any literal change into a visible diff that PR review can catch.
-func TestVoluntaryExitWireSlotPinned(t *testing.T) {
+func TestVoluntaryExitDutySlotPinned(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, phase0.Slot(4), voluntaryExitWireSlotsToPostpone)
+	require.Equal(t, phase0.Slot(4), voluntaryExitDutySlotsToPostpone)
 }
 
 func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
@@ -189,14 +189,14 @@ func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistan
 		BlockNumber:    blockNumber,
 	}
 	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.FollowDistance)
-	// expectedDuty.Slot uses the wire slot — what gets signed and what peers
-	// (including pre-#2851 ones) use to validate. The execution gate (at
-	// blockNumber + voluntaryExitExecutionSlotsToPostpone) fires later but
-	// does not affect what's on the wire.
+	// expectedDuty.Slot uses the shared duty slot — what gets signed and what
+	// peers (including pre-#2851 ones) use to validate. The execution gate
+	// (at blockNumber + voluntaryExitExecutionSlotsToPostpone) fires later
+	// but does not affect what's on the wire.
 	expectedDuty := []*spectypes.ValidatorDuty{{
 		Type:           spectypes.BNRoleVoluntaryExit,
 		PubKey:         lateObservedExit.PubKey,
-		Slot:           phase0.Slot(blockNumber) + voluntaryExitWireSlotsToPostpone,
+		Slot:           phase0.Slot(blockNumber) + voluntaryExitDutySlotsToPostpone,
 		ValidatorIndex: lateObservedExit.ValidatorIndex,
 	}}
 
@@ -248,7 +248,7 @@ func assert1to1BlockSlotMapping(t *testing.T, scheduler *Scheduler) {
 }
 
 // expectedExecutedVoluntaryExitDuties builds the duties we expect to see
-// dispatched for the given descriptors. Slot is the wire/duty slot — what
+// dispatched for the given descriptors. Slot is the shared duty slot — what
 // gets signed and what peers validate — which intentionally differs from the
 // (later) local execution slot at which we actually broadcast.
 func expectedExecutedVoluntaryExitDuties(descriptors []ExitDescriptor) []*spectypes.ValidatorDuty {
@@ -257,7 +257,7 @@ func expectedExecutedVoluntaryExitDuties(descriptors []ExitDescriptor) []*specty
 		expectedDuties = append(expectedDuties, &spectypes.ValidatorDuty{
 			Type:           spectypes.BNRoleVoluntaryExit,
 			PubKey:         d.PubKey,
-			Slot:           phase0.Slot(d.BlockNumber) + voluntaryExitWireSlotsToPostpone,
+			Slot:           phase0.Slot(d.BlockNumber) + voluntaryExitDutySlotsToPostpone,
 			ValidatorIndex: d.ValidatorIndex,
 		})
 	}

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -18,6 +18,16 @@ import (
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 )
 
+// TestVoluntaryExitWireSlotPinned guards a wire-format invariant: pre-#2851
+// peers compute and validate against blockSlot + 4, so this operator must
+// emit the same value for cross-version interop. Bumping the constant is a
+// coordinated network-wide upgrade, not a code-cleanup change — this test
+// turns any literal change into a visible diff that PR review can catch.
+func TestVoluntaryExitWireSlotPinned(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, phase0.Slot(4), voluntaryExitWireSlotsToPostpone)
+}
+
 func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 	t.Parallel()
 

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -191,7 +191,7 @@ func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistan
 	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.FollowDistance)
 	// expectedDuty.Slot uses the shared duty slot — what gets signed and what
 	// peers (including pre-#2851 ones) use to validate. The execution gate
-	// (at blockNumber + voluntaryExitExecutionSlotsToPostpone) fires later
+	// (at blockNumber + voluntaryExitExecutionSlotsToPostpone) trips later
 	// but does not affect what's on the wire.
 	expectedDuty := []*spectypes.ValidatorDuty{{
 		Type:           spectypes.BNRoleVoluntaryExit,

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -25,7 +25,7 @@ import (
 // turns any literal change into a visible diff that PR review can catch.
 func TestVoluntaryExitDutySlotPinned(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, phase0.Slot(4), voluntaryExitDutySlotsToPostpone)
+	require.EqualValues(t, 4, voluntaryExitDutySlotsToPostpone)
 }
 
 func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {

--- a/operator/duties/voluntary_exit_test.go
+++ b/operator/duties/voluntary_exit_test.go
@@ -94,58 +94,58 @@ func TestVoluntaryExitHandler_HandleDuties(t *testing.T) {
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = block + postpone - 1, block = 1 - no execution", func(t *testing.T) {
-		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitSlotsToPostpone-1)
-		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitSlotsToPostpone - 1)
+	t.Run("slot = block + executionPostpone - 1, block = 1 - no execution", func(t *testing.T) {
+		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitExecutionSlotsToPostpone-1)
+		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone - 1)
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = block + postpone, block = 1 - executing duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + executionPostpone, block = 1 - executing duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
-		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitSlotsToPostpone)
+		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuties[:1])
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
 	exitCh <- sameBlockExit
 
-	t.Run("slot = block + postpone, block = 1 - executing another duty, no block number fetch", func(t *testing.T) {
+	t.Run("slot = block + executionPostpone, block = 1 - executing another duty, no block number fetch", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
-		ticker.Send(phase0.Slot(sameBlockExit.BlockNumber) + voluntaryExitSlotsToPostpone)
+		ticker.Send(phase0.Slot(sameBlockExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuties[1:2])
 		require.EqualValues(t, 2, blockByNumberCalls.Load())
 	})
 
 	exitCh <- newBlockExit
 
-	t.Run("slot = block + postpone, block = 2 - no execution", func(t *testing.T) {
-		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitSlotsToPostpone)
-		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitSlotsToPostpone)
+	t.Run("slot = block + executionPostpone, block = 2 - no execution", func(t *testing.T) {
+		waitForSlotN(scheduler.beaconConfig, phase0.Slot(normalExit.BlockNumber)+voluntaryExitExecutionSlotsToPostpone)
+		ticker.Send(phase0.Slot(normalExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone)
 		waitForNoAction(t, nil, nil, noActionTimeout)
 		require.EqualValues(t, 3, blockByNumberCalls.Load())
 	})
 
-	t.Run("slot = block + postpone, block = 2 - executing new duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + executionPostpone, block = 2 - executing new duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
-		ticker.Send(phase0.Slot(newBlockExit.BlockNumber) + voluntaryExitSlotsToPostpone)
+		ticker.Send(phase0.Slot(newBlockExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuties[2:3])
 		require.EqualValues(t, 3, blockByNumberCalls.Load())
 	})
 
 	exitCh <- pastBlockExit
 
-	t.Run("slot = block + postpone + 1, block = 5 - executing past duty, fetching block number", func(t *testing.T) {
+	t.Run("slot = block + executionPostpone + 1, block = 5 - executing past duty, fetching block number", func(t *testing.T) {
 		executeDutiesCall := make(chan []*spectypes.ValidatorDuty)
 		setExecuteDutyFunc(scheduler, executeDutiesCall, 1)
 
-		ticker.Send(phase0.Slot(pastBlockExit.BlockNumber) + voluntaryExitSlotsToPostpone + 1)
+		ticker.Send(phase0.Slot(pastBlockExit.BlockNumber) + voluntaryExitExecutionSlotsToPostpone + 1)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuties[3:4])
 		require.EqualValues(t, 4, blockByNumberCalls.Load())
 	})
@@ -179,10 +179,14 @@ func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistan
 		BlockNumber:    blockNumber,
 	}
 	lateObservationSlot := phase0.Slot(blockNumber) + phase0.Slot(executionclient.FollowDistance)
+	// expectedDuty.Slot uses the wire slot — what gets signed and what peers
+	// (including pre-#2851 ones) use to validate. The execution gate (at
+	// blockNumber + voluntaryExitExecutionSlotsToPostpone) fires later but
+	// does not affect what's on the wire.
 	expectedDuty := []*spectypes.ValidatorDuty{{
 		Type:           spectypes.BNRoleVoluntaryExit,
 		PubKey:         lateObservedExit.PubKey,
-		Slot:           phase0.Slot(blockNumber) + voluntaryExitSlotsToPostpone,
+		Slot:           phase0.Slot(blockNumber) + voluntaryExitWireSlotsToPostpone,
 		ValidatorIndex: lateObservedExit.ValidatorIndex,
 	}}
 
@@ -197,9 +201,9 @@ func TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistan
 		waitForNoAction(t, nil, executeDutiesCall, noActionTimeout)
 	})
 
-	t.Run("slot = block + postponed exit slot - execute", func(t *testing.T) {
-		waitForSlotN(scheduler.beaconConfig, phase0.Slot(blockNumber)+voluntaryExitSlotsToPostpone)
-		ticker.Send(phase0.Slot(blockNumber) + voluntaryExitSlotsToPostpone)
+	t.Run("slot = block + executionPostpone - execute", func(t *testing.T) {
+		waitForSlotN(scheduler.beaconConfig, phase0.Slot(blockNumber)+voluntaryExitExecutionSlotsToPostpone)
+		ticker.Send(phase0.Slot(blockNumber) + voluntaryExitExecutionSlotsToPostpone)
 		waitForDutiesExecution(t, nil, executeDutiesCall, timeout, expectedDuty)
 	})
 
@@ -233,13 +237,17 @@ func assert1to1BlockSlotMapping(t *testing.T, scheduler *Scheduler) {
 	require.EqualValues(t, blockNumber, slot)
 }
 
+// expectedExecutedVoluntaryExitDuties builds the duties we expect to see
+// dispatched for the given descriptors. Slot is the wire/duty slot — what
+// gets signed and what peers validate — which intentionally differs from the
+// (later) local execution slot at which we actually broadcast.
 func expectedExecutedVoluntaryExitDuties(descriptors []ExitDescriptor) []*spectypes.ValidatorDuty {
 	expectedDuties := make([]*spectypes.ValidatorDuty, 0, len(descriptors))
 	for _, d := range descriptors {
 		expectedDuties = append(expectedDuties, &spectypes.ValidatorDuty{
 			Type:           spectypes.BNRoleVoluntaryExit,
 			PubKey:         d.PubKey,
-			Slot:           phase0.Slot(d.BlockNumber) + voluntaryExitSlotsToPostpone,
+			Slot:           phase0.Slot(d.BlockNumber) + voluntaryExitWireSlotsToPostpone,
 			ValidatorIndex: d.ValidatorIndex,
 		})
 	}


### PR DESCRIPTION
## What changed

Split the single `voluntaryExitSlotsToPostpone` constant introduced by #2851 into two with distinct roles:

- **`voluntaryExitWireSlotsToPostpone` (= 4)** — the deterministic wire/duty slot. Feeds the dutyStore key, the outbound partial-sig envelope's `Slot` field, and the slot fed into `EstimatedEpochAtSlot` when constructing the BLS-signed `VoluntaryExit` object. Kept at 4 so a node running this code remains wire-compatible with pre-#2851 peers.
- **`voluntaryExitExecutionSlotsToPostpone` (= `FollowDistance + slack` = 12)** — a purely local "earliest broadcast" gate. Preserves the cross-operator race protection introduced by #2851 (don't broadcast until peers' EL streaming pipelines have plausibly caught up), but never appears on the wire.

The voluntary-exit `dutyQueue` now stores `(duty, earliestExecutionSlot)` tuples; `processExecution` gates on `earliestExecutionSlot` rather than `duty.Slot`. Because `duty.Slot` is now intentionally in the past relative to firing time, the scheduler's `⚠️ late duty execution` warning and slot-delay histogram would fire on every exit; we special-case voluntary-exit in `Scheduler.ExecuteDuties` to skip both while still incrementing the scheduled-duty counter via a new `recordDutyScheduledNoDelay` helper.

## Why

PR #2851 collapsed two distinct concerns into one constant. The new value (12) is correct for *when this operator broadcasts*, but it also leaks onto the wire as the message slot, the dutyStore key, and the slot from which the signed `VoluntaryExit.Epoch` is derived. Pre-#2851 nodes still use 4 for all of those, so the two versions can no longer cross-validate each other's voluntary-exit partial-sigs:

- New emits `messageSlot = blockSlot + 12`; old's local dutyStore has only `blockSlot + 4` registered → `dutyLimit = 0`, `dutyCount > dutyLimit` → `ErrTooManyDutiesPerEpoch` → `ValidationIgnore` at pubsub-validation, message dropped.
- Reverse direction is symmetric.

In a 4-operator cluster with quorum 3, a 2-old / 2-new split leaves each side with at most 2 partial-sigs of its own version — neither reaches quorum, and the exit silently fails to submit until the cluster becomes homogeneous on a single version.

Decoupling the two responsibilities keeps the bug fix from #2851 (don't fire before EL streaming has settled) while restoring wire compatibility with older nodes. Any mix of old and new operators in a cluster can now form quorum on the shared `blockSlot + 4` wire slot.

## Impact

- Existing pre-#2851 operators interoperate cleanly with upgraded operators during rollout — no flag day required.
- All-new clusters still benefit from the deferred-broadcast race protection (we still don't fire until slot `blockSlot + FollowDistance + 4`).
- `VoluntaryExit.Epoch` now reflects the epoch of `blockSlot + 4` (the wire slot) instead of `blockSlot + 12` that post-#2851 nodes were signing — effectively reverting the *signed epoch* back to pre-#2851 behavior. This is the intended outcome, since it's what makes mixed clusters cross-validate, and it's safe because the beacon chain accepts any `Epoch <= current_epoch` for a voluntary exit, so a slightly-earlier epoch is functionally equivalent.
- The `scheduler.executions` counter still tracks voluntary-exit dispatches; the `scheduler.slot_ticker_delay.duration` histogram no longer receives the (meaningless) ~96-second values for the voluntary-exit role.

## Verification

- `go test ./operator/duties -count=1`
- Existing `TestVoluntaryExitHandler_HandleDuties_LateObservedExitWaitsPastFollowDistance` continues to assert that the duty waits past the FollowDistance window (now: until `blockNumber + voluntaryExitExecutionSlotsToPostpone`) and that the executed duty's `Slot` is the wire slot (`blockNumber + voluntaryExitWireSlotsToPostpone`).

Related to https://github.com/ssvlabs/ssv-node-board/issues/1066