### PR TITLE
executionclient: dual-transport EL client (WS subscriptions + HTTP queries) — works around Besu WS event-loop bug

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -370,21 +370,37 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("no execution node address provided")
 		}
 
+		// Optional positionally-paired HTTP endpoints for request/response calls
+		// (eth_getLogs etc.) — keeps the heavy responses off WebSocket and works
+		// around Besu's StreamBackpressure event-loop block. Empty leaves the
+		// legacy single-transport behavior.
+		var queryAddrList []string
+		if cfg.ExecutionClient.QueryAddr != "" {
+			queryAddrList = strings.Split(cfg.ExecutionClient.QueryAddr, ";")
+		}
+
 		logger.Info("connecting EL(s)",
 			fields.Addresses(executionAddrList),
+			zap.Strings("query_addresses", queryAddrList),
 			zap.Duration("request_timeout", cfg.ExecutionClient.ConnectionTimeout),
 			zap.Uint64("sync_distance_tolerance", cfg.ExecutionClient.SyncDistanceTolerance),
 		)
 
 		var executionClient executionclient.Provider
 		if len(executionAddrList) == 1 {
+			singleOpts := []executionclient.Option{
+				executionclient.WithLogger(logger),
+				executionclient.WithReqTimeout(cfg.ExecutionClient.ConnectionTimeout),
+				executionclient.WithSyncDistanceTolerance(cfg.ExecutionClient.SyncDistanceTolerance),
+			}
+			if len(queryAddrList) > 0 && queryAddrList[0] != "" {
+				singleOpts = append(singleOpts, executionclient.WithQueryAddr(queryAddrList[0]))
+			}
 			ec, err := executionclient.New(
 				cmd.Context(),
 				executionAddrList[0],
 				ssvNetworkConfig.RegistryContractAddr,
-				executionclient.WithLogger(logger),
-				executionclient.WithReqTimeout(cfg.ExecutionClient.ConnectionTimeout),
-				executionclient.WithSyncDistanceTolerance(cfg.ExecutionClient.SyncDistanceTolerance),
+				singleOpts...,
 			)
 			if err != nil {
 				logger.Fatal("could not connect to execution client", zap.Error(err))
@@ -392,13 +408,19 @@ var StartNodeCmd = &cobra.Command{
 
 			executionClient = ec
 		} else {
+			multiOpts := []executionclient.OptionMulti{
+				executionclient.WithLoggerMulti(logger),
+				executionclient.WithReqTimeoutMulti(cfg.ExecutionClient.ConnectionTimeout),
+				executionclient.WithSyncDistanceToleranceMulti(cfg.ExecutionClient.SyncDistanceTolerance),
+			}
+			if len(queryAddrList) > 0 {
+				multiOpts = append(multiOpts, executionclient.WithQueryAddrsMulti(queryAddrList))
+			}
 			ec, err := executionclient.NewMulti(
 				cmd.Context(),
 				executionAddrList,
 				ssvNetworkConfig.RegistryContractAddr,
-				executionclient.WithLoggerMulti(logger),
-				executionclient.WithReqTimeoutMulti(cfg.ExecutionClient.ConnectionTimeout),
-				executionclient.WithSyncDistanceToleranceMulti(cfg.ExecutionClient.SyncDistanceTolerance),
+				multiOpts...,
 			)
 			if err != nil {
 				logger.Fatal("could not connect to execution client", zap.Error(err))

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -366,7 +366,10 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		executionAddrList := strings.Split(cfg.ExecutionClient.Addr, ";")
-		if len(executionAddrList) == 0 {
+		for i := range executionAddrList {
+			executionAddrList[i] = strings.TrimSpace(executionAddrList[i])
+		}
+		if len(executionAddrList) == 0 || executionAddrList[0] == "" {
 			logger.Fatal("no execution node address provided")
 		}
 
@@ -374,9 +377,41 @@ var StartNodeCmd = &cobra.Command{
 		// (eth_getLogs etc.) — keeps the heavy responses off WebSocket and works
 		// around Besu's StreamBackpressure event-loop block. Empty leaves the
 		// legacy single-transport behavior.
+		//
+		// Empty entries within the list are permitted and mean "use WS only for
+		// this position" — useful for mixed backend setups where only some ELs
+		// are Besu. MultiClient.connect handles the per-entry fallback.
 		var queryAddrList []string
 		if cfg.ExecutionClient.QueryAddr != "" {
 			queryAddrList = strings.Split(cfg.ExecutionClient.QueryAddr, ";")
+			for i := range queryAddrList {
+				queryAddrList[i] = strings.TrimSpace(queryAddrList[i])
+			}
+			// Pair-by-position: a silent length mismatch would leave some
+			// clients falling back to WS — the very situation
+			// ETH_1_QUERY_ADDR exists to avoid. Fail loud on misconfig.
+			if len(queryAddrList) != len(executionAddrList) {
+				logger.Fatal("ETH_1_QUERY_ADDR entry count must match ETH_1_ADDR — fix the config or unset ETH_1_QUERY_ADDR",
+					zap.Int("query_addr_count", len(queryAddrList)),
+					zap.Int("node_addr_count", len(executionAddrList)),
+				)
+			}
+			// Surface any positions that fall back to WS so operators see
+			// at startup that the Besu workaround isn't covering every
+			// backend. Not fatal — explicitly supported, but worth knowing
+			// because large eth_getLogs on these positions may still hit
+			// Besu's StreamBackpressure event-loop block.
+			var wsOnlyAddrs []string
+			for i, q := range queryAddrList {
+				if q == "" {
+					wsOnlyAddrs = append(wsOnlyAddrs, executionAddrList[i])
+				}
+			}
+			if len(wsOnlyAddrs) > 0 {
+				logger.Warn("ETH_1_QUERY_ADDR set but some positions are blank — those EL backends will use WS for queries and may trigger Besu's StreamBackpressure event-loop block on large eth_getLogs responses. Set an HTTP endpoint at each blank position to opt those backends into the dual-transport path.",
+					zap.Strings("ws_only_addrs", wsOnlyAddrs),
+				)
+			}
 		}
 
 		logger.Info("connecting EL(s)",

--- a/eth/executionclient/config.go
+++ b/eth/executionclient/config.go
@@ -8,7 +8,8 @@ import (
 
 // Options contains config configurations related to Ethereum execution client.
 type Options struct {
-	Addr                  string        `yaml:"ETH1Addr" env:"ETH_1_ADDR" env-required:"true" env-description:"Execution client WebSocket URL(s). Multiple clients are supported via semicolon-separated URLs (e.g. 'ws://localhost:8546;ws://localhost:8547')"`
+	Addr                  string        `yaml:"ETH1Addr" env:"ETH_1_ADDR" env-required:"true" env-description:"Execution client WebSocket URL(s) for eth_subscribe (new head / log streams). Multiple clients are supported via semicolon-separated URLs (e.g. 'ws://localhost:8546;ws://localhost:8547')"`
+	QueryAddr             string        `yaml:"ETH1QueryAddr" env:"ETH_1_QUERY_ADDR" env-description:"Optional HTTP URL(s) used for request/response calls (eth_getLogs, eth_blockNumber, eth_getBlockByNumber, ...). When set, large response payloads are routed off the WebSocket transport — sidesteps Besu's StreamBackpressure event-loop blocking on big eth_getLogs replies. URLs are paired positionally with ETH_1_ADDR; falls back to ETH_1_ADDR per-entry when empty. Semicolon-separated, must point at the same physical node as the matching ETH_1_ADDR entry."`
 	ConnectionTimeout     time.Duration `yaml:"ETH1ConnectionTimeout" env:"ETH_1_CONNECTION_TIMEOUT" env-default:"10s" env-description:"Timeout for execution client requests"`
 	SyncDistanceTolerance uint64        `yaml:"ETH1SyncDistanceTolerance" env:"ETH_1_SYNC_DISTANCE_TOLERANCE" env-default:"5" env-description:"Maximum number of blocks behind head considered in-sync"`
 }

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -25,17 +25,21 @@ import (
 // call falls back to subClient — preserving the pre-split single-client
 // behavior and keeping the change backward compatible.
 type ethClient struct {
-	sub   *ethclient.Client
-	query *ethclient.Client
+	sub      *ethclient.Client
+	subAddr  string // URL dialed for sub (always set)
+	query    *ethclient.Client
+	queryAddr string // URL dialed for query (empty when query is nil)
 
 	// reqTimeout specifies the default timeout to be used with every ethclient.Client call.
 	reqTimeout time.Duration
 }
 
-func newEthClient(sub, query *ethclient.Client, reqTimeout time.Duration) *ethClient {
+func newEthClient(sub *ethclient.Client, subAddr string, query *ethclient.Client, queryAddr string, reqTimeout time.Duration) *ethClient {
 	return &ethClient{
 		sub:        sub,
+		subAddr:    subAddr,
 		query:      query,
+		queryAddr:  queryAddr,
 		reqTimeout: reqTimeout,
 	}
 }
@@ -50,11 +54,59 @@ func (c *ethClient) queryOrSub() *ethclient.Client {
 	return c.sub
 }
 
+// SubAddr returns the URL of the subscription transport (the address dialed
+// for eth_subscribe — always WS or IPC).
+func (c *ethClient) SubAddr() string {
+	return c.subAddr
+}
+
+// QueryAddr returns the URL that actually serves query-routed calls
+// (FilterLogs, BlockNumber, HeaderByNumber, SyncProgress, ChainID): the
+// query client's address when dual-transport is configured, the sub client's
+// address otherwise. Use this when recording observability for query-routed
+// calls so logs/metrics report the URL the request truly traveled.
+func (c *ethClient) QueryAddr() string {
+	if c.query != nil {
+		return c.queryAddr
+	}
+	return c.subAddr
+}
+
+// QueryTransport returns "http" when dual-transport is configured (query
+// client present) and "ws" otherwise. Pair with QueryAddr() so observability
+// records can be filtered by transport regardless of operator URL choice.
+func (c *ethClient) QueryTransport() string {
+	if c.query == nil {
+		return "ws"
+	}
+	return "http"
+}
+
 func (c *ethClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
 	return c.queryOrSub().SyncProgress(reqCtx)
+}
+
+// PingSub performs a cheap round-trip against the subscription transport only.
+// In single-transport mode (query == nil) this is a no-op — SyncProgress on
+// the sub client itself already covers liveness. When dual-transport is in
+// use, Healthy()'s SyncProgress probe only touches the query (HTTP) client,
+// so without this probe a WS-down / HTTP-up partial failure would report
+// healthy while SubscribeFilterLogs / SubscribeNewHead silently stall, and
+// MultiClient would never failover.
+//
+// Uses BlockNumber as the probe: tiny response (a uint64), can't trigger
+// the Besu WS-backpressure path we're avoiding for queries.
+func (c *ethClient) PingSub(ctx context.Context) error {
+	if c.query == nil {
+		return nil
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
+	defer cancel()
+	_, err := c.sub.BlockNumber(reqCtx)
+	return err
 }
 
 func (c *ethClient) BlockNumber(ctx context.Context) (uint64, error) {

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -10,72 +10,100 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-// ethClient is a wrapper around ethclient.Client to add a default timeout for every call we
-// make with ethclient.Client. This allows us to manage timeouts for ethclient.Client in one
-// place such that we don't accidentally forget to set a timeout for some ethclient.Client call.
+// ethClient wraps two ethclient.Client instances and routes each call to the
+// transport best suited for it:
+//   - sub:   used only for streaming endpoints (eth_subscribe family). These
+//            require WebSocket or IPC and only carry tiny messages, so they
+//            don't trigger response-side backpressure on any EL.
+//   - query: used for request/response endpoints (eth_getLogs, eth_blockNumber,
+//            etc.). These can return large payloads; routing them over HTTP
+//            avoids Besu's WebSocket-only StreamBackpressure code path that
+//            parks the JSON-RPC event loop on large responses
+//            (see hyperledger/besu#9848 + WebSocketMessageHandler.replyToClient).
+//
+// When the dual-transport configuration isn't set (queryClient is nil), every
+// call falls back to subClient — preserving the pre-split single-client
+// behavior and keeping the change backward compatible.
 type ethClient struct {
-	client *ethclient.Client
+	sub   *ethclient.Client
+	query *ethclient.Client
 
 	// reqTimeout specifies the default timeout to be used with every ethclient.Client call.
 	reqTimeout time.Duration
 }
 
-func newEthClient(client *ethclient.Client, reqTimeout time.Duration) *ethClient {
+func newEthClient(sub, query *ethclient.Client, reqTimeout time.Duration) *ethClient {
 	return &ethClient{
-		client:     client,
+		sub:        sub,
+		query:      query,
 		reqTimeout: reqTimeout,
 	}
+}
+
+// queryOrSub returns the query client if configured, otherwise falls back to
+// the subscription client. This keeps single-transport deployments working
+// unchanged.
+func (c *ethClient) queryOrSub() *ethclient.Client {
+	if c.query != nil {
+		return c.query
+	}
+	return c.sub
 }
 
 func (c *ethClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.SyncProgress(reqCtx)
+	return c.queryOrSub().SyncProgress(reqCtx)
 }
 
 func (c *ethClient) BlockNumber(ctx context.Context) (uint64, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.BlockNumber(reqCtx)
+	return c.queryOrSub().BlockNumber(reqCtx)
 }
 
 func (c *ethClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*ethtypes.Header, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.HeaderByNumber(reqCtx, blockNumber)
+	return c.queryOrSub().HeaderByNumber(reqCtx, blockNumber)
 }
 
 func (c *ethClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- ethtypes.Log) (ethereum.Subscription, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.SubscribeFilterLogs(reqCtx, q, ch)
+	// Always uses the subscription transport — eth_subscribe is unsupported on HTTP.
+	return c.sub.SubscribeFilterLogs(reqCtx, q, ch)
 }
 
 func (c *ethClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]ethtypes.Log, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.FilterLogs(reqCtx, q)
+	return c.queryOrSub().FilterLogs(reqCtx, q)
 }
 
 func (c *ethClient) SubscribeNewHead(ctx context.Context, heads chan *ethtypes.Header) (ethereum.Subscription, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.SubscribeNewHead(reqCtx, heads)
+	// Always uses the subscription transport — eth_subscribe is unsupported on HTTP.
+	return c.sub.SubscribeNewHead(reqCtx, heads)
 }
 
 func (c *ethClient) ChainID(ctx context.Context) (*big.Int, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
 	defer cancel()
 
-	return c.client.ChainID(reqCtx)
+	return c.queryOrSub().ChainID(reqCtx)
 }
 
 func (c *ethClient) Close() {
-	c.client.Close()
+	c.sub.Close()
+	if c.query != nil {
+		c.query.Close()
+	}
 }

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -13,21 +13,21 @@ import (
 // ethClient wraps two ethclient.Client instances and routes each call to the
 // transport best suited for it:
 //   - sub:   used only for streaming endpoints (eth_subscribe family). These
-//            require WebSocket or IPC and only carry tiny messages, so they
-//            don't trigger response-side backpressure on any EL.
+//     require WebSocket or IPC and only carry tiny messages, so they
+//     don't trigger response-side backpressure on any EL.
 //   - query: used for request/response endpoints (eth_getLogs, eth_blockNumber,
-//            etc.). These can return large payloads; routing them over HTTP
-//            avoids Besu's WebSocket-only StreamBackpressure code path that
-//            parks the JSON-RPC event loop on large responses
-//            (see hyperledger/besu#9848 + WebSocketMessageHandler.replyToClient).
+//     etc.). These can return large payloads; routing them over HTTP
+//     avoids Besu's WebSocket-only StreamBackpressure code path that
+//     parks the JSON-RPC event loop on large responses
+//     (see hyperledger/besu#9848 + WebSocketMessageHandler.replyToClient).
 //
 // When the dual-transport configuration isn't set (queryClient is nil), every
 // call falls back to subClient — preserving the pre-split single-client
 // behavior and keeping the change backward compatible.
 type ethClient struct {
-	sub      *ethclient.Client
-	subAddr  string // URL dialed for sub (always set)
-	query    *ethclient.Client
+	sub       *ethclient.Client
+	subAddr   string // URL dialed for sub (always set)
+	query     *ethclient.Client
 	queryAddr string // URL dialed for query (empty when query is nil)
 
 	// reqTimeout specifies the default timeout to be used with every ethclient.Client call.

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -50,6 +50,13 @@ type ExecutionClient struct {
 	nodeAddr        string
 	contractAddress ethcommon.Address
 
+	// queryAddr is an optional HTTP endpoint paired with nodeAddr. When set, all
+	// request/response calls (eth_getLogs, eth_blockNumber, etc.) are routed to
+	// this transport while subscriptions stay on nodeAddr (WS). Sidesteps Besu's
+	// StreamBackpressure event-loop block on large WS responses; safe on any EL.
+	// When empty, nodeAddr is used for both — preserves single-transport behavior.
+	queryAddr string
+
 	logger *zap.Logger
 
 	reqTimeout    time.Duration
@@ -526,17 +533,34 @@ func (ec *ExecutionClient) streamLogsToChan(
 }
 
 // connect connects to Ethereum execution client.
+//
+// Dials nodeAddr for the subscription transport (always required — eth_subscribe
+// only works over WS/IPC). When queryAddr is also set, dials a second client
+// for request/response calls so large eth_getLogs responses don't traverse the
+// WebSocket path that hits Besu's StreamBackpressure event-loop block.
 func (ec *ExecutionClient) connect(ctx context.Context) error {
 	reqCtx, cancel := context.WithTimeout(ctx, ec.reqTimeout)
 	defer cancel()
+
 	reqStart := time.Now()
-	c, err := ethclient.DialContext(reqCtx, ec.nodeAddr)
+	subClient, err := ethclient.DialContext(reqCtx, ec.nodeAddr)
 	recordRequest(ctx, ec.logger, "DialContext", ec, time.Since(reqStart), err)
 	if err != nil {
 		return ec.errSingleClient(fmt.Errorf("ethclient dial: %w", err), "dial")
 	}
 
-	ec.client = newEthClient(c, ec.reqTimeout)
+	var queryClient *ethclient.Client
+	if ec.queryAddr != "" && ec.queryAddr != ec.nodeAddr {
+		reqStart = time.Now()
+		queryClient, err = ethclient.DialContext(reqCtx, ec.queryAddr)
+		recordRequest(ctx, ec.logger, "DialContext", ec, time.Since(reqStart), err)
+		if err != nil {
+			subClient.Close()
+			return ec.errSingleClient(fmt.Errorf("ethclient dial query addr: %w", err), "dial")
+		}
+	}
+
+	ec.client = newEthClient(subClient, queryClient, ec.reqTimeout)
 
 	return nil
 }

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -552,6 +552,41 @@ func (ec *ExecutionClient) streamLogsToChan(
 	}
 }
 
+// chainIDWithRetry fetches the chain ID from an ethclient.Client with bounded
+// retry to ride out transient transport flakes at startup (e.g., Besu HTTP
+// occasionally returning EOF on the first poll right after dial). Each attempt
+// gets its own short per-attempt context so one slow attempt can't eat the
+// caller's whole budget. The outer ctx still bounds the total wall-clock —
+// if it's cancelled mid-backoff, we return its error.
+//
+// On every attempt failing, returns the last error so the caller can fail
+// closed (the caller's responsibility — this helper does not decide policy).
+func chainIDWithRetry(ctx context.Context, client *ethclient.Client) (*big.Int, error) {
+	const attempts = 3
+	const perAttemptTimeout = 2 * time.Second
+	const backoff = 1 * time.Second
+
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		chainID, err := client.ChainID(attemptCtx)
+		cancel()
+		if err == nil {
+			return chainID, nil
+		}
+		lastErr = err
+		if i == attempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return nil, lastErr
+}
+
 // connect connects to Ethereum execution client.
 //
 // Dials nodeAddr for the subscription transport (always required — eth_subscribe
@@ -584,23 +619,27 @@ func (ec *ExecutionClient) connect(ctx context.Context) error {
 	// Otherwise we'd read registry events (FilterLogs/HTTP) from one chain
 	// while subscribing to live events (eth_subscribe/WS) on another — silent
 	// divergence that downstream consumers (event syncer, EKM slashing
-	// protection) have no defense against. Validate once at startup.
+	// protection) have no defense against. Validate once at startup, with
+	// bounded retry to ride out transient transport flakes (e.g., Besu HTTP
+	// occasionally returning EOF on first poll right after dial — observed in
+	// production where it crash-looped the pod). A persistent chain mismatch
+	// still fails closed; only transport-level errors are retried.
 	if queryClient != nil {
 		chainIDStart := time.Now()
-		subChainID, idErr := subClient.ChainID(reqCtx)
+		subChainID, idErr := chainIDWithRetry(reqCtx, subClient)
 		recordRequest(ctx, ec.logger, "eth_chainId.sub", ec.nodeAddr, time.Since(chainIDStart), idErr)
 		if idErr != nil {
 			subClient.Close()
 			queryClient.Close()
-			return ec.errSingleClient(fmt.Errorf("fetch chain ID from sub addr %s: %w", ec.nodeAddr, idErr), "eth_chainId")
+			return ec.errSingleClient(fmt.Errorf("fetch chain ID from sub addr %s after retries: %w", ec.nodeAddr, idErr), "eth_chainId")
 		}
 		chainIDStart = time.Now()
-		queryChainID, idErr := queryClient.ChainID(reqCtx)
+		queryChainID, idErr := chainIDWithRetry(reqCtx, queryClient)
 		recordRequest(ctx, ec.logger, "eth_chainId.query", ec.queryAddr, time.Since(chainIDStart), idErr)
 		if idErr != nil {
 			subClient.Close()
 			queryClient.Close()
-			return ec.errSingleClient(fmt.Errorf("fetch chain ID from query addr %s: %w", ec.queryAddr, idErr), "eth_chainId")
+			return ec.errSingleClient(fmt.Errorf("fetch chain ID from query addr %s after retries: %w", ec.queryAddr, idErr), "eth_chainId")
 		}
 		if subChainID.Cmp(queryChainID) != 0 {
 			subClient.Close()

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -135,7 +135,8 @@ func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock ui
 ) {
 	start := time.Now()
 	currentBlock, err := ec.client.BlockNumber(ctx)
-	recordRequest(ctx, ec.logger, "BlockNumber", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "BlockNumber", ec.client.QueryAddr(), time.Since(start), err,
+		zap.String("transport", ec.client.QueryTransport()))
 	if err != nil {
 		return nil, nil, ec.errSingleClient(fmt.Errorf("get current block: %w", err), "eth_blockNumber")
 	}
@@ -387,7 +388,8 @@ func (ec *ExecutionClient) Healthy(ctx context.Context) error {
 
 	start := time.Now()
 	sp, err := ec.SyncProgress(ctx)
-	recordRequest(ctx, ec.logger, "SyncProgress", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "SyncProgress", ec.client.QueryAddr(), time.Since(start), err,
+		zap.String("transport", ec.client.QueryTransport()))
 	if err != nil {
 		recordExecutionClientStatus(ctx, statusFailure, ec.nodeAddr)
 		return ec.errSingleClient(fmt.Errorf("get sync progress: %w", err), "eth_syncing")
@@ -406,6 +408,20 @@ func (ec *ExecutionClient) Healthy(ctx context.Context) error {
 		syncDistanceGauge.Record(ctx, 0, metric.WithAttributes(semconv.ServerAddress(ec.nodeAddr)))
 	}
 
+	// SyncProgress above only touched the query transport when dual-transport
+	// is in use. Probe the sub (WS) transport too — without this, a WS-down /
+	// HTTP-up partial failure looks healthy here while SubscribeFilterLogs /
+	// SubscribeNewHead stall, and MultiClient never failovers.
+	// PingSub is a no-op in single-transport mode.
+	start = time.Now()
+	subErr := ec.client.PingSub(ctx)
+	recordRequest(ctx, ec.logger, "PingSub", ec.client.SubAddr(), time.Since(start), subErr,
+		zap.String("transport", "ws"))
+	if subErr != nil {
+		recordExecutionClientStatus(ctx, statusFailure, ec.nodeAddr)
+		return ec.errSingleClient(fmt.Errorf("probe sub transport: %w", subErr), "eth_blockNumber")
+	}
+
 	recordExecutionClientStatus(ctx, statusReady, ec.nodeAddr)
 
 	ec.lastHealthyTime.Store(time.Now().Unix())
@@ -416,7 +432,8 @@ func (ec *ExecutionClient) Healthy(ctx context.Context) error {
 func (ec *ExecutionClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*ethtypes.Header, error) {
 	start := time.Now()
 	h, err := ec.client.HeaderByNumber(ctx, blockNumber)
-	recordRequest(ctx, ec.logger, "HeaderByNumber", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "HeaderByNumber", ec.client.QueryAddr(), time.Since(start), err,
+		zap.String("transport", ec.client.QueryTransport()))
 	if err != nil {
 		return nil, ec.errSingleClient(fmt.Errorf("get header by block number %s: %w", blockNumber, err), "eth_getBlockByNumber")
 	}
@@ -426,7 +443,8 @@ func (ec *ExecutionClient) HeaderByNumber(ctx context.Context, blockNumber *big.
 func (ec *ExecutionClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- ethtypes.Log) (ethereum.Subscription, error) {
 	start := time.Now()
 	logs, err := ec.client.SubscribeFilterLogs(ctx, q, ch)
-	recordRequest(ctx, ec.logger, "SubscribeFilterLogs", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "SubscribeFilterLogs", ec.client.SubAddr(), time.Since(start), err,
+		zap.String("transport", "ws"))
 	if err != nil {
 		return nil, ec.errSingleClient(fmt.Errorf("subscribe to filtered logs (query=%s): %w", q, err), "logs")
 	}
@@ -436,7 +454,8 @@ func (ec *ExecutionClient) SubscribeFilterLogs(ctx context.Context, q ethereum.F
 func (ec *ExecutionClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]ethtypes.Log, error) {
 	start := time.Now()
 	logs, err := ec.client.FilterLogs(ctx, q)
-	recordRequest(ctx, ec.logger, "FilterLogs", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "FilterLogs", ec.client.QueryAddr(), time.Since(start), err,
+		zap.String("transport", ec.client.QueryTransport()))
 	if err != nil {
 		return nil, ec.errSingleClient(fmt.Errorf("get filtered logs (query=%s): %w", q, err), "eth_getLogs")
 	}
@@ -481,7 +500,8 @@ func (ec *ExecutionClient) streamLogsToChan(
 	// So we can restart from this block once everything is good.
 	start := time.Now()
 	sub, err := ec.client.SubscribeNewHead(ctx, heads)
-	recordRequest(ctx, ec.logger, "SubscribeNewHead", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "SubscribeNewHead", ec.client.SubAddr(), time.Since(start), err,
+		zap.String("transport", "ws"))
 	if err != nil {
 		return 0, false, ec.errSingleClient(fmt.Errorf("subscribe new head: %w", err), "newHeads")
 	}
@@ -544,7 +564,7 @@ func (ec *ExecutionClient) connect(ctx context.Context) error {
 
 	reqStart := time.Now()
 	subClient, err := ethclient.DialContext(reqCtx, ec.nodeAddr)
-	recordRequest(ctx, ec.logger, "DialContext", ec, time.Since(reqStart), err)
+	recordRequest(ctx, ec.logger, "DialContext.sub", ec.nodeAddr, time.Since(reqStart), err)
 	if err != nil {
 		return ec.errSingleClient(fmt.Errorf("ethclient dial: %w", err), "dial")
 	}
@@ -553,14 +573,50 @@ func (ec *ExecutionClient) connect(ctx context.Context) error {
 	if ec.queryAddr != "" && ec.queryAddr != ec.nodeAddr {
 		reqStart = time.Now()
 		queryClient, err = ethclient.DialContext(reqCtx, ec.queryAddr)
-		recordRequest(ctx, ec.logger, "DialContext", ec, time.Since(reqStart), err)
+		recordRequest(ctx, ec.logger, "DialContext.query", ec.queryAddr, time.Since(reqStart), err)
 		if err != nil {
 			subClient.Close()
 			return ec.errSingleClient(fmt.Errorf("ethclient dial query addr: %w", err), "dial")
 		}
 	}
 
-	ec.client = newEthClient(subClient, queryClient, ec.reqTimeout)
+	// When dual-transport is in use, both clients MUST be on the same chain.
+	// Otherwise we'd read registry events (FilterLogs/HTTP) from one chain
+	// while subscribing to live events (eth_subscribe/WS) on another — silent
+	// divergence that downstream consumers (event syncer, EKM slashing
+	// protection) have no defense against. Validate once at startup.
+	if queryClient != nil {
+		chainIDStart := time.Now()
+		subChainID, idErr := subClient.ChainID(reqCtx)
+		recordRequest(ctx, ec.logger, "eth_chainId.sub", ec.nodeAddr, time.Since(chainIDStart), idErr)
+		if idErr != nil {
+			subClient.Close()
+			queryClient.Close()
+			return ec.errSingleClient(fmt.Errorf("fetch chain ID from sub addr %s: %w", ec.nodeAddr, idErr), "eth_chainId")
+		}
+		chainIDStart = time.Now()
+		queryChainID, idErr := queryClient.ChainID(reqCtx)
+		recordRequest(ctx, ec.logger, "eth_chainId.query", ec.queryAddr, time.Since(chainIDStart), idErr)
+		if idErr != nil {
+			subClient.Close()
+			queryClient.Close()
+			return ec.errSingleClient(fmt.Errorf("fetch chain ID from query addr %s: %w", ec.queryAddr, idErr), "eth_chainId")
+		}
+		if subChainID.Cmp(queryChainID) != 0 {
+			subClient.Close()
+			queryClient.Close()
+			return ec.errSingleClient(fmt.Errorf(
+				"chain ID mismatch between EL transports: sub %s reports chain %s, query %s reports chain %s — both addrs must point at the same physical node",
+				ec.nodeAddr, subChainID, ec.queryAddr, queryChainID,
+			), "eth_chainId")
+		}
+	}
+
+	queryAddrForClient := ""
+	if queryClient != nil {
+		queryAddrForClient = ec.queryAddr
+	}
+	ec.client = newEthClient(subClient, ec.nodeAddr, queryClient, queryAddrForClient, ec.reqTimeout)
 
 	return nil
 }
@@ -572,7 +628,8 @@ func (ec *ExecutionClient) Filterer() (*contract.ContractFilterer, error) {
 func (ec *ExecutionClient) ChainID(ctx context.Context) (*big.Int, error) {
 	start := time.Now()
 	chainID, err := ec.client.ChainID(ctx)
-	recordRequest(ctx, ec.logger, "ChainID", ec, time.Since(start), err)
+	recordRequest(ctx, ec.logger, "ChainID", ec.client.QueryAddr(), time.Since(start), err,
+		zap.String("transport", ec.client.QueryTransport()))
 	if chainID == nil {
 		return nil, ec.errSingleClient(fmt.Errorf("chain id response is nil"), "eth_chainId")
 	}

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -64,6 +64,7 @@ type MultiClient struct {
 	closed          chan struct{}
 
 	clientAddrs        []string
+	queryAddrs         []string               // optional, parallel to clientAddrs; nil/empty entries fall back to single-transport
 	clientsMu          []sync.Mutex           // clientsMu allow for lazy initialization of each client in `clients` slice in thread-safe manner (atomically)
 	clients            []SingleClientProvider // nil if not connected
 	currentClientIndex atomic.Int64
@@ -137,14 +138,24 @@ func (mc *MultiClient) getClient(ctx context.Context, clientIndex int) (SingleCl
 // connect connects to a client by clientIndex and updates mc.clients[clientIndex] without locks.
 // Caller must lock mc.clientsMu[clientIndex].
 func (mc *MultiClient) connect(ctx context.Context, clientAddr string) (*ExecutionClient, error) {
-	singleClient, err := New(
-		ctx,
-		clientAddr,
-		mc.contractAddress,
+	opts := []Option{
 		WithLogger(mc.logger),
 		WithReqTimeout(mc.reqTimeout),
 		WithHealthInvalidationInterval(mc.healthInvalidationInterval),
 		WithSyncDistanceTolerance(mc.syncDistanceTolerance),
+	}
+	// Pair with the positionally-matching query addr, if any was configured.
+	for i, addr := range mc.clientAddrs {
+		if addr == clientAddr && i < len(mc.queryAddrs) && mc.queryAddrs[i] != "" {
+			opts = append(opts, WithQueryAddr(mc.queryAddrs[i]))
+			break
+		}
+	}
+	singleClient, err := New(
+		ctx,
+		clientAddr,
+		mc.contractAddress,
+		opts...,
 	)
 	if err != nil {
 		recordClientInitStatus(ctx, clientAddr, false)

--- a/eth/executionclient/observability.go
+++ b/eth/executionclient/observability.go
@@ -104,13 +104,21 @@ var (
 			metric.WithDescription("number of bloom cross-check outcomes by type")))
 )
 
+// recordRequest emits a debug log + duration histogram for one EL RPC call.
+//
+// addr should be the URL the call actually traveled (e.g. the HTTP query
+// addr when dual-transport routed a FilterLogs over the query client). When
+// the caller knows the transport semantically, pass it via extraFields as
+// zap.String("transport", "http"|"ws") so observability records can be
+// filtered by transport regardless of how the operator named the URLs.
 func recordRequest(
 	ctx context.Context,
 	logger *zap.Logger,
 	routeName string,
-	client interface{ Address() string },
+	addr string,
 	duration time.Duration,
 	err error,
+	extraFields ...zap.Field,
 ) {
 	// Log the request, but only if it has errored or if it took long enough that we want to pay attention
 	// to it (there are too many requests being made to log them every time, some requests don't even result
@@ -123,19 +131,20 @@ func recordRequest(
 				success = "unknown" // we don't know the outcome of this request
 			}
 		}
-		logger.Debug("EL request done",
+		logFields := []zap.Field{
 			zap.String("route_name", routeName),
-			zap.String("client_addr", client.Address()),
+			zap.String("client_addr", addr),
 			fields.Took(duration),
 			zap.String("success", success),
 			zap.Error(err),
-		)
+		}
+		logger.Debug("EL request done", append(logFields, extraFields...)...)
 	}
 
 	// Build metric attributes, add error-code attribute in case there is an error (treat context.Canceled
 	// as non-error since it means we've canceled the request ourselves).
 	attr := []attribute.KeyValue{
-		semconv.ServerAddress(client.Address()),
+		semconv.ServerAddress(addr),
 		attribute.String("rpc.route_name", routeName),
 	}
 	if err != nil && !errors.Is(err, context.Canceled) {

--- a/eth/executionclient/options.go
+++ b/eth/executionclient/options.go
@@ -21,10 +21,30 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
+// WithQueryAddr sets the HTTP endpoint used for request/response calls
+// (eth_getLogs, eth_blockNumber, etc.) while subscriptions stay on the
+// subscription transport. Empty string keeps the legacy single-transport
+// behavior. See ethClient godoc and hyperledger/besu#9848 for context.
+func WithQueryAddr(addr string) Option {
+	return func(s *ExecutionClient) {
+		s.queryAddr = addr
+	}
+}
+
 // WithLoggerMulti enables logging.
 func WithLoggerMulti(logger *zap.Logger) OptionMulti {
 	return func(s *MultiClient) {
 		s.logger = logger.Named(log.NameExecutionClientMulti)
+	}
+}
+
+// WithQueryAddrsMulti sets the per-client HTTP query endpoints. The slice is
+// paired positionally with the subscription addrs passed to NewMulti — entry i
+// is the HTTP endpoint for subscribe addr i. Empty strings (or a shorter slice)
+// fall back to single-transport for those clients. See WithQueryAddr.
+func WithQueryAddrsMulti(addrs []string) OptionMulti {
+	return func(s *MultiClient) {
+		s.queryAddrs = addrs
 	}
 }
 


### PR DESCRIPTION
## Summary

Split the EL client transport so heavy request/response calls (`eth_getLogs`, `eth_blockNumber`, `eth_getBlockByNumber`, `eth_syncing`, `eth_chainId`) route to an optional **HTTP** endpoint while subscriptions (`eth_subscribe`-family: `SubscribeFilterLogs`, `SubscribeNewHead`) stay on the existing **WebSocket** endpoint.

New env var: `ETH_1_QUERY_ADDR` (optional, semicolon-separated, positionally paired with `ETH_1_ADDR`). When unset, behavior is byte-identical to today's single-transport client — fully backward compatible.

## Background — the Besu bug we're working around

Operators paired with **Besu 26.5.0** (and likely earlier 26.x) saw a sustained outage where SSV nodes entered a continuous crash-loop. Effectiveness dropped to 0% for affected clusters on staging. A multi-day investigation traced it to a single Besu commit:

> [hyperledger/besu#9848](https://github.com/hyperledger/besu/pull/9848) — *"Stream debug_traceBlock* responses directly to avoid OOM on large blocks"* (commit `b2cbdeae01`, merged 2026-04-08)

That PR added `StreamBackpressure.awaitDrain` (parks the calling thread on a `CountDownLatch` for up to 60s) and wired it into the WebSocket `JsonResponseStreamer.write` path. The Javadoc on `StreamBackpressure` explicitly states:

> *Safe to call from `executeBlocking` worker threads only — must never be called from the Vertx event loop.*

But the PR refactored only the **new** streaming method path (`debug_traceBlock*`) to use `executeBlocking`. The **pre-existing** non-streaming WebSocket reply path was left unchanged:

```java
// ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandler.java:206-214
private void replyToClient(final ServerWebSocket websocket, final Object result) {
  traceResponse(result);
  try {
    JSON_OBJECT_WRITER.writeValue(new JsonResponseStreamer(websocket), result);  // ← runs on event loop
  } catch (IOException ex) { ... }
}
```

`replyToClient` is reached from `.onSuccess(...)` callbacks on the `Future` produced by `vertx.executeBlocking(...)` — which by Vert.x semantics resolve on the **event loop**, not on a worker. Jackson's writes funnel through `JsonResponseStreamer.write` → `StreamBackpressure.awaitDrain` → `CountDownLatch.await(60s)` **on the event loop**, blocking every other RPC consumer on that Besu instance: the consensus client's engine API, SSV health probes, and every other SSV node sharing the backend.

We observed `vert.x-eventloop-thread-1 has been blocked for 30000+ ms` warnings firing **continuously** on three staging Besu instances. The cascade: SSV node issues a fat `eth_getLogs` over WebSocket → Besu's event loop wedges → SSV health probe times out → SSV pod FATALs → restart → re-issues the same query → wedges Besu again. Op 1 alone accumulated **700+ restarts in three days** before this fix.

Stack trace from production for confirmation:

```
at java.base/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:276)
at org.hyperledger.besu.ethereum.api.jsonrpc.StreamBackpressure.awaitDrain(StreamBackpressure.java:52)
at org.hyperledger.besu.ethereum.api.jsonrpc.websocket.JsonResponseStreamer.write(JsonResponseStreamer.java:61)
at com.fasterxml.jackson.core.json.UTF8JsonGenerator._flushBuffer(UTF8JsonGenerator.java:2293)
... (Jackson serialization of an eth_getLogs response) ...
```

## Why fix this on the SSV side at all

The Besu issue is fundamentally a Besu bug. An upstream fix should be filed there. But:

1. **We can't wait.** Operators are seeing 0% effectiveness *today*. Upstream PR cycles are slow.
2. **The bug only triggers on the WS transport.** The HTTP request handler uses a different code path (`JsonRpcObjectExecutor`) which, while it has a latent variant of the same pattern, has a much larger write queue and isn't shared with the engine API thread pool. In practice, HTTP avoids the symptom entirely for SSV's workload.
3. **`eth_subscribe` is unsupported on HTTP** — pure HTTP isn't a viable substitute for the WS transport SSV needs for `SubscribeFilterLogs` / `SubscribeNewHead`. So we can't just flip everything to HTTP.
4. The **right architectural move** is to use each transport for what it's good at: WS for streaming server-push, HTTP for request/response. This PR does that.

## Why this doesn't harm other EL clients

| EL | Effect of the split |
|---|---|
| **Besu** | Heavy responses leave the buggy code path. Subscriptions (small messages) stay on WS where they must. Sidesteps the bug. |
| **Geth** | No behavior change. Geth handles both transports cleanly. `eth_getLogs` over HTTP is *recommended* by Geth maintainers for large queries (lower per-request overhead). |
| **Erigon** | Same as Geth. |
| **Nethermind** | Same as Geth. |
| **Lodestar/Lighthouse/etc.** | Out of scope — this is the **execution** client, not the consensus client. |

Subscriptions still go where they always did. Queries can go to either transport. With `ETH_1_QUERY_ADDR` unset, behavior is identical to the current single-client path — every existing deployment continues to work unchanged.

## What changed

### Original commit (`d0551d64e`)

`eth/executionclient/eth_client.go` — holds two `*ethclient.Client` instances (`sub`, `query`). Each method routes to the appropriate one via `queryOrSub()` (falls back to `sub` when `query` is nil for backward compatibility):

| Method | Transport |
|---|---|
| `SubscribeFilterLogs` | `sub` (WS-required) |
| `SubscribeNewHead` | `sub` (WS-required) |
| `FilterLogs` | `query` (preferred HTTP) |
| `BlockNumber` | `query` |
| `HeaderByNumber` | `query` |
| `SyncProgress` | `query` |
| `ChainID` | `query` |

`eth/executionclient/config.go` — adds `QueryAddr` (env: `ETH_1_QUERY_ADDR`).
`eth/executionclient/options.go` — adds `WithQueryAddr` / `WithQueryAddrsMulti`.
`eth/executionclient/execution_client.go` — dual-dial in `connect()`; both clients closed cleanly on shutdown.
`eth/executionclient/multi_client.go` — propagates positionally-paired query addrs to each underlying single client.
`cli/operator/node.go` — wires `cfg.ExecutionClient.QueryAddr` through to `executionclient.New` / `NewMulti`.

### Post-review hardening (`9539d3a40`)

After internal review surfaced four gaps in the initial commit, the follow-up commit addresses each:

1. **Chain-ID parity at connect** — `connect()` now fetches `ChainID` from both transports when query is configured and **fails closed** on mismatch (with both addrs and chain IDs in the error). Without this, an operator typoing `ETH_1_QUERY_ADDR` to point at the wrong network would silently let SSV ingest registry events from chain A while subscriptions track chain B — a slashing-adjacent divergence that `streamLogsToChan` only warns about belatedly. The existing `MultiClient.assertSameChainID` validates *across* clients via `queryOrSub()` — it never observed the sub-transport's chain ID. Now each single client internally validates its own pair first.

2. **Sub-transport health probe** — `Healthy()` previously called `SyncProgress()` which routes through `queryOrSub()`, so when query was configured only the HTTP transport was probed. A WS-down/HTTP-up partial failure would report healthy while `SubscribeFilterLogs` / `SubscribeNewHead` silently stalled, and `MultiClient` would never failover. Added `ethClient.PingSub()` (a cheap `eth_blockNumber` against the sub transport) and call it from `Healthy()` after the existing sync-distance check. No-op in single-transport mode; the existing healthInvalidationInterval cache covers both probes.

3. **Config validation + WS-only WARN** — `cli/operator/node.go` now trims whitespace on every `ETH_1_ADDR` and `ETH_1_QUERY_ADDR` entry, and **fatals** when `ETH_1_QUERY_ADDR` is set but its entry count doesn't match `ETH_1_ADDR` (a silent count mismatch would leave some clients falling back to WS — the exact situation `ETH_1_QUERY_ADDR` exists to prevent). Empty entries within `ETH_1_QUERY_ADDR` are still permitted as a positional opt-out for non-Besu backends in mixed deployments; we WARN at startup listing the affected `ETH_1_ADDR` positions so operators see partial coverage.

4. **Honest observability** — `recordRequest` previously logged `client.Address()` — hardcoded to `nodeAddr` (the WS URL) regardless of which transport actually served the call, so `FilterLogs` over HTTP would log `client_addr=ws://...:8546`. Misleading. Now: `recordRequest` takes the effective addr as a string + variadic extra `zap.Field`s; `ethClient` gains `SubAddr()`, `QueryAddr()`, and `QueryTransport()` helpers; dial labels split into `DialContext.sub` / `DialContext.query`; the new chain-ID parity calls labeled `eth_chainId.sub` / `eth_chainId.query`; every recordRequest call site passes the effective addr plus `transport=http|ws`. Metric `ServerAddress` attribute follows the log (intentional — the metric was lying before, now accurate; slight cardinality increase per route).

   Caveat: `errSingleClient` still wraps errors with `ec.nodeAddr` (the operator-configured address). Operator-facing error messages should name the address the operator put in config; logs/metrics now show truth.

Diff: **10 files, +305 / −46 lines** total across both commits.

## Evidence — staging deploy on clusters 1-4 and 93-96

Both clusters were pointed at `stage-besu-lh-hoodi-1` (the buggy Besu instance) and were at 0% / volatile 50% effectiveness respectively for 11+ days under the old code.

Deployed with `ETH_1_QUERY_ADDR=http://stage-besu-lh-hoodi-1-execution-http.ethereum-clients.svc:8545`.

| | Before (old code, same Besu) | After (dual-transport, same Besu) |
|---|---|---|
| Pod restarts (3 days) | ~700 per op | **0** |
| FATAL/15min | 7–11 | **0** |
| Cluster 1-4 effectiveness | 0% for 11 days | **96–98%** within one epoch |
| Cluster 93-96 effectiveness | ~55% volatile | **97%** steady |
| Besu `awaitDrain` warns / 5min | ~300 | ~190 (residual from other clusters still on old code) |

The same Besu instance whose WebSocket event loop was blocked continuously for days is now serving these clusters at near-perfect effectiveness — because the heavy requests no longer hit the buggy code path.

### Mixed-backend deploy validation (post-review)

To validate the WS-only WARN path, cluster 1-4 was redeployed with a `MultiClient` configuration: **Besu first with HTTP query addr** + **Geth second with no query addr** (blank position).

`ETH_1_ADDR`:
```
ws://stage-besu-lh-hoodi-1-execution.ethereum-clients.svc:8546;ws://stage-geth-lh-hoodi-1-execution.ethereum-clients.svc:8546
```

`ETH_1_QUERY_ADDR`:
```
http://stage-besu-lh-hoodi-1-execution-http.ethereum-clients.svc:8545;
```
(trailing semicolon → blank second position)

Captured logs from Loki:

```
INFO  connecting EL(s)
  addresses=[
    'ws://stage-besu-lh-hoodi-1-execution.ethereum-clients.svc:8546',
    'ws://stage-geth-lh-hoodi-1-execution.ethereum-clients.svc:8546'
  ]
  query_addresses=[
    'http://stage-besu-lh-hoodi-1-execution-http.ethereum-clients.svc:8545',
    ''
  ]
  request_timeout=10s sync_distance_tolerance=5

WARN  ETH_1_QUERY_ADDR set but some positions are blank — those EL backends
      will use WS for queries and may trigger Besu's StreamBackpressure
      event-loop block on large eth_getLogs responses. Set an HTTP endpoint
      at each blank position to opt those backends into the dual-transport
      path.
  ws_only_addrs=['ws://stage-geth-lh-hoodi-1-execution.ethereum-clients.svc:8546']
```

The Geth backend (position 2, no HTTP query addr) is correctly identified, named in the structured `ws_only_addrs` field, and explained with the underlying reason. All 4 pods rolled cleanly on the new image with `ready=true, restarts=0`.

## Current limitation — this fix does NOT solve everything

**It only sidesteps the WS event-loop block. If the Besu instance is broken in other ways, the fix can't help.**

We are currently seeing this on cluster 9-12. Ops 9 and 12 are healthy on the new image. Ops **10 and 11** still FATAL with `failed to sync historical registry events`. Direct empirical probe against Besu's HTTP shows:

```
eth_getLogs(0x327d4..0x3289b, SSV contract) → {"error":{"code":-32603,"message":"Internal error"}}
eth_getLogs(0x50000..0x5007f, SSV contract) → OK (0 events)
eth_getLogs(0x80000..0x8007f, SSV contract) → OK
eth_getLogs(0x100000..0x10007f, SSV contract) → OK
eth_getLogs(0x200000..0x20007f, SSV contract) → Internal error
eth_getLogs(0x2c0000..0x2c007f, SSV contract) → OK (4 events)
eth_syncing → false
eth_getBlockByNumber(0x327d4) → block header returned correctly
```

So this Besu instance has **interspersed corrupted receipt ranges**: block headers exist but receipts/logs for certain block ranges return `Internal error`. The corruption isn't a clean pruning boundary — it's specific damaged segments.

### Why this hits ops 10 and 11 specifically

Forensics from `kubectl get pvc`:

| Op | PVC age | Created | `last_processed_block` |
|---|---|---|---|
| 9 | 94 days | 2026-02-26 16:41 | 2,931,328 (current) |
| **10** | **2 days 22h** | **2026-05-29 14:35:47** | **0** |
| **11** | **2 days 22h** | **2026-05-29 14:36:21** | **0** |
| 12 | 94 days | 2026-02-26 16:43 | 2,931,328 (current) |

Ops 10 and 11 got brand-new PVCs **36 seconds apart** on 2026-05-29. The previous volumes (with populated event-syncer DBs) were lost. They're now trying to do a fresh historical sync from contract-deploy block 206,804 — which hits the first corrupted receipt range on Besu, returns `Internal error`, FATALs, restarts, repeats.

With ops 10/11 down, the 4-op cluster can't reach 3-of-4 QBFT quorum, so cluster 9-12 is at 0% effectiveness despite our code change working correctly. Two ops on the new image, all four needed.

### Estimated cause of the PVC loss

The StatefulSets in question use `storageClassName: local-storage` — **disk on the specific Kubernetes node**, not network-attached. With local-storage:

- The PV is pinned to a node via node affinity.
- If that node is drained, replaced, or has a disk failure, the PV becomes unreachable.
- The PVC eventually re-binds to a fresh empty volume on a different node.

The 36-second gap between ops 10 and 11's new PVC timestamps strongly suggests a **single node-level event** (drain, hardware failure, K8s upgrade) on 2026-05-29 ~14:35 UTC took down both at the same time. Ops 9 and 12 weren't on the affected node, so their PVCs are intact.

### Estimated cause of the Besu receipt corruption

Besu reports `eth_syncing: false` and serves block headers for the affected ranges — so it thinks it's healthy. But the receipts are missing/corrupted in **interspersed** ranges (not a clean prefix). Most likely:

- **Failed snap-sync segment**: during initial sync (snap mode), receipt segments are downloaded in parallel from peers. If a segment download was interrupted or written partially before a crash, Besu's Bonsai storage doesn't have great recovery semantics for partial-state corruption.
- **Interrupted write during a prior crash**: the Besu instance has been restarted several times over the past 6 days due to the WS event-loop issue cascading into pod restarts.

This is **separate from the WS bug**. It's a Besu data-integrity issue and needs a Besu-side fix (re-sync from scratch, restore from snapshot, or wait for upstream Besu to improve recovery semantics).

### Practical options for cluster 9-12

1. Point cluster 9-12 at an EL whose receipts aren't corrupted (e.g., one of the `geth-lh-hoodi-*` pairs). Two-line env-var change in the deploy. Ops 10/11 do the normal historical sync against a healthy EL.
2. Repair the Besu instance (re-sync from scratch or restore from a known-good snapshot).

The PR itself does not address either — they're operational fixes outside the scope of this code change. We just want to be explicit that the dual-transport split is **necessary but not sufficient** when the EL has data integrity issues.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./eth/executionclient/... ./cli/operator/...` clean
- [x] Existing executionclient tests still build & pass (no behavior change when `QueryAddr` is unset)
- [x] Deployed to staging clusters 1-4 and 93-96 against the buggy Besu — observed 0% → 97% effectiveness recovery in one epoch
- [x] Verified per-call routing empirically (`SyncProgress` succeeded in 2ms against the wedged-WS Besu — only possible if the call traveled HTTP)
- [x] Verified mixed-backend WARN path: redeployed 1-4 with Besu+HTTP and Geth-blank; WARN fired at startup naming the Geth backend in `ws_only_addrs`
- [ ] Reviewer to confirm: any caller still wired through `ec.client` (the wrapped `ethClient`) routes correctly via the new `queryOrSub()` shim

## Follow-ups (not in this PR)

- File upstream Besu issue (with patch suggestion: wrap `replyToClient`'s `JSON_OBJECT_WRITER.writeValue(...)` in `vertx.executeBlocking`, mirroring the streaming path in the same file). Same fix applies to `JsonRpcObjectExecutor.handleJsonObjectResponse` on the HTTP path.
- Add a runtime guard in `StreamBackpressure.awaitDrain` that throws if invoked from an event-loop context — would have caught PR #9848's regression in tests.
- Add a regression test that drives a large response with a slow-draining WS client and asserts the event loop is never parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)