### PR TITLE
ssvsigner, runner: pin fixed-fork signing domains (voluntary exit + validator registration)

### DIFF
--- a/networkconfig/beacon.go
+++ b/networkconfig/beacon.go
@@ -166,6 +166,11 @@ func (b *Beacon) ForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase0.Fork
 	return version, &fork
 }
 
+func (b *Beacon) ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool) {
+	fork, ok := b.Forks[version]
+	return fork, ok
+}
+
 func (b *Beacon) AssertSame(other *Beacon) error {
 	if b.Name != other.Name {
 		return fmt.Errorf("different Name")

--- a/protocol/v2/ssv/partial_sig_container.go
+++ b/protocol/v2/ssv/partial_sig_container.go
@@ -103,6 +103,26 @@ func (ps *PartialSigContainer) Remove(validatorIndex phase0.ValidatorIndex, sign
 	delete(signers, signer)
 }
 
+// ResolveDuplicateSignature handles a second partial signature for an already-seen
+// (validator, signer, root): it keeps the existing one if it still verifies against
+// committee, otherwise replaces it with msg's signature when that verifies. It returns
+// an error when the incoming signature is invalid.
+func (ps *PartialSigContainer) ResolveDuplicateSignature(msg *spectypes.PartialSignatureMessage, committee []*spectypes.ShareMember) error {
+	if existing, err := ps.GetSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot); err == nil {
+		if types.VerifyBeaconPartialSignature(msg.Signer, existing, msg.SigningRoot, committee) == nil {
+			return nil
+		}
+	}
+
+	ps.Remove(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
+
+	if err := types.VerifyBeaconPartialSignature(msg.Signer, msg.PartialSignature, msg.SigningRoot, committee); err != nil {
+		return err
+	}
+	ps.AddSignature(msg)
+	return nil
+}
+
 // ReconstructSignature aggregates collected partial sigs and verifies the result.
 func (ps *PartialSigContainer) ReconstructSignature(root [32]byte, validatorPubKey []byte, validatorIndex phase0.ValidatorIndex) ([]byte, error) {
 	ps.signaturesMu.RLock()

--- a/protocol/v2/ssv/partial_sig_container_test.go
+++ b/protocol/v2/ssv/partial_sig_container_test.go
@@ -1,0 +1,77 @@
+package ssv
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/herumi/bls-eth-go-binary/bls"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+// TestResolveDuplicateSignature covers the three outcomes when a second partial signature
+// arrives for an already-seen (validator, signer, root): keep a still-valid existing one,
+// replace an invalid existing one with a valid incoming one, or drop both when neither verifies.
+func TestResolveDuplicateSignature(t *testing.T) {
+	require.NoError(t, bls.Init(bls.BLS12_381))
+	require.NoError(t, bls.SetETHmode(bls.EthModeDraft07))
+
+	sk := &bls.SecretKey{}
+	sk.SetByCSPRNG()
+	pk := sk.GetPublicKey().Serialize()
+
+	const signer = spectypes.OperatorID(3)
+	const vIdx = phase0.ValidatorIndex(7)
+	committee := []*spectypes.ShareMember{{Signer: signer, SharePubKey: pk}}
+
+	var root [32]byte
+	copy(root[:], "the-root-we-expect-to-be-signed.")
+	var otherRoot [32]byte
+	copy(otherRoot[:], "a-different-root-the-wrong-domain")
+
+	validSig := sk.SignByte(root[:]).Serialize()        // verifies against root
+	invalidSig := sk.SignByte(otherRoot[:]).Serialize() // valid BLS, but over the wrong root
+
+	msg := func(sig spectypes.Signature) *spectypes.PartialSignatureMessage {
+		return &spectypes.PartialSignatureMessage{
+			PartialSignature: sig,
+			SigningRoot:      root,
+			Signer:           signer,
+			ValidatorIndex:   vIdx,
+		}
+	}
+
+	t.Run("keeps a valid existing signature", func(t *testing.T) {
+		ps := NewPartialSigContainer(1)
+		ps.AddSignature(msg(validSig))
+
+		require.NoError(t, ps.ResolveDuplicateSignature(msg(invalidSig), committee))
+
+		got, err := ps.GetSignature(vIdx, signer, root)
+		require.NoError(t, err)
+		require.NoError(t, types.VerifyBeaconPartialSignature(signer, got, root, committee))
+	})
+
+	t.Run("replaces an invalid existing signature with the valid one", func(t *testing.T) {
+		ps := NewPartialSigContainer(1)
+		ps.AddSignature(msg(invalidSig))
+
+		require.NoError(t, ps.ResolveDuplicateSignature(msg(validSig), committee))
+
+		got, err := ps.GetSignature(vIdx, signer, root)
+		require.NoError(t, err)
+		require.NoError(t, types.VerifyBeaconPartialSignature(signer, got, root, committee))
+	})
+
+	t.Run("drops the signature and errors when neither verifies", func(t *testing.T) {
+		ps := NewPartialSigContainer(1)
+		ps.AddSignature(msg(invalidSig))
+
+		require.Error(t, ps.ResolveDuplicateSignature(msg(invalidSig), committee))
+
+		_, err := ps.GetSignature(vIdx, signer, root)
+		require.Error(t, err)
+	})
+}

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -440,7 +440,9 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 
 		// Check if it has two signatures for the same signer
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
-			b.resolveDuplicateSignature(container, msg)
+			// A failure means neither signature was valid; the container is left without
+			// one, which is fine here since we only track quorum.
+			_ = container.ResolveDuplicateSignature(msg, b.Share[msg.ValidatorIndex].Committee)
 		} else {
 			container.AddSignature(msg)
 		}

--- a/protocol/v2/ssv/runner/runner_signatures.go
+++ b/protocol/v2/ssv/runner/runner_signatures.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
-	"github.com/herumi/bls-eth-go-binary/bls"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/networkconfig"
-	"github.com/ssvlabs/ssv/protocol/v2/ssv"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
@@ -134,59 +132,4 @@ func (b *BaseRunner) validateValidatorIndexInPartialSigMsg(
 		}
 	}
 	return nil
-}
-
-func (b *BaseRunner) verifyBeaconPartialSignature(signer spectypes.OperatorID, signature spectypes.Signature, root [32]byte,
-	committee []*spectypes.ShareMember) error {
-	for _, n := range committee {
-		if n.Signer == signer {
-			pk, err := ssvtypes.DeserializeBLSPublicKey(n.SharePubKey)
-			if err != nil {
-				return fmt.Errorf("could not deserialized pk: %w", err)
-			}
-			sig := &bls.Sign{}
-			if err := sig.Deserialize(signature); err != nil {
-				return fmt.Errorf("could not deserialized Signature: %w", err)
-			}
-
-			// verify
-			if !sig.VerifyByte(&pk, root[:]) {
-				return errors.New("wrong signature")
-			}
-			return nil
-		}
-	}
-	return errors.New("unknown signer")
-}
-
-// Stores the container's existing signature or the new one, depending on their validity. If both are invalid, remove the existing one
-func (b *BaseRunner) resolveDuplicateSignature(container *ssv.PartialSigContainer, msg *spectypes.PartialSignatureMessage) {
-	// Check previous signature validity
-	previousSignature, err := container.GetSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
-	if err == nil {
-		err = b.verifyBeaconPartialSignature(
-			msg.Signer,
-			previousSignature,
-			msg.SigningRoot,
-			b.Share[msg.ValidatorIndex].Committee,
-		)
-		if err == nil {
-			// Keep the previous signature since it's correct
-			return
-		}
-	}
-
-	// Previous signature is incorrect or doesn't exist
-	container.Remove(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
-
-	// Hold the new signature, if correct
-	err = b.verifyBeaconPartialSignature(
-		msg.Signer,
-		msg.PartialSignature,
-		msg.SigningRoot,
-		b.Share[msg.ValidatorIndex].Committee,
-	)
-	if err == nil {
-		container.AddSignature(msg)
-	}
 }

--- a/protocol/v2/ssv/runner/runner_validations.go
+++ b/protocol/v2/ssv/runner/runner_validations.go
@@ -13,6 +13,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 func (b *BaseRunner) ValidatePreConsensusMsg(
@@ -49,7 +50,7 @@ func (b *BaseRunner) FallBackAndVerifyEachSignature(container *ssv.PartialSigCon
 	signatures := container.GetSignatures(validatorIndex, root)
 
 	for operatorID, signature := range signatures {
-		if err := b.verifyBeaconPartialSignature(operatorID, signature, root, committee); err != nil {
+		if err := ssvtypes.VerifyBeaconPartialSignature(operatorID, signature, root, committee); err != nil {
 			container.Remove(validatorIndex, operatorID, root)
 		}
 	}

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -190,7 +190,9 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 		spectypes.DomainVoluntaryExit,
 	)
 	if err != nil {
-		return fmt.Errorf("could not sign VoluntaryExit object: %w", err)
+		// EIP-7044 pins exits to the Capella domain; a remote signer that disagrees on the
+		// fork (e.g. a wrong Web3Signer --network) rejects exits while other duties still sign.
+		return fmt.Errorf("could not sign voluntary exit (the remote signer may be misconfigured, e.g. a wrong Web3Signer --network): %w", err)
 	}
 
 	msgs := &spectypes.PartialSignatureMessages{

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -161,7 +161,7 @@ func (r *VoluntaryExitRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRo
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *VoluntaryExitRunner) expectedPostConsensusRootsAndDomain(context.Context) ([]ssz.HashRoot, phase0.DomainType, error) {
-	return nil, [4]byte{}, errors.New("no post consensus roots for voluntary exit")
+	return nil, spectypes.DomainError, errors.New("no post consensus roots for voluntary exit")
 }
 
 func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) error {
@@ -190,9 +190,9 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 		spectypes.DomainVoluntaryExit,
 	)
 	if err != nil {
-		// EIP-7044 pins exits to the Capella domain; a remote signer that disagrees on the
-		// fork (e.g. a wrong Web3Signer --network) rejects exits while other duties still sign.
-		return fmt.Errorf("could not sign voluntary exit (the remote signer may be misconfigured, e.g. a wrong Web3Signer --network): %w", err)
+		// EIP-7044 pins exits to the Capella domain, so a signer that disagrees on the fork
+		// rejects exits while other duties still sign (e.g. a remote Web3Signer with the wrong --network).
+		return fmt.Errorf("could not sign voluntary exit (if signing remotely, check the signer config, e.g. the Web3Signer --network): %w", err)
 	}
 
 	msgs := &spectypes.PartialSignatureMessages{

--- a/protocol/v2/ssv/validator/committee_observer.go
+++ b/protocol/v2/ssv/validator/committee_observer.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/jellydator/ttlcache/v3"
 	"go.uber.org/zap"
 
@@ -262,7 +261,7 @@ func (ncv *CommitteeObserver) VerifySig(partialMsgs *spectypes.PartialSignatureM
 			slotValidators[msg.ValidatorIndex] = container
 		}
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
-			if err := ncv.resolveDuplicateSignature(container, msg, validator); err != nil {
+			if err := container.ResolveDuplicateSignature(msg, validator.Committee); err != nil {
 				return err
 			}
 		} else {
@@ -298,7 +297,7 @@ func (ncv *CommitteeObserver) verifySigAndgetQuorums(
 			slotValidators[msg.ValidatorIndex] = container
 		}
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
-			_ = ncv.resolveDuplicateSignature(container, msg, validator)
+			_ = container.ResolveDuplicateSignature(msg, validator.Committee)
 		} else {
 			container.AddSignature(msg)
 		}
@@ -334,54 +333,6 @@ func (ncv *CommitteeObserver) pruneOldSlots(currentSlot phase0.Slot) {
 			}
 		}
 	}
-}
-
-// Stores the container's existing signature or the new one, depending on their validity. If both are invalid, remove the existing one
-// copied from BaseRunner
-func (ncv *CommitteeObserver) resolveDuplicateSignature(container *ssv.PartialSigContainer, msg *spectypes.PartialSignatureMessage, share *ssvtypes.SSVShare) error {
-	// Check previous signature validity
-	previousSignature, err := container.GetSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
-	if err == nil {
-		err = ncv.verifyBeaconPartialSignature(msg.Signer, previousSignature, msg.SigningRoot, share)
-		if err == nil {
-			// Keep the previous signature since it's correct
-			return nil
-		}
-	}
-
-	// Previous signature is incorrect or doesn't exist
-	container.Remove(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
-
-	// Hold the new signature, if correct
-	err = ncv.verifyBeaconPartialSignature(msg.Signer, msg.PartialSignature, msg.SigningRoot, share)
-	if err == nil {
-		container.AddSignature(msg)
-	}
-
-	return err
-}
-
-// copied from BaseRunner
-func (ncv *CommitteeObserver) verifyBeaconPartialSignature(signer uint64, signature spectypes.Signature, root phase0.Root, share *ssvtypes.SSVShare) error {
-	for _, n := range share.Committee {
-		if n.Signer == signer {
-			pk, err := ssvtypes.DeserializeBLSPublicKey(n.SharePubKey)
-			if err != nil {
-				return fmt.Errorf("could not deserialized pk: %w", err)
-			}
-
-			sig := &bls.Sign{}
-			if err := sig.Deserialize(signature); err != nil {
-				return fmt.Errorf("could not deserialized Signature: %w", err)
-			}
-
-			if !sig.VerifyByte(&pk, root[:]) {
-				return fmt.Errorf("wrong signature")
-			}
-			return nil
-		}
-	}
-	return fmt.Errorf("unknown signer")
 }
 
 func (ncv *CommitteeObserver) SaveRoots(ctx context.Context, msg *queue.SSVMessage) error {

--- a/protocol/v2/types/crypto.go
+++ b/protocol/v2/types/crypto.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/herumi/bls-eth-go-binary/bls"
@@ -17,4 +18,28 @@ func VerifyReconstructedSignature(sig *bls.Sign, validatorPubKey []byte, root [3
 		return spectypes.NewError(spectypes.ReconstructSignatureErrorCode, "could not reconstruct a valid signature")
 	}
 	return nil
+}
+
+// VerifyBeaconPartialSignature verifies a single operator's partial signature over root
+// against that operator's share public key, looked up in committee by signer ID. It
+// returns an error if the signer is not in the committee or the signature is invalid.
+func VerifyBeaconPartialSignature(signer spectypes.OperatorID, signature spectypes.Signature, root [32]byte, committee []*spectypes.ShareMember) error {
+	for _, member := range committee {
+		if member.Signer != signer {
+			continue
+		}
+		pk, err := DeserializeBLSPublicKey(member.SharePubKey)
+		if err != nil {
+			return fmt.Errorf("could not deserialize share public key: %w", err)
+		}
+		sig := &bls.Sign{}
+		if err := sig.Deserialize(signature); err != nil {
+			return fmt.Errorf("could not deserialize signature: %w", err)
+		}
+		if !sig.VerifyByte(&pk, root[:]) {
+			return errors.New("wrong signature")
+		}
+		return nil
+	}
+	return errors.New("unknown signer")
 }

--- a/protocol/v2/types/crypto_test.go
+++ b/protocol/v2/types/crypto_test.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/herumi/bls-eth-go-binary/bls"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyBeaconPartialSignature(t *testing.T) {
+	require.NoError(t, bls.Init(bls.BLS12_381))
+	require.NoError(t, bls.SetETHmode(bls.EthModeDraft07))
+
+	sk := &bls.SecretKey{}
+	sk.SetByCSPRNG()
+	pk := sk.GetPublicKey().Serialize()
+
+	const signer = spectypes.OperatorID(3)
+	committee := []*spectypes.ShareMember{{Signer: signer, SharePubKey: pk}}
+
+	var root [32]byte
+	copy(root[:], "the-root-we-expect-to-be-signed.")
+	goodSig := sk.SignByte(root[:]).Serialize()
+
+	// a correct signature over the expected root, by a committee member, verifies
+	require.NoError(t, VerifyBeaconPartialSignature(signer, goodSig, root, committee))
+
+	// a signature over a different root (the wrong-domain / misconfigured-signer case) is rejected
+	var otherRoot [32]byte
+	copy(otherRoot[:], "a-different-root-the-wrong-domain")
+	require.Error(t, VerifyBeaconPartialSignature(signer, sk.SignByte(otherRoot[:]).Serialize(), root, committee))
+
+	// a signer not in the committee is rejected
+	require.Error(t, VerifyBeaconPartialSignature(spectypes.OperatorID(99), goodSig, root, committee))
+}

--- a/ssvsigner/e2e/signing/validator_registration_test.go
+++ b/ssvsigner/e2e/signing/validator_registration_test.go
@@ -1,0 +1,87 @@
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/ssvlabs/ssv/ssvsigner/e2e"
+)
+
+// ValidatorRegistrationSigningTestSuite covers validator-registration signing. Like
+// voluntary exit, the registration (application builder) domain is derived from a fixed
+// fork - the genesis fork version - rather than the current one, so a node/signer fork
+// disagreement would surface here.
+type ValidatorRegistrationSigningTestSuite struct {
+	e2e.E2ETestSuite
+}
+
+// TestValidatorRegistrationSigningConsistency verifies that LocalKeyManager,
+// RemoteKeyManager (via SSV-Signer + Web3Signer), and Web3Signer-direct all produce the
+// same validator-registration signature over the application-builder domain, even though
+// "now" is in the Fulu era and the current fork differs from genesis. This extends the
+// voluntary-exit consistency check to the other fixed-fork domain.
+func (s *ValidatorRegistrationSigningTestSuite) TestValidatorRegistrationSigningConsistency() {
+	// Place the chain clock in the Fulu era (mainnet Fulu @ epoch 411392) so the current
+	// fork is well past genesis; the application-builder domain must still be computed
+	// over the genesis fork version regardless.
+	testCurrentEpoch := phase0.Epoch(411392 + 256)
+	s.GetEnv().SetTestCurrentEpoch(testCurrentEpoch)
+
+	ctx, cancel := context.WithTimeout(s.GetContext(), 60*time.Second)
+	defer cancel()
+
+	validatorKeyPair := s.AddValidator(ctx)
+
+	slot := s.GetEnv().GetBeaconConfig().FirstSlotAtEpoch(testCurrentEpoch)
+
+	registration := &eth2apiv1.ValidatorRegistration{
+		FeeRecipient: bellatrix.ExecutionAddress{0x01, 0x02, 0x03},
+		GasLimit:     30_000_000,
+		Timestamp:    time.Unix(1_700_000_000, 0),
+		Pubkey:       validatorKeyPair.BLSPubKey,
+	}
+
+	// The application-builder domain uses the genesis fork version, not the current fork.
+	domain, err := s.CalculateValidatorRegistrationDomain()
+	s.Require().NoError(err, "Failed to calculate validator registration domain")
+
+	s.T().Logf("✍️ Signing validator registration (current fork = Fulu) over the genesis builder domain")
+
+	localSig, localRoot, err := s.GetEnv().GetLocalKeyManager().SignBeaconObject(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Local key manager failed to sign validator registration")
+	s.Require().NotEmpty(localSig)
+	s.Require().NotEmpty(localRoot)
+
+	remoteSig, remoteRoot, err := s.GetEnv().GetRemoteKeyManager().SignBeaconObject(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Remote key manager failed to sign validator registration")
+	s.Require().NotEmpty(remoteSig)
+	s.Require().NotEmpty(remoteRoot)
+
+	web3Sig, web3Root, err := s.SignWeb3Signer(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Web3Signer failed to sign validator registration")
+	s.Require().NotEmpty(web3Sig)
+	s.Require().NotEmpty(web3Root)
+
+	// All three paths must agree on both the (genesis builder) signing root and the signature.
+	s.Require().Equal(localRoot, remoteRoot, "local vs remote signing root should match")
+	s.Require().Equal(remoteRoot, web3Root, "remote vs web3signer signing root should match")
+	s.Require().Equal(localSig, remoteSig, "local vs remote signature should match")
+	s.Require().Equal(remoteSig, web3Sig, "remote vs web3signer signature should match")
+
+	s.T().Logf("✅ All signers agree on the genesis-builder-domain validator registration signature")
+}
+
+// TestValidatorRegistrationSigning runs the validator registration signing test suite.
+func TestValidatorRegistrationSigning(t *testing.T) {
+	suite.Run(t, new(ValidatorRegistrationSigningTestSuite))
+}

--- a/ssvsigner/e2e/signing/voluntary_exit_test.go
+++ b/ssvsigner/e2e/signing/voluntary_exit_test.go
@@ -1,0 +1,84 @@
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/ssvlabs/ssv/ssvsigner/e2e"
+)
+
+// VoluntaryExitSigningTestSuite covers voluntary-exit signing, which (per EIP-7044)
+// must always use the Capella fork domain regardless of the current fork.
+type VoluntaryExitSigningTestSuite struct {
+	e2e.E2ETestSuite
+}
+
+// TestVoluntaryExitSigningConsistency verifies that LocalKeyManager, RemoteKeyManager
+// (via SSV-Signer + Web3Signer), and Web3Signer-direct all produce the same voluntary
+// exit signature, computed over the Capella domain — even though "now" is in the Fulu
+// era and the current fork differs from Capella. This mirrors the Hoodi incident where
+// the remote path was sending the current fork instead of Capella, and guards the
+// Capella fork pinning in RemoteKeyManager.prepareSignRequest.
+func (s *VoluntaryExitSigningTestSuite) TestVoluntaryExitSigningConsistency() {
+	// Place the chain clock in the Fulu era (mainnet Fulu @ epoch 411392) so the
+	// current fork (0x06000000) is well past Capella (0x03000000). Web3Signer is run
+	// with --network=mainnet, so at this epoch it applies the EIP-7044 override and
+	// signs exits with the Capella fork version.
+	testCurrentEpoch := phase0.Epoch(411392 + 256)
+	s.GetEnv().SetTestCurrentEpoch(testCurrentEpoch)
+
+	ctx, cancel := context.WithTimeout(s.GetContext(), 60*time.Second)
+	defer cancel()
+
+	validatorKeyPair := s.AddValidator(ctx)
+
+	exitEpoch := testCurrentEpoch
+	exitSlot := s.GetEnv().GetBeaconConfig().FirstSlotAtEpoch(exitEpoch)
+
+	voluntaryExit := &phase0.VoluntaryExit{
+		Epoch:          exitEpoch,
+		ValidatorIndex: 1,
+	}
+
+	// EIP-7044: exits are signed over the Capella domain, not the current fork's.
+	domain, err := s.CalculateVoluntaryExitDomain()
+	s.Require().NoError(err, "Failed to calculate voluntary exit domain")
+
+	s.T().Logf("✍️ Signing voluntary exit (epoch %d, current fork = Fulu) over the Capella domain", exitEpoch)
+
+	localSig, localRoot, err := s.GetEnv().GetLocalKeyManager().SignBeaconObject(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Local key manager failed to sign voluntary exit")
+	s.Require().NotEmpty(localSig)
+	s.Require().NotEmpty(localRoot)
+
+	remoteSig, remoteRoot, err := s.GetEnv().GetRemoteKeyManager().SignBeaconObject(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Remote key manager failed to sign voluntary exit")
+	s.Require().NotEmpty(remoteSig)
+	s.Require().NotEmpty(remoteRoot)
+
+	web3Sig, web3Root, err := s.SignWeb3Signer(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Web3Signer failed to sign voluntary exit")
+	s.Require().NotEmpty(web3Sig)
+	s.Require().NotEmpty(web3Root)
+
+	// All three paths must agree on both the (Capella) signing root and the signature.
+	s.Require().Equal(localRoot, remoteRoot, "local vs remote signing root should match")
+	s.Require().Equal(remoteRoot, web3Root, "remote vs web3signer signing root should match")
+	s.Require().Equal(localSig, remoteSig, "local vs remote signature should match")
+	s.Require().Equal(remoteSig, web3Sig, "remote vs web3signer signature should match")
+
+	s.T().Logf("✅ All signers agree on the Capella-domain voluntary exit signature")
+}
+
+// TestVoluntaryExitSigning runs the voluntary exit signing test suite.
+func TestVoluntaryExitSigning(t *testing.T) {
+	suite.Run(t, new(VoluntaryExitSigningTestSuite))
+}

--- a/ssvsigner/e2e/signing/voluntary_exit_test.go
+++ b/ssvsigner/e2e/signing/voluntary_exit_test.go
@@ -21,9 +21,14 @@ type VoluntaryExitSigningTestSuite struct {
 // TestVoluntaryExitSigningConsistency verifies that LocalKeyManager, RemoteKeyManager
 // (via SSV-Signer + Web3Signer), and Web3Signer-direct all produce the same voluntary
 // exit signature, computed over the Capella domain — even though "now" is in the Fulu
-// era and the current fork differs from Capella. This mirrors the Hoodi incident where
-// the remote path was sending the current fork instead of Capella, and guards the
-// Capella fork pinning in RemoteKeyManager.prepareSignRequest.
+// era and the current fork differs from Capella.
+//
+// Note: this only exercises the EIP-7044-correct path. With --network=mainnet,
+// Web3Signer applies the EIP-7044 override itself and derives the Capella domain from
+// its own config, so the roots match regardless of the Capella pin in
+// RemoteKeyManager.prepareSignRequest. The Hoodi incident — a signer that falls back
+// to the fork_info we send — is not reproduced here; the Capella assertion in
+// remote_key_manager_test.go (SignVoluntaryExit) is what guards the pin.
 func (s *VoluntaryExitSigningTestSuite) TestVoluntaryExitSigningConsistency() {
 	// Place the chain clock in the Fulu era (mainnet Fulu @ epoch 411392) so the
 	// current fork (0x06000000) is well past Capella (0x03000000). Web3Signer is run

--- a/ssvsigner/e2e/suite.go
+++ b/ssvsigner/e2e/suite.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/sourcegraph/conc/pool"
@@ -77,6 +79,60 @@ func (s *E2ETestSuite) CalculateDomain(domainType phase0.DomainType, epoch phase
 	return domain, nil
 }
 
+// CalculateVoluntaryExitDomain computes the voluntary-exit signing domain, which per
+// EIP-7044 is permanently fixed to the Capella fork version (unlike CalculateDomain,
+// which uses the fork active at the given epoch). This mirrors what the SSV node's
+// beacon client computes for exits.
+func (s *E2ETestSuite) CalculateVoluntaryExitDomain() (phase0.Domain, error) {
+	capellaFork, ok := s.env.GetBeaconConfig().ForkAtVersion(spec.DataVersionCapella)
+	if !ok {
+		return phase0.Domain{}, errors.New("capella fork not configured")
+	}
+
+	forkData := &phase0.ForkData{
+		CurrentVersion:        capellaFork.CurrentVersion,
+		GenesisValidatorsRoot: s.env.GetBeaconConfig().GenesisValidatorsRoot,
+	}
+
+	forkDataRoot, err := forkData.HashTreeRoot()
+	if err != nil {
+		return phase0.Domain{}, err
+	}
+
+	domain := phase0.Domain{}
+	copy(domain[:4], spectypes.DomainVoluntaryExit[:])
+	copy(domain[4:], forkDataRoot[:28])
+
+	return domain, nil
+}
+
+// CalculateValidatorRegistrationDomain computes the validator-registration (application
+// builder) signing domain, which uses the genesis fork version and an empty genesis
+// validators root - independent of the current fork. Like the voluntary-exit domain it
+// is fixed, so it mirrors what the SSV node's beacon client computes for registrations.
+func (s *E2ETestSuite) CalculateValidatorRegistrationDomain() (phase0.Domain, error) {
+	genesisFork, ok := s.env.GetBeaconConfig().ForkAtVersion(spec.DataVersionPhase0)
+	if !ok {
+		return phase0.Domain{}, errors.New("genesis (phase0) fork not configured")
+	}
+
+	forkData := &phase0.ForkData{
+		CurrentVersion:        genesisFork.CurrentVersion,
+		GenesisValidatorsRoot: phase0.Root{},
+	}
+
+	forkDataRoot, err := forkData.HashTreeRoot()
+	if err != nil {
+		return phase0.Domain{}, err
+	}
+
+	domain := phase0.Domain{}
+	copy(domain[:4], spectypes.DomainApplicationBuilder[:])
+	copy(domain[4:], forkDataRoot[:28])
+
+	return domain, nil
+}
+
 // RequireSlashingError verifies that Web3Signer returns HTTP 412 for slashing protection violations
 func (s *E2ETestSuite) RequireSlashingError(err error, operation string) {
 	var httpErr web3signer.HTTPResponseError
@@ -118,6 +174,28 @@ func (s *E2ETestSuite) SignWeb3Signer(
 		}
 		req.Type = web3signer.TypeBlockV2
 		req.BeaconBlock = beaconBlockData
+
+	case spectypes.DomainVoluntaryExit:
+		data, ok := obj.(*phase0.VoluntaryExit)
+		if !ok {
+			return nil, phase0.Root{}, errors.New("could not cast obj to VoluntaryExit")
+		}
+		// Unlike the production RemoteKeyManager (which pins Capella, see
+		// voluntaryExitForkInfo), this helper intentionally forwards the current fork.
+		// The caller's signing_root is already over the Capella domain (EIP-7044), and
+		// the e2e Web3Signer (--network=mainnet) overrides the exit fork to Capella
+		// itself, so the roots still match — this exercises Web3Signer's own EIP-7044
+		// path. Do not "align" this with the production path without that context.
+		req.Type = web3signer.TypeVoluntaryExit
+		req.VoluntaryExit = data
+
+	case spectypes.DomainApplicationBuilder:
+		data, ok := obj.(*eth2apiv1.ValidatorRegistration)
+		if !ok {
+			return nil, phase0.Root{}, errors.New("could not cast obj to ValidatorRegistration")
+		}
+		req.Type = web3signer.TypeValidatorRegistration
+		req.ValidatorRegistration = data
 
 	default:
 		return nil, phase0.Root{}, errors.New("unsupported domain type for testing")

--- a/ssvsigner/ekm/contracts.go
+++ b/ssvsigner/ekm/contracts.go
@@ -48,4 +48,8 @@ type BeaconNetwork interface {
 	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
 	EstimatedSlotAtTime(time time.Time) phase0.Slot
 	ForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase0.Fork)
+	// ForkAtVersion returns the configured fork for a data version, and whether it exists.
+	// Used to pin a fixed fork (Capella for exits per EIP-7044, genesis for registrations)
+	// independently of the current fork.
+	ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool)
 }

--- a/ssvsigner/ekm/mock.go
+++ b/ssvsigner/ekm/mock.go
@@ -50,20 +50,6 @@ func (m *MockRemoteSigner) OperatorSign(ctx context.Context, payload []byte) ([]
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-type MockBeaconNetwork struct {
-	mock.Mock
-}
-
-func (m *MockBeaconNetwork) NetworkName() string {
-	args := m.Called()
-	return args.String(0)
-}
-
-func (m *MockBeaconNetwork) GenesisRoot() phase0.Root {
-	args := m.Called()
-	return args.Get(0).(phase0.Root)
-}
-
 type MockDatabase struct {
 	mock.Mock
 }

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -293,6 +294,15 @@ func (km *RemoteKeyManager) prepareSignRequest(
 			return web3signer.SignRequest{}, phase0.Root{}, errors.New("could not cast obj to VoluntaryExit")
 		}
 
+		// EIP-7044 pins voluntary exits to the Capella domain. Override the current fork
+		// (from GetForkInfo) with Capella to match the signing_root computed below; else a
+		// signer that doesn't apply EIP-7044 (e.g. a wrong Web3Signer --network) rejects it.
+		forkInfo, err := km.voluntaryExitForkInfo()
+		if err != nil {
+			return web3signer.SignRequest{}, phase0.Root{}, err
+		}
+		req.ForkInfo = forkInfo
+
 		req.Type = web3signer.TypeVoluntaryExit
 		req.VoluntaryExit = data
 
@@ -381,6 +391,15 @@ func (km *RemoteKeyManager) prepareSignRequest(
 			return web3signer.SignRequest{}, phase0.Root{}, errors.New("could not cast obj to ValidatorRegistration")
 		}
 
+		// The application-builder domain is fixed to the genesis fork, independent of the
+		// current fork. Pin it to match the signing_root computed below, mirroring the
+		// voluntary-exit case (a no-op for a correct signer, which derives the domain itself).
+		forkInfo, err := km.validatorRegistrationForkInfo()
+		if err != nil {
+			return web3signer.SignRequest{}, phase0.Root{}, err
+		}
+		req.ForkInfo = forkInfo
+
 		req.Type = web3signer.TypeValidatorRegistration
 		req.ValidatorRegistration = data
 	default:
@@ -459,6 +478,35 @@ func (km *RemoteKeyManager) GetForkInfo(epoch phase0.Epoch) web3signer.ForkInfo 
 		Fork:                  currentFork,
 		GenesisValidatorsRoot: km.genesisRoot,
 	}
+}
+
+// voluntaryExitForkInfo returns ForkInfo pinned to the Capella fork, as EIP-7044 requires for
+// voluntary exits. See the DomainVoluntaryExit case in prepareSignRequest.
+func (km *RemoteKeyManager) voluntaryExitForkInfo() (web3signer.ForkInfo, error) {
+	capellaFork, ok := km.beaconConfig.ForkAtVersion(spec.DataVersionCapella)
+	if !ok {
+		return web3signer.ForkInfo{}, errors.New("capella fork not configured")
+	}
+
+	return web3signer.ForkInfo{
+		Fork:                  &capellaFork,
+		GenesisValidatorsRoot: km.genesisRoot,
+	}, nil
+}
+
+// validatorRegistrationForkInfo returns ForkInfo pinned to the genesis fork and an empty
+// genesis validators root, matching the fixed application-builder domain. See the
+// DomainApplicationBuilder case in prepareSignRequest.
+func (km *RemoteKeyManager) validatorRegistrationForkInfo() (web3signer.ForkInfo, error) {
+	genesisFork, ok := km.beaconConfig.ForkAtVersion(spec.DataVersionPhase0)
+	if !ok {
+		return web3signer.ForkInfo{}, errors.New("genesis fork not configured")
+	}
+
+	return web3signer.ForkInfo{
+		Fork:                  &genesisFork,
+		GenesisValidatorsRoot: phase0.Root{},
+	}, nil
 }
 
 func (km *RemoteKeyManager) Sign(payload []byte) ([]byte, error) {

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -13,6 +13,7 @@ import (
 	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
 	apiv1electra "github.com/attestantio/go-eth2-client/api/v1/electra"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
@@ -1444,18 +1445,78 @@ func (s *RemoteKeyManagerTestSuite) TestSignBeaconObjectAdditionalDomains() {
 	slot := phase0.Slot(123)
 
 	s.Run("SignVoluntaryExit", func() {
+		// Use a post-Capella slot (epoch 6 = Fulu in the test config) so the current
+		// fork differs from Capella — that difference is what makes the EIP-7044
+		// pinning observable. Signing an exit must use the Capella fork regardless.
+		exitSlot := phase0.Slot(6 * testNetCfg.SlotsPerEpoch)
+		exitEpoch := testNetCfg.EstimatedEpochAtSlot(exitSlot)
+
 		voluntaryExit := &phase0.VoluntaryExit{
-			Epoch:          123,
+			Epoch:          exitEpoch,
 			ValidatorIndex: 456,
 		}
 
-		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).Return(expectedSignature, nil).Once()
+		var capturedReq web3signer.SignRequest
+		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).
+			Run(func(args mock.Arguments) {
+				capturedReq = args.Get(2).(web3signer.SignRequest)
+			}).
+			Return(expectedSignature, nil).Once()
 
-		signature, root, err := rm.SignBeaconObject(ctx, voluntaryExit, domain, pubKey, slot, spectypes.DomainVoluntaryExit)
+		signature, root, err := rm.SignBeaconObject(ctx, voluntaryExit, domain, pubKey, exitSlot, spectypes.DomainVoluntaryExit)
 
 		s.NoError(err)
 		s.EqualValues(expectedSignature[:], signature)
 		s.NotEqual([32]byte{}, root)
+
+		// EIP-7044: the exit must be signed with the Capella fork, not the current one.
+		s.Equal(web3signer.TypeVoluntaryExit, capturedReq.Type)
+		s.Require().NotNil(capturedReq.ForkInfo.Fork)
+		capellaFork, ok := testNetCfg.ForkAtVersion(spec.DataVersionCapella)
+		s.Require().True(ok)
+		s.Equal(capellaFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		_, currentFork := testNetCfg.ForkAtEpoch(exitEpoch)
+		s.NotEqual(currentFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+
+		s.client.AssertExpectations(s.T())
+	})
+
+	s.Run("SignValidatorRegistration", func() {
+		// Validator registration uses the application-builder domain, fixed to the
+		// genesis fork version regardless of the current fork. Use a post-genesis slot
+		// (epoch 6 = Fulu in the test config) so the current fork differs from genesis;
+		// the request must carry the pinned genesis fork and an empty genesis root.
+		registrationSlot := phase0.Slot(6 * testNetCfg.SlotsPerEpoch)
+
+		registration := &eth2api.ValidatorRegistration{
+			FeeRecipient: bellatrix.ExecutionAddress{1, 2, 3},
+			GasLimit:     30000000,
+			Timestamp:    time.Unix(1700000000, 0),
+			Pubkey:       pubKey,
+		}
+
+		var capturedReq web3signer.SignRequest
+		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).
+			Run(func(args mock.Arguments) {
+				capturedReq = args.Get(2).(web3signer.SignRequest)
+			}).
+			Return(expectedSignature, nil).Once()
+
+		signature, root, err := rm.SignBeaconObject(ctx, registration, domain, pubKey, registrationSlot, spectypes.DomainApplicationBuilder)
+
+		s.NoError(err)
+		s.EqualValues(expectedSignature[:], signature)
+		s.NotEqual([32]byte{}, root)
+
+		s.Equal(web3signer.TypeValidatorRegistration, capturedReq.Type)
+		s.Require().NotNil(capturedReq.ForkInfo.Fork)
+		genesisFork, ok := testNetCfg.ForkAtVersion(spec.DataVersionPhase0)
+		s.Require().True(ok)
+		s.Equal(genesisFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		_, currentFork := testNetCfg.ForkAtEpoch(testNetCfg.EstimatedEpochAtSlot(registrationSlot))
+		s.NotEqual(currentFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		s.Equal(phase0.Root{}, capturedReq.ForkInfo.GenesisValidatorsRoot)
+
 		s.client.AssertExpectations(s.T())
 	})
 

--- a/ssvsigner/internal/beaconcfg/config.go
+++ b/ssvsigner/internal/beaconcfg/config.go
@@ -97,3 +97,8 @@ func (b *Config) ForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase0.Fork
 
 	return previousVersion, &previousFork
 }
+
+func (b *Config) ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool) {
+	fork, ok := b.Forks[version]
+	return fork, ok
+}


### PR DESCRIPTION
## Summary

Voluntary exits signed via the remote signer (ssv-signer → Web3Signer) put the **current** fork in `fork_info` while computing the signing root over the **Capella** domain that [EIP-7044](https://eips.ethereum.org/EIPS/eip-7044) permanently pins for exits. The request was internally inconsistent. It worked only because a network-aware Web3Signer applies EIP-7044 itself and ignores the fork we send — a misconfigured one rejected it and the exit never signed.

This PR makes the remote request self-consistent (mirroring the already-correct local signer) and generalizes the fix to the fixed-fork signing domains.

## Root cause

SSV computes the exit signing root over the Capella domain on both paths, and always sends it as `signing_root`. Web3Signer recomputes its own root from `fork_info` + the exit and rejects with HTTP 400 on mismatch ([`Eth2SignForIdentifierHandler`](https://github.com/Consensys/web3signer/blob/master/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java)):

- **Network-aware signer:** applies EIP-7044, uses Capella regardless of our `fork_info` → recomputed root matches → signs. This masked the inconsistency.
- **Misconfigured signer:** does not apply EIP-7044 for the exit's epoch and falls back to the fork we sent (current) → current-fork root → mismatch → **HTTP 400, exit never signs**.

The misconfiguration is easy to hit because Web3Signer's `--network` is **optional and silently defaults to `mainnet`**. On a young network like Hoodi (genesis March 2025), an operator who simply omits `--network` gets the mainnet fork schedule; Hoodi's current epoch is far below mainnet's Deneb epoch (269568), so the exit resolves to a **pre-Deneb** milestone, EIP-7044 is not applied, and Web3Signer derives the exit domain from the fork we send. That is the Hoodi incident — no exotic misconfiguration required, just a missing flag.

The local signer builds the exit domain from Capella directly, so it was never affected.

## Changes

- **Pin Capella for voluntary exits (the fix).** `prepareSignRequest` overrides `fork_info` with the Capella fork for `DomainVoluntaryExit`. The request is now self-consistent regardless of the signer's network-awareness: a correct signer still applies EIP-7044, and a signer that fell back to our fork now derives the Capella domain instead of rejecting. Removes SSV's reliance on the signer's EIP-7044 override.
- **Pin the genesis builder fork for validator registration (parity).** `DomainApplicationBuilder` is the other fixed-fork domain (genesis fork version + empty genesis validators root). Web3Signer derives this domain itself, so this is a no-op for a correct signer — purely request self-consistency and parity with the exit pin (no known incident).
- **Actionable error on exit signing failure.** A failed voluntary-exit signing is wrapped with a hint pointing at the Web3Signer `--network`, in `VoluntaryExitRunner.executeDuty` — the caller that already knows the duty type, so the generic signing helper stays domain-agnostic. Scoped to exits (the rare, high-signal case) so frequent registrations don't get a misleading hint.
- **Refactor.** Deduplicate the partial-signature verification helper (`ssvtypes.VerifyBeaconPartialSignature`) and the duplicate-signature resolution (`PartialSigContainer.ResolveDuplicateSignature`) into shared code — both were copied between `BaseRunner` and `CommitteeObserver`. Remove the dead `MockBeaconNetwork`.

## QA notes

**Reproduction** — Hoodi, remote signer, with `--network` omitted on Web3Signer (so it silently defaults to mainnet):

| | Voluntary exit | Attestations / aggregations (same window) |
|---|---|---|
| **Before** | duty dispatched to all operators never completes; Web3Signer returns **HTTP 400** (signing-root mismatch) | signing works fine |
| **After** | exit is signed and broadcast; duty completes, validator exits | signing works fine |

The "attestations succeed but the exit 400s" split is the tell that you are hitting this and not a generic signer outage: every other duty derives its domain from the fork the node sends, so only the EIP-7044 exit domain is affected.

**Automated coverage (added/strengthened):**

- Unit (`RemoteKeyManager`): assert the request carries the **Capella** fork for exits and the **genesis** fork + empty root for registrations, at a post-Capella (Fulu-era) slot so the wrong fork is observable — verified these fail without the fix.
- Unit (`ssvtypes.VerifyBeaconPartialSignature`): correct / wrong-root / unknown-signer.
- Unit (`PartialSigContainer.ResolveDuplicateSignature`): keep-valid-existing / replace-invalid-with-valid / drop-both-invalid.
- e2e (`ssvsigner/e2e/signing`): local, remote, and Web3Signer-direct agree on the Capella-domain exit and genesis-builder-domain registration signatures with the clock in the Fulu era. Run against Web3Signer 25.11.0 + Postgres + ssv-signer.
- `go build` / `go vet` (both modules), unit tests, the e2e suite, and `gofmt` / `goimports` all clean.

## Notes

- For a correctly network-configured Web3Signer this is a no-op for exits (it already applies EIP-7044); in that case the proximate cause is the Web3Signer config. The change removes SSV's reliance on signer network-awareness either way.
- "Wrong/missing `--network`" spans two buckets: a signer that resolves the exit epoch **pre-Deneb** falls back to our fork (fixed by the pin — the case hit on Hoodi today), while a signer network-aware for the **wrong** network applies EIP-7044 with that network's Capella version and still rejects (not fixed by the pin; the `--network` error hint is the only part that surfaces it).
