### PR TITLE
Suggested fixes for review feedback on #2843

### DIFF
--- a/network/topics/observability.go
+++ b/network/topics/observability.go
@@ -38,7 +38,7 @@ var (
 		meter.Int64Counter(
 			observability.InstrumentName(pubsubObservabilityNamespace, "received"),
 			metric.WithUnit("{message}"),
-			metric.WithDescription("total number of messages received by the pubsub topic validator")))
+			metric.WithDescription("total number of messages delivered to the pubsub topic validator, before SSV validation runs (compare with ssv_p2p_messages_in_total for the post-validation rate)")))
 
 	msgIDHandlerBufferFallbackCounter = metrics.New(
 		meter.Int64Counter(
@@ -62,6 +62,9 @@ func messageTypeAttribute(value uint64) attribute.KeyValue {
 	}
 }
 
+// recordPubsubMessageReceived is called from the topic validator wrapper before the inner SSV
+// validator runs, so the counter increments for every message libp2p hands to the validator
+// regardless of validation outcome (accept/ignore/reject/timeout).
 func recordPubsubMessageReceived(ctx context.Context, topic string) {
 	pubsubMessagesReceivedCounter.Add(ctx, 1, metric.WithAttributes(pubsubTopicAttribute(topic)))
 }

--- a/network/topics/observability_test.go
+++ b/network/topics/observability_test.go
@@ -27,12 +27,12 @@ func TestRecordPubsubMessageReceived(t *testing.T) {
 	require.NoError(t, reader.Collect(t.Context(), &rm))
 
 	for _, scopeMetrics := range rm.ScopeMetrics {
-		for _, metric := range scopeMetrics.Metrics {
-			if metric.Name != "ssv.p2p.pubsub.messages.received" {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name != "ssv.p2p.pubsub.messages.received" {
 				continue
 			}
 
-			sum, ok := metric.Data.(metricdata.Sum[int64])
+			sum, ok := m.Data.(metricdata.Sum[int64])
 			require.True(t, ok)
 			require.Len(t, sum.DataPoints, 1)
 			require.EqualValues(t, 2, sum.DataPoints[0].Value)


### PR DESCRIPTION
Suggested resolutions for the inline review feedback on #2843. Each commit-included change matches one inline comment in that review — merge as-is, cherry-pick, or close if you'd rather address differently.

## Changes

- **Tighten `ssv_p2p_pubsub_messages_received_total` description** so an operator reading the metric registry can immediately tell it is the *pre-validation* counterpart of `ssv_p2p_messages_in_total`.
- **Add a brief comment on `recordPubsubMessageReceived`** noting it is called from the validator wrapper before the inner validator runs, so all outcomes (accept/ignore/reject/timeout) are counted — useful context for the next reader.
- **Rename test loop variable** that shadowed the imported `go.opentelemetry.io/otel/sdk/metric` package (lint-only nit).

## Not included

The cross-counter attribute-key fragmentation (`ssv.p2p.pubsub.topic` vs `ssv.p2p.message.topic` vs `ssv.p2p.topic.name`) is left for you to decide on — that one is a design call rather than a mechanical fix.

## Test plan

- [x] `go build ./network/topics/...`
- [x] `go test -run TestRecordPubsubMessageReceived ./network/topics/ -count=1`