### PR TITLE
qbft/instance: document the intentional cutoff-boundary round-change drop

### DIFF
--- a/protocol/v2/qbft/instance/timeout.go
+++ b/protocol/v2/qbft/instance/timeout.go
@@ -36,6 +36,12 @@ func (i *Instance) UponRoundTimeout(ctx context.Context, logger *zap.Logger) err
 	// Always move on to the next round. The round-change message broadcast is a best-effort thing, the QBFT
 	// cluster as a whole can progress further even if our round-change message cannot be created/broadcast
 	// for whatever reason.
+	//
+	// We bump *before* the broadcast (unlike ssv-spec, which defers it). At the cutoff boundary
+	// (prevRound == CutOffRound-1) this advances State.Round into CutOffRound, so the Broadcast below sees
+	// !IsRelevant() and rejects the final round-change, and UponRoundTimeout returns an error. That is
+	// intentional and inert: CutOffRound is the cluster-wide give-up round (no instance can decide at or
+	// past it), so the dropped round-change carries no liveness value.
 	i.bumpToRound(newRound)
 
 	roundChange, err := i.CreateRoundChange(newRound)

--- a/protocol/v2/qbft/instance/timeout_test.go
+++ b/protocol/v2/qbft/instance/timeout_test.go
@@ -62,6 +62,11 @@ func TestUponRoundTimeoutKilledInstance(t *testing.T) {
 func TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound(t *testing.T) {
 	env := newInstanceTestEnv(t, 2)
 	env.inst.StartValue = []byte("start-value")
+	// CutOffRound == State.Round+1, so the first timeout fires at the last relevant round and bumps the
+	// instance *into* the cutoff round. Because the bump runs before Broadcast, the final round-change is
+	// intentionally dropped and UponRoundTimeout returns the "no longer relevant" error (CutOffRound is the
+	// cluster-wide give-up point, so that RC has no liveness value). The second call then exercises the
+	// plain already-at-cutoff path.
 	env.config.CutOffRound = env.inst.State.Round + 1
 
 	err := env.inst.UponRoundTimeout(t.Context(), zap.NewNop())


### PR DESCRIPTION
Comment-only. Documents the intentional cutoff-boundary behavior in `UponRoundTimeout` so it stops getting re-flagged (it's been independently raised more than once).

At the cutoff boundary (`State.Round == CutOffRound-1`), the eager `bumpToRound` advances the instance into `CutOffRound` before `Broadcast`, so the final round-change is dropped and `UponRoundTimeout` returns an error. This is intentional and inert: `CutOffRound` is the cluster-wide give-up round — no instance can decide at or past it — so the dropped round-change has no liveness value. (ssv-spec defers the bump and would broadcast it; the divergence is behaviorally inert at this give-up boundary.)

Adds a clarifying comment at the bump and in `TestUponRoundTimeoutStopsProcessingAfterReachingCutOffRound` (whose setup is the boundary case, not the already-at-cutoff case its name suggests).

**No behavior change.**

## Context
- Corrected acknowledgment of the finding: https://github.com/ssvlabs/ssv/pull/2866#issuecomment-4612482365
- The behavior-change alternative, closed won't-fix: #2872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
