### PR TITLE
api, network/peers: prevent panic on peer NodeInfo without metadata

### DIFF
--- a/api/handlers/node/mock_test.go
+++ b/api/handlers/node/mock_test.go
@@ -140,7 +140,10 @@ type MockPeersIndex struct {
 }
 
 func (m *MockPeersIndex) Self() *records.NodeInfo {
-	return m.self
+	// Mirror the real peersIndex.Self which returns a clone — this ensures
+	// the Identity handler tests exercise the same Clone path that runs in
+	// production, including its nil-Metadata behavior.
+	return m.self.Clone()
 }
 
 func (m *MockPeersIndex) NodeInfo(id peer.ID) *records.NodeInfo {

--- a/api/handlers/node/mock_test.go
+++ b/api/handlers/node/mock_test.go
@@ -140,9 +140,9 @@ type MockPeersIndex struct {
 }
 
 func (m *MockPeersIndex) Self() *records.NodeInfo {
-	// Mirror the real peersIndex.Self which returns a clone — this ensures
-	// the Identity handler tests exercise the same Clone path that runs in
-	// production, including its nil-Metadata behavior.
+	// Mirror the real peersIndex.Self which returns a clone — keeps the mock
+	// faithful to production semantics so test callers can't accidentally
+	// mutate the stored NodeInfo through the returned pointer.
 	return m.self.Clone()
 }
 

--- a/api/handlers/node/node.go
+++ b/api/handlers/node/node.go
@@ -53,15 +53,9 @@ func NewNode(
 func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
 	nodeInfo := h.peersIndex.Self()
 	resp := identityJSON{
-		PeerID: h.network.LocalPeer(),
-	}
-	// invariant: setupPeerServices initializes self.Metadata at startup, so on
-	// the live path nodeInfo.Metadata is always non-nil. The guard mirrors the
-	// `peers` handler below and keeps the response well-formed even if the
-	// invariant is weakened in the future.
-	if nodeInfo != nil && nodeInfo.Metadata != nil {
-		resp.Subnets = nodeInfo.Metadata.Subnets
-		resp.Version = nodeInfo.Metadata.NodeVersion
+		PeerID:  h.network.LocalPeer(),
+		Subnets: nodeInfo.Metadata.Subnets,
+		Version: nodeInfo.Metadata.NodeVersion,
 	}
 	for _, addr := range h.network.ListenAddresses() {
 		resp.Addresses = append(resp.Addresses, addr.String())

--- a/api/handlers/node/node.go
+++ b/api/handlers/node/node.go
@@ -53,9 +53,15 @@ func NewNode(
 func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
 	nodeInfo := h.peersIndex.Self()
 	resp := identityJSON{
-		PeerID:  h.network.LocalPeer(),
-		Subnets: nodeInfo.Metadata.Subnets,
-		Version: nodeInfo.Metadata.NodeVersion,
+		PeerID: h.network.LocalPeer(),
+	}
+	// invariant: setupPeerServices initializes self.Metadata at startup, so on
+	// the live path nodeInfo.Metadata is always non-nil. The guard mirrors the
+	// `peers` handler below and keeps the response well-formed even if the
+	// invariant is weakened in the future.
+	if nodeInfo != nil && nodeInfo.Metadata != nil {
+		resp.Subnets = nodeInfo.Metadata.Subnets
+		resp.Version = nodeInfo.Metadata.NodeVersion
 	}
 	for _, addr := range h.network.ListenAddresses() {
 		resp.Addresses = append(resp.Addresses, addr.String())
@@ -146,7 +152,11 @@ func (h *Node) peers(peers []peer.ID) []peerJSON {
 		}
 
 		nodeInfo := h.peersIndex.NodeInfo(id)
-		if nodeInfo == nil {
+		if nodeInfo == nil || nodeInfo.Metadata == nil {
+			// Metadata can be nil if the peer sent a NodeInfo envelope without a
+			// metadata block; we reject such peers at handshake time
+			// (verifyTheirNodeInfo), but historical entries from before that fix
+			// — or from a future reader path — should not crash this endpoint.
 			continue
 		}
 		resp[i].Version = nodeInfo.Metadata.NodeVersion

--- a/api/handlers/node/node.go
+++ b/api/handlers/node/node.go
@@ -53,9 +53,15 @@ func NewNode(
 func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
 	nodeInfo := h.peersIndex.Self()
 	resp := identityJSON{
-		PeerID:  h.network.LocalPeer(),
-		Subnets: nodeInfo.Metadata.Subnets,
-		Version: nodeInfo.Metadata.NodeVersion,
+		PeerID: h.network.LocalPeer(),
+	}
+	// invariant: setupPeerServices initializes self.Metadata at startup, so on
+	// the live path nodeInfo.Metadata is always non-nil. The guard defends
+	// against a future UpdateSelfRecord caller that returns a NodeInfo without
+	// a Metadata block — cheap insurance and mirrors the peers-handler shape.
+	if nodeInfo != nil && nodeInfo.Metadata != nil {
+		resp.Subnets = nodeInfo.Metadata.Subnets
+		resp.Version = nodeInfo.Metadata.NodeVersion
 	}
 	for _, addr := range h.network.ListenAddresses() {
 		resp.Addresses = append(resp.Addresses, addr.String())

--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -256,39 +256,6 @@ func TestPeers_SkipsNilMetadata(t *testing.T) {
 	})
 }
 
-// TestIdentity_SkipsNilMetadata verifies that the Identity handler doesn't
-// panic when the local self NodeInfo lacks a Metadata block. Local self should
-// always have Metadata in practice (set in p2p_setup.go), so this is a
-// belt-and-suspenders check matching the same defensive guard added on the
-// peers handler.
-func TestIdentity_SkipsNilMetadata(t *testing.T) {
-	node := CreateTestNode(t)
-
-	mockIdx, ok := node.peersIndex.(*MockPeersIndex)
-	require.True(t, ok)
-	mockIdx.self = &records.NodeInfo{
-		NetworkID: "self",
-		// Metadata intentionally left nil
-	}
-
-	req, err := http.NewRequest("GET", "/v1/node/identity", nil)
-	require.NoError(t, err)
-
-	rr := httptest.NewRecorder()
-	api.Handler(node.Identity).ServeHTTP(rr, req)
-
-	require.Equal(t, http.StatusOK, rr.Code)
-
-	var resp nodeIdentity
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	// PeerID and Addresses are independent of Metadata and should still be
-	// populated; Subnets/Version are sourced from Metadata and should be empty.
-	require.NotEmpty(t, resp.PeerID)
-	require.NotEmpty(t, resp.Addresses)
-	require.Empty(t, resp.Version)
-	require.Empty(t, resp.Subnets)
-}
-
 // TestHealthCheckJSONString verifies that healthCheckJSON.String() returns correctly formatted JSON.
 func TestHealthCheckJSONString(t *testing.T) {
 	hc := healthCheckJSON{

--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -208,6 +208,87 @@ func TestNodeHandlers(t *testing.T) {
 	}
 }
 
+// TestPeers_SkipsNilMetadata verifies that the Peers and Health handlers don't
+// panic when a peer's stored NodeInfo lacks a Metadata block. This happens in
+// practice when a peer sends a NodeInfo envelope without the Metadata entry —
+// we now reject such peers at handshake time, but historical entries in the
+// index (or any future reader path) must not crash the API handler.
+func TestPeers_SkipsNilMetadata(t *testing.T) {
+	node := CreateTestNode(t)
+
+	// Swap in a NodeInfo with Metadata == nil. CreateTestNode wires a
+	// MockPeersIndex that returns the same NodeInfo for every peer ID, so
+	// both connected peers end up looking like nil-Metadata peers.
+	mockIdx, ok := node.peersIndex.(*MockPeersIndex)
+	require.True(t, ok)
+	mockIdx.nodeInfo = &records.NodeInfo{
+		NetworkID: "mainnet",
+		// Metadata intentionally left nil
+	}
+
+	t.Run("peers handler does not panic", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/v1/node/peers", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		api.Handler(node.Peers).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var peers []peerInfo
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &peers))
+		// Peers with nil Metadata still appear in the response — only the
+		// Version field is empty, since we skip the NodeVersion assignment.
+		require.GreaterOrEqual(t, len(peers), 1)
+		for _, p := range peers {
+			require.Empty(t, p.Version, "expected empty version for nil-metadata peer")
+		}
+	})
+
+	t.Run("health handler does not panic", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/v1/node/health", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		api.Handler(node.Health).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+// TestIdentity_SkipsNilMetadata verifies that the Identity handler doesn't
+// panic when the local self NodeInfo lacks a Metadata block. Local self should
+// always have Metadata in practice (set in p2p_setup.go), so this is a
+// belt-and-suspenders check matching the same defensive guard added on the
+// peers handler.
+func TestIdentity_SkipsNilMetadata(t *testing.T) {
+	node := CreateTestNode(t)
+
+	mockIdx, ok := node.peersIndex.(*MockPeersIndex)
+	require.True(t, ok)
+	mockIdx.self = &records.NodeInfo{
+		NetworkID: "self",
+		// Metadata intentionally left nil
+	}
+
+	req, err := http.NewRequest("GET", "/v1/node/identity", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	api.Handler(node.Identity).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp nodeIdentity
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	// PeerID and Addresses are independent of Metadata and should still be
+	// populated; Subnets/Version are sourced from Metadata and should be empty.
+	require.NotEmpty(t, resp.PeerID)
+	require.NotEmpty(t, resp.Addresses)
+	require.Empty(t, resp.Version)
+	require.Empty(t, resp.Subnets)
+}
+
 // TestHealthCheckJSONString verifies that healthCheckJSON.String() returns correctly formatted JSON.
 func TestHealthCheckJSONString(t *testing.T) {
 	hc := healthCheckJSON{

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 	"runtime"
 	"time"
@@ -47,7 +48,7 @@ func New(
 		},
 	}
 
-	router.Use(middleware.Recoverer)
+	router.Use(middlewareRecover(s.logger))
 	router.Use(middleware.Throttle(runtime.NumCPU() * 4))
 	router.Use(middleware.Compress(5, "application/json"))
 	router.Use(middlewareLogger(s.logger))
@@ -149,4 +150,43 @@ func middlewareNodeVersion(next http.Handler) http.Handler {
 		w.Header().Set("X-SSV-Node-Version", commons.GetNodeVersion())
 		next.ServeHTTP(w, r)
 	})
+}
+
+// middlewareRecover replaces chi's middleware.Recoverer with a zap-based
+// equivalent. It logs panics at ERROR level with full request context (method,
+// path, remote address, panic value, and the stack) instead of dumping the
+// stack to stderr via debug.PrintStack — which makes panics queryable in log
+// aggregators alongside the request that triggered them.
+//
+// http.ErrAbortHandler is rethrown unchanged: it's a sentinel used by callers
+// (including net/http itself) to abort a request without it being logged as a
+// real panic, and we match chi's behavior here so existing assumptions hold.
+func middlewareRecover(logger *zap.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				rvr := recover()
+				if rvr == nil {
+					return
+				}
+				if err, ok := rvr.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+					// Don't recover — let http.ErrAbortHandler propagate as
+					// the standard library expects.
+					panic(rvr)
+				}
+				logger.Error("panic serving SSV API request",
+					zap.String("method", r.Method),
+					zap.String("path", r.URL.Path),
+					zap.String("remote_addr", r.RemoteAddr),
+					zap.Any("panic", rvr),
+					zap.Stack("stack"),
+				)
+				// Best-effort 500 response. If headers were already written
+				// this will produce a "superfluous WriteHeader" warning from
+				// net/http but won't change the client-visible behavior.
+				w.WriteHeader(http.StatusInternalServerError)
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -170,8 +170,11 @@ func middlewareRecover(logger *zap.Logger) func(next http.Handler) http.Handler 
 					return
 				}
 				if err, ok := rvr.(error); ok && errors.Is(err, http.ErrAbortHandler) {
-					// Don't recover — let http.ErrAbortHandler propagate as
-					// the standard library expects.
+					// Re-panic so net/http's outer recover (in conn.serve)
+					// catches the sentinel and silently aborts the response
+					// / closes the connection — the behavior callers rely
+					// on. The panic stays within this single request's
+					// goroutine, so it cannot crash the process.
 					panic(rvr)
 				}
 				logger.Error("panic serving SSV API request",

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/ssvlabs/ssv/api"
 	hexporter "github.com/ssvlabs/ssv/api/handlers/exporter"
@@ -29,7 +32,7 @@ import (
 func setupTestServer(t *testing.T) *httptest.Server {
 	router := chi.NewRouter()
 
-	router.Use(middleware.Recoverer)
+	router.Use(middlewareRecover(zaptest.NewLogger(t)))
 	router.Use(middleware.Throttle(runtime.NumCPU() * 4))
 	router.Use(middleware.Compress(5, "application/json"))
 	router.Use(middlewareLogger(zaptest.NewLogger(t)))
@@ -291,6 +294,76 @@ func TestMiddlewareLogger(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "test", w.Body.String())
+}
+
+// TestMiddlewareRecover verifies that middlewareRecover catches panics from a
+// downstream handler, logs them with structured fields at ERROR level, and
+// returns a 500 to the client. The companion sub-test confirms that
+// http.ErrAbortHandler propagates unchanged (matching chi's behavior).
+func TestMiddlewareRecover(t *testing.T) {
+	t.Parallel()
+
+	t.Run("captures panic and returns 500", func(t *testing.T) {
+		core, observed := observer.New(zapcore.ErrorLevel)
+		logger := zap.New(core)
+
+		handler := middlewareRecover(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("boom")
+		}))
+
+		req := httptest.NewRequest("GET", "/v1/node/peers", nil)
+		req.RemoteAddr = "1.2.3.4:5678"
+		rr := httptest.NewRecorder()
+
+		require.NotPanics(t, func() {
+			handler.ServeHTTP(rr, req)
+		})
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		require.Equal(t, 1, observed.Len())
+		entry := observed.All()[0]
+		require.Equal(t, "panic serving SSV API request", entry.Message)
+
+		fields := entry.ContextMap()
+		require.Equal(t, "GET", fields["method"])
+		require.Equal(t, "/v1/node/peers", fields["path"])
+		require.Equal(t, "1.2.3.4:5678", fields["remote_addr"])
+		require.Equal(t, "boom", fields["panic"])
+		require.Contains(t, fields, "stack")
+	})
+
+	t.Run("rethrows http.ErrAbortHandler", func(t *testing.T) {
+		logger := zap.NewNop()
+
+		handler := middlewareRecover(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic(http.ErrAbortHandler)
+		}))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		rr := httptest.NewRecorder()
+
+		require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+			handler.ServeHTTP(rr, req)
+		})
+	})
+
+	t.Run("passthrough on no panic", func(t *testing.T) {
+		core, observed := observer.New(zapcore.ErrorLevel)
+		logger := zap.New(core)
+
+		handler := middlewareRecover(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, "ok", rr.Body.String())
+		require.Equal(t, 0, observed.Len(), "no panic should produce no log")
+	})
 }
 
 // TestMiddlewareNodeVersion tests the node version middleware.

--- a/network/p2p/observability.go
+++ b/network/p2p/observability.go
@@ -130,6 +130,10 @@ func recordPeerIdentities(ctx context.Context, host host.Host, index peers.Index
 			nodeVersion := "unknown"
 			ni := index.NodeInfo(pid)
 			if ni != nil {
+				// invariant: handshaker.verifyTheirNodeInfo rejects nil-Metadata
+				// before storing in peersIndex, so this nested check guards only
+				// against stale historical entries and any future reader path
+				// that bypasses the handshake.
 				if ni.Metadata != nil {
 					nodeVersion = ni.Metadata.NodeVersion
 				}

--- a/network/peers/connections/handshaker.go
+++ b/network/peers/connections/handshaker.go
@@ -146,6 +146,25 @@ func (h *handshaker) Handler() libp2pnetwork.StreamHandler {
 }
 
 func (h *handshaker) verifyTheirNodeInfo(logger *zap.Logger, sender peer.ID, ni *records.NodeInfo) error {
+	// Resolve the peer's libp2p identify-protocol AgentVersion up front so we
+	// can attach it to both the success and rejection logs below — it's the
+	// single most useful diagnostic for identifying misbehaving clients.
+	agentVersion := peerAgentVersion(h.net, sender)
+
+	if ni.Metadata == nil {
+		// Peers must advertise NodeMetadata in their NodeInfo envelope; without
+		// it the rest of the codebase has no node-version/subnets/etc. to work
+		// with, and downstream readers (e.g. the /v1/node/peers API) can panic
+		// on the missing pointer. Rejecting here keeps such records out of the
+		// peers index entirely.
+		logger.Warn("rejecting handshake: nodeinfo is missing metadata",
+			fields.PeerID(sender),
+			zap.String("networkID", ni.GetNodeInfo().NetworkID),
+			zap.String("agent_version", agentVersion),
+		)
+		return errors.New("nodeinfo is missing metadata")
+	}
+
 	h.updateNodeSubnets(logger, sender, ni.GetNodeInfo())
 
 	if err := h.applyFilters(sender, ni); err != nil {
@@ -158,9 +177,34 @@ func (h *handshaker) verifyTheirNodeInfo(logger *zap.Logger, sender peer.ID, ni 
 		fields.PeerID(sender),
 		zap.Any("metadata", ni.GetNodeInfo().Metadata),
 		zap.String("networkID", ni.GetNodeInfo().NetworkID),
+		zap.String("agent_version", agentVersion),
 	)
 
 	return nil
+}
+
+// peerAgentVersion returns the AgentVersion advertised by the peer through
+// libp2p's identify protocol, or empty string if unavailable. It's looked up
+// from the libp2p peerstore under the well-known "AgentVersion" key (set by
+// the identify protocol on the inbound side automatically).
+//
+// The lookup is best-effort: identify may not have completed yet when we land
+// here, in which case the peerstore returns an error and we yield "" — that's
+// fine for log diagnostics.
+func peerAgentVersion(net libp2pnetwork.Network, pid peer.ID) string {
+	if net == nil {
+		return ""
+	}
+	ps := net.Peerstore()
+	if ps == nil {
+		return ""
+	}
+	val, err := ps.Get(pid, "AgentVersion")
+	if err != nil {
+		return ""
+	}
+	av, _ := val.(string)
+	return av
 }
 
 // Handshake initiates handshake with the given conn
@@ -199,6 +243,10 @@ func (h *handshaker) updatePeerInfo(pid peer.ID, handshakeErr error) {
 
 // updateNodeSubnets tries to update the subnets of the given peer
 func (h *handshaker) updateNodeSubnets(logger *zap.Logger, pid peer.ID, ni *records.NodeInfo) {
+	// invariant: verifyTheirNodeInfo rejects nil-Metadata before calling this,
+	// so ni.Metadata is non-nil on the live handshake path. Kept as
+	// belt-and-suspenders in case the invariant is weakened or this helper is
+	// reused from another call site.
 	if ni.Metadata != nil {
 		subnets, err := commons.SubnetsFromString(ni.Metadata.Subnets)
 		if err == nil {

--- a/network/peers/connections/handshaker_test.go
+++ b/network/peers/connections/handshaker_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 	"time"
 
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ssvlabs/ssv/network/peers/connections/mock"
+	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/observability/log"
 )
 
@@ -43,5 +46,88 @@ func TestHandshakeTestData(t *testing.T) {
 		td := getTestingData(t)
 		td.Handshaker.streams = mock.StreamController{}
 		require.Error(t, td.Handshaker.Handshake(testLogger, td.Conn))
+	})
+}
+
+// TestVerifyTheirNodeInfo_RejectsNilMetadata covers the case where a peer sends
+// a NodeInfo envelope without a Metadata block (only ForkVersion + NetworkID).
+// We reject such peers at handshake time so the partially-populated NodeInfo
+// never lands in the peers index, where readers like the /v1/node/peers API
+// would otherwise nil-deref on `.Metadata.NodeVersion`.
+func TestVerifyTheirNodeInfo_RejectsNilMetadata(t *testing.T) {
+	testLogger := log.TestLogger(t)
+	td := getTestingData(t)
+
+	// Build a NodeInfo with Metadata == nil and have the (mocked) stream
+	// controller return its sealed bytes — that's what Consume on the local
+	// side will parse and pass to verifyTheirNodeInfo.
+	nodeInfoNoMeta := &records.NodeInfo{
+		NetworkID: "some-network-id",
+		// Metadata intentionally left nil
+	}
+	networkPrivateKey, _, err := libp2pcrypto.GenerateKeyPair(libp2pcrypto.ECDSA, 0)
+	require.NoError(t, err)
+	sealed, err := nodeInfoNoMeta.Seal(networkPrivateKey)
+	require.NoError(t, err)
+	td.Handshaker.streams = mock.StreamController{MockRequest: sealed}
+
+	beforeHandshake := time.Now()
+	err = td.Handshaker.Handshake(testLogger, td.Conn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing metadata")
+
+	// The handshake should be recorded as failed on the peer-info side so the
+	// connection handler will reject the connection.
+	pi := td.Handshaker.peerInfos.PeerInfo(td.SenderPeerID)
+	require.NotNil(t, pi)
+	require.True(t, pi.LastHandshake.After(beforeHandshake))
+	require.Error(t, pi.LastHandshakeError)
+
+	// Crucially: verify that we did NOT store a NodeInfo for this peer.
+	// `mock.NodeInfoIndex.SetNodeInfo` is a no-op so we assert via a sentinel
+	// observation: the only side-effect on a successful path is updateNodeSubnets
+	// adding subnets to the index — for a nil-Metadata reject we expect none.
+	_, ok := td.Handshaker.subnetsIdx.GetPeerSubnets(td.SenderPeerID)
+	require.False(t, ok, "subnets should not have been recorded for a rejected peer")
+}
+
+// TestPeerAgentVersion exercises the AgentVersion lookup helper across the
+// realistic libp2p peerstore states: identify hasn't populated yet (error),
+// identify has populated with a string, and the network/peerstore are nil
+// (defensive paths). The helper is expected to degrade to "" in every failure
+// mode, since it's used purely for log diagnostics.
+func TestPeerAgentVersion(t *testing.T) {
+	t.Run("nil network", func(t *testing.T) {
+		require.Equal(t, "", peerAgentVersion(nil, "any"))
+	})
+
+	t.Run("peerstore returns non-string", func(t *testing.T) {
+		// The default mock peerstore configured in getTestingData includes
+		// SenderPeerID in ExistingPIDs and returns the peer.ID itself for any
+		// key — not a string, so the helper's type assertion fails and it
+		// yields "".
+		td := getTestingData(t)
+		require.Equal(t, "", peerAgentVersion(td.Handshaker.net, td.SenderPeerID))
+	})
+
+	t.Run("peerstore returns configured string", func(t *testing.T) {
+		td := getTestingData(t)
+		ps := mock.Peerstore{
+			ExistingPIDs: []peer.ID{td.SenderPeerID},
+			MockValues: map[peer.ID]map[string]any{
+				td.SenderPeerID: {"AgentVersion": "ssv/v2.4.2"},
+			},
+		}
+		td.Handshaker.net = mock.Net{MockPeerstore: ps}
+		require.Equal(t, "ssv/v2.4.2", peerAgentVersion(td.Handshaker.net, td.SenderPeerID))
+	})
+
+	t.Run("peerstore returns error", func(t *testing.T) {
+		td := getTestingData(t)
+		ps := mock.Peerstore{
+			// No ExistingPIDs → Get returns an error for any (pid, key).
+		}
+		td.Handshaker.net = mock.Net{MockPeerstore: ps}
+		require.Equal(t, "", peerAgentVersion(td.Handshaker.net, td.SenderPeerID))
 	})
 }

--- a/network/peers/connections/handshaker_test.go
+++ b/network/peers/connections/handshaker_test.go
@@ -75,7 +75,9 @@ func TestVerifyTheirNodeInfo_RejectsNilMetadata(t *testing.T) {
 
 	// Swap the default mock NodeInfoIndex for a recording variant so we can
 	// assert directly that SetNodeInfo was never called on the rejection path.
-	recorder := &recordingNodeInfoIndex{NodeInfoIndex: td.Handshaker.nodeInfos.(mock.NodeInfoIndex)}
+	base, ok := td.Handshaker.nodeInfos.(mock.NodeInfoIndex)
+	require.True(t, ok, "expected getTestingData to wire mock.NodeInfoIndex")
+	recorder := &recordingNodeInfoIndex{NodeInfoIndex: base}
 	td.Handshaker.nodeInfos = recorder
 
 	// Build a NodeInfo with Metadata == nil and have the (mocked) stream

--- a/network/peers/connections/handshaker_test.go
+++ b/network/peers/connections/handshaker_test.go
@@ -8,10 +8,25 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/peers/connections/mock"
 	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/observability/log"
 )
+
+// recordingNodeInfoIndex wraps mock.NodeInfoIndex and records every
+// SetNodeInfo call so tests can assert directly on storage rather than
+// inferring it from a downstream side-effect.
+type recordingNodeInfoIndex struct {
+	mock.NodeInfoIndex
+	setCalls []peer.ID
+}
+
+func (r *recordingNodeInfoIndex) SetNodeInfo(id peer.ID, _ *records.NodeInfo) {
+	r.setCalls = append(r.setCalls, id)
+}
+
+var _ peers.NodeInfoIndex = (*recordingNodeInfoIndex)(nil)
 
 // TestHandshakeTestData is a test for testing data and mocks
 func TestHandshakeTestData(t *testing.T) {
@@ -58,6 +73,11 @@ func TestVerifyTheirNodeInfo_RejectsNilMetadata(t *testing.T) {
 	testLogger := log.TestLogger(t)
 	td := getTestingData(t)
 
+	// Swap the default mock NodeInfoIndex for a recording variant so we can
+	// assert directly that SetNodeInfo was never called on the rejection path.
+	recorder := &recordingNodeInfoIndex{NodeInfoIndex: td.Handshaker.nodeInfos.(mock.NodeInfoIndex)}
+	td.Handshaker.nodeInfos = recorder
+
 	// Build a NodeInfo with Metadata == nil and have the (mocked) stream
 	// controller return its sealed bytes — that's what Consume on the local
 	// side will parse and pass to verifyTheirNodeInfo.
@@ -84,11 +104,8 @@ func TestVerifyTheirNodeInfo_RejectsNilMetadata(t *testing.T) {
 	require.Error(t, pi.LastHandshakeError)
 
 	// Crucially: verify that we did NOT store a NodeInfo for this peer.
-	// `mock.NodeInfoIndex.SetNodeInfo` is a no-op so we assert via a sentinel
-	// observation: the only side-effect on a successful path is updateNodeSubnets
-	// adding subnets to the index — for a nil-Metadata reject we expect none.
-	_, ok := td.Handshaker.subnetsIdx.GetPeerSubnets(td.SenderPeerID)
-	require.False(t, ok, "subnets should not have been recorded for a rejected peer")
+	// Direct assertion via the recording index — no proxy needed.
+	require.Empty(t, recorder.setCalls, "SetNodeInfo must not be called when handshake is rejected")
 }
 
 // TestPeerAgentVersion exercises the AgentVersion lookup helper across the

--- a/network/peers/connections/mock/mock_peerstore.go
+++ b/network/peers/connections/mock/mock_peerstore.go
@@ -17,6 +17,11 @@ var _ peerstore.Peerstore = Peerstore{}
 type Peerstore struct {
 	ExistingPIDs               []peer.ID
 	MockFirstSupportedProtocol libp2p_protocol.ID
+	// MockValues lets tests configure specific key/value pairs returned by Get
+	// for given peers — e.g. `{"AgentVersion": "ssv/v2.4.2"}`. When unset or
+	// missing for the requested (pid, key), Get falls back to the legacy
+	// behavior of returning the peer ID itself for known PIDs.
+	MockValues map[peer.ID]map[string]any
 }
 
 func (p Peerstore) Close() error {
@@ -95,6 +100,13 @@ func (p Peerstore) PeersWithKeys() peer.IDSlice {
 }
 
 func (p Peerstore) Get(pid peer.ID, key string) (any, error) {
+	if vals, ok := p.MockValues[pid]; ok {
+		if v, ok := vals[key]; ok {
+			return v, nil
+		}
+	}
+	// Legacy behavior preserved for existing tests: return the peer ID itself
+	// as the value for any key, for any peer in ExistingPIDs.
 	for _, epid := range p.ExistingPIDs {
 		if epid == pid {
 			return epid, nil

--- a/network/records/metadata.go
+++ b/network/records/metadata.go
@@ -42,6 +42,9 @@ func (nm *NodeMetadata) Decode(data []byte) error {
 }
 
 func (nm *NodeMetadata) Clone() *NodeMetadata {
+	if nm == nil {
+		return nil
+	}
 	cpy := *nm
 	return &cpy
 }

--- a/network/records/node_info.go
+++ b/network/records/node_info.go
@@ -127,6 +127,9 @@ func (ni *NodeInfo) UnmarshalRecord(data []byte) error {
 }
 
 func (ni *NodeInfo) Clone() *NodeInfo {
+	if ni == nil {
+		return nil
+	}
 	return &NodeInfo{
 		NetworkID: ni.NetworkID,
 		Metadata:  ni.Metadata.Clone(),

--- a/network/records/node_info_test.go
+++ b/network/records/node_info_test.go
@@ -33,6 +33,32 @@ func TestNodeInfo_Seal_Consume(t *testing.T) {
 	require.True(t, reflect.DeepEqual(ni, parsedRec))
 }
 
+// TestNodeInfo_Clone_NilSafety covers the three nil shapes Clone can encounter:
+// a nil NodeInfo receiver, a NodeInfo with nil Metadata, and a nil NodeMetadata
+// receiver. These matter because peersIndex.Self/UpdateSelfRecord clone on
+// every call, and a missing Metadata block (e.g. a peer that handshakes with a
+// 2-entry NodeInfo envelope) would otherwise nil-deref inside Clone before any
+// caller-side guard runs.
+func TestNodeInfo_Clone_NilSafety(t *testing.T) {
+	t.Run("nil NodeInfo receiver", func(t *testing.T) {
+		var ni *NodeInfo
+		require.Nil(t, ni.Clone())
+	})
+
+	t.Run("nil Metadata field", func(t *testing.T) {
+		ni := &NodeInfo{NetworkID: "testnet"}
+		cloned := ni.Clone()
+		require.NotNil(t, cloned)
+		require.Equal(t, "testnet", cloned.NetworkID)
+		require.Nil(t, cloned.Metadata)
+	})
+
+	t.Run("nil NodeMetadata receiver", func(t *testing.T) {
+		var nm *NodeMetadata
+		require.Nil(t, nm.Clone())
+	})
+}
+
 func TestNodeInfo_Marshal_Unmarshal(t *testing.T) {
 	oldSerializedData := []byte(`{"Entries":["", "testnet", "{\"NodeVersion\":\"v0.1.12\",\"ExecutionNode\":\"geth/x\",\"ConsensusNode\":\"prysm/x\",\"Subnets\":\"ffffffffffffffffffffffffffffffff\"}"]}`)
 


### PR DESCRIPTION
## Summary

A peer sending a NodeInfo envelope without a Metadata block (only ForkVersion + NetworkID, per [`UnmarshalRecord`'s <3-entries path](https://github.com/ssvlabs/ssv/blob/stage/network/records/node_info.go#L117-L119)) lands in the peers index with `Metadata == nil`. The [`/v1/node/peers`](https://github.com/ssvlabs/ssv/blob/stage/api/handlers/node/node.go#L152) and `/v1/node/health` handlers then nil-deref on `nodeInfo.Metadata.NodeVersion` in `(*Node).peers`, panicking once per probe per such peer.

Mainnet is currently hit by one peer at `51.161.197.214` (libp2p ID `16Uiu2HAmUiHi…CYgo`) that connects to every operator and sends 2-entry NodeInfo records on every handshake. Local stage code never produces 2-entry records (`setupPeerServices` always sets `self.Metadata`), so this is a remote client — exact identity unknown without the `agent_version` field this PR also adds.

The unguarded dereference at `node.go:152` has existed since [`60f386fec4`](https://github.com/ssvlabs/ssv/commit/60f386fec4) (Jul 2023) — it's a latent bug, and the recent panics are because of a new misbehaving peer in the cluster, not a regression on our side.

## Core fix

- **`api/handlers/node/node.go`**: guard `nodeInfo.Metadata.NodeVersion` with a nil check so the API can't panic regardless of what's in the index. The peer still appears in the response with `Version` left empty.
- **`network/peers/connections/handshaker.go`**: reject `nil-Metadata` in `verifyTheirNodeInfo` before `SetNodeInfo`, so such records never get stored. The handshake error propagates through the existing `defer-updatePeerInfo` path; `conn_handler` then disconnects the peer (same outcome as the existing subnet-share rejection, just earlier).
- **AgentVersion logging**: new `peerAgentVersion()` helper queries libp2p's identify-protocol `AgentVersion` from the peerstore; added as `agent_version` to both the existing `"Verified handshake nodeinfo"` INFO log and the new rejection WARN log. Lets us identify misbehaving clients in production.

## Consistency / completeness

- `Identity` handler gets the same nil-Metadata guard for symmetry with the `peers` handler.
- Existing `if Metadata != nil` checks at `handshaker.updateNodeSubnets` and `p2p/observability.go` get `// invariant:` comments documenting why they remain after the handshake-side rejection.
- **`api/server`**: replace `chi.Recoverer` with a zap-based `middlewareRecover` that logs panics at ERROR level with `method`/`path`/`remote_addr`/`panic`/`stack` as structured fields. `chi.Recoverer` writes the stack to stderr via `debug.PrintStack` and can't be correlated with the triggering request in log aggregators — which is what made the original investigation slow. Matches `chi`'s `http.ErrAbortHandler` semantics.
- **`network/peers/connections/mock`**: `MockPeerstore.Get` gains a `MockValues map[peer.ID]map[string]any` for per-key lookups, so handshake `AgentVersion` tests can exercise the real identify-protocol path. Legacy "return peer.ID for any key" fallback preserved for existing tests.

## Tests

| Test | What it covers |
|---|---|
| `TestPeers_SkipsNilMetadata` | `peers` + `health` handlers don't panic on nil-Metadata NodeInfo |
| `TestIdentity_SkipsNilMetadata` | `identity` handler symmetric behavior |
| `TestVerifyTheirNodeInfo_RejectsNilMetadata` | Handshake rejects + doesn't store nil-Metadata + handshake error propagates |
| `TestPeerAgentVersion` | 4 sub-cases: nil net, non-string value, configured string (via `MockValues`), peerstore error |
| `TestMiddlewareRecover` | Panic capture + 500 + `http.ErrAbortHandler` rethrow + passthrough |

Pre-existing `TestHandshakeTestData/happy_flow` continues to pass with `agent_version` added to its observed log.

## Verification

Locally on the touched packages:

- ✅ `go build ./...` and `go vet ./...`
- ✅ `gofmt` clean
- ✅ `golangci-lint run` — 0 issues
- ✅ `openapi-lint` — 0 issues
- ✅ All tests pass: `./api/handlers/node/...`, `./api/server/...`, `./network/peers/connections/...`

`./network/p2p/...` has a pre-existing flaky goroutine-leak issue with `libp2p/zeroconf` unrelated to this change — confirmed it reproduces on clean `stage` as well.

## Operational follow-up

Independent of this PR — the offending peer (`51.161.197.214`, libp2p ID `16Uiu2HAmUiHi…CYgo`) is currently active on mainnet. With this PR merged we still won't connect to it (subnet-share check rejects anyway), and we'll now have its `agent_version` in the WARN log for identification. If the client identifies itself meaningfully via libp2p `identify`, that may give us enough to determine whether it's a third-party SSV-compatible client, an old release, or something adversarial.

---

- [ ] E2E passed - [action log](put link here)