### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -556,7 +556,7 @@ func createBeaconServer(t *testing.T, options beaconServerResponseOptions) (*htt
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			resp := []byte(fmt.Sprintf(`{
+			resp := fmt.Appendf(nil, `{
 				"execution_optimistic": false,
 				"finalized": false,
 				"data": {
@@ -573,7 +573,7 @@ func createBeaconServer(t *testing.T, options beaconServerResponseOptions) (*htt
 					"root": "0x2922d4d36529c39ae7c463bc0a18f434d616954bdc0a38f7c24e0847a181de15",
 					"canonical": true
 				}
-			}`, options.SlotReturnedFromHeaderEndpoint))
+			}`, options.SlotReturnedFromHeaderEndpoint)
 			if _, err := w.Write(resp); err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -643,7 +643,7 @@ func createAttestationDataResponse(
 	blockRoot, sourceRoot, targetRoot string,
 	sourceEpoch, targetEpoch phase0.Epoch,
 ) []byte {
-	resp := []byte(fmt.Sprintf(`{
+	resp := fmt.Appendf(nil, `{
 		"data": {
 		  "slot": "%d",
 		  "index": "%d",
@@ -657,7 +657,7 @@ func createAttestationDataResponse(
 			"root": "%s"
 		  }
 		}
-	  }`, slot, committeeIndex, blockRoot, sourceEpoch, sourceRoot, targetEpoch, targetRoot))
+	  }`, slot, committeeIndex, blockRoot, sourceEpoch, sourceRoot, targetEpoch, targetRoot)
 
 	return resp
 }

--- a/exporter/api/ws_session_test.go
+++ b/exporter/api/ws_session_test.go
@@ -25,7 +25,7 @@ func TestWSSession_Send_FullQueue(t *testing.T) {
 	require.NoError(t, sess.ctx.Err(), "ctx should not be canceled before overflow")
 
 	for i := 0; i < chanSize+2; i++ {
-		sess.Send([]byte(fmt.Sprintf("test-%d", i)))
+		sess.Send(fmt.Appendf(nil, "test-%d", i))
 	}
 	require.Error(t, sess.ctx.Err(), "ctx should be canceled after overflow")
 

--- a/operator/fee_recipient/controller_test.go
+++ b/operator/fee_recipient/controller_test.go
@@ -275,8 +275,8 @@ func TestSubmitProposal(t *testing.T) {
 			owner := common.HexToAddress(fmt.Sprintf("0x%040x", i))
 			share := &types.SSVShare{
 				Share: spectypes.Share{
-					ValidatorPubKey: spectypes.ValidatorPK([]byte(fmt.Sprintf("pk%046d", i))),
-					SharePubKey:     []byte(fmt.Sprintf("pk%046d", i)),
+					ValidatorPubKey: spectypes.ValidatorPK(fmt.Appendf(nil, "pk%046d", i)),
+					SharePubKey:     fmt.Appendf(nil, "pk%046d", i),
 					ValidatorIndex:  phase0.ValidatorIndex(i),
 					Committee:       []*spectypes.ShareMember{{Signer: operatorData.ID}},
 				},
@@ -336,8 +336,8 @@ func populateStorage(t *testing.T, storage registrystorage.Shares, operatorData 
 		ownerAddr := common.HexToAddress(fmt.Sprintf("0x%040x", index))
 		return &types.SSVShare{
 			Share: spectypes.Share{
-				ValidatorPubKey: spectypes.ValidatorPK([]byte(fmt.Sprintf("pk%046d", index))),
-				SharePubKey:     []byte(fmt.Sprintf("pk%046d", index)),
+				ValidatorPubKey: spectypes.ValidatorPK(fmt.Appendf(nil, "pk%046d", index)),
+				SharePubKey:     fmt.Appendf(nil, "pk%046d", index),
 				ValidatorIndex:  phase0.ValidatorIndex(index),
 				Committee:       []*spectypes.ShareMember{{Signer: operatorID}},
 			},

--- a/operator/storage/storage_test.go
+++ b/operator/storage/storage_test.go
@@ -279,7 +279,7 @@ func Test_OperatorData(t *testing.T) {
 	operatorIDs := []uint64{1, 2, 3}
 
 	for _, id := range operatorIDs {
-		pubkey := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("publicKey%d", id)))
+		pubkey := base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "publicKey%d", id))
 		operatorData := &registrystorage.OperatorData{
 			ID:           id,
 			PublicKey:    pubkey,

--- a/operator/validator/router_test.go
+++ b/operator/validator/router_test.go
@@ -51,7 +51,7 @@ func TestRouter(t *testing.T) {
 			SSVMessage: &spectypes.SSVMessage{
 				MsgType: spectypes.MsgType(i % 3),
 				MsgID:   spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, []byte{1, 1, 1, 1, 1}, spectypes.RoleCommittee),
-				Data:    []byte(fmt.Sprintf("data-%d", i)),
+				Data:    fmt.Appendf(nil, "data-%d", i),
 			},
 		}
 

--- a/registry/storage/operators_test.go
+++ b/registry/storage/operators_test.go
@@ -127,7 +127,7 @@ func TestStorage_ListOperators(t *testing.T) {
 	for i := 0; i < n; i++ {
 		randNum := rand.Int()
 		operator := storage.OperatorData{
-			PublicKey: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("samplePublicKey%d", randNum))),
+			PublicKey: base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "samplePublicKey%d", randNum)),
 			ID:        spectypes.OperatorID(i),
 		}
 		_, err := storageCollection.SaveOperatorData(nil, &operator)
@@ -158,7 +158,7 @@ func TestStorage_DeleteOperatorAndDropOperators(t *testing.T) {
 	for i := 0; i < n; i++ {
 		randNum := rand.Int()
 		operator := storage.OperatorData{
-			PublicKey: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("samplePublicKey%d", randNum))),
+			PublicKey: base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "samplePublicKey%d", randNum)),
 			ID:        spectypes.OperatorID(i),
 		}
 		_, err := storageCollection.SaveOperatorData(nil, &operator)

--- a/registry/storage/recipients_test.go
+++ b/registry/storage/recipients_test.go
@@ -177,7 +177,7 @@ func TestStorage_SaveAndGetRecipientData(t *testing.T) {
 		var expectedRecipients []bellatrix.ExecutionAddress
 
 		for i := 0; i < 10; i++ {
-			owner := common.BytesToAddress([]byte(fmt.Sprintf("owner%d", i)))
+			owner := common.BytesToAddress(fmt.Appendf(nil, "owner%d", i))
 			var feeRecipient bellatrix.ExecutionAddress
 			copy(feeRecipient[:], fmt.Sprintf("fee%d", i))
 
@@ -473,7 +473,7 @@ func TestGetFeeRecipient(t *testing.T) {
 	t.Run("drop clears in-memory map", func(t *testing.T) {
 		// Add multiple recipients
 		for i := 0; i < 5; i++ {
-			owner := common.BytesToAddress([]byte(fmt.Sprintf("drop%d", i)))
+			owner := common.BytesToAddress(fmt.Appendf(nil, "drop%d", i))
 			var feeRecipient bellatrix.ExecutionAddress
 			copy(feeRecipient[:], fmt.Sprintf("fee%d", i))
 
@@ -483,7 +483,7 @@ func TestGetFeeRecipient(t *testing.T) {
 
 		// Verify they exist
 		for i := 0; i < 5; i++ {
-			owner := common.BytesToAddress([]byte(fmt.Sprintf("drop%d", i)))
+			owner := common.BytesToAddress(fmt.Appendf(nil, "drop%d", i))
 			_, err := storageCollection.GetFeeRecipient(owner)
 			require.NoError(t, err)
 		}
@@ -494,7 +494,7 @@ func TestGetFeeRecipient(t *testing.T) {
 
 		// Verify all are gone
 		for i := 0; i < 5; i++ {
-			owner := common.BytesToAddress([]byte(fmt.Sprintf("drop%d", i)))
+			owner := common.BytesToAddress(fmt.Appendf(nil, "drop%d", i))
 			_, err := storageCollection.GetFeeRecipient(owner)
 			require.Error(t, err)
 		}

--- a/storage/badger/badger_test.go
+++ b/storage/badger/badger_test.go
@@ -131,8 +131,8 @@ func TestBasicOperations(t *testing.T) {
 		itemCount := 5
 
 		for i := 0; i < itemCount; i++ {
-			key := []byte(fmt.Sprintf("key-%d", i))
-			value := []byte(fmt.Sprintf("value-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
+			value := fmt.Appendf(nil, "value-%d", i)
 
 			require.NoError(t, db.Set(prefix, key, value))
 		}
@@ -517,8 +517,8 @@ func TestTransactions(t *testing.T) {
 		itemCount := 10
 
 		for i := 0; i < itemCount; i++ {
-			key := []byte(fmt.Sprintf("key%d", i))
-			value := []byte(fmt.Sprintf("value%d", i))
+			key := fmt.Appendf(nil, "key%d", i)
+			value := fmt.Appendf(nil, "value%d", i)
 
 			require.NoError(t, db.Set(prefix, key, value))
 		}

--- a/storage/badger/gc_test.go
+++ b/storage/badger/gc_test.go
@@ -48,7 +48,7 @@ func TestQuickGC_WithGarbage(t *testing.T) {
 	setupDataset(t, db, prefix, 100)
 
 	for i := 0; i < 50; i++ {
-		key := []byte(fmt.Sprintf("test-%d", i))
+		key := fmt.Appendf(nil, "test-%d", i)
 
 		require.NoError(t, db.Delete(prefix, key))
 	}
@@ -101,7 +101,7 @@ func TestFullGC_WithGarbage(t *testing.T) {
 	setupDataset(t, db, prefix, 100)
 
 	for i := 0; i < 50; i++ {
-		key := []byte(fmt.Sprintf("test-%d", i))
+		key := fmt.Appendf(nil, "test-%d", i)
 
 		require.NoError(t, db.Delete(prefix, key))
 	}
@@ -223,7 +223,7 @@ func TestPeriodicGC(t *testing.T) {
 	setupDataset(t, db, prefix, 100)
 
 	for i := 0; i < 50; i++ {
-		key := []byte(fmt.Sprintf("test-%d", i))
+		key := fmt.Appendf(nil, "test-%d", i)
 
 		require.NoError(t, db.Delete(prefix, key))
 	}

--- a/storage/badger/txn_test.go
+++ b/storage/badger/txn_test.go
@@ -29,8 +29,8 @@ func setupTxnWithData(t *testing.T, prefix []byte, keyCount int) (*DB, *badgerTx
 
 	// Populate with test data
 	for i := 0; i < keyCount; i++ {
-		key := []byte(fmt.Sprintf("key-%d", i))
-		value := []byte(fmt.Sprintf("value-%d", i))
+		key := fmt.Appendf(nil, "key-%d", i)
+		value := fmt.Appendf(nil, "value-%d", i)
 		err := txn.Set(prefix, key, value)
 
 		require.NoError(t, err)
@@ -155,8 +155,8 @@ func TestTxnSetMany(t *testing.T) {
 		itemCount := 10
 
 		err := txn.SetMany(prefix, itemCount, func(i int) (basedb.Obj, error) {
-			key := []byte(fmt.Sprintf("key-%d", i))
-			value := []byte(fmt.Sprintf("value-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
+			value := fmt.Appendf(nil, "value-%d", i)
 
 			return basedb.Obj{Key: key, Value: value}, nil
 		})
@@ -164,8 +164,8 @@ func TestTxnSetMany(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := 0; i < itemCount; i++ {
-			key := []byte(fmt.Sprintf("key-%d", i))
-			expectedValue := []byte(fmt.Sprintf("value-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
+			expectedValue := fmt.Appendf(nil, "value-%d", i)
 
 			obj, found, err := txn.Get(prefix, key)
 
@@ -197,15 +197,15 @@ func TestTxnSetMany(t *testing.T) {
 
 		err := txnClosed.SetMany(prefix, 3, func(i int) (basedb.Obj, error) {
 			return basedb.Obj{
-				Key:   []byte(fmt.Sprintf("key-%d", i)),
-				Value: []byte(fmt.Sprintf("value-%d", i)),
+				Key:   fmt.Appendf(nil, "key-%d", i),
+				Value: fmt.Appendf(nil, "value-%d", i),
 			}, nil
 		})
 
 		require.Error(t, err)
 
 		for i := 0; i < 3; i++ {
-			key := []byte(fmt.Sprintf("key-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
 			_, found, err := db.Get(prefix, key)
 
 			require.NoError(t, err)
@@ -225,8 +225,8 @@ func TestTxnGet(t *testing.T) {
 
 	t.Run("get existing key", func(t *testing.T) {
 		for i := 0; i < 3; i++ {
-			key := []byte(fmt.Sprintf("key-%d", i))
-			expectedValue := []byte(fmt.Sprintf("value-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
+			expectedValue := fmt.Appendf(nil, "value-%d", i)
 
 			obj, found, err := txn.Get(prefix, key)
 
@@ -429,7 +429,7 @@ func TestTxnDelete(t *testing.T) {
 			if i == 2 {
 				continue // we skipped this key
 			}
-			key := []byte(fmt.Sprintf("key-%d", i))
+			key := fmt.Appendf(nil, "key-%d", i)
 			_, found, err := txn.Get(prefix, key)
 
 			require.NoError(t, err)

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -81,7 +81,7 @@ func (h *handler) httpHandler() func(w http.ResponseWriter, _ *http.Request) {
 		allNodes := h.listener.AllNodes()
 		write(w, []byte("Nodes stored in the table:\n"))
 		for i, n := range allNodes {
-			write(w, []byte(fmt.Sprintf("Node %d\n", i)))
+			write(w, fmt.Appendf(nil, "Node %d\n", i))
 			write(w, []byte(n.String()+"\n"))
 			write(w, []byte("Node ID: "+n.ID().String()+"\n"))
 			write(w, []byte("IP: "+n.IP().String()+"\n"))

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -85,8 +85,8 @@ func (h *handler) httpHandler() func(w http.ResponseWriter, _ *http.Request) {
 			write(w, []byte(n.String()+"\n"))
 			write(w, []byte("Node ID: "+n.ID().String()+"\n"))
 			write(w, []byte("IP: "+n.IP().String()+"\n"))
-			write(w, []byte(fmt.Sprintf("UDP Port: %d", n.UDP())+"\n"))
-			write(w, []byte(fmt.Sprintf("TCP Port: %d", n.TCP())+"\n\n"))
+			write(w, fmt.Appendf(nil, "UDP Port: %d\n", n.UDP()))
+			write(w, fmt.Appendf(nil, "TCP Port: %d\n\n", n.TCP()))
 		}
 	}
 }


### PR DESCRIPTION
 I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice. 
 
 This change enhances performance by directly appending the formatted string to the byte slice, avoiding the need for intermediate memory allocation created by fmt.Sprintf. 
 
 The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.
 
 More info can see https://github.com/golang/go/issues/47579