### PR TITLE
beacon/goclient: clarify multi-client init comments (follow-up to #2845)

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -205,7 +205,10 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 		activatedClients:                   hashmap.New[string, struct{}](),
 	}
 
-	// First error stops the loop on purpose - a malformed CL address must surface to the operator, not be silently skipped.
+	// First error stops the loop on purpose. addSingleClient sets WithAllowDelayedStart(true), so a valid
+	// but currently-unreachable CL does not error here - it's tolerated and connected to later. Only a genuine
+	// construction error (e.g. a malformed address) surfaces, and that must reach the operator rather than be
+	// silently skipped.
 	for _, beaconAddr := range beaconAddrList {
 		if err := client.addSingleClient(ctx, beaconAddr); err != nil {
 			return nil, err

--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -194,6 +194,12 @@ func TestTimeouts(t *testing.T) {
 	)
 
 	// CLs unresponsive at startup: New must wait under ctx, not fatal eagerly with "client is not active".
+	//
+	// The mock sleeps longer than commonTimeout on every request, so each activation ping times out at
+	// commonTimeout (well before the server would respond) and the client never becomes active - forcing New
+	// to wait out ctx and return DeadlineExceeded rather than eager ErrNotActive. The ctx deadline only needs
+	// to exceed commonTimeout; it does not race the server response, since the per-request commonTimeout fires
+	// first (here ctx and the mock sleep share a value only for convenience, not because they're timed to race).
 	{
 		undialableServer := mocks.NewServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			time.Sleep(commonTimeout + timeoutMargin)


### PR DESCRIPTION
## Summary
Two comment-only follow-ups addressing the non-blocking review nits left on #2845 ([review](https://github.com/ssvlabs/ssv/pull/2845#pullrequestreview-4279759294)). **No behavior change** — documentation only.

- **`New()` address loop** ([nit](https://github.com/ssvlabs/ssv/pull/2845#discussion_r3232655498)): the old comment only mentioned that a malformed address must surface. Sharpened it to make the distinction explicit — `addSingleClient` sets `WithAllowDelayedStart(true)`, so a valid-but-unreachable CL is *not* an error here (it's tolerated and connected to later); only a genuine construction error (e.g. a malformed address) surfaces and bails the loop.
- **`TestTimeouts` first sub-block** ([nit](https://github.com/ssvlabs/ssv/pull/2845#discussion_r3232655489)): the reviewer read the equal `ctx` deadline and mock-sleep values as a razor-thin race. They aren't — each activation ping times out at the per-request `commonTimeout` (800ms), a full `timeoutMargin` (400ms) before the server would respond, so the client never becomes active and `New` deterministically waits out `ctx` and returns `DeadlineExceeded`. Added a comment documenting this so the shared value doesn't read as a timed race. Deliberately **did not** bump the ctx as suggested — that would only slow the test (~2x) with no robustness gain.

## Test plan
- [x] `go build ./beacon/goclient/...` clean
- [x] `go vet ./beacon/goclient/...` clean
- [x] `go test -count=1 -run '^TestTimeouts$' ./beacon/goclient/` passes