### PR TITLE
qbft/instance: defer round bump in UponRoundTimeout so the cutoff-boundary round-change is broadcast

### DIFF
--- a/protocol/v2/qbft/instance/timeout.go
+++ b/protocol/v2/qbft/instance/timeout.go
@@ -24,6 +24,17 @@ func (i *Instance) UponRoundTimeout(ctx context.Context, logger *zap.Logger) err
 	prevRound := i.State.Round
 	newRound := prevRound + 1
 
+	// Always move on to the next round. The round-change message broadcast is a best-effort thing, the QBFT
+	// cluster as a whole can progress further even if our round-change message cannot be created/broadcast
+	// for whatever reason — hence the bump is deferred, so it still runs even when CreateRoundChange/Broadcast
+	// below return early with an error.
+	//
+	// Deferring also keeps State.Round at prevRound while we create and broadcast the round change. Bumping
+	// eagerly would advance the instance into the cut-off round at the boundary (prevRound == CutOffRound-1),
+	// at which point Broadcast rejects the message as no-longer-relevant and this final round-change — the one
+	// the spec expects us to send — would never go out.
+	defer i.bumpToRound(newRound)
+
 	i.metrics.EndStage(ctx, prevRound)
 	i.metrics.StartStage(stageRoundChange)
 	i.metrics.RecordRoundChange(ctx, prevRound, reasonTimeout)
@@ -32,11 +43,6 @@ func (i *Instance) UponRoundTimeout(ctx context.Context, logger *zap.Logger) err
 	logger = logger.With(zap.String("qbft_start_value_root", hex.EncodeToString(startValueRoot[:])))
 
 	logger.Debug("⌛ round timed out")
-
-	// Always move on to the next round. The round-change message broadcast is a best-effort thing, the QBFT
-	// cluster as a whole can progress further even if our round-change message cannot be created/broadcast
-	// for whatever reason.
-	i.bumpToRound(newRound)
 
 	roundChange, err := i.CreateRoundChange(newRound)
 	if err != nil {

--- a/protocol/v2/qbft/instance/timeout_test.go
+++ b/protocol/v2/qbft/instance/timeout_test.go
@@ -7,6 +7,8 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
 )
 
 func TestUponRoundTimeoutBumpsRound(t *testing.T) {
@@ -26,8 +28,10 @@ func TestUponRoundTimeoutBumpsRound(t *testing.T) {
 
 	network := &recordingNetwork{
 		onBroadcast: func(message *spectypes.SignedSSVMessage) error {
-			require.Equal(t, specqbft.Round(2), env.inst.State.Round)
-			require.Nil(t, env.inst.State.ProposalAcceptedForCurrentRound)
+			// The round change is created and broadcast while the instance is still in the previous round —
+			// the bump is deferred until after the broadcast, matching the ssv-spec UponRoundTimeout ordering.
+			require.Equal(t, specqbft.Round(1), env.inst.State.Round)
+			require.NotNil(t, env.inst.State.ProposalAcceptedForCurrentRound)
 			return nil
 		},
 	}
@@ -62,7 +66,9 @@ func TestUponRoundTimeoutKilledInstance(t *testing.T) {
 func TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound(t *testing.T) {
 	env := newInstanceTestEnv(t, 2)
 	env.inst.StartValue = []byte("start-value")
-	env.config.CutOffRound = env.inst.State.Round + 1
+	// At the cut-off round the instance is no longer relevant: a timeout must be a no-op error and must neither
+	// advance the round nor broadcast anything.
+	env.inst.State.Round = env.config.CutOffRound
 
 	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
 	require.ErrorContains(t, err, "instance is no longer considered relevant")
@@ -71,4 +77,33 @@ func TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound(t *testing.T) {
 	err = env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
 	require.ErrorContains(t, err, "instance is no longer considered relevant")
 	require.Equal(t, env.config.CutOffRound, env.inst.State.Round)
+
+	require.Empty(t, env.network.BroadcastedMsgs)
+}
+
+// TestUponRoundTimeoutBroadcastsRoundChangeAtCutOffBoundary covers the round just below the cut-off round, where
+// a timeout produces the terminal round-change. The instance is still relevant, so the round change must be
+// broadcast and UponRoundTimeout must return nil before the round is bumped into the (now irrelevant) cut-off
+// round. Bumping eagerly (the previous behavior) advanced the instance into the cut-off round mid-call, so the
+// subsequent Broadcast rejected the message as no-longer-relevant — suppressing this final round-change and
+// returning a spurious error, a deviation from the ssv-spec UponRoundTimeout.
+func TestUponRoundTimeoutBroadcastsRoundChangeAtCutOffBoundary(t *testing.T) {
+	env := newInstanceTestEnv(t, 2)
+	env.inst.StartValue = []byte("start-value")
+	env.config.CutOffRound = roundtimer.CutOffRound
+	env.inst.State.Round = roundtimer.CutOffRound - 1 // last relevant round
+
+	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())
+	require.NoError(t, err)
+
+	// The round was bumped into the cut-off round and the timer was scheduled for it.
+	require.Equal(t, roundtimer.CutOffRound, env.inst.State.Round)
+	require.Equal(t, roundtimer.CutOffRound, env.roundTimer.State.Round)
+	require.Equal(t, 1, env.roundTimer.State.Timeouts)
+
+	// The terminal round-change was broadcast, carrying the cut-off round.
+	require.Len(t, env.network.BroadcastedMsgs, 1)
+	msg := env.broadcastedProcessingMessage(0)
+	require.Equal(t, specqbft.RoundChangeMsgType, msg.QBFTMessage.MsgType)
+	require.Equal(t, roundtimer.CutOffRound, msg.QBFTMessage.Round)
 }


### PR DESCRIPTION
## What

At the terminal timeout (round `CutOffRound-1` → `CutOffRound`), `UponRoundTimeout` bumped `State.Round` **before** broadcasting the round change. The bump made the instance irrelevant (`State.Round == CutOffRound`, since `IsRelevant()` requires `State.Round < CutOffRound`), so the subsequent `Broadcast` rejected the message with an `InstanceStoppedProcessingMessagesErrorCode` ("instance is no longer considered relevant"). `UponRoundTimeout` then returned a spurious error and the final timeout-driven round-change was never sent.

The fix defers the bump (mirroring ssv-spec [`qbft/timeout.go`](https://github.com/ssvlabs/ssv-spec/blob/main/qbft/timeout.go) `UponRoundTimeout`, which bumps in a `defer`), so the round change is created and broadcast while `State.Round` is still `prevRound` (`< CutOffRound`, i.e. still relevant). Using `defer` also preserves the existing intentional *"always move on to the next round; the round-change broadcast is best-effort"* behavior (commit f977043b2): the bump still runs even when `CreateRoundChange`/`Broadcast` return early with an error.

## Impact

Low. This only occurs at the last round after ~11 consecutive timeouts, when the duty is already being abandoned cluster-wide. It does **not** affect healthy duties. It is a real deviation from the ssv-spec reference that produced a spurious error return plus a missing final round-change broadcast.

## Tests

- Adds `TestUponRoundTimeoutBroadcastsRoundChangeAtCutOffBoundary` — covers the `CutOffRound-1` → `CutOffRound` boundary (the real `CutOffRound` = 12, i.e. round 11→12): asserts the round-change **is** broadcast and `UponRoundTimeout` returns `nil`. The existing ssv-spec timeout tests cover rounds 1/2/3/5/15 but not this boundary, which is why it slipped through.
- Reworks `TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound` — it previously encoded the buggy behavior (error on the round that bumps *into* the cutoff). It now tests the genuine "stop" case: already *at* the cutoff round → no-op error, no broadcast, round unchanged.
- Updates `TestUponRoundTimeoutBumpsRound`'s in-broadcast assertions to reflect the spec ordering (round change created/broadcast while still in the previous round, before the deferred bump).

`make spec-test` (qbft + ssv spectest, `-race`) and `go test ./protocol/v2/qbft/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)