### PR TITLE
cli/operator,operator: converge startup Fatals into errgroup-coordinated shutdown

### DIFF
--- a/cli/operator/config.go
+++ b/cli/operator/config.go
@@ -294,9 +294,9 @@ func (e signingConfigError) Error() string          { return e.err.Error() }
 func (e signingConfigError) Unwrap() error          { return e.err }
 func (e signingConfigError) logFields() []zap.Field { return e.fields }
 
-// startupError wraps an error returned from runNode() with structured log fields, so the single
-// top-level fatal preserves the context (e.g. the ssv-signer endpoint). Mirrors signingConfigError,
-// for non-validation startup failures.
+// startupError attaches structured log fields to a startup error, so whoever logs it preserves
+// context (e.g. the ssv-signer endpoint) that the message alone can't carry. Mirrors
+// signingConfigError, for non-validation startup failures.
 type startupError struct {
 	err    error
 	fields []zap.Field
@@ -313,8 +313,8 @@ type fieldedError interface {
 	logFields() []zap.Field
 }
 
-// startupErrorLogFields returns the structured log fields for an error returned by runNode(): the
-// error itself, plus any context carried by a fieldedError (signingConfigError / startupError).
+// startupErrorLogFields returns the structured log fields for a startup error: the error itself,
+// plus any context carried by a fieldedError (signingConfigError / startupError).
 func startupErrorLogFields(err error) []zap.Field {
 	fields := []zap.Field{zap.Error(err)}
 	var fe fieldedError

--- a/cli/operator/config_test.go
+++ b/cli/operator/config_test.go
@@ -106,7 +106,7 @@ func Test_resolveAndValidate_signingErrorContext(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot enable both remote signing")
 
-	// start_node.go logs runNode()'s error via startupErrorLogFields — the signing-source context
+	// start_node.go logs the startup error via startupErrorLogFields — the signing-source context
 	// must be preserved as queryable structured fields, without exposing the key value.
 	core, recorded := observer.New(zapcore.ErrorLevel)
 	zap.New(core).Error("could not start node", startupErrorLogFields(err)...)

--- a/cli/operator/db.go
+++ b/cli/operator/db.go
@@ -28,7 +28,7 @@ func setupBadgerDB(
 		return nil, fmt.Errorf("failed to open db: %w", err)
 	}
 	// On any later failure here (migrations/GC), close the freshly-opened db; on success the
-	// caller (newNode) owns it and tears it down via node.Close().
+	// caller (newNode) owns it and tears it down via node.close().
 	defer func() {
 		if err != nil {
 			_ = db.Close()
@@ -55,7 +55,7 @@ func setupPebbleDB(
 		return nil, fmt.Errorf("failed to open db: %w", err)
 	}
 	// On any later failure here (migrations/GC), close the freshly-opened db; on success the
-	// caller (newNode) owns it and tears it down via node.Close().
+	// caller (newNode) owns it and tears it down via node.close().
 	defer func() {
 		if err != nil {
 			_ = db.Close()

--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -67,6 +67,22 @@ func syncContractEvents(
 		eventsyncer.WithLogger(logger),
 	)
 
+	// load & parse local events yaml if exists, otherwise sync from contract
+	if len(cfg.LocalEventsPath) != 0 {
+		localEvents, err := localevents.Load(cfg.LocalEventsPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load local events: %w", err)
+		}
+
+		if err := eventHandler.HandleLocalEvents(ctx, localEvents); err != nil {
+			return nil, nil, fmt.Errorf("error occurred while running event data handler: %w", err)
+		}
+
+		// No ongoing sync in local-events mode.
+		return eventSyncer, nil, nil
+	}
+
+	// Determine the block to resume contract sync from.
 	fromBlock, found, err := nodeStorage.GetLastProcessedBlock(nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("syncing registry contract events failed, could not get last processed block: %w", err)
@@ -80,82 +96,67 @@ func syncContractEvents(
 		fromBlock = new(big.Int).SetUint64(fromBlock.Uint64() + 1)
 	}
 
-	// Set only on the contract-sync path below; nil in local-events mode (no ongoing sync there).
-	var startOngoingSync func(context.Context) error
-
-	// load & parse local events yaml if exists, otherwise sync from contract
-	if len(cfg.LocalEventsPath) != 0 {
-		localEvents, err := localevents.Load(cfg.LocalEventsPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load local events: %w", err)
-		}
-
-		if err := eventHandler.HandleLocalEvents(ctx, localEvents); err != nil {
-			return nil, nil, fmt.Errorf("error occurred while running event data handler: %w", err)
-		}
-	} else {
-		// Sync historical registry events.
-		logger.Debug("syncing historical registry events", zap.Uint64("fromBlock", fromBlock.Uint64()))
-		lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, fromBlock.Uint64())
-		switch {
-		case errors.Is(err, executionclient.ErrNothingToSync):
-			// Nothing was synced, keep fromBlock as is.
-			logger.Info("finished syncing historical events, nothing to sync",
-				zap.Uint64("from_block", fromBlock.Uint64()),
-			)
-		case err == nil:
-			// Successfully synced up to a fresh block, advance fromBlock to the block after lastProcessedBlock.
-			logger.Info("finished syncing historical events to a fresh block",
-				zap.Uint64("from_block", fromBlock.Uint64()),
-				zap.Uint64("last_processed_block", lastProcessedBlock),
-			)
-			fromBlock = new(big.Int).SetUint64(lastProcessedBlock + 1)
-		default:
-			return nil, nil, fmt.Errorf("failed to sync historical registry events: %w", err)
-		}
-
-		// Print registry stats.
-		shares := nodeStorage.Shares().List(nil)
-		operators, err := nodeStorage.ListOperatorsAll(nil)
-		if err != nil {
-			logger.Error("failed to get operators", zap.Error(err))
-		}
-
-		operatorValidators := 0
-		liquidatedValidators := 0
-		operatorID := operatorDataStore.GetOperatorID()
-		if operatorDataStore.OperatorIDReady() {
-			for _, share := range shares {
-				if share.BelongsToOperator(operatorID) {
-					operatorValidators++
-				}
-				if share.Liquidated {
-					liquidatedValidators++
-				}
-			}
-		}
-		logger.Info("historical registry sync stats",
-			zap.Uint64("my_operator_id", operatorID),
-			zap.Int("operators", len(operators)),
-			zap.Int("validators", len(shares)),
-			zap.Int("liquidated_validators", liquidatedValidators),
-			zap.Int("my_validators", operatorValidators),
+	// Sync historical registry events.
+	logger.Debug("syncing historical registry events", zap.Uint64("fromBlock", fromBlock.Uint64()))
+	lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, fromBlock.Uint64())
+	switch {
+	case errors.Is(err, executionclient.ErrNothingToSync):
+		// Nothing was synced, keep fromBlock as is.
+		logger.Info("finished syncing historical events, nothing to sync",
+			zap.Uint64("from_block", fromBlock.Uint64()),
 		)
+	case err == nil:
+		// Successfully synced up to a fresh block, advance fromBlock to the block after lastProcessedBlock.
+		logger.Info("finished syncing historical events to a fresh block",
+			zap.Uint64("from_block", fromBlock.Uint64()),
+			zap.Uint64("last_processed_block", lastProcessedBlock),
+		)
+		fromBlock = new(big.Int).SetUint64(lastProcessedBlock + 1)
+	default:
+		return nil, nil, fmt.Errorf("failed to sync historical registry events: %w", err)
+	}
 
-		// Sync ongoing registry events; the node must terminate if this stops. It can't operate
-		// without staying current with Ethereum events, and until reorg handling exists, restarting
-		// from persisted state is safer than continuing on possibly-incorrect state. A clean ctx
-		// cancellation returns nil; any other error is returned as a startupError carrying
-		// last_processed_block.
-		startOngoingSync = func(ctx context.Context) error {
-			if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
-				return startupError{
-					err:    fmt.Errorf("failed syncing ongoing registry events: %w", err),
-					fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
-				}
+	// Print registry stats.
+	shares := nodeStorage.Shares().List(nil)
+	operators, err := nodeStorage.ListOperatorsAll(nil)
+	if err != nil {
+		logger.Error("failed to get operators", zap.Error(err))
+	}
+
+	operatorValidators := 0
+	liquidatedValidators := 0
+	operatorID := operatorDataStore.GetOperatorID()
+	if operatorDataStore.OperatorIDReady() {
+		for _, share := range shares {
+			if share.BelongsToOperator(operatorID) {
+				operatorValidators++
 			}
-			return nil
+			if share.Liquidated {
+				liquidatedValidators++
+			}
 		}
+	}
+	logger.Info("historical registry sync stats",
+		zap.Uint64("my_operator_id", operatorID),
+		zap.Int("operators", len(operators)),
+		zap.Int("validators", len(shares)),
+		zap.Int("liquidated_validators", liquidatedValidators),
+		zap.Int("my_validators", operatorValidators),
+	)
+
+	// Sync ongoing registry events; the node must terminate if this stops. It can't operate
+	// without staying current with Ethereum events, and until reorg handling exists, restarting
+	// from persisted state is safer than continuing on possibly-incorrect state. A clean ctx
+	// cancellation returns nil; any other error is returned as a startupError carrying
+	// last_processed_block.
+	startOngoingSync := func(ctx context.Context) error {
+		if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
+			return startupError{
+				err:    fmt.Errorf("failed syncing ongoing registry events: %w", err),
+				fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
+			}
+		}
+		return nil
 	}
 
 	return eventSyncer, startOngoingSync, nil

--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -20,10 +20,10 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 )
 
-// syncContractEvents blocks until historical events are synced, then returns the event syncer along
-// with a start-func for ongoing event sync (nil in local-events mode). The caller runs the start-func
-// as a long-lived errgroup member so an ongoing-sync failure returns up to the single top-level Fatal
-// (with Close running) instead of os.Exit-ing the process from inside a goroutine.
+// syncContractEvents blocks until historical events are synced, then returns the event syncer plus a
+// start-func for ongoing event sync (nil in local-events mode). The caller runs the start-func as an
+// errgroup member, so an ongoing-sync failure surfaces up to the top-level Fatal instead of
+// os.Exit-ing from a goroutine.
 func syncContractEvents(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -81,8 +81,7 @@ func syncContractEvents(
 		fromBlock = new(big.Int).SetUint64(fromBlock.Uint64() + 1)
 	}
 
-	// Set only in the contract-sync path below; stays nil in local-events mode, where there is no
-	// ongoing sync to run.
+	// Set only on the contract-sync path below; nil in local-events mode (no ongoing sync there).
 	var startOngoingSync func(context.Context) error
 
 	// load & parse local events yaml if exists, otherwise sync from contract
@@ -144,12 +143,11 @@ func syncContractEvents(
 			zap.Int("my_validators", operatorValidators),
 		)
 
-		// Sync ongoing registry events. Terminate the node if it stops: the node can't operate without
+		// Sync ongoing registry events; terminate the node if it stops. The node can't operate without
 		// staying current with Ethereum events, and until reorg handling exists, restarting from
 		// persisted state is safer than continuing on possibly-incorrect state. A clean ctx
-		// cancellation (normal shutdown) returns nil; any other failure returns up to the single
-		// top-level Fatal (with Close running). startupError carries last_processed_block so that
-		// context is preserved through the returned-error path.
+		// cancellation returns nil; any other error surfaces up to the top-level Fatal, with
+		// last_processed_block preserved via startupError.
 		startOngoingSync = func(ctx context.Context) error {
 			if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
 				return startupError{

--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -21,9 +21,8 @@ import (
 )
 
 // syncContractEvents blocks until historical events are synced, then returns the event syncer plus a
-// start-func for ongoing event sync (nil in local-events mode). The caller runs the start-func as an
-// errgroup member, so an ongoing-sync failure surfaces up to the top-level Fatal instead of
-// os.Exit-ing from a goroutine.
+// start-func for ongoing event sync (nil in local-events mode). The start-func runs until a clean
+// ctx cancellation (→ nil) or a sync failure (→ a startupError carrying last_processed_block).
 func syncContractEvents(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -143,11 +142,11 @@ func syncContractEvents(
 			zap.Int("my_validators", operatorValidators),
 		)
 
-		// Sync ongoing registry events; terminate the node if it stops. The node can't operate without
-		// staying current with Ethereum events, and until reorg handling exists, restarting from
-		// persisted state is safer than continuing on possibly-incorrect state. A clean ctx
-		// cancellation returns nil; any other error surfaces up to the top-level Fatal, with
-		// last_processed_block preserved via startupError.
+		// Sync ongoing registry events; the node must terminate if this stops. It can't operate
+		// without staying current with Ethereum events, and until reorg handling exists, restarting
+		// from persisted state is safer than continuing on possibly-incorrect state. A clean ctx
+		// cancellation returns nil; any other error is returned as a startupError carrying
+		// last_processed_block.
 		startOngoingSync = func(ctx context.Context) error {
 			if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
 				return startupError{

--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -20,7 +20,10 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 )
 
-// syncContractEvents blocks until historical events are synced and then spawns a goroutine syncing ongoing events.
+// syncContractEvents blocks until historical events are synced, then returns the event syncer along
+// with a start-func for ongoing event sync (nil in local-events mode). The caller runs the start-func
+// as a long-lived errgroup member so an ongoing-sync failure returns up to the single top-level Fatal
+// (with Close running) instead of os.Exit-ing the process from inside a goroutine.
 func syncContractEvents(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -32,15 +35,15 @@ func syncContractEvents(
 	operatorDataStore operatordatastore.OperatorDataStore,
 	keyManager ekm.KeyManager,
 	doppelgangerHandler eventhandler.DoppelgangerProvider,
-) (*eventsyncer.EventSyncer, error) {
+) (*eventsyncer.EventSyncer, func(context.Context) error, error) {
 	eventFilterer, err := executionClient.Filterer()
 	if err != nil {
-		return nil, fmt.Errorf("failed to set up event filterer: %w", err)
+		return nil, nil, fmt.Errorf("failed to set up event filterer: %w", err)
 	}
 
 	eventParser, err := eventparser.New(eventFilterer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create event parser: %w", err)
+		return nil, nil, fmt.Errorf("failed to create event parser: %w", err)
 	}
 
 	eventHandler, err := eventhandler.New(
@@ -55,7 +58,7 @@ func syncContractEvents(
 		eventhandler.WithLogger(logger),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup event data handler: %w", err)
+		return nil, nil, fmt.Errorf("failed to setup event data handler: %w", err)
 	}
 
 	eventSyncer := eventsyncer.New(
@@ -67,26 +70,30 @@ func syncContractEvents(
 
 	fromBlock, found, err := nodeStorage.GetLastProcessedBlock(nil)
 	if err != nil {
-		return nil, fmt.Errorf("syncing registry contract events failed, could not get last processed block: %w", err)
+		return nil, nil, fmt.Errorf("syncing registry contract events failed, could not get last processed block: %w", err)
 	}
 	if !found {
 		fromBlock = networkConfig.RegistrySyncOffset
 	} else if fromBlock == nil {
-		return nil, fmt.Errorf("syncing registry contract events failed, last processed block is nil")
+		return nil, nil, fmt.Errorf("syncing registry contract events failed, last processed block is nil")
 	} else {
 		// Start syncing from the next block.
 		fromBlock = new(big.Int).SetUint64(fromBlock.Uint64() + 1)
 	}
 
+	// Set only in the contract-sync path below; stays nil in local-events mode, where there is no
+	// ongoing sync to run.
+	var startOngoingSync func(context.Context) error
+
 	// load & parse local events yaml if exists, otherwise sync from contract
 	if len(cfg.LocalEventsPath) != 0 {
 		localEvents, err := localevents.Load(cfg.LocalEventsPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load local events: %w", err)
+			return nil, nil, fmt.Errorf("failed to load local events: %w", err)
 		}
 
 		if err := eventHandler.HandleLocalEvents(ctx, localEvents); err != nil {
-			return nil, fmt.Errorf("error occurred while running event data handler: %w", err)
+			return nil, nil, fmt.Errorf("error occurred while running event data handler: %w", err)
 		}
 	} else {
 		// Sync historical registry events.
@@ -106,7 +113,7 @@ func syncContractEvents(
 			)
 			fromBlock = new(big.Int).SetUint64(lastProcessedBlock + 1)
 		default:
-			return nil, fmt.Errorf("failed to sync historical registry events: %w", err)
+			return nil, nil, fmt.Errorf("failed to sync historical registry events: %w", err)
 		}
 
 		// Print registry stats.
@@ -137,19 +144,22 @@ func syncContractEvents(
 			zap.Int("my_validators", operatorValidators),
 		)
 
-		// Sync ongoing registry events in the background. Crash if it stops: the node can't operate
-		// without staying current with Ethereum events, and until reorg handling exists, restarting
-		// from persisted state is safer than continuing on possibly-incorrect state.
-		go func() {
-			err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64())
-			if err != nil && !errors.Is(err, context.Canceled) {
-				logger.Fatal("failed syncing ongoing registry events",
-					zap.Uint64("last_processed_block", lastProcessedBlock),
-					zap.Error(err),
-				)
+		// Sync ongoing registry events. Terminate the node if it stops: the node can't operate without
+		// staying current with Ethereum events, and until reorg handling exists, restarting from
+		// persisted state is safer than continuing on possibly-incorrect state. A clean ctx
+		// cancellation (normal shutdown) returns nil; any other failure returns up to the single
+		// top-level Fatal (with Close running). startupError carries last_processed_block so that
+		// context is preserved through the returned-error path.
+		startOngoingSync = func(ctx context.Context) error {
+			if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
+				return startupError{
+					err:    fmt.Errorf("failed syncing ongoing registry events: %w", err),
+					fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
+				}
 			}
-		}()
+			return nil
+		}
 	}
 
-	return eventSyncer, nil
+	return eventSyncer, startOngoingSync, nil
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -511,6 +511,11 @@ func (n *node) start() error {
 	defer cancel()
 	g, gctx := errgroup.WithContext(ctx)
 
+	// The metrics server starts here but its serveErr is buffered (cap 1) and only joined in
+	// runServices, after historical event sync — which can take a long time on a fresh node. A serve
+	// crash during that window is surfaced when runServices reads the channel, not immediately. That
+	// delay is acceptable: the metrics server is diagnostic, and deferring the crash keeps a long,
+	// resumable sync from being aborted by a non-critical server.
 	var metricsServeErr <-chan error
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
@@ -640,6 +645,11 @@ func (n *node) runServices(
 	healthProber *hprobe.HealthProber,
 	startOngoingSync func(context.Context) error,
 ) error {
+	// Both HTTP servers were started with gctx, so their ctx-aware Shutdown watcher fires on cancel
+	// and closes serveErr (http.Server.Serve returns ErrServerClosed as soon as the listener closes,
+	// independent of connection draining). A plain receive therefore can't wedge g.Wait() — unlike
+	// the WS server in the operator package, whose shutdown is bound to a different ctx and so needs
+	// an explicit gctx-escape select.
 	if metricsServeErr != nil {
 		g.Go(func() error {
 			if err := <-metricsServeErr; err != nil {

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -175,16 +175,6 @@ type beaconClient interface {
 
 var _ beaconClient = (*goclient.GoClient)(nil)
 
-// operatorNode is the operator.Node surface that start() drives: Start (run as a long-lived
-// errgroup member) plus HealthCheck (wired into the metrics handler as its health checker). It's a
-// seam so the normal-shutdown invariant can be unit-tested with a stub in place of a real *operator.Node.
-type operatorNode interface {
-	Start(context.Context) error
-	HealthCheck() error
-}
-
-var _ operatorNode = (*operator.Node)(nil)
-
 // node bundles the constructed pieces that start() runs and Close() tears down.
 type node struct {
 	ctx    context.Context
@@ -210,7 +200,7 @@ type node struct {
 	storageMap          *ibftstorage.ParticipantStores
 	collector           *dutytracer.Collector
 	p2pNetwork          network.P2PNetwork
-	operatorNode        operatorNode
+	operatorNode        *operator.Node
 }
 
 // newNode wires the node's components from config + the injected beacon/EL clients. On any
@@ -500,20 +490,18 @@ func (n *node) Close() error {
 // start launches the node's long-lived services (metrics + SSV API servers, the health prober,
 // contract-event sync) and blocks until the node's ctx is canceled or the first service fails.
 //
-// All long-lived services join an errgroup bound to a child of the node's ctx. The first failure
-// cancels gctx — which tears down the HTTP servers via their ctx-aware Shutdown watchers — and
-// surfaces as the group error; a plain ctx cancellation has every service return nil, so a clean
-// shutdown returns nil. The synchronous bring-up below returns its errors directly; the defer
-// cancel() then unwinds any service already started. Every failure path thus returns up through
-// runNode() to the single top-level Fatal, with node.Close() running on the way out.
+// All long-lived services join an errgroup derived from the node's ctx. The first failure cancels
+// gctx — which tears down the HTTP servers via their ctx-aware Shutdown watchers — and surfaces as
+// the group error; a plain ctx cancellation has every service return nil, so a clean shutdown
+// returns nil. The synchronous bring-up below returns its errors directly; an already-started HTTP
+// server is then torn down by node.Close() (deferred in runNode, which cancels the node ctx). Every
+// failure path thus returns up through runNode() to the single top-level Fatal, with Close() running.
 func (n *node) start() error {
-	ctx, cancel := context.WithCancel(n.ctx)
-	defer cancel()
-	g, gctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(n.ctx)
 
-	// The metrics server starts here but its serveErr is buffered (cap 1) and only joined in
-	// runServices, after historical event sync — which can take a long time on a fresh node. A serve
-	// crash during that window is surfaced when runServices reads the channel, not immediately. That
+	// The metrics server starts here but its serveErr is buffered (cap 1) and only joined into the
+	// errgroup below, after historical event sync — which can take a long time on a fresh node. A
+	// serve crash during that window surfaces when the join reads the channel, not immediately. That
 	// delay is acceptable: the metrics server is diagnostic, and deferring the crash keeps a long,
 	// resumable sync from being aborted by a non-critical server.
 	var metricsServeErr <-chan error
@@ -627,29 +615,13 @@ func (n *node) start() error {
 		apiServeErr = serveErr
 	}
 
-	return n.runServices(g, gctx, metricsServeErr, apiServeErr, healthProber, startOngoingSync)
-}
-
-// runServices joins the node's long-lived services into the errgroup and blocks until the first one
-// fails or gctx is canceled. The two HTTP serve loops join via their serveErr channels (nil channel
-// = server disabled), each yielding nil when the server shuts down cleanly (channel closed) or the
-// serve error otherwise; the health prober and the ongoing event sync (nil = local-events mode) join
-// directly; and operatorNode.Start runs as a member too — never returned ahead of g.Wait(), so its
-// failure is awaited alongside the rest rather than skipping the group. The first non-nil return
-// cancels gctx (unwinding the HTTP servers and the other members) and is returned to start().
-func (n *node) runServices(
-	g *errgroup.Group,
-	gctx context.Context,
-	metricsServeErr <-chan error,
-	apiServeErr <-chan error,
-	healthProber *hprobe.HealthProber,
-	startOngoingSync func(context.Context) error,
-) error {
-	// Both HTTP servers were started with gctx, so their ctx-aware Shutdown watcher fires on cancel
-	// and closes serveErr (http.Server.Serve returns ErrServerClosed as soon as the listener closes,
-	// independent of connection draining). A plain receive therefore can't wedge g.Wait() — unlike
-	// the WS server in the operator package, whose shutdown is bound to a different ctx and so needs
-	// an explicit gctx-escape select.
+	// Join the long-lived services into the errgroup and block until the first fails or gctx is
+	// canceled (clean shutdown → every service returns nil → nil). operatorNode.Start runs as a
+	// member too — never returned ahead of g.Wait(), so its failure is awaited alongside the rest.
+	// Both HTTP servers were started with gctx, so their ctx-aware Shutdown closes serveErr on cancel
+	// (Serve returns ErrServerClosed once the listener closes), and a plain receive can't wedge
+	// g.Wait() — unlike the WS server in the operator package, whose shutdown is bound to a different
+	// ctx and so needs an explicit gctx-escape select.
 	if metricsServeErr != nil {
 		g.Go(func() error {
 			if err := <-metricsServeErr; err != nil {

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	hexporter "github.com/ssvlabs/ssv/api/handlers/exporter"
 	hnode "github.com/ssvlabs/ssv/api/handlers/node"
@@ -174,6 +175,16 @@ type beaconClient interface {
 
 var _ beaconClient = (*goclient.GoClient)(nil)
 
+// operatorNode is the operator.Node surface that start() drives: Start (run as a long-lived
+// errgroup member) plus HealthCheck (wired into the metrics handler as its health checker). It's a
+// seam so the normal-shutdown invariant can be unit-tested with a stub in place of a real *operator.Node.
+type operatorNode interface {
+	Start(context.Context) error
+	HealthCheck() error
+}
+
+var _ operatorNode = (*operator.Node)(nil)
+
 // node bundles the constructed pieces that start() runs and Close() tears down.
 type node struct {
 	ctx    context.Context
@@ -199,7 +210,7 @@ type node struct {
 	storageMap          *ibftstorage.ParticipantStores
 	collector           *dutytracer.Collector
 	p2pNetwork          network.P2PNetwork
-	operatorNode        *operator.Node
+	operatorNode        operatorNode
 }
 
 // newNode wires the node's components from config + the injected beacon/EL clients. On any
@@ -486,33 +497,39 @@ func (n *node) Close() error {
 	return errors.Join(errs...)
 }
 
-// start launches the node's long-lived services (metrics + SSV API servers, the health
-// prober, contract-event sync) and blocks on operatorNode.Start until the node's ctx is canceled.
-// NOTE: the metrics/SSV-API server goroutines call logger.Fatal on failure — crashing the
-// process and bypassing Close() — a candidate for errgroup-based coordinated shutdown.
+// start launches the node's long-lived services (metrics + SSV API servers, the health prober,
+// contract-event sync) and blocks until the node's ctx is canceled or the first service fails.
+//
+// All long-lived services join an errgroup bound to a child of the node's ctx. The first failure
+// cancels gctx — which tears down the HTTP servers via their ctx-aware Shutdown watchers — and
+// surfaces as the group error; a plain ctx cancellation has every service return nil, so a clean
+// shutdown returns nil. The synchronous bring-up below returns its errors directly; the defer
+// cancel() then unwinds any service already started. Every failure path thus returns up through
+// runNode() to the single top-level Fatal, with node.Close() running on the way out.
 func (n *node) start() error {
+	ctx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+	g, gctx := errgroup.WithContext(ctx)
+
+	var metricsServeErr <-chan error
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
-		_, metricsServeErr, err := metricsHandler.Start(n.ctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
+		_, serveErr, err := metricsHandler.Start(gctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
 		if err != nil {
-			n.logger.Fatal("failed to start metrics server", zap.Error(err))
+			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
-		go func() {
-			if err := <-metricsServeErr; err != nil {
-				n.logger.Fatal("metrics server serve loop exited", zap.Error(err))
-			}
-		}()
+		metricsServeErr = serveErr
 	}
 
 	healthProber := hprobe.NewHealthProber(n.logger)
 	healthProber.AddComponent(clComponentName, n.consensusClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
 	healthProber.AddComponent(elComponentName, n.executionClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
-	if err := ensureComponentsHealthy(n.ctx, n.logger, healthProber); err != nil {
+	if err := ensureComponentsHealthy(gctx, n.logger, healthProber); err != nil {
 		return err
 	}
 
-	eventSyncer, err := syncContractEvents(
-		n.ctx,
+	eventSyncer, startOngoingSync, err := syncContractEvents(
+		gctx,
 		n.logger,
 		n.cfg,
 		n.executionClient,
@@ -530,14 +547,12 @@ func (n *node) start() error {
 		healthProber.AddComponent(eventSyncerComponentName, eventSyncer, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
 	}
 
-	go startHealthProber(n.ctx, n.logger, healthProber)
-
-	if _, err := n.metadataSyncer.SyncAll(n.ctx); err != nil {
+	if _, err := n.metadataSyncer.SyncAll(gctx); err != nil {
 		return fmt.Errorf("failed to sync metadata on startup: %w", err)
 	}
 
 	if n.usingSSVSigner {
-		if err := ensureNoMissingKeys(n.ctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
+		if err := ensureNoMissingKeys(gctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
 			return err
 		}
 	}
@@ -577,6 +592,7 @@ func (n *node) start() error {
 		return err
 	}
 
+	var apiServeErr <-chan error
 	if n.cfg.SSVAPIPort > 0 {
 		warnIfSSVAPIAddressUnset(n.logger, n.cfg.SSVAPIAddress, n.cfg.SSVAPIPort)
 		apiServer := apiserver.New(
@@ -599,21 +615,63 @@ func (n *node) start() error {
 			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore()),
 			n.mode == modeExporterArchive,
 		)
-		_, apiServeErr, err := apiServer.Start(n.ctx)
+		_, serveErr, err := apiServer.Start(gctx)
 		if err != nil {
-			n.logger.Fatal("failed to start API server", zap.Error(err))
+			return fmt.Errorf("failed to start API server: %w", err)
 		}
-		go func() {
-			if err := <-apiServeErr; err != nil {
-				n.logger.Fatal("API server serve loop exited", zap.Error(err))
-			}
-		}()
-	}
-	if err := n.operatorNode.Start(n.ctx); err != nil {
-		return fmt.Errorf("failed to start SSV node: %w", err)
+		apiServeErr = serveErr
 	}
 
-	return nil
+	return n.runServices(g, gctx, metricsServeErr, apiServeErr, healthProber, startOngoingSync)
+}
+
+// runServices joins the node's long-lived services into the errgroup and blocks until the first one
+// fails or gctx is canceled. The two HTTP serve loops join via their serveErr channels (nil channel
+// = server disabled), each yielding nil when the server shuts down cleanly (channel closed) or the
+// serve error otherwise; the health prober and the ongoing event sync (nil = local-events mode) join
+// directly; and operatorNode.Start runs as a member too — never returned ahead of g.Wait(), so its
+// failure is awaited alongside the rest rather than skipping the group. The first non-nil return
+// cancels gctx (unwinding the HTTP servers and the other members) and is returned to start().
+func (n *node) runServices(
+	g *errgroup.Group,
+	gctx context.Context,
+	metricsServeErr <-chan error,
+	apiServeErr <-chan error,
+	healthProber *hprobe.HealthProber,
+	startOngoingSync func(context.Context) error,
+) error {
+	if metricsServeErr != nil {
+		g.Go(func() error {
+			if err := <-metricsServeErr; err != nil {
+				return fmt.Errorf("metrics server serve loop exited: %w", err)
+			}
+			return nil
+		})
+	}
+	if apiServeErr != nil {
+		g.Go(func() error {
+			if err := <-apiServeErr; err != nil {
+				return fmt.Errorf("API server serve loop exited: %w", err)
+			}
+			return nil
+		})
+	}
+	g.Go(func() error {
+		return startHealthProber(gctx, n.logger, healthProber)
+	})
+	if startOngoingSync != nil {
+		g.Go(func() error {
+			return startOngoingSync(gctx)
+		})
+	}
+	g.Go(func() error {
+		if err := n.operatorNode.Start(gctx); err != nil {
+			return fmt.Errorf("failed to start SSV node: %w", err)
+		}
+		return nil
+	})
+
+	return g.Wait()
 }
 
 // startNetwork wires validator stats into the p2p layer, then sets up + starts the network and

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -329,7 +329,7 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 	var newDecidedHandler qbftcontroller.NewDecidedHandler
 	var decidedStreamPublisherFn func(dutytracer.DecidedInfo)
 	if cfg.WsAPIPort != 0 {
-		ws := exporterapi.NewWsServer(ctx, logger, nil, http.NewServeMux(), cfg.WithPing, fmt.Sprintf(":%d", cfg.WsAPIPort))
+		ws := exporterapi.NewWsServer(logger, nil, http.NewServeMux(), cfg.WithPing, fmt.Sprintf(":%d", cfg.WsAPIPort))
 		cfg.SSVOptions.WS = ws
 		newDecidedHandler = decided.NewStreamPublisher(logger, networkConfig.DomainType, ws)
 		decidedStreamPublisherFn = decided.NewDecidedListener(logger, networkConfig.DomainType, ws, nodeStorage.ValidatorStore())
@@ -504,8 +504,7 @@ func (n *node) start() error {
 			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
 		// Plain receive is safe: the server's gctx-bound Shutdown closes serveErr on cancel, so this
-		// can't wedge g.Wait(). The operator-package WS loop needs a gctx-escape select only because
-		// its shutdown ctx differs.
+		// can't wedge g.Wait().
 		g.Go(func() error {
 			if err := <-metricsServeErr; err != nil {
 				return fmt.Errorf("metrics server serve loop exited: %w", err)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -14,7 +14,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	hexporter "github.com/ssvlabs/ssv/api/handlers/exporter"
 	hnode "github.com/ssvlabs/ssv/api/handlers/node"
@@ -55,12 +54,21 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
+// shutdownGraceTimeout bounds the whole graceful teardown — services unwinding plus the node close —
+// once the first terminal event has landed. Past it teardown gives up and surfaces the terminal
+// cause instead of hanging forever on something ignoring the cancellation convention; the leftovers
+// are reaped at process exit. 15s is generous against the designed sub-second unwind and leaves
+// room ahead of orchestrator kill grace.
+const shutdownGraceTimeout = 15 * time.Second
+
 func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
-	// runNode owns the parent ctx for the clients it builds directly (goclient, execution) before
-	// newNode exists. goclient has no Close() of its own — ctx cancellation is its only shutdown —
-	// so cancel on return to release it once the node has stopped and we unwind.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// runNode owns the root ctx everything below binds to: the clients it builds directly (goclient,
+	// execution — goclient has no Close() of its own, ctx cancellation is its only shutdown), the
+	// goroutines newNode wires, and the long-lived services. It dies on the first terminal event,
+	// carrying it as the cause: a service or bring-up failure (→ that error), or a deliberate stop
+	// (the parent canceled on a shutdown signal → context.Canceled).
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
 
 	// Validate the configuration up front, before any network I/O, so a misconfigured node
 	// fails fast (e.g. an invalid ProposerDelay is rejected before the beacon client is built,
@@ -154,19 +162,51 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 		_ = executionClient.Close()
 		return err
 	}
-	defer func() {
+	// Every long-lived service runs through spawn: the first to fail cancels ctx with its error as
+	// the cause, telling everything else to stop.
+	var wg sync.WaitGroup
+	spawn := func(service func() error) {
+		wg.Go(func() {
+			if err := service(); err != nil {
+				cancel(err)
+			}
+		})
+	}
+
+	if err := n.start(ctx, spawn); err != nil {
+		cancel(err) // a bring-up failure is a terminal event too (the first cause wins)
+	}
+
+	// Block until the first terminal event, then run the whole graceful teardown — services
+	// unwinding, then Close releasing the resources they were using — under one grace window:
+	// something ignoring cancellation must not hang teardown forever, so past the window give up
+	// and surface the cause (the leftovers are reaped at process exit).
+	<-ctx.Done()
+	cause := context.Cause(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
 		if err := n.Close(); err != nil {
 			logger.Error("could not cleanly close node", zap.Error(err))
 		}
+		close(done)
 	}()
+	select {
+	case <-done:
+	case <-time.After(shutdownGraceTimeout):
+		return fmt.Errorf("graceful shutdown timed out after %s: %w", shutdownGraceTimeout, cause)
+	}
 
-	return n.start()
+	// The cause may be context.Canceled (a deliberate stop) — the caller classifies it off its
+	// signal ctx.
+	return cause
 }
 
-// beaconClient is the beacon-node surface that newNode()/start() consume: the duty-call
-// interface plus the Healthy probe used to register it as a health-prober component. runNode()
-// passes in a *goclient.GoClient as this interface, so an in-process smoke test can inject a
-// stub instead of a real beacon connection.
+// beaconClient is the beacon-node surface the node consumes: the duty-call interface plus the
+// Healthy probe used to register it as a health-prober component. An interface (satisfied by
+// *goclient.GoClient) so an in-process smoke test can inject a stub instead of a real beacon
+// connection.
 type beaconClient interface {
 	beaconprotocol.BeaconNode
 	doppelganger.BeaconNode // adds ValidatorLiveness, required by doppelganger.NewHandler
@@ -175,11 +215,8 @@ type beaconClient interface {
 
 var _ beaconClient = (*goclient.GoClient)(nil)
 
-// node bundles the constructed pieces that start() runs and Close() tears down.
+// node bundles the constructed pieces that start() brings up and Close() tears down.
 type node struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-
 	logger *zap.Logger
 
 	cfg            *config
@@ -205,21 +242,20 @@ type node struct {
 
 // newNode wires the node's components from config + the injected beacon/EL clients. On any
 // error it closes whatever it already opened (db/p2p) via the error-only defers below; on
-// success the returned *node owns those closers (runNode() defers n.Close()). It mutates cfg
+// success the returned *node owns those closers, released via node.Close(). Goroutines wired
+// here (the VRSubmitter; in exporter modes the duty-trace collector / slot-pruning) bind to ctx:
+// cancel it before Close, so they've stopped using the resources Close releases. It mutates cfg
 // in place (filling SSVOptions/P2pNetworkConfig with runtime deps), so a given cfg is single-use.
-func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved, networkConfig *networkconfig.Network, consensusClient beaconClient, executionClient executionclient.Provider) (_ *node, err error) {
+func newNode(
+	ctx context.Context,
+	cfg *config,
+	logger *zap.Logger,
+	res resolved,
+	networkConfig *networkconfig.Network,
+	consensusClient beaconClient,
+	executionClient executionclient.Provider,
+) (_ *node, err error) {
 	usingSSVSigner := res.usingSSVSigner
-
-	// Derive the node's own ctx from the parent so node.Close() can stop the ctx-bound goroutines
-	// wired below — the VRSubmitter, plus (in exporter modes) the duty-trace collector / slot-pruning.
-	// On assembly failure cancel here so a half-wired node doesn't leak the ctx-bound ones; on success
-	// Close() owns it.
-	ctx, cancel := context.WithCancel(ctx)
-	defer func() {
-		if err != nil {
-			cancel()
-		}
-	}()
 
 	identity, err := resolveOperatorIdentity(ctx, logger, cfg, res)
 	if err != nil {
@@ -440,8 +476,6 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 	operatorNode := operator.New(logger, cfg.SSVOptions, cfg.ExporterOptions, slotTickerProvider, storageMap)
 
 	return &node{
-		ctx:                 ctx,
-		cancel:              cancel,
 		logger:              logger,
 		cfg:                 cfg,
 		mode:                res.mode,
@@ -464,13 +498,12 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 	}, nil
 }
 
-// Close stops the node's background work and tears down its resources. It cancels the node's ctx
-// (stopping the VRSubmitter and, in exporter modes, the duty-trace collector / slot-pruning) and
-// calls validatorCtrl.Stop() (the controller's ttlcache cleanup loops, which aren't ctx-bound), then
-// closes the CLI-owned resources (p2p network and execution client, then the db that p2p depends on).
-// newNode is the only constructor, so all these fields are always set.
+// Close tears down the node's resources: validatorCtrl.Stop() (the controller's ttlcache cleanup
+// loops, which aren't ctx-bound), then the CLI-owned resources (p2p network and execution client,
+// then the db that p2p depends on). The ctx given to newNode must be canceled first, so the
+// ctx-bound goroutines have stopped using these resources. newNode is the only constructor, so all
+// these fields are always set.
 func (n *node) Close() error {
-	n.cancel()
 	n.validatorCtrl.Stop()
 
 	var errs []error
@@ -486,26 +519,20 @@ func (n *node) Close() error {
 	return errors.Join(errs...)
 }
 
-// start launches the node's long-lived services and blocks until the node's ctx is canceled (clean
-// shutdown → nil) or the first service fails (→ that error). Every failure path returns up through
-// runNode() to the single top-level Fatal, with node.Close() running on the way out.
-func (n *node) start() error {
-	// The long-lived members below run on gctx, so any one's failure cancels it and tears the rest
-	// down. On an early return, defer cancel() signals the already-joined members to stop (it doesn't
-	// await them — they wind down alongside runNode's Close()).
-	ctx, cancel := context.WithCancel(n.ctx)
-	defer cancel()
-	g, gctx := errgroup.WithContext(ctx)
-
+// start brings the node up: it runs the synchronous bring-up steps and registers every long-lived
+// service via spawn, returning once the node is up (nil) or a bring-up step has failed (that
+// error). Everything binds to ctx — when it dies, bring-up aborts mid-step and the services stop;
+// the services' terminal errors travel through spawn, not through the return value.
+func (n *node) start(ctx context.Context, spawn func(func() error)) error {
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
-		_, metricsServeErr, err := metricsHandler.Start(gctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
+		_, metricsServeErr, err := metricsHandler.Start(ctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
 		if err != nil {
 			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
-		// Plain receive is safe: the server's gctx-bound Shutdown closes serveErr on cancel, so this
-		// can't wedge g.Wait().
-		g.Go(func() error {
+		// Plain receive is safe: the server's ctx-bound Shutdown closes serveErr on cancel, so this
+		// service can't wedge teardown.
+		spawn(func() error {
 			if err := <-metricsServeErr; err != nil {
 				return fmt.Errorf("metrics server serve loop exited: %w", err)
 			}
@@ -516,12 +543,12 @@ func (n *node) start() error {
 	healthProber := hprobe.NewHealthProber(n.logger)
 	healthProber.AddComponent(clComponentName, n.consensusClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
 	healthProber.AddComponent(elComponentName, n.executionClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
-	if err := ensureComponentsHealthy(n.ctx, n.logger, healthProber); err != nil {
+	if err := ensureComponentsHealthy(ctx, n.logger, healthProber); err != nil {
 		return err
 	}
 
 	eventSyncer, startOngoingSync, err := syncContractEvents(
-		n.ctx,
+		ctx,
 		n.logger,
 		n.cfg,
 		n.executionClient,
@@ -537,58 +564,29 @@ func (n *node) start() error {
 	}
 	if startOngoingSync != nil {
 		healthProber.AddComponent(eventSyncerComponentName, eventSyncer, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
-		g.Go(func() error {
-			return startOngoingSync(gctx)
+		spawn(func() error {
+			return startOngoingSync(ctx)
 		})
 	}
 
-	if _, err := n.metadataSyncer.SyncAll(n.ctx); err != nil {
+	if _, err := n.metadataSyncer.SyncAll(ctx); err != nil {
 		return fmt.Errorf("failed to sync metadata on startup: %w", err)
 	}
 
 	if n.usingSSVSigner {
-		if err := ensureNoMissingKeys(n.ctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
+		if err := ensureNoMissingKeys(ctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
 			return err
 		}
 	}
 
-	// Increase MaxPeers if the operator is subscribed to many subnets.
-	// TODO: use OperatorCommittees when it's fixed.
-	if n.cfg.P2pNetworkConfig.DynamicMaxPeers {
-		var (
-			baseMaxPeers        = 60
-			maxPeersLimit       = n.cfg.P2pNetworkConfig.DynamicMaxPeersLimit
-			idealPeersPerSubnet = 3
-		)
-		start := time.Now()
-		myValidators := n.nodeStorage.ValidatorStore().OperatorValidators(n.operatorDataStore.GetOperatorID())
-		mySubnets := networkcommons.Subnets{}
-		myActiveSubnets := 0
-		for _, v := range myValidators {
-			subnet := networkcommons.CommitteeSubnet(v.CommitteeID())
-			if !mySubnets.IsSet(subnet) {
-				mySubnets.Set(subnet)
-				myActiveSubnets++
-			}
-		}
-		idealMaxPeers := min(baseMaxPeers+idealPeersPerSubnet*myActiveSubnets, maxPeersLimit)
-		if n.cfg.P2pNetworkConfig.MaxPeers < idealMaxPeers {
-			n.logger.Warn("increasing MaxPeers to match the operator's subscribed subnets",
-				zap.Int("old_max_peers", n.cfg.P2pNetworkConfig.MaxPeers),
-				zap.Int("new_max_peers", idealMaxPeers),
-				zap.Int("subscribed_subnets", myActiveSubnets),
-				fields.Took(time.Since(start)),
-			)
-			n.cfg.P2pNetworkConfig.MaxPeers = idealMaxPeers
-		}
-	}
+	n.applyDynamicMaxPeers()
 
 	if err := n.startNetwork(healthProber); err != nil {
 		return err
 	}
 	// After startNetwork, so the prober's components (CL/EL, event-syncer, p2p) are all registered.
-	g.Go(func() error {
-		return startHealthProber(gctx, n.logger, healthProber)
+	spawn(func() error {
+		return startHealthProber(ctx, n.logger, healthProber)
 	})
 
 	if n.cfg.SSVAPIPort > 0 {
@@ -613,11 +611,11 @@ func (n *node) start() error {
 			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore()),
 			n.mode == modeExporterArchive,
 		)
-		_, apiServeErr, err := apiServer.Start(gctx)
+		_, apiServeErr, err := apiServer.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to start API server: %w", err)
 		}
-		g.Go(func() error {
+		spawn(func() error {
 			if err := <-apiServeErr; err != nil {
 				return fmt.Errorf("API server serve loop exited: %w", err)
 			}
@@ -625,14 +623,51 @@ func (n *node) start() error {
 		})
 	}
 
-	g.Go(func() error {
-		if err := n.operatorNode.Start(gctx); err != nil {
+	spawn(func() error {
+		if err := n.operatorNode.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start SSV node: %w", err)
 		}
 		return nil
 	})
 
-	return g.Wait()
+	return nil
+}
+
+// applyDynamicMaxPeers raises the configured MaxPeers to match the number of subnets the operator is
+// subscribed to, so a default sized for small operators doesn't starve a large one for peers. No-op
+// unless DynamicMaxPeers is enabled; must run before startNetwork so the network comes up with the
+// raised value.
+// TODO: use OperatorCommittees when it's fixed.
+func (n *node) applyDynamicMaxPeers() {
+	if !n.cfg.P2pNetworkConfig.DynamicMaxPeers {
+		return
+	}
+	var (
+		baseMaxPeers        = 60
+		maxPeersLimit       = n.cfg.P2pNetworkConfig.DynamicMaxPeersLimit
+		idealPeersPerSubnet = 3
+	)
+	start := time.Now()
+	myValidators := n.nodeStorage.ValidatorStore().OperatorValidators(n.operatorDataStore.GetOperatorID())
+	mySubnets := networkcommons.Subnets{}
+	myActiveSubnets := 0
+	for _, v := range myValidators {
+		subnet := networkcommons.CommitteeSubnet(v.CommitteeID())
+		if !mySubnets.IsSet(subnet) {
+			mySubnets.Set(subnet)
+			myActiveSubnets++
+		}
+	}
+	idealMaxPeers := min(baseMaxPeers+idealPeersPerSubnet*myActiveSubnets, maxPeersLimit)
+	if n.cfg.P2pNetworkConfig.MaxPeers < idealMaxPeers {
+		n.logger.Warn("increasing MaxPeers to match the operator's subscribed subnets",
+			zap.Int("old_max_peers", n.cfg.P2pNetworkConfig.MaxPeers),
+			zap.Int("new_max_peers", idealMaxPeers),
+			zap.Int("subscribed_subnets", myActiveSubnets),
+			fields.Took(time.Since(start)),
+		)
+		n.cfg.P2pNetworkConfig.MaxPeers = idealMaxPeers
+	}
 }
 
 // startNetwork wires validator stats into the p2p layer, then sets up + starts the network and

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -329,9 +329,8 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 	var newDecidedHandler qbftcontroller.NewDecidedHandler
 	var decidedStreamPublisherFn func(dutytracer.DecidedInfo)
 	if cfg.WsAPIPort != 0 {
-		ws := exporterapi.NewWsServer(ctx, logger, nil, http.NewServeMux(), cfg.WithPing)
+		ws := exporterapi.NewWsServer(ctx, logger, nil, http.NewServeMux(), cfg.WithPing, fmt.Sprintf(":%d", cfg.WsAPIPort))
 		cfg.SSVOptions.WS = ws
-		cfg.SSVOptions.WsAPIPort = cfg.WsAPIPort
 		newDecidedHandler = decided.NewStreamPublisher(logger, networkConfig.DomainType, ws)
 		decidedStreamPublisherFn = decided.NewDecidedListener(logger, networkConfig.DomainType, ws, nodeStorage.ValidatorStore())
 	}
@@ -487,19 +486,16 @@ func (n *node) Close() error {
 	return errors.Join(errs...)
 }
 
-// start launches the node's long-lived services (metrics + SSV API servers, the health prober,
-// contract-event sync, operatorNode.Start) and blocks until the node's ctx is canceled or the first
-// service fails.
-//
-// Each service joins an errgroup on gctx as it is brought up; the first failure cancels gctx — which
-// tears down the others (and the ctx-aware HTTP servers) — and surfaces as the group error, while a
-// plain ctx cancellation has every service return nil (clean shutdown → nil). The synchronous
-// bring-up steps run on n.ctx, not gctx, so they abort only on actual shutdown: a long resumable step
-// (e.g. historical sync) is not torn down when a non-critical service (e.g. a diagnostic HTTP server)
-// crashes — that error still surfaces, at g.Wait. Every failure path returns up through runNode() to
-// the single top-level Fatal, with node.Close() running on the way out.
+// start launches the node's long-lived services and blocks until the node's ctx is canceled (clean
+// shutdown → nil) or the first service fails (→ that error). Every failure path returns up through
+// runNode() to the single top-level Fatal, with node.Close() running on the way out.
 func (n *node) start() error {
-	g, gctx := errgroup.WithContext(n.ctx)
+	// The long-lived members below run on gctx, so any one's failure cancels it and tears the rest
+	// down. On an early return, defer cancel() signals the already-joined members to stop (it doesn't
+	// await them — they wind down alongside runNode's Close()).
+	ctx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+	g, gctx := errgroup.WithContext(ctx)
 
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
@@ -507,10 +503,9 @@ func (n *node) start() error {
 		if err != nil {
 			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
-		// The serve loops join on gctx with a plain receive: each server's ctx-aware Shutdown closes
-		// serveErr on cancel (Serve returns ErrServerClosed once the listener closes), so this can't
-		// wedge g.Wait() — unlike the operator-package WS loop, whose shutdown ctx differs and so needs
-		// an explicit gctx-escape select.
+		// Plain receive is safe: the server's gctx-bound Shutdown closes serveErr on cancel, so this
+		// can't wedge g.Wait(). The operator-package WS loop needs a gctx-escape select only because
+		// its shutdown ctx differs.
 		g.Go(func() error {
 			if err := <-metricsServeErr; err != nil {
 				return fmt.Errorf("metrics server serve loop exited: %w", err)
@@ -541,9 +536,7 @@ func (n *node) start() error {
 	if err != nil {
 		return err
 	}
-	if len(n.cfg.LocalEventsPath) == 0 {
-		// Contract-sync mode: register the event syncer for health probing and join its ongoing sync
-		// (startOngoingSync is non-nil only on this path).
+	if startOngoingSync != nil {
 		healthProber.AddComponent(eventSyncerComponentName, eventSyncer, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
 		g.Go(func() error {
 			return startOngoingSync(gctx)
@@ -594,8 +587,7 @@ func (n *node) start() error {
 	if err := n.startNetwork(healthProber); err != nil {
 		return err
 	}
-	// The prober joins here — after startNetwork, so all its components (CL/EL, event-syncer, p2p) are
-	// registered. It returns nil on clean cancel and the unhealth error on a watchdog trip.
+	// After startNetwork, so the prober's components (CL/EL, event-syncer, p2p) are all registered.
 	g.Go(func() error {
 		return startHealthProber(gctx, n.logger, healthProber)
 	})
@@ -634,8 +626,6 @@ func (n *node) start() error {
 		})
 	}
 
-	// operatorNode.Start runs as a member too — never returned ahead of g.Wait(), so its failure is
-	// awaited alongside the rest.
 	g.Go(func() error {
 		if err := n.operatorNode.Start(gctx); err != nil {
 			return fmt.Errorf("failed to start SSV node: %w", err)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -61,26 +61,22 @@ import (
 // room ahead of orchestrator kill grace.
 const shutdownGraceTimeout = 15 * time.Second
 
-func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
-	// runNode owns the root ctx everything below binds to: the clients it builds directly (goclient,
-	// execution — goclient has no Close() of its own, ctx cancellation is its only shutdown), the
-	// goroutines newNode wires, and the long-lived services. It dies on the first terminal event,
-	// carrying it as the cause: a service or bring-up failure (→ that error), or a deliberate stop
-	// (the parent canceled on a shutdown signal → context.Canceled).
-	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(nil)
-
+// buildNode builds the node graph: it validates config up front (before any network I/O, so a
+// misconfigured node fails fast), connects the CL/EL clients — binding them to ctx, whose
+// cancellation is goclient's only shutdown — and wires everything together via newNode. The returned
+// *node owns the resources newNode opened; runNode's teardown releases them.
+func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, error) {
 	// Validate the configuration up front, before any network I/O, so a misconfigured node
 	// fails fast (e.g. an invalid ProposerDelay is rejected before the beacon client is built,
 	// rather than after connecting to the beacon). resolveAndValidate only reads cfg.
 	res, err := cfg.resolveAndValidate(logger)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	ssvNetworkConfig, err := setupSSVNetwork(logger, cfg)
 	if err != nil {
-		return fmt.Errorf("could not setup network: %w", err)
+		return nil, fmt.Errorf("could not setup network: %w", err)
 	}
 
 	logger.Info("connecting CL(s)",
@@ -91,14 +87,14 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 
 	cliopt, err := goclient.NewOptions(cfg.ConsensusClient, cfg.ProposerDelay)
 	if err != nil {
-		return startupError{
+		return nil, startupError{
 			err:    fmt.Errorf("failed to create beacon client options: %w", err),
 			fields: []zap.Field{fields.Address(cfg.ConsensusClient.BeaconNodeAddr)},
 		}
 	}
 	consensusClient, err := goclient.New(ctx, logger, cliopt)
 	if err != nil {
-		return startupError{
+		return nil, startupError{
 			err:    fmt.Errorf("failed to create beacon go-client: %w", err),
 			fields: []zap.Field{fields.Address(cfg.ConsensusClient.BeaconNodeAddr)},
 		}
@@ -116,7 +112,7 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 		}
 	}
 	if len(executionAddrList) == 0 {
-		return fmt.Errorf("no execution node address provided")
+		return nil, fmt.Errorf("no execution node address provided")
 	}
 
 	logger.Info("connecting EL(s)",
@@ -136,7 +132,7 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 			executionclient.WithSyncDistanceTolerance(cfg.ExecutionClient.SyncDistanceTolerance),
 		)
 		if err != nil {
-			return fmt.Errorf("could not connect to execution client: %w", err)
+			return nil, fmt.Errorf("could not connect to execution client: %w", err)
 		}
 
 		executionClient = ec
@@ -150,7 +146,7 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 			executionclient.WithSyncDistanceToleranceMulti(cfg.ExecutionClient.SyncDistanceTolerance),
 		)
 		if err != nil {
-			return fmt.Errorf("could not connect to execution client: %w", err)
+			return nil, fmt.Errorf("could not connect to execution client: %w", err)
 		}
 
 		executionClient = ec
@@ -158,12 +154,25 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 
 	n, err := newNode(ctx, cfg, logger, res, networkConfig, consensusClient, executionClient)
 	if err != nil {
-		// newNode failed before node.Close() owns the EL client, so close it here.
+		// newNode failed before node.close() owns the EL client, so close it here.
 		_ = executionClient.Close()
-		return err
+		return nil, err
 	}
-	// Every long-lived service runs through spawn: the first to fail cancels ctx with its error as
-	// the cause, telling everything else to stop.
+
+	return n, nil
+}
+
+// runNode runs an already-built node under terminal-cause supervision and returns the cause that
+// brought it down. It owns the cancel-cause root the node's services bind to: every long-lived
+// service runs through spawn, and the first to fail cancels the root with its error as the cause,
+// telling everything else to stop (a bring-up failure is a terminal event too). A service returning
+// nil just means it stopped cleanly (it only does so once the root is already canceled), so only a
+// non-nil error is a terminal cause. The cause is context.Canceled for a deliberate stop — the
+// caller classifies it off its signal ctx.
+func runNode(ctx context.Context, logger *zap.Logger, n *node) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	var wg sync.WaitGroup
 	spawn := func(service func() error) {
 		wg.Go(func() {
@@ -172,35 +181,29 @@ func runNode(ctx context.Context, cfg *config, logger *zap.Logger) error {
 			}
 		})
 	}
-
 	if err := n.start(ctx, spawn); err != nil {
 		cancel(err) // a bring-up failure is a terminal event too (the first cause wins)
 	}
 
-	// Block until the first terminal event, then run the whole graceful teardown — services
-	// unwinding, then Close releasing the resources they were using — under one grace window:
-	// something ignoring cancellation must not hang teardown forever, so past the window give up
-	// and surface the cause (the leftovers are reaped at process exit).
+	// Block until the first terminal event, then tear the node down within one grace window: wait for
+	// the services to unwind, then close. Past the window give up and surface the cause rather than
+	// hang forever on something ignoring cancellation (the leftovers are reaped at process exit).
 	<-ctx.Done()
 	cause := context.Cause(ctx)
-
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
-		if err := n.Close(); err != nil {
+		if err := n.close(); err != nil {
 			logger.Error("could not cleanly close node", zap.Error(err))
 		}
 		close(done)
 	}()
 	select {
 	case <-done:
+		return cause
 	case <-time.After(shutdownGraceTimeout):
 		return fmt.Errorf("graceful shutdown timed out after %s: %w", shutdownGraceTimeout, cause)
 	}
-
-	// The cause may be context.Canceled (a deliberate stop) — the caller classifies it off its
-	// signal ctx.
-	return cause
 }
 
 // beaconClient is the beacon-node surface the node consumes: the duty-call interface plus the
@@ -215,7 +218,7 @@ type beaconClient interface {
 
 var _ beaconClient = (*goclient.GoClient)(nil)
 
-// node bundles the constructed pieces that start() brings up and Close() tears down.
+// node bundles the constructed pieces that start() brings up and close() tears down.
 type node struct {
 	logger *zap.Logger
 
@@ -236,13 +239,15 @@ type node struct {
 	metadataSyncer      *metadata.Syncer
 	storageMap          *ibftstorage.ParticipantStores
 	collector           *dutytracer.Collector
+	vrSubmitter         *runner.VRSubmitter
+	slotTickerProvider  slotticker.Provider
 	p2pNetwork          network.P2PNetwork
 	operatorNode        *operator.Node
 }
 
 // newNode wires the node's components from config + the injected beacon/EL clients. On any
 // error it closes whatever it already opened (db/p2p) via the error-only defers below; on
-// success the returned *node owns those closers, released via node.Close(). Goroutines wired
+// success the returned *node owns those closers, released via node.close(). Goroutines wired
 // here (the VRSubmitter; in exporter modes the duty-trace collector / slot-pruning) bind to ctx:
 // cancel it before Close, so they've stopped using the resources Close releases. It mutates cfg
 // in place (filling SSVOptions/P2pNetworkConfig with runtime deps), so a given cfg is single-use.
@@ -310,9 +315,9 @@ func newNode(
 		return nil, err
 	}
 	validatorProvider := nodeStorage.ValidatorStore().WithOperatorID(operatorDataStore.GetOperatorID)
-	var validatorRegistrationSubmitter runner.ValidatorRegistrationSubmitter
+	var vrSubmitter *runner.VRSubmitter
 	if !res.isExporter() {
-		validatorRegistrationSubmitter = runner.NewVRSubmitter(ctx, logger, networkConfig.Beacon, consensusClient, validatorProvider)
+		vrSubmitter = runner.NewVRSubmitter(logger, networkConfig.Beacon, consensusClient, validatorProvider)
 	}
 
 	keyManager, operatorSigner, err := buildKeyManager(ctx, logger, cfg, res, networkConfig.Beacon, db, ssvSignerClient, operatorPrivKey, operatorDataStore)
@@ -395,12 +400,6 @@ func newNode(
 		})
 	}
 
-	if res.mode == modeExporterStandard {
-		retain := cfg.ExporterOptions.RetainSlots
-		threshold := networkConfig.EstimatedCurrentSlot()
-		initSlotPruning(ctx, storageMap, slotTickerProvider, threshold, retain)
-	}
-
 	fixedSubnets, err := networkcommons.SubnetsFromString(cfg.P2pNetworkConfig.Subnets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse fixed subnets: %w", err)
@@ -433,7 +432,6 @@ func newNode(
 			dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 			dutyStore)
 
-		go collector.Start(ctx, slotTickerProvider)
 		cfg.SSVOptions.ExporterRead = exporter2.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
 	case modeExporterStandard:
 		logger.Info("exporter mode: standard")
@@ -458,7 +456,11 @@ func newNode(
 	valOpts.OperatorDataStore = operatorDataStore
 	valOpts.RegistryStorage = nodeStorage
 	valOpts.ValidatorStore = nodeStorage.ValidatorStore()
-	valOpts.ValidatorRegistrationSubmitter = validatorRegistrationSubmitter
+	if vrSubmitter != nil {
+		// Guarded so the interface field stays a true nil in exporter mode — assigning a nil
+		// *VRSubmitter would make it a non-nil typed-nil interface. start() uses the concrete type.
+		valOpts.ValidatorRegistrationSubmitter = vrSubmitter
+	}
 	valOpts.NewDecidedHandler = newDecidedHandler
 	valOpts.DutyRoles = []spectypes.BeaconRole{spectypes.BNRoleAttester} // TODO could be better to set in other place
 	valOpts.StorageMap = storageMap
@@ -493,17 +495,19 @@ func newNode(
 		metadataSyncer:      metadataSyncer,
 		storageMap:          storageMap,
 		collector:           collector,
+		vrSubmitter:         vrSubmitter,
+		slotTickerProvider:  slotTickerProvider,
 		p2pNetwork:          p2pNetwork,
 		operatorNode:        operatorNode,
 	}, nil
 }
 
-// Close tears down the node's resources: validatorCtrl.Stop() (the controller's ttlcache cleanup
+// close tears down the node's resources: validatorCtrl.Stop() (the controller's ttlcache cleanup
 // loops, which aren't ctx-bound), then the CLI-owned resources (p2p network and execution client,
 // then the db that p2p depends on). The ctx given to newNode must be canceled first, so the
 // ctx-bound goroutines have stopped using these resources. newNode is the only constructor, so all
 // these fields are always set.
-func (n *node) Close() error {
+func (n *node) close() error {
 	n.validatorCtrl.Stop()
 
 	var errs []error
@@ -524,6 +528,17 @@ func (n *node) Close() error {
 // error). Everything binds to ctx — when it dies, bring-up aborts mid-step and the services stop;
 // the services' terminal errors travel through spawn, not through the return value.
 func (n *node) start(ctx context.Context, spawn func(func() error)) error {
+	// Background services wired (but not started) by newNode, mode-dependent.
+	if n.vrSubmitter != nil {
+		spawn(func() error { n.vrSubmitter.Start(ctx); return nil })
+	}
+	if n.collector != nil {
+		spawn(func() error { n.collector.Start(ctx, n.slotTickerProvider); return nil })
+	}
+	if n.mode == modeExporterStandard {
+		startSlotPruning(ctx, spawn, n.storageMap, n.slotTickerProvider, n.networkConfig.EstimatedCurrentSlot(), n.cfg.ExporterOptions.RetainSlots)
+	}
+
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
 		_, metricsServeErr, err := metricsHandler.Start(ctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
@@ -718,26 +733,25 @@ func setupOperatorDataStore(
 	return operatordatastore.New(operatorData), nil
 }
 
-func initSlotPruning(ctx context.Context, stores *ibftstorage.ParticipantStores, slotTickerProvider slotticker.Provider, slot phase0.Slot, retain uint64) {
-	var wg sync.WaitGroup
-
+// startSlotPruning runs the one-time initial slot GC (synchronously, in parallel across stores) and
+// then spawns a per-store background cleanup loop joined to the supervised lifecycle.
+func startSlotPruning(ctx context.Context, spawn func(func() error), stores *ibftstorage.ParticipantStores, slotTickerProvider slotticker.Provider, slot phase0.Slot, retain uint64) {
 	threshold := slot - phase0.Slot(retain)
 
-	// async perform initial slot gc
+	// One-time initial GC: prune each store in parallel, wait for all.
+	var wg sync.WaitGroup
 	_ = stores.Each(func(_ spectypes.BeaconRole, store ibftstorage.ParticipantStore) error {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			store.Prune(ctx, threshold)
-		}()
+		wg.Go(func() { store.Prune(ctx, threshold) })
 		return nil
 	})
-
 	wg.Wait()
 
-	// start background job for removing old slots on every tick
+	// Background per-store cleanup on every tick.
 	_ = stores.Each(func(_ spectypes.BeaconRole, store ibftstorage.ParticipantStore) error {
-		go store.PruneContinuously(ctx, slotTickerProvider, phase0.Slot(retain))
+		spawn(func() error {
+			store.PruneContinuously(ctx, slotTickerProvider, phase0.Slot(retain))
+			return nil
+		})
 		return nil
 	})
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -488,41 +488,46 @@ func (n *node) Close() error {
 }
 
 // start launches the node's long-lived services (metrics + SSV API servers, the health prober,
-// contract-event sync) and blocks until the node's ctx is canceled or the first service fails.
+// contract-event sync, operatorNode.Start) and blocks until the node's ctx is canceled or the first
+// service fails.
 //
-// All long-lived services join an errgroup derived from the node's ctx. The first failure cancels
-// gctx — which tears down the HTTP servers via their ctx-aware Shutdown watchers — and surfaces as
-// the group error; a plain ctx cancellation has every service return nil, so a clean shutdown
-// returns nil. The synchronous bring-up below returns its errors directly; an already-started HTTP
-// server is then torn down by node.Close() (deferred in runNode, which cancels the node ctx). Every
-// failure path thus returns up through runNode() to the single top-level Fatal, with Close() running.
+// Each service joins an errgroup on gctx as it is brought up; the first failure cancels gctx — which
+// tears down the others (and the ctx-aware HTTP servers) — and surfaces as the group error, while a
+// plain ctx cancellation has every service return nil (clean shutdown → nil). The synchronous
+// bring-up steps run on n.ctx, not gctx, so they abort only on actual shutdown: a long resumable step
+// (e.g. historical sync) is not torn down when a non-critical service (e.g. a diagnostic HTTP server)
+// crashes — that error still surfaces, at g.Wait. Every failure path returns up through runNode() to
+// the single top-level Fatal, with node.Close() running on the way out.
 func (n *node) start() error {
 	g, gctx := errgroup.WithContext(n.ctx)
 
-	// The metrics server starts here but its serveErr is buffered (cap 1) and only joined into the
-	// errgroup below, after historical event sync — which can take a long time on a fresh node. A
-	// serve crash during that window surfaces when the join reads the channel, not immediately. That
-	// delay is acceptable: the metrics server is diagnostic, and deferring the crash keeps a long,
-	// resumable sync from being aborted by a non-critical server.
-	var metricsServeErr <-chan error
 	if n.cfg.MetricsAPIPort > 0 {
 		metricsHandler := metrics.NewHandler(n.logger, n.db, n.cfg.EnableProfile, n.operatorNode)
-		_, serveErr, err := metricsHandler.Start(gctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
+		_, metricsServeErr, err := metricsHandler.Start(gctx, http.NewServeMux(), fmt.Sprintf(":%d", n.cfg.MetricsAPIPort))
 		if err != nil {
 			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
-		metricsServeErr = serveErr
+		// The serve loops join on gctx with a plain receive: each server's ctx-aware Shutdown closes
+		// serveErr on cancel (Serve returns ErrServerClosed once the listener closes), so this can't
+		// wedge g.Wait() — unlike the operator-package WS loop, whose shutdown ctx differs and so needs
+		// an explicit gctx-escape select.
+		g.Go(func() error {
+			if err := <-metricsServeErr; err != nil {
+				return fmt.Errorf("metrics server serve loop exited: %w", err)
+			}
+			return nil
+		})
 	}
 
 	healthProber := hprobe.NewHealthProber(n.logger)
 	healthProber.AddComponent(clComponentName, n.consensusClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
 	healthProber.AddComponent(elComponentName, n.executionClient, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
-	if err := ensureComponentsHealthy(gctx, n.logger, healthProber); err != nil {
+	if err := ensureComponentsHealthy(n.ctx, n.logger, healthProber); err != nil {
 		return err
 	}
 
 	eventSyncer, startOngoingSync, err := syncContractEvents(
-		gctx,
+		n.ctx,
 		n.logger,
 		n.cfg,
 		n.executionClient,
@@ -537,15 +542,20 @@ func (n *node) start() error {
 		return err
 	}
 	if len(n.cfg.LocalEventsPath) == 0 {
+		// Contract-sync mode: register the event syncer for health probing and join its ongoing sync
+		// (startOngoingSync is non-nil only on this path).
 		healthProber.AddComponent(eventSyncerComponentName, eventSyncer, proberHealthcheckTimeout, proberRetriesMax, proberRetryDelay)
+		g.Go(func() error {
+			return startOngoingSync(gctx)
+		})
 	}
 
-	if _, err := n.metadataSyncer.SyncAll(gctx); err != nil {
+	if _, err := n.metadataSyncer.SyncAll(n.ctx); err != nil {
 		return fmt.Errorf("failed to sync metadata on startup: %w", err)
 	}
 
 	if n.usingSSVSigner {
-		if err := ensureNoMissingKeys(gctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
+		if err := ensureNoMissingKeys(n.ctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
 			return err
 		}
 	}
@@ -584,8 +594,12 @@ func (n *node) start() error {
 	if err := n.startNetwork(healthProber); err != nil {
 		return err
 	}
+	// The prober joins here — after startNetwork, so all its components (CL/EL, event-syncer, p2p) are
+	// registered. It returns nil on clean cancel and the unhealth error on a watchdog trip.
+	g.Go(func() error {
+		return startHealthProber(gctx, n.logger, healthProber)
+	})
 
-	var apiServeErr <-chan error
 	if n.cfg.SSVAPIPort > 0 {
 		warnIfSSVAPIAddressUnset(n.logger, n.cfg.SSVAPIAddress, n.cfg.SSVAPIPort)
 		apiServer := apiserver.New(
@@ -608,29 +622,10 @@ func (n *node) start() error {
 			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore()),
 			n.mode == modeExporterArchive,
 		)
-		_, serveErr, err := apiServer.Start(gctx)
+		_, apiServeErr, err := apiServer.Start(gctx)
 		if err != nil {
 			return fmt.Errorf("failed to start API server: %w", err)
 		}
-		apiServeErr = serveErr
-	}
-
-	// Join the long-lived services into the errgroup and block until the first fails or gctx is
-	// canceled (clean shutdown → every service returns nil → nil). operatorNode.Start runs as a
-	// member too — never returned ahead of g.Wait(), so its failure is awaited alongside the rest.
-	// Both HTTP servers were started with gctx, so their ctx-aware Shutdown closes serveErr on cancel
-	// (Serve returns ErrServerClosed once the listener closes), and a plain receive can't wedge
-	// g.Wait() — unlike the WS server in the operator package, whose shutdown is bound to a different
-	// ctx and so needs an explicit gctx-escape select.
-	if metricsServeErr != nil {
-		g.Go(func() error {
-			if err := <-metricsServeErr; err != nil {
-				return fmt.Errorf("metrics server serve loop exited: %w", err)
-			}
-			return nil
-		})
-	}
-	if apiServeErr != nil {
 		g.Go(func() error {
 			if err := <-apiServeErr; err != nil {
 				return fmt.Errorf("API server serve loop exited: %w", err)
@@ -638,14 +633,9 @@ func (n *node) start() error {
 			return nil
 		})
 	}
-	g.Go(func() error {
-		return startHealthProber(gctx, n.logger, healthProber)
-	})
-	if startOngoingSync != nil {
-		g.Go(func() error {
-			return startOngoingSync(gctx)
-		})
-	}
+
+	// operatorNode.Start runs as a member too — never returned ahead of g.Wait(), so its failure is
+	// awaited alongside the rest.
 	g.Go(func() error {
 		if err := n.operatorNode.Start(gctx); err != nil {
 			return fmt.Errorf("failed to start SSV node: %w", err)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -64,7 +64,7 @@ const shutdownGraceTimeout = 15 * time.Second
 // buildNode builds the node graph: it validates config up front (before any network I/O, so a
 // misconfigured node fails fast), connects the CL/EL clients — binding them to ctx, whose
 // cancellation is goclient's only shutdown — and wires everything together via newNode. The returned
-// *node owns the resources newNode opened; runNode's teardown releases them.
+// *node owns the resources newNode opened; node.close releases them at teardown.
 func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, error) {
 	// Validate the configuration up front, before any network I/O, so a misconfigured node
 	// fails fast (e.g. an invalid ProposerDelay is rejected before the beacon client is built,
@@ -160,50 +160,6 @@ func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, err
 	}
 
 	return n, nil
-}
-
-// runNode runs an already-built node under terminal-cause supervision and returns the cause that
-// brought it down. It owns the cancel-cause root the node's services bind to: every long-lived
-// service runs through spawn, and the first to fail cancels the root with its error as the cause,
-// telling everything else to stop (a bring-up failure is a terminal event too). A service returning
-// nil just means it stopped cleanly (it only does so once the root is already canceled), so only a
-// non-nil error is a terminal cause. The cause is context.Canceled for a deliberate stop — the
-// caller classifies it off its signal ctx.
-func runNode(ctx context.Context, logger *zap.Logger, n *node) error {
-	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(nil)
-
-	var wg sync.WaitGroup
-	spawn := func(service func() error) {
-		wg.Go(func() {
-			if err := service(); err != nil {
-				cancel(err)
-			}
-		})
-	}
-	if err := n.start(ctx, spawn); err != nil {
-		cancel(err) // a bring-up failure is a terminal event too (the first cause wins)
-	}
-
-	// Block until the first terminal event, then tear the node down within one grace window: wait for
-	// the services to unwind, then close. Past the window give up and surface the cause rather than
-	// hang forever on something ignoring cancellation (the leftovers are reaped at process exit).
-	<-ctx.Done()
-	cause := context.Cause(ctx)
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		if err := n.close(); err != nil {
-			logger.Error("could not cleanly close node", zap.Error(err))
-		}
-		close(done)
-	}()
-	select {
-	case <-done:
-		return cause
-	case <-time.After(shutdownGraceTimeout):
-		return fmt.Errorf("graceful shutdown timed out after %s: %w", shutdownGraceTimeout, cause)
-	}
 }
 
 // beaconClient is the beacon-node surface the node consumes: the duty-call interface plus the

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/hprobe"
+	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
@@ -258,4 +260,28 @@ func Test_node_startNetwork_wiresStatsRegardlessOfDynamicMaxPeers(t *testing.T) 
 			require.True(t, stubNet.startCalled, "p2p Start must run regardless of DynamicMaxPeers")
 		})
 	}
+}
+
+// Test_startSlotPruning_spawnsContinuousPrunerPerStore checks the wiring the goroutine-free refactor
+// introduced: the per-store background pruning is launched through spawn (one per store) rather than
+// a bare go, and the synchronous initial GC runs without hanging. The spawn here only counts — it
+// doesn't run the pruners — so this asserts the wiring, not the pruning semantics (those live in
+// ibft/storage).
+func Test_startSlotPruning_spawnsContinuousPrunerPerStore(t *testing.T) {
+	db, err := kv.New(zap.NewNop(), basedb.Options{Path: t.TempDir(), Ctx: context.Background()})
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	stores := ibftstorage.NewStores()
+	stores.Add(spectypes.BNRoleAttester, ibftstorage.New(zap.NewNop(), db, spectypes.BNRoleAttester))
+	stores.Add(spectypes.BNRoleProposer, ibftstorage.New(zap.NewNop(), db, spectypes.BNRoleProposer))
+
+	spawned := 0
+	spawn := func(func() error) { spawned++ } // count, don't run — testing the wiring, not pruning
+
+	// slot > retain so the initial-GC threshold doesn't underflow; the ticker provider is never
+	// invoked because spawn doesn't run the pruners.
+	startSlotPruning(context.Background(), spawn, stores, nil, 1000, 100)
+
+	require.Equal(t, 2, spawned, "one continuous-pruner must be spawned per store")
 }

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -39,7 +39,7 @@ func Test_runNode_invalidConfigReturns(t *testing.T) {
 // promotes every method so the type compiles as a beaconClient, while implementing only what the
 // test path actually invokes. In operator mode with Doppelganger disabled, newNode() never calls
 // a beacon method synchronously (it only stores the client); the one async caller is the
-// NewVRSubmitter goroutine, which a.Close() stops by canceling the node's ctx.
+// NewVRSubmitter goroutine, which stops when the test cancels its ctx.
 type stubBeaconClient struct {
 	beaconClient
 }
@@ -118,9 +118,10 @@ func Test_newNode_wiresOperatorNode(t *testing.T) {
 			_, isNoOp := a.doppelgangerHandler.(doppelganger.NoOpHandler)
 			require.Equal(t, !tc.doppelgangerOn, isNoOp, "doppelganger handler must match the configured protection")
 
-			// a.Close() cancels the node's ctx (stopping the VRSubmitter goroutine newNode started in
-			// operator mode), then closes the CLI-owned resources cleanly — the p2p network was
-			// constructed but never Setup/Start'd.
+			// Mirror production teardown ordering: cancel the ctx first (stopping the VRSubmitter
+			// goroutine newNode started in operator mode), then Close releases the CLI-owned
+			// resources cleanly — the p2p network was constructed but never Setup/Start'd.
+			cancel()
 			require.NoError(t, a.Close())
 		})
 	}
@@ -176,6 +177,8 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 				require.Nil(t, a.collector, "standard mode has no duty-trace collector")
 			}
 
+			// Mirror production teardown ordering: ctx-bound goroutines stop before Close.
+			cancel()
 			require.NoError(t, a.Close())
 		})
 	}
@@ -215,8 +218,8 @@ func Test_newNode_closesDBOnAssemblyFailure(t *testing.T) {
 	require.ErrorContains(t, err, "failed to setup network private key") // i.e. failed in setupP2P, after db-open
 	require.Nil(t, a)
 
-	// newNode's error path cancels the node's ctx itself (stopping the VRSubmitter goroutine it started before the
-	// failure), so the test no longer has to.
+	// Goroutines newNode started before the failure (the VRSubmitter) bind to the test's ctx and
+	// stop via the deferred cancel above.
 	//
 	// The error-only defer must have closed the db: a fresh badger open of the same dir succeeds
 	// only if the previous handle released its directory lock.

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/attestantio/go-eth2-client/api"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -21,25 +20,25 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-// Test_runNode_invalidConfigReturns verifies runNode() returns the configuration error instead of
+// Test_buildNode_invalidConfigReturns verifies buildNode() returns the configuration error instead of
 // calling logger.Fatal (which would os.Exit the test process) when resolveAndValidate fails.
-// A conflicting signing config trips resolveAndValidate — the first thing runNode() does — before
+// A conflicting signing config trips resolveAndValidate — the first thing buildNode() does — before
 // any network I/O, so the call is safe to make in-process.
-func Test_runNode_invalidConfigReturns(t *testing.T) {
+func Test_buildNode_invalidConfigReturns(t *testing.T) {
 	c := config{}
 	c.SSVSigner.Endpoint = testSignerEndpoint
 	c.OperatorPrivateKey = testOperatorKey // remote + local signing => rejected by resolveAndValidate
 
-	err := runNode(context.Background(), &c, zap.NewNop())
+	_, err := buildNode(context.Background(), &c, zap.NewNop())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot enable both remote signing")
 }
 
 // stubBeaconClient satisfies the in-package beaconClient interface by embedding it (nil): it
 // promotes every method so the type compiles as a beaconClient, while implementing only what the
-// test path actually invokes. In operator mode with Doppelganger disabled, newNode() never calls
-// a beacon method synchronously (it only stores the client); the one async caller is the
-// NewVRSubmitter goroutine, which stops when the test cancels its ctx.
+// test path actually invokes. newNode() starts no goroutines and — with Doppelganger disabled —
+// invokes only one beacon method synchronously during assembly (SetProposalPreparationsProvider),
+// so that's the sole override needed.
 type stubBeaconClient struct {
 	beaconClient
 }
@@ -49,21 +48,13 @@ type stubBeaconClient struct {
 func (stubBeaconClient) SetProposalPreparationsProvider(func() ([]*eth2apiv1.ProposalPreparation, error)) {
 }
 
-// SubmitValidatorRegistrations is called unconditionally on each slot tick by the NewVRSubmitter
-// goroutine newNode() starts in operator mode. A no-op makes the smoke test structurally safe if
-// that goroutine ticks before ctx is canceled, rather than relying on the slot interval winning the
-// race (it would otherwise hit the embedded-nil beacon and panic).
-func (stubBeaconClient) SubmitValidatorRegistrations(context.Context, []*api.VersionedSignedValidatorRegistration) error {
-	return nil
-}
-
 // stubExecutionClient satisfies executionclient.Provider the same way. newNode() only stores the
 // EL client (it is consumed in start(), not here), so no method is invoked during assembly.
 type stubExecutionClient struct {
 	executionclient.Provider
 }
 
-// Close is a no-op: node.Close() (invoked by the smoke tests during teardown) calls it, so it must
+// Close is a no-op: node.close() (invoked by the smoke tests during teardown) calls it, so it must
 // not fall through to the nil embedded Provider.
 func (stubExecutionClient) Close() error { return nil }
 
@@ -118,11 +109,11 @@ func Test_newNode_wiresOperatorNode(t *testing.T) {
 			_, isNoOp := a.doppelgangerHandler.(doppelganger.NoOpHandler)
 			require.Equal(t, !tc.doppelgangerOn, isNoOp, "doppelganger handler must match the configured protection")
 
-			// Mirror production teardown ordering: cancel the ctx first (stopping the VRSubmitter
-			// goroutine newNode started in operator mode), then Close releases the CLI-owned
-			// resources cleanly — the p2p network was constructed but never Setup/Start'd.
+			// Mirror production teardown ordering: cancel the ctx, then close. newNode starts no
+			// goroutines, so nothing is racing here — the p2p network was constructed but never
+			// Setup/Start'd.
 			cancel()
-			require.NoError(t, a.Close())
+			require.NoError(t, a.close())
 		})
 	}
 }
@@ -177,9 +168,9 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 				require.Nil(t, a.collector, "standard mode has no duty-trace collector")
 			}
 
-			// Mirror production teardown ordering: ctx-bound goroutines stop before Close.
+			// Mirror production teardown ordering: cancel the ctx, then close (newNode starts no goroutines).
 			cancel()
-			require.NoError(t, a.Close())
+			require.NoError(t, a.close())
 		})
 	}
 }
@@ -218,8 +209,7 @@ func Test_newNode_closesDBOnAssemblyFailure(t *testing.T) {
 	require.ErrorContains(t, err, "failed to setup network private key") // i.e. failed in setupP2P, after db-open
 	require.Nil(t, a)
 
-	// Goroutines newNode started before the failure (the VRSubmitter) bind to the test's ctx and
-	// stop via the deferred cancel above.
+	// newNode starts no goroutines, so the failed assembly leaves nothing running.
 	//
 	// The error-only defer must have closed the db: a fresh badger open of the same dir succeeds
 	// only if the previous handle released its directory lock.

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -2,16 +2,13 @@ package operator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/doppelganger"
 	"github.com/ssvlabs/ssv/eth/executionclient"
@@ -69,23 +66,6 @@ type stubExecutionClient struct {
 // Close is a no-op: node.Close() (invoked by the smoke tests during teardown) calls it, so it must
 // not fall through to the nil embedded Provider.
 func (stubExecutionClient) Close() error { return nil }
-
-// stubOperatorNode is a test double for the operatorNode seam. Its Start blocks until ctx is
-// canceled and then returns nil — mirroring a clean operator.Node shutdown — unless startErr is set,
-// in which case Start returns it immediately to exercise failure propagation through the errgroup.
-type stubOperatorNode struct {
-	startErr error
-}
-
-func (s stubOperatorNode) Start(ctx context.Context) error {
-	if s.startErr != nil {
-		return s.startErr
-	}
-	<-ctx.Done()
-	return nil
-}
-
-func (stubOperatorNode) HealthCheck() error { return nil }
 
 // Test_newNode_wiresOperatorNode is the in-process smoke test for the newNode() seam: with
 // stubbed beacon/EL clients and a minimal operator-mode config, the full wiring graph
@@ -285,59 +265,4 @@ func Test_node_startNetwork_wiresStatsRegardlessOfDynamicMaxPeers(t *testing.T) 
 			require.True(t, stubNet.startCalled, "p2p Start must run regardless of DynamicMaxPeers")
 		})
 	}
-}
-
-// Test_node_runServices_returnsNilOnCtxCancel locks in the normal-shutdown invariant: every
-// long-lived service joined by runServices must return nil on a plain ctx cancellation, so a clean
-// SIGINT unwinds through start() -> runNode() as nil rather than tripping the single top-level Fatal.
-// It drives runServices with stand-ins for each member shape — HTTP serve-error channels that close
-// on shutdown (as the real ctx-aware servers do), an empty health prober (ProbeAll over zero
-// components is a no-op), an ongoing-sync func that returns nil on cancel, and a stub operatorNode
-// that blocks until cancel — then cancels ctx and asserts runServices returns nil.
-func Test_node_runServices_returnsNilOnCtxCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	g, gctx := errgroup.WithContext(ctx)
-
-	// Mimic the ctx-aware HTTP servers: their serveErr channel is closed (silently) once gctx-driven
-	// shutdown completes, so the joined <-serveErr yields nil.
-	metricsServeErr := make(chan error, 1)
-	apiServeErr := make(chan error, 1)
-	go func() { <-gctx.Done(); close(metricsServeErr) }()
-	go func() { <-gctx.Done(); close(apiServeErr) }()
-
-	ongoingSync := func(c context.Context) error { <-c.Done(); return nil }
-
-	n := &node{logger: zap.NewNop(), operatorNode: stubOperatorNode{}}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- n.runServices(g, gctx, metricsServeErr, apiServeErr, hprobe.NewHealthProber(zap.NewNop()), ongoingSync)
-	}()
-
-	cancel()
-
-	select {
-	case err := <-done:
-		require.NoError(t, err, "runServices must return nil on a clean ctx cancellation")
-	case <-time.After(5 * time.Second):
-		t.Fatal("runServices did not return after ctx cancellation")
-	}
-}
-
-// Test_node_runServices_propagatesMemberError verifies the failure path: when one joined service
-// returns an error, runServices cancels the group (so the siblings unwind via gctx) and returns that
-// error up to start() -> runNode() -> the single top-level Fatal. A stub operatorNode that fails
-// immediately stands in for any long-lived service failure.
-func Test_node_runServices_propagatesMemberError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	g, gctx := errgroup.WithContext(ctx)
-
-	wantErr := errors.New("boom")
-	n := &node{logger: zap.NewNop(), operatorNode: stubOperatorNode{startErr: wantErr}}
-
-	// No HTTP servers (nil channels) and no ongoing sync (nil func); the empty prober returns nil on
-	// the group cancellation the failing operatorNode member triggers.
-	err := n.runServices(g, gctx, nil, nil, hprobe.NewHealthProber(zap.NewNop()), nil)
-	require.ErrorIs(t, err, wantErr)
 }

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -2,13 +2,16 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/doppelganger"
 	"github.com/ssvlabs/ssv/eth/executionclient"
@@ -66,6 +69,23 @@ type stubExecutionClient struct {
 // Close is a no-op: node.Close() (invoked by the smoke tests during teardown) calls it, so it must
 // not fall through to the nil embedded Provider.
 func (stubExecutionClient) Close() error { return nil }
+
+// stubOperatorNode is a test double for the operatorNode seam. Its Start blocks until ctx is
+// canceled and then returns nil — mirroring a clean operator.Node shutdown — unless startErr is set,
+// in which case Start returns it immediately to exercise failure propagation through the errgroup.
+type stubOperatorNode struct {
+	startErr error
+}
+
+func (s stubOperatorNode) Start(ctx context.Context) error {
+	if s.startErr != nil {
+		return s.startErr
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func (stubOperatorNode) HealthCheck() error { return nil }
 
 // Test_newNode_wiresOperatorNode is the in-process smoke test for the newNode() seam: with
 // stubbed beacon/EL clients and a minimal operator-mode config, the full wiring graph
@@ -265,4 +285,59 @@ func Test_node_startNetwork_wiresStatsRegardlessOfDynamicMaxPeers(t *testing.T) 
 			require.True(t, stubNet.startCalled, "p2p Start must run regardless of DynamicMaxPeers")
 		})
 	}
+}
+
+// Test_node_runServices_returnsNilOnCtxCancel locks in the normal-shutdown invariant: every
+// long-lived service joined by runServices must return nil on a plain ctx cancellation, so a clean
+// SIGINT unwinds through start() -> runNode() as nil rather than tripping the single top-level Fatal.
+// It drives runServices with stand-ins for each member shape — HTTP serve-error channels that close
+// on shutdown (as the real ctx-aware servers do), an empty health prober (ProbeAll over zero
+// components is a no-op), an ongoing-sync func that returns nil on cancel, and a stub operatorNode
+// that blocks until cancel — then cancels ctx and asserts runServices returns nil.
+func Test_node_runServices_returnsNilOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Mimic the ctx-aware HTTP servers: their serveErr channel is closed (silently) once gctx-driven
+	// shutdown completes, so the joined <-serveErr yields nil.
+	metricsServeErr := make(chan error, 1)
+	apiServeErr := make(chan error, 1)
+	go func() { <-gctx.Done(); close(metricsServeErr) }()
+	go func() { <-gctx.Done(); close(apiServeErr) }()
+
+	ongoingSync := func(c context.Context) error { <-c.Done(); return nil }
+
+	n := &node{logger: zap.NewNop(), operatorNode: stubOperatorNode{}}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- n.runServices(g, gctx, metricsServeErr, apiServeErr, hprobe.NewHealthProber(zap.NewNop()), ongoingSync)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "runServices must return nil on a clean ctx cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runServices did not return after ctx cancellation")
+	}
+}
+
+// Test_node_runServices_propagatesMemberError verifies the failure path: when one joined service
+// returns an error, runServices cancels the group (so the siblings unwind via gctx) and returns that
+// error up to start() -> runNode() -> the single top-level Fatal. A stub operatorNode that fails
+// immediately stands in for any long-lived service failure.
+func Test_node_runServices_propagatesMemberError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, gctx := errgroup.WithContext(ctx)
+
+	wantErr := errors.New("boom")
+	n := &node{logger: zap.NewNop(), operatorNode: stubOperatorNode{startErr: wantErr}}
+
+	// No HTTP servers (nil channels) and no ongoing sync (nil func); the empty prober returns nil on
+	// the group cancellation the failing operatorNode member triggers.
+	err := n.runServices(g, gctx, nil, nil, hprobe.NewHealthProber(zap.NewNop()), nil)
+	require.ErrorIs(t, err, wantErr)
 }

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -27,11 +27,18 @@ const (
 
 const componentsUnhealthyErrorMsg = "component(s) are not healthy"
 
-func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
-	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+// probe runs a single ProbeAll over all registered components, bounded by timeout, and returns the
+// prober's error verbatim. It is the shared core of the one-shot startup gate (ensureComponentsHealthy)
+// and the periodic runtime watchdog (startHealthProber), which differ only in timeout and the policy
+// wrapped around it — fail-fast vs. shutdown-trip.
+func probe(ctx context.Context, p *hprobe.HealthProber, timeout time.Duration) error {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	return p.ProbeAll(probeCtx)
+}
 
-	if err := p.ProbeAll(probeCtx); err != nil {
+func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
+	if err := probe(ctx, p, 30*time.Second); err != nil {
 		return fmt.Errorf("%s: %w", componentsUnhealthyErrorMsg, err)
 	}
 
@@ -39,33 +46,35 @@ func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.
 	return nil
 }
 
-func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) {
+// startHealthProber is a runtime liveness watchdog: every probeFrequency it probes all components,
+// and on persistent unhealth returns an error so the node terminates gracefully (errgroup -> Close ->
+// non-zero exit) and the orchestrator restarts it — potentially onto a healthy endpoint. A clean ctx
+// cancellation (normal shutdown) returns nil. The crash-and-restart on persistent unhealth is
+// intentional: a node idling with a dead EL while reporting healthy at the process level is a silent
+// failure, worse than a loud restart — so this must not degrade to "log and retry forever".
+func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
 	const probeFrequency = 60 * time.Second
 
 	ticker := time.NewTicker(probeFrequency)
 	defer ticker.Stop()
 
 	for {
-		func() {
-			logger.Debug("health-prober tick: probing all components")
-			defer logger.Debug("health-prober tick: probing all components done")
-
-			probeCtx, cancel := context.WithTimeout(ctx, probeFrequency)
-			defer cancel()
-
-			if err := p.ProbeAll(probeCtx); err != nil {
-				// TODO(#2867): trigger graceful shutdown (-> Close -> non-zero exit) instead of Fatal,
-				// which bypasses Close. Crash-and-restart on persistent unhealth is intentional; the
-				// goroutine os.Exit mechanism is the wart.
-				logger.Fatal(componentsUnhealthyErrorMsg, zap.Error(err))
+		logger.Debug("health-prober tick: probing all components")
+		if err := probe(ctx, p, probeFrequency); err != nil {
+			// A canceled ctx means we're shutting down, not that a component is unhealthy: the probe
+			// inherits ctx, so cancellation surfaces here as a probe error. Return nil (exit 0) rather
+			// than tripping the watchdog (non-zero exit).
+			if ctx.Err() != nil {
+				return nil
 			}
-		}()
+			return fmt.Errorf("%s: %w", componentsUnhealthyErrorMsg, err)
+		}
+		logger.Debug("health-prober tick: probing all components done")
 
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-ticker.C:
-			continue
 		}
 	}
 }

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -61,9 +61,12 @@ func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.Health
 	for {
 		logger.Debug("health-prober tick: probing all components")
 		if err := probe(ctx, p, probeFrequency); err != nil {
-			// A canceled ctx means we're shutting down, not that a component is unhealthy: the probe
-			// inherits ctx, so cancellation surfaces here as a probe error. Return nil (exit 0) rather
-			// than tripping the watchdog (non-zero exit).
+			// Discriminate "we're shutting down" from "a component is unhealthy" by the parent ctx
+			// state, not the error value. A wedged component (e.g. a hung EL) surfaces as a probe
+			// DeadlineExceeded while ctx is still live, and that MUST trip the watchdog — inspecting
+			// err for context.Canceled/DeadlineExceeded would wrongly suppress real unhealth. Only a
+			// canceled parent ctx means a deliberate stop: normal shutdown, or a sibling errgroup
+			// member already failed (its error drives the non-zero exit, so returning nil here is safe).
 			if ctx.Err() != nil {
 				return nil
 			}

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -18,7 +18,8 @@ const (
 	p2pComponentName         = "p2p"
 )
 
-// Common prober parameters we use to health check various prober-components.
+// Health-check parameters shared by the prober components. A component's full probe schedule — the
+// initial attempt plus retries, with delays in between — adds up to ~110s.
 const (
 	proberHealthcheckTimeout = 10 * time.Second
 	proberRetriesMax         = 5
@@ -28,10 +29,18 @@ const (
 const componentsUnhealthyErrorMsg = "component(s) are not healthy"
 
 func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
-	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// Deliberately cuts the full ~110s probe schedule short: at bring-up a component should answer
+	// within a couple of attempts, and a failed gate just gets the node restarted.
+	const gateTimeout = 30 * time.Second
+
+	probeCtx, cancel := context.WithTimeout(ctx, gateTimeout)
 	defer cancel()
 
 	if err := p.ProbeAll(probeCtx); err != nil {
+		// A canceled parent ctx is a deliberate stop (eg. shutdown), everything else fails the gate.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return fmt.Errorf("%s: %w", componentsUnhealthyErrorMsg, err)
 	}
 
@@ -39,28 +48,31 @@ func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.
 	return nil
 }
 
-// startHealthProber is a runtime liveness watchdog: it probes all components every probeFrequency
+// startHealthProber is a runtime liveness watchdog: it probes all components every probeInterval
 // and, on persistent unhealth, returns an error so the node terminates gracefully (via Close,
 // non-zero exit) and the orchestrator restarts it; a clean ctx cancellation returns nil. Crashing on
 // persistent unhealth is intentional — a node idling with a dead EL while reporting healthy is a
 // silent failure, worse than a restart — so it must not degrade to log-and-retry.
 func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
 	const (
-		probeFrequency = 60 * time.Second // how often a probe round runs
-		probeTimeout   = 60 * time.Second // max time for one probe round (ProbeAll)
+		// probeInterval is the pause between probe rounds, measured from round end — a round that runs
+		// long (components burning retries before recovering) still leaves a full quiet gap after it,
+		// never back-to-back rounds.
+		probeInterval = 60 * time.Second
+		// probeTimeout bounds one round (ProbeAll) as the watchdog's own liveness guard: even a
+		// Healthy impl that ignores its ctx can't stall the loop. Like the bring-up gate's timeout,
+		// it deliberately cuts the full probe schedule short — failing solidly for a whole round is
+		// exactly the unhealth the watchdog exists to trip on.
+		probeTimeout = 60 * time.Second
 	)
-
-	ticker := time.NewTicker(probeFrequency)
-	defer ticker.Stop()
 
 	for {
 		logger.Debug("health-prober tick: probing all components")
 		probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 		err := p.ProbeAll(probeCtx)
-		cancel() // not deferred: this is a loop, so release each tick's ctx immediately
+		cancel() // not deferred: this is a loop, so release each round's ctx immediately
 		if err != nil {
-			// A canceled parent ctx is a deliberate stop (shutdown or sibling failure). Otherwise the
-			// probe genuinely failed (e.g. a wedged component) — real unhealth, so trip the watchdog.
+			// A canceled parent ctx is a deliberate stop (eg. shutdown), everything else trips the watchdog.
 			if ctx.Err() != nil {
 				return nil
 			}
@@ -71,7 +83,7 @@ func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.Health
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-ticker.C:
+		case <-time.After(probeInterval):
 		}
 	}
 }

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -59,10 +59,8 @@ func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.Health
 		err := p.ProbeAll(probeCtx)
 		cancel() // not deferred: this is a loop, so release each tick's ctx immediately
 		if err != nil {
-			// Key off the parent ctx, not the error value: a wedged component (e.g. a hung EL) surfaces
-			// as a probe DeadlineExceeded while ctx is still live and must trip the watchdog, so
-			// matching context.Canceled/DeadlineExceeded would suppress real unhealth. A canceled
-			// parent ctx means a deliberate stop (shutdown, or a sibling already failed), so nil is safe.
+			// A canceled parent ctx is a deliberate stop (shutdown or sibling failure). Otherwise the
+			// probe genuinely failed (e.g. a wedged component) — real unhealth, so trip the watchdog.
 			if ctx.Err() != nil {
 				return nil
 			}

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -27,18 +27,11 @@ const (
 
 const componentsUnhealthyErrorMsg = "component(s) are not healthy"
 
-// probe runs a single ProbeAll over all registered components, bounded by timeout, and returns the
-// prober's error verbatim. It is the shared core of the one-shot startup gate (ensureComponentsHealthy)
-// and the periodic runtime watchdog (startHealthProber), which differ only in timeout and the policy
-// wrapped around it — fail-fast vs. shutdown-trip.
-func probe(ctx context.Context, p *hprobe.HealthProber, timeout time.Duration) error {
-	probeCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	return p.ProbeAll(probeCtx)
-}
-
 func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
-	if err := probe(ctx, p, 30*time.Second); err != nil {
+	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := p.ProbeAll(probeCtx); err != nil {
 		return fmt.Errorf("%s: %w", componentsUnhealthyErrorMsg, err)
 	}
 
@@ -46,27 +39,30 @@ func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.
 	return nil
 }
 
-// startHealthProber is a runtime liveness watchdog: every probeFrequency it probes all components,
-// and on persistent unhealth returns an error so the node terminates gracefully (errgroup -> Close ->
-// non-zero exit) and the orchestrator restarts it — potentially onto a healthy endpoint. A clean ctx
-// cancellation (normal shutdown) returns nil. The crash-and-restart on persistent unhealth is
-// intentional: a node idling with a dead EL while reporting healthy at the process level is a silent
-// failure, worse than a loud restart — so this must not degrade to "log and retry forever".
+// startHealthProber is a runtime liveness watchdog: it probes all components every probeFrequency
+// and, on persistent unhealth, returns an error so the node terminates gracefully (via Close,
+// non-zero exit) and the orchestrator restarts it; a clean ctx cancellation returns nil. Crashing on
+// persistent unhealth is intentional — a node idling with a dead EL while reporting healthy is a
+// silent failure, worse than a restart — so it must not degrade to log-and-retry.
 func startHealthProber(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
-	const probeFrequency = 60 * time.Second
+	const (
+		probeFrequency = 60 * time.Second // how often a probe round runs
+		probeTimeout   = 60 * time.Second // max time for one probe round (ProbeAll)
+	)
 
 	ticker := time.NewTicker(probeFrequency)
 	defer ticker.Stop()
 
 	for {
 		logger.Debug("health-prober tick: probing all components")
-		if err := probe(ctx, p, probeFrequency); err != nil {
-			// Discriminate "we're shutting down" from "a component is unhealthy" by the parent ctx
-			// state, not the error value. A wedged component (e.g. a hung EL) surfaces as a probe
-			// DeadlineExceeded while ctx is still live, and that MUST trip the watchdog — inspecting
-			// err for context.Canceled/DeadlineExceeded would wrongly suppress real unhealth. Only a
-			// canceled parent ctx means a deliberate stop: normal shutdown, or a sibling errgroup
-			// member already failed (its error drives the non-zero exit, so returning nil here is safe).
+		probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+		err := p.ProbeAll(probeCtx)
+		cancel() // not deferred: this is a loop, so release each tick's ctx immediately
+		if err != nil {
+			// Key off the parent ctx, not the error value: a wedged component (e.g. a hung EL) surfaces
+			// as a probe DeadlineExceeded while ctx is still live and must trip the watchdog, so
+			// matching context.Canceled/DeadlineExceeded would suppress real unhealth. A canceled
+			// parent ctx means a deliberate stop (shutdown, or a sibling already failed), so nil is safe.
 			if ctx.Err() != nil {
 				return nil
 			}

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -18,8 +18,10 @@ const (
 	p2pComponentName         = "p2p"
 )
 
-// Health-check parameters shared by the prober components. A component's full probe schedule — the
-// initial attempt plus retries, with delays in between — adds up to ~110s.
+// Health-check parameters shared by the prober components. Probing one component is an initial
+// attempt plus proberRetriesMax retries, each capped at proberHealthcheckTimeout and spaced by
+// proberRetryDelay — so a component stuck timing out takes ~110s (6 attempts x 10s + 5 gaps x 10s)
+// to be declared unhealthy.
 const (
 	proberHealthcheckTimeout = 10 * time.Second
 	proberRetriesMax         = 5
@@ -29,8 +31,9 @@ const (
 const componentsUnhealthyErrorMsg = "component(s) are not healthy"
 
 func ensureComponentsHealthy(ctx context.Context, logger *zap.Logger, p *hprobe.HealthProber) error {
-	// Deliberately cuts the full ~110s probe schedule short: at bring-up a component should answer
-	// within a couple of attempts, and a failed gate just gets the node restarted.
+	// gateTimeout cuts the full per-component probe schedule (~110s; see the prober consts) short at
+	// bring-up: a component should answer within a couple of attempts, and a failed gate just gets the
+	// node restarted.
 	const gateTimeout = 30 * time.Second
 
 	probeCtx, cancel := context.WithTimeout(ctx, gateTimeout)

--- a/cli/operator/prober_test.go
+++ b/cli/operator/prober_test.go
@@ -1,0 +1,56 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/hprobe"
+)
+
+// wedgedComponent is a hprobe component that never responds: its Healthy blocks until the
+// health-check ctx times out, surfacing as DeadlineExceeded — the realistic "hung EL/CL" case the
+// watchdog must catch.
+type wedgedComponent struct{}
+
+func (wedgedComponent) Healthy(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Test_startHealthProber_tripsOnUnhealthyComponent verifies the watchdog returns the unhealth error
+// (so the node terminates non-zero and the orchestrator restarts it) when a component is persistently
+// unhealthy while the ctx is still live — here a wedged component whose failure surfaces as a probe
+// DeadlineExceeded. This is the liveness property the watchdog exists for, and it must trip off the
+// parent ctx state rather than the error value (a DeadlineExceeded must not be mistaken for a cancel).
+func Test_startHealthProber_tripsOnUnhealthyComponent(t *testing.T) {
+	p := hprobe.NewHealthProber(zap.NewNop())
+	// Wedged component: blocks until its 20ms health-check ctx times out -> DeadlineExceeded. No
+	// retries, so the watchdog trips on the first tick.
+	p.AddComponent("el", wedgedComponent{}, 20*time.Millisecond, 0, 0)
+
+	err := startHealthProber(context.Background(), zap.NewNop(), p)
+	require.ErrorContains(t, err, componentsUnhealthyErrorMsg)
+}
+
+// Test_startHealthProber_returnsNilOnCtxCancel verifies a clean ctx cancellation (normal shutdown)
+// returns nil rather than tripping the watchdog.
+func Test_startHealthProber_returnsNilOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := hprobe.NewHealthProber(zap.NewNop()) // no components -> ProbeAll is a no-op
+
+	done := make(chan error, 1)
+	go func() { done <- startHealthProber(ctx, zap.NewNop(), p) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "startHealthProber must return nil on a clean ctx cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("startHealthProber did not return after ctx cancellation")
+	}
+}

--- a/cli/operator/prober_test.go
+++ b/cli/operator/prober_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -34,6 +35,37 @@ func Test_startHealthProber_tripsOnUnhealthyComponent(t *testing.T) {
 
 	err := startHealthProber(context.Background(), zap.NewNop(), p)
 	require.ErrorContains(t, err, componentsUnhealthyErrorMsg)
+}
+
+// cancelMaskingComponent mimics a real client that surfaces ctx cancellation as its own transport
+// error instead of ctx.Err(): hprobe forgives a bare context.Canceled (not a component failure), so
+// only a masked error makes a probe round fail because of a shutdown — reaching the watchdog as
+// ordinary unhealth that only its own ctx.Err() guard can classify correctly.
+type cancelMaskingComponent struct{}
+
+func (cancelMaskingComponent) Healthy(ctx context.Context) error {
+	<-ctx.Done()
+	return errors.New("connection reset")
+}
+
+// Test_startHealthProber_returnsNilOnCancelMidProbe verifies the shutdown-vs-unhealth race: the
+// parent ctx is canceled while a probe is in flight, so the round fails (with a non-ctx error, as
+// real clients produce) at the same time as ctx.Err() != nil. The watchdog must classify that as a
+// clean shutdown (nil), not unhealth — pinning the ctx.Err() guard ahead of the error return.
+func Test_startHealthProber_returnsNilOnCancelMidProbe(t *testing.T) {
+	p := hprobe.NewHealthProber(zap.NewNop())
+	// Generous healthcheck timeout: the probe must still be in flight when cancel lands, so its
+	// failure is cancellation-caused — not a timeout, which must keep tripping the watchdog.
+	p.AddComponent("el", cancelMaskingComponent{}, 10*time.Second, 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := startHealthProber(ctx, zap.NewNop(), p)
+	require.NoError(t, err, "a probe failure caused by shutdown cancellation must not trip the watchdog")
 }
 
 // Test_startHealthProber_returnsNilOnCtxCancel verifies a clean ctx cancellation (normal shutdown)

--- a/cli/operator/prober_test.go
+++ b/cli/operator/prober_test.go
@@ -86,3 +86,41 @@ func Test_startHealthProber_returnsNilOnCtxCancel(t *testing.T) {
 		t.Fatal("startHealthProber did not return after ctx cancellation")
 	}
 }
+
+// fixedComponent is a hprobe component whose health is a fixed result — nil for healthy, a non-nil
+// error for unhealthy — answered immediately (no ctx dependence). Enough to drive the bring-up gate.
+type fixedComponent struct{ err error }
+
+func (c fixedComponent) Healthy(context.Context) error { return c.err }
+
+// Test_ensureComponentsHealthy_passesWhenHealthy: a healthy component clears the gate (nil).
+func Test_ensureComponentsHealthy_passesWhenHealthy(t *testing.T) {
+	p := hprobe.NewHealthProber(zap.NewNop())
+	p.AddComponent("el", fixedComponent{nil}, 10*time.Second, 0, 0)
+	require.NoError(t, ensureComponentsHealthy(context.Background(), zap.NewNop(), p))
+}
+
+// Test_ensureComponentsHealthy_failsWhenUnhealthy: an unhealthy component fails the gate (so the
+// node restarts) — the error carries componentsUnhealthyErrorMsg.
+func Test_ensureComponentsHealthy_failsWhenUnhealthy(t *testing.T) {
+	p := hprobe.NewHealthProber(zap.NewNop())
+	p.AddComponent("el", fixedComponent{errors.New("el down")}, 10*time.Second, 0, 0)
+	err := ensureComponentsHealthy(context.Background(), zap.NewNop(), p)
+	require.ErrorContains(t, err, componentsUnhealthyErrorMsg)
+}
+
+// Test_ensureComponentsHealthy_doesNotReportUnhealthOnCancel: a canceled parent (a deliberate stop)
+// is never classified as component unhealth. The gate returns nil or the ctx error — depending on
+// whether the probe surfaced its failure before the cancel was observed — but never the unhealthy
+// verdict, which would trip a restart for the wrong reason.
+func Test_ensureComponentsHealthy_doesNotReportUnhealthOnCancel(t *testing.T) {
+	p := hprobe.NewHealthProber(zap.NewNop())
+	p.AddComponent("el", fixedComponent{errors.New("el down")}, 10*time.Second, 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := ensureComponentsHealthy(ctx, zap.NewNop(), p)
+	if err != nil {
+		require.ErrorIs(t, err, context.Canceled, "a deliberate stop must surface the ctx error, never unhealth")
+	}
+}

--- a/cli/operator/start_node.go
+++ b/cli/operator/start_node.go
@@ -75,12 +75,18 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("received second shutdown signal, exiting immediately", zap.String("signal", sig.String()))
 		}()
 
-		if err := runNode(ctx, &cfg, logger); err != nil {
-			// runNode surfaces the terminal cause — for a deliberate stop that's context.Canceled,
-			// or whatever was in flight when the signal landed. Key on whether a signal arrived, not
-			// the error's nature: a deliberate stop exits 0 (running the deferred observability
-			// shutdown) even if a genuine error coincided — whoever sent the signal isn't restarting
-			// on exit code anyway.
+		// Build the node, then run it: runNode owns the node's lifecycle and blocks until the first
+		// terminal event (a service/bring-up failure, or the signal canceling ctx) brings it down.
+		n, err := buildNode(ctx, &cfg, logger)
+		if err == nil {
+			err = runNode(ctx, logger, n)
+		}
+		if err != nil {
+			// buildNode/runNode surface the terminal cause — for a deliberate stop that's
+			// context.Canceled, or whatever was in flight when the signal landed. Key on whether a
+			// signal arrived (ctx), not the error's nature: a deliberate stop exits 0 (running the
+			// deferred observability shutdown) even if a genuine error coincided — whoever sent the
+			// signal isn't restarting on exit code anyway.
 			if ctx.Err() != nil {
 				logger.Info("node stopped on signal", startupErrorLogFields(err)...)
 				return

--- a/cli/operator/start_node.go
+++ b/cli/operator/start_node.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -56,7 +59,20 @@ var StartNodeCmd = &cobra.Command{
 
 		logger.Info(fmt.Sprintf("starting %v", commons.GetBuildData()))
 
-		if err := runNode(cmd.Context(), &cfg, logger); err != nil {
+		// Cancel the node ctx on SIGINT/SIGTERM so shutdown unwinds gracefully through the errgroup
+		// (long-lived services return nil, node.Close() runs) instead of the process being terminated
+		// abruptly. Scoped to start-node so other subcommands keep cobra's default signal behavior.
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		if err := runNode(ctx, &cfg, logger); err != nil {
+			// A signal during the synchronous startup phase surfaces as an error rather than the
+			// errgroup's clean-cancel (nil) path; treat it as a deliberate stop, not a startup failure
+			// — exit 0 (letting the deferred observability shutdown run) instead of Fatal.
+			if ctx.Err() != nil {
+				logger.Info("node shut down before startup completed", zap.Error(err))
+				return
+			}
 			logger.Fatal("could not start node", startupErrorLogFields(err)...)
 		}
 	},

--- a/cli/operator/start_node.go
+++ b/cli/operator/start_node.go
@@ -67,22 +67,18 @@ var StartNodeCmd = &cobra.Command{
 		defer cancel()
 		sigC := make(chan os.Signal, 2)
 		signal.Notify(sigC, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			sig := <-sigC
-			logger.Info("received shutdown signal, shutting down gracefully (repeat to force-exit)", zap.String("signal", sig.String()))
-			cancel()
-			sig = <-sigC
+		go handleShutdownSignals(sigC, logger, cancel, func(sig os.Signal) {
 			logger.Fatal("received second shutdown signal, exiting immediately", zap.String("signal", sig.String()))
-		}()
+		})
 
-		// Build the node, then run it: runNode owns the node's lifecycle and blocks until the first
-		// terminal event (a service/bring-up failure, or the signal canceling ctx) brings it down.
+		// Build the node, then supervise it: supervise blocks until the first terminal event (a
+		// service/bring-up failure, or the signal canceling ctx) brings the node down.
 		n, err := buildNode(ctx, &cfg, logger)
 		if err == nil {
-			err = runNode(ctx, logger, n)
+			err = supervise(ctx, logger, shutdownGraceTimeout, n.start, n.close)
 		}
 		if err != nil {
-			// buildNode/runNode surface the terminal cause — for a deliberate stop that's
+			// buildNode/supervise surface the terminal cause — for a deliberate stop that's
 			// context.Canceled, or whatever was in flight when the signal landed. Key on whether a
 			// signal arrived (ctx), not the error's nature: a deliberate stop exits 0 (running the
 			// deferred observability shutdown) even if a genuine error coincided — whoever sent the
@@ -94,6 +90,19 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("could not start node", startupErrorLogFields(err)...)
 		}
 	},
+}
+
+// handleShutdownSignals implements the two-stage stop scoped to start-node: the first signal calls
+// gracefulStop (cancel the node ctx so shutdown unwinds cleanly), and a second one calls forceStop —
+// the escape hatch for a graceful teardown that wedged. forceStop is injected (it's logger.Fatal in
+// production, which os.Exits) so the two-stage behavior is testable.
+func handleShutdownSignals(sigC <-chan os.Signal, logger *zap.Logger, gracefulStop func(), forceStop func(os.Signal)) {
+	sig := <-sigC
+	logger.Info("received shutdown signal, shutting down gracefully (repeat to force-exit)", zap.String("signal", sig.String()))
+	gracefulStop()
+
+	sig = <-sigC
+	forceStop(sig)
 }
 
 // buildObservabilityOptions assembles the observability stack options (logger plus

--- a/cli/operator/start_node.go
+++ b/cli/operator/start_node.go
@@ -67,10 +67,11 @@ var StartNodeCmd = &cobra.Command{
 
 		if err := runNode(ctx, &cfg, logger); err != nil {
 			// A signal during the synchronous startup phase surfaces as an error rather than the
-			// errgroup's clean-cancel (nil) path; treat it as a deliberate stop, not a startup failure
-			// — exit 0 (letting the deferred observability shutdown run) instead of Fatal.
+			// clean-cancel (nil) path. Key on whether a signal arrived, not the error's nature: a
+			// deliberate stop exits 0 (running the deferred observability shutdown) even if a genuine
+			// error coincided — whoever sent the signal isn't restarting on exit code anyway.
 			if ctx.Err() != nil {
-				logger.Info("node shut down before startup completed", zap.Error(err))
+				logger.Info("node stopped on signal", startupErrorLogFields(err)...)
 				return
 			}
 			logger.Fatal("could not start node", startupErrorLogFields(err)...)

--- a/cli/operator/start_node.go
+++ b/cli/operator/start_node.go
@@ -59,17 +59,28 @@ var StartNodeCmd = &cobra.Command{
 
 		logger.Info(fmt.Sprintf("starting %v", commons.GetBuildData()))
 
-		// Cancel the node ctx on SIGINT/SIGTERM so shutdown unwinds gracefully through the errgroup
-		// (long-lived services return nil, node.Close() runs) instead of the process being terminated
-		// abruptly. Scoped to start-node so other subcommands keep cobra's default signal behavior.
-		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
+		// First SIGINT/SIGTERM cancels the node ctx so shutdown unwinds gracefully (services stop,
+		// node Close runs); a second one force-exits via Fatal — the escape hatch for a graceful
+		// teardown that wedged. Scoped to start-node so other subcommands keep cobra's default
+		// signal behavior.
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+		sigC := make(chan os.Signal, 2)
+		signal.Notify(sigC, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			sig := <-sigC
+			logger.Info("received shutdown signal, shutting down gracefully (repeat to force-exit)", zap.String("signal", sig.String()))
+			cancel()
+			sig = <-sigC
+			logger.Fatal("received second shutdown signal, exiting immediately", zap.String("signal", sig.String()))
+		}()
 
 		if err := runNode(ctx, &cfg, logger); err != nil {
-			// A signal during the synchronous startup phase surfaces as an error rather than the
-			// clean-cancel (nil) path. Key on whether a signal arrived, not the error's nature: a
-			// deliberate stop exits 0 (running the deferred observability shutdown) even if a genuine
-			// error coincided — whoever sent the signal isn't restarting on exit code anyway.
+			// runNode surfaces the terminal cause — for a deliberate stop that's context.Canceled,
+			// or whatever was in flight when the signal landed. Key on whether a signal arrived, not
+			// the error's nature: a deliberate stop exits 0 (running the deferred observability
+			// shutdown) even if a genuine error coincided — whoever sent the signal isn't restarting
+			// on exit code anyway.
 			if ctx.Err() != nil {
 				logger.Info("node stopped on signal", startupErrorLogFields(err)...)
 				return

--- a/cli/operator/start_node_test.go
+++ b/cli/operator/start_node_test.go
@@ -1,0 +1,44 @@
+package operator
+
+import (
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Test_handleShutdownSignals_firstStopsGracefullySecondForces pins the two-stage behavior: the first
+// signal triggers the graceful stop (and nothing else), a second one triggers the force-exit hatch.
+func Test_handleShutdownSignals_firstStopsGracefullySecondForces(t *testing.T) {
+	sigC := make(chan os.Signal, 2)
+	var gracefulStopped atomic.Bool
+	forced := make(chan os.Signal, 1)
+
+	go handleShutdownSignals(sigC, zap.NewNop(),
+		func() { gracefulStopped.Store(true) },
+		func(sig os.Signal) { forced <- sig },
+	)
+
+	// First signal: graceful stop fires, force-exit does not.
+	sigC <- syscall.SIGTERM
+	require.Eventually(t, gracefulStopped.Load, time.Second, 5*time.Millisecond,
+		"first signal must trigger the graceful stop")
+	select {
+	case <-forced:
+		t.Fatal("force-exit must not fire before a second signal")
+	default:
+	}
+
+	// Second signal: force-exit fires, carrying that signal.
+	sigC <- syscall.SIGINT
+	select {
+	case sig := <-forced:
+		require.Equal(t, syscall.SIGINT, sig)
+	case <-time.After(time.Second):
+		t.Fatal("second signal must trigger the force-exit")
+	}
+}

--- a/cli/operator/supervise.go
+++ b/cli/operator/supervise.go
@@ -1,0 +1,62 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// service is a long-lived unit of work run by supervise: it runs in its own goroutine, and the first
+// service to return a non-nil error becomes the terminal cause that unwinds the rest.
+type service = func() error
+
+// supervise runs a lifecycle and blocks until it ends: start launches the long-lived services through
+// spawn, and supervise waits until the first spawned service returns an error, start itself fails, or
+// the parent ctx is canceled (a shutdown signal → context.Canceled) — whichever comes first. That
+// cause then tears everything down within graceTimeout (awaiting the still-running services, then
+// teardown) and is returned. start returns once the services are up; what's supervised is the
+// services it spawned. Past the grace window supervise surfaces the cause rather than hang forever on
+// something ignoring cancellation (the leftovers are reaped at process exit).
+func supervise(
+	ctx context.Context,
+	logger *zap.Logger,
+	graceTimeout time.Duration,
+	start func(ctx context.Context, spawn func(service)) error,
+	teardown func() error,
+) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	var wg sync.WaitGroup
+	spawn := func(svc service) {
+		wg.Go(func() {
+			if err := svc(); err != nil {
+				cancel(err)
+			}
+		})
+	}
+	if err := start(ctx, spawn); err != nil {
+		cancel(err) // a start failure is a terminal event too (the first cause wins)
+	}
+
+	<-ctx.Done()
+	cause := context.Cause(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		if err := teardown(); err != nil {
+			logger.Error("graceful teardown reported an error", zap.Error(err))
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		return cause
+	case <-time.After(graceTimeout):
+		return fmt.Errorf("graceful shutdown timed out after %s: %w", graceTimeout, cause)
+	}
+}

--- a/cli/operator/supervise_test.go
+++ b/cli/operator/supervise_test.go
@@ -1,0 +1,87 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// superviseTestGrace is generous enough that the graceful-teardown window never fires for the
+// well-behaved cases below (whose teardown is ~instant), so those assert the cause, not the timeout.
+const superviseTestGrace = 5 * time.Second
+
+// Test_supervise_startFailureBecomesCause: a start failure is a terminal event — supervise returns
+// it as the cause and still runs teardown.
+func Test_supervise_startFailureBecomesCause(t *testing.T) {
+	errBoom := errors.New("start boom")
+	var torn atomic.Bool
+
+	err := supervise(context.Background(), zap.NewNop(), superviseTestGrace,
+		func(context.Context, func(func() error)) error { return errBoom },
+		func() error { torn.Store(true); return nil })
+
+	require.ErrorIs(t, err, errBoom)
+	require.True(t, torn.Load(), "teardown must run even when start fails")
+}
+
+// Test_supervise_serviceFailureBecomesCause: a long-lived service that fails cancels the root with
+// its error as the cause, which supervise returns after tearing down.
+func Test_supervise_serviceFailureBecomesCause(t *testing.T) {
+	errBoom := errors.New("service boom")
+	var torn atomic.Bool
+
+	err := supervise(context.Background(), zap.NewNop(), superviseTestGrace,
+		func(_ context.Context, spawn func(func() error)) error {
+			spawn(func() error { return errBoom })
+			return nil
+		},
+		func() error { torn.Store(true); return nil })
+
+	require.ErrorIs(t, err, errBoom)
+	require.True(t, torn.Load(), "teardown must run on the way out")
+}
+
+// Test_supervise_signalCancelSurfacesAsCanceled: a deliberate stop (the parent ctx canceled, as a
+// shutdown signal does) surfaces as context.Canceled — not a failure — while still tearing down.
+func Test_supervise_signalCancelSurfacesAsCanceled(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	defer cancelParent()
+	var torn atomic.Bool
+
+	go cancelParent() // the "signal"
+
+	err := supervise(parent, zap.NewNop(), superviseTestGrace,
+		func(ctx context.Context, spawn func(func() error)) error {
+			// A well-behaved long-lived service: stays up until the root is canceled, then returns nil.
+			spawn(func() error { <-ctx.Done(); return nil })
+			return nil
+		},
+		func() error { torn.Store(true); return nil })
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, torn.Load(), "teardown must run on a deliberate stop")
+}
+
+// Test_supervise_wedgedServiceHitsGraceTimeout: a service that ignores cancellation must not hang
+// teardown — past the grace window supervise gives up and returns the cause wrapped in a timeout.
+func Test_supervise_wedgedServiceHitsGraceTimeout(t *testing.T) {
+	errBoom := errors.New("trigger boom")
+	release := make(chan struct{})
+	defer close(release) // let the wedged goroutine exit at test end rather than leak permanently
+
+	err := supervise(context.Background(), zap.NewNop(), 50*time.Millisecond,
+		func(_ context.Context, spawn func(func() error)) error {
+			spawn(func() error { <-release; return nil }) // wedged: ignores ctx
+			spawn(func() error { return errBoom })        // fails -> terminal event
+			return nil
+		},
+		func() error { return nil })
+
+	require.ErrorContains(t, err, "graceful shutdown timed out")
+	require.ErrorIs(t, err, errBoom, "the timeout error must still wrap the terminal cause")
+}

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -28,9 +28,8 @@ const (
 type WebSocketServer interface {
 	// Start binds a listener on the address passed to NewWsServer and serves in the background. It
 	// returns the bound address (useful with a :0 port) plus a channel that emits a non-graceful
-	// serve error, closed silently once shutdown completes. Canceling the ctx passed to NewWsServer
-	// triggers shutdown.
-	Start() (string, <-chan error, error)
+	// serve error, closed silently once shutdown completes. Canceling ctx triggers shutdown.
+	Start(ctx context.Context) (string, <-chan error, error)
 	BroadcastFeed() *event.Feed
 	UseQueryHandler(handler QueryMessageHandler)
 }
@@ -53,9 +52,8 @@ type wsServer struct {
 }
 
 // NewWsServer creates a new instance that listens on addr when Started.
-func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool, addr string) WebSocketServer {
+func NewWsServer(logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool, addr string) WebSocketServer {
 	ws := wsServer{
-		ctx:         ctx,
 		addr:        addr,
 		logger:      logger.Named(log.NameWSServer),
 		handler:     handler,
@@ -73,9 +71,11 @@ func (ws *wsServer) UseQueryHandler(handler QueryMessageHandler) {
 	ws.handler = handler
 }
 
-// Start binds the listener and serves in the background until the ctx passed to NewWsServer is
-// canceled. See the WebSocketServer interface for the returned address and error channel.
-func (ws *wsServer) Start() (string, <-chan error, error) {
+// Start binds the listener and serves in the background until ctx is canceled. See the
+// WebSocketServer interface for the returned address and error channel.
+func (ws *wsServer) Start(ctx context.Context) (string, <-chan error, error) {
+	ws.ctx = ctx
+
 	l, err := net.Listen("tcp", ws.addr)
 	if err != nil {
 		return "", nil, fmt.Errorf("listen on %s: %w", ws.addr, err)

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -26,12 +26,11 @@ const (
 // dispatches query messages to the registered handler, and broadcasts
 // stream messages from BroadcastFeed to every connected /stream client.
 type WebSocketServer interface {
-	// Start binds a listener on addr and begins serving in the background.
-	// It returns the bound address (useful when addr has a :0 port) once the
-	// listener is ready to accept connections, plus a channel that emits a
-	// non-graceful serve error (the channel is closed silently when the
-	// ctx-driven shutdown completes).
-	Start(addr string) (string, <-chan error, error)
+	// Start binds a listener on the address passed to NewWsServer and serves in the background. It
+	// returns the bound address (useful with a :0 port) plus a channel that emits a non-graceful
+	// serve error, closed silently once shutdown completes. Canceling the ctx passed to NewWsServer
+	// triggers shutdown.
+	Start() (string, <-chan error, error)
 	BroadcastFeed() *event.Feed
 	UseQueryHandler(handler QueryMessageHandler)
 }
@@ -40,6 +39,7 @@ type WebSocketServer interface {
 type wsServer struct {
 	logger *zap.Logger
 	ctx    context.Context
+	addr   string
 
 	router    *http.ServeMux
 	endpoints []string
@@ -52,10 +52,11 @@ type wsServer struct {
 	withPing bool
 }
 
-// NewWsServer creates a new instance.
-func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool) WebSocketServer {
+// NewWsServer creates a new instance that listens on addr when Started.
+func NewWsServer(ctx context.Context, logger *zap.Logger, handler QueryMessageHandler, mux *http.ServeMux, withPing bool, addr string) WebSocketServer {
 	ws := wsServer{
 		ctx:         ctx,
+		addr:        addr,
 		logger:      logger.Named(log.NameWSServer),
 		handler:     handler,
 		router:      mux,
@@ -72,16 +73,12 @@ func (ws *wsServer) UseQueryHandler(handler QueryMessageHandler) {
 	ws.handler = handler
 }
 
-// Start binds a listener on addr and serves the websocket server in the
-// background. It returns the bound address once the listener is ready (so
-// callers using a :0 port can discover the kernel-assigned one) and a channel
-// that emits a non-graceful serve error (the channel is closed silently when
-// the ctx-driven shutdown completes). The server shuts down when the ctx
-// passed to NewWsServer is canceled.
-func (ws *wsServer) Start(addr string) (string, <-chan error, error) {
-	l, err := net.Listen("tcp", addr)
+// Start binds the listener and serves in the background until the ctx passed to NewWsServer is
+// canceled. See the WebSocketServer interface for the returned address and error channel.
+func (ws *wsServer) Start() (string, <-chan error, error) {
+	l, err := net.Listen("tcp", ws.addr)
 	if err != nil {
-		return "", nil, fmt.Errorf("listen on %s: %w", addr, err)
+		return "", nil, fmt.Errorf("listen on %s: %w", ws.addr, err)
 	}
 	boundAddr := l.Addr().String()
 

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -24,8 +24,8 @@ func TestHandleQuery(t *testing.T) {
 		nm.Msg.Data = []registrystorage.OperatorData{
 			{PublicKey: fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From)},
 		}
-	}, mux, false)
-	addr, _, err := ws.Start("127.0.0.1:0")
+	}, mux, false, "127.0.0.1:0")
+	addr, _, err := ws.Start()
 	require.NoError(t, err)
 
 	clientCtx, cancelClientCtx := context.WithCancel(ctx)
@@ -65,8 +65,8 @@ func TestHandleQuery_ServerCtxCancelClosesIdleConn(t *testing.T) {
 	defer cancel()
 
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), func(nm *NetworkMessage) {}, mux, false)
-	addr, _, err := ws.Start("127.0.0.1:0")
+	ws := NewWsServer(ctx, zap.NewNop(), func(nm *NetworkMessage) {}, mux, false, "127.0.0.1:0")
+	addr, _, err := ws.Start()
 	require.NoError(t, err)
 
 	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/query", nil)
@@ -84,8 +84,8 @@ func TestHandleStream(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	ctx := t.Context()
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false)
-	addr, _, err := ws.Start("127.0.0.1:0")
+	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false, "127.0.0.1:0")
+	addr, _, err := ws.Start()
 	require.NoError(t, err)
 
 	testCtx, cancelCtx := context.WithCancel(ctx)

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -20,12 +20,12 @@ func TestHandleQuery(t *testing.T) {
 	ctx, cancelServerCtx := context.WithCancel(t.Context())
 	defer cancelServerCtx()
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), func(nm *NetworkMessage) {
+	ws := NewWsServer(zap.NewNop(), func(nm *NetworkMessage) {
 		nm.Msg.Data = []registrystorage.OperatorData{
 			{PublicKey: fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From)},
 		}
 	}, mux, false, "127.0.0.1:0")
-	addr, _, err := ws.Start()
+	addr, _, err := ws.Start(ctx)
 	require.NoError(t, err)
 
 	clientCtx, cancelClientCtx := context.WithCancel(ctx)
@@ -65,8 +65,8 @@ func TestHandleQuery_ServerCtxCancelClosesIdleConn(t *testing.T) {
 	defer cancel()
 
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), func(nm *NetworkMessage) {}, mux, false, "127.0.0.1:0")
-	addr, _, err := ws.Start()
+	ws := NewWsServer(zap.NewNop(), func(nm *NetworkMessage) {}, mux, false, "127.0.0.1:0")
+	addr, _, err := ws.Start(ctx)
 	require.NoError(t, err)
 
 	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/query", nil)
@@ -84,8 +84,8 @@ func TestHandleStream(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	ctx := t.Context()
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, zap.NewNop(), nil, mux, false, "127.0.0.1:0")
-	addr, _, err := ws.Start()
+	ws := NewWsServer(zap.NewNop(), nil, mux, false, "127.0.0.1:0")
+	addr, _, err := ws.Start(ctx)
 	require.NoError(t, err)
 
 	testCtx, cancelCtx := context.WithCancel(ctx)

--- a/hprobe/mock_component_test.go
+++ b/hprobe/mock_component_test.go
@@ -25,6 +25,14 @@ func (m *stuckComponentMock) Healthy(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// ctxIgnoringComponentMock simulates a buggy component whose Healthy ignores its ctx entirely
+// (stuck mutex, broken client): it never returns, leaking its probe goroutine by design.
+type ctxIgnoringComponentMock struct{}
+
+func (m *ctxIgnoringComponentMock) Healthy(context.Context) error {
+	select {} // blocks forever
+}
+
 type glitchyComponentMock struct {
 	calledCnt        atomic.Uint64
 	glitchedCallsCnt uint64

--- a/hprobe/prober.go
+++ b/hprobe/prober.go
@@ -77,31 +77,32 @@ func (p *HealthProber) ProbeAll(ctx context.Context) error {
 		close(errsCh)
 	}()
 
+	// Collect failures until every worker returns (errsCh closed) or ctx ends the round. A timeout is
+	// itself a failure and returns straight away; the other two exits fall through to the verdict below.
 	var errs error
+collect:
 	for {
 		select {
 		case err, ok := <-errsCh:
 			if !ok {
-				// Every worker returned: the verdict is complete.
-				if errs != nil {
-					return fmt.Errorf("probe health-check failed: %w", errs)
-				}
-				return nil
+				break collect // every worker returned
 			}
 			errs = errors.Join(errs, err)
 		case <-ctx.Done():
 			// Don't wait out a wedged worker (a Healthy impl ignoring its ctx): report what's known.
 			// A wedged probe goroutine is unreapable — it leaks until process exit.
-			if errors.Is(ctx.Err(), context.Canceled) {
-				// Canceled is not a verdict: report only real failures, if any.
-				if errs != nil {
-					return fmt.Errorf("probe health-check failed: %w", errs)
-				}
-				return nil
+			if !errors.Is(ctx.Err(), context.Canceled) {
+				return fmt.Errorf("probe health-check timed out: %w", errors.Join(errs, ctx.Err()))
 			}
-			return fmt.Errorf("probe health-check timed out: %w", errors.Join(errs, ctx.Err()))
+			break collect // cancellation isn't a verdict — report only the real failures, if any
 		}
 	}
+
+	// Verdict: the joined component failures, or nil if none were observed.
+	if errs != nil {
+		return fmt.Errorf("probe health-check failed: %w", errs)
+	}
+	return nil
 }
 
 func (p *HealthProber) Probe(ctx context.Context, componentName string) error {

--- a/hprobe/prober.go
+++ b/hprobe/prober.go
@@ -44,24 +44,29 @@ func NewHealthProber(logger *zap.Logger) *HealthProber {
 	}
 }
 
+// ProbeAll probes all components in parallel and returns the joined failure verdict (nil if no
+// failure was observed). It returns when every probe finishes or when ctx expires, whichever comes
+// first — a Healthy impl that ignores its ctx can't stall the round past its deadline.
 func (p *HealthProber) ProbeAll(ctx context.Context) error {
-	// Probe all components in parallel, use cancel to quit early canceling irrelevant workers.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// The internal cancel quits the remaining probes early once one component has failed.
+	probeCtx, probeCancel := context.WithCancel(ctx)
+	defer probeCancel()
 
 	var wg sync.WaitGroup
-	errsCh := make(chan error)
+	// Buffered to component count so a worker never blocks on send: it can deposit its error and
+	// exit even after ProbeAll has already returned on ctx expiry below.
+	errsCh := make(chan error, p.components.SlowLen())
 
 	p.components.Range(func(name string, n pComponent) bool {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			err := p.probeComponent(ctx, n)
+			err := p.probeComponent(probeCtx, n)
 			if err != nil {
-				// Relay the error and quit early.
+				// Relay the failure and quit the other probes early.
 				errsCh <- fmt.Errorf("probe component %s: %w", name, err)
-				cancel()
+				probeCancel()
 			}
 		}()
 		return true
@@ -73,13 +78,30 @@ func (p *HealthProber) ProbeAll(ctx context.Context) error {
 	}()
 
 	var errs error
-	for err := range errsCh {
-		errs = errors.Join(errs, err)
+	for {
+		select {
+		case err, ok := <-errsCh:
+			if !ok {
+				// Every worker returned: the verdict is complete.
+				if errs != nil {
+					return fmt.Errorf("probe health-check failed: %w", errs)
+				}
+				return nil
+			}
+			errs = errors.Join(errs, err)
+		case <-ctx.Done():
+			// Don't wait out a wedged worker (a Healthy impl ignoring its ctx): report what's known.
+			// A wedged probe goroutine is unreapable — it leaks until process exit.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				// Canceled is not a verdict: report only real failures, if any.
+				if errs != nil {
+					return fmt.Errorf("probe health-check failed: %w", errs)
+				}
+				return nil
+			}
+			return fmt.Errorf("probe health-check timed out: %w", errors.Join(errs, ctx.Err()))
+		}
 	}
-	if errs != nil {
-		errs = fmt.Errorf("probe health-check failed: %w", errs)
-	}
-	return errs
 }
 
 func (p *HealthProber) Probe(ctx context.Context, componentName string) error {
@@ -109,7 +131,7 @@ func (p *HealthProber) probeComponent(ctx context.Context, c pComponent) (err er
 			return c.c.Healthy(healthCtx)
 		}()
 		if errors.Is(err, context.Canceled) {
-			return nil // probing was canceled (it's not an error then)
+			return nil // probing was cut short (canceled) — not a component failure
 		}
 		if err == nil {
 			return nil // success
@@ -127,6 +149,9 @@ func (p *HealthProber) probeComponent(ctx context.Context, c pComponent) (err er
 		// Wait before the next attempt.
 		select {
 		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil // probing was cut short (canceled) — not a component failure
+			}
 			return ctx.Err()
 		case <-time.After(c.retryDelay):
 		}

--- a/hprobe/prober_test.go
+++ b/hprobe/prober_test.go
@@ -96,6 +96,18 @@ func TestProber(t *testing.T) {
 		require.ErrorContains(t, err, "deadline exceeded")
 	})
 
+	t.Run("1 component, probe canceled is not an error", func(t *testing.T) {
+		clComponent := &stuckComponentMock{}
+
+		p := NewHealthProber(log.TestLogger(t))
+		p.AddComponent(clComponentName, clComponent, 10*time.Second, 5, 0)
+
+		probeCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := p.Probe(probeCtx, clComponentName)
+		require.NoError(t, err)
+	})
+
 	t.Run("all components are healthy", func(t *testing.T) {
 		clComponent := &componentMock{}
 		clComponent.healthy.Store(nil)
@@ -253,6 +265,42 @@ func TestProber(t *testing.T) {
 		cancel()
 		err := p.ProbeAll(probeCtx)
 		require.NoError(t, err)
+	})
+
+	t.Run("wedged component cannot stall the round past its deadline", func(t *testing.T) {
+		// A Healthy impl that ignores its ctx never returns; the round must still end at the ctx
+		// deadline with a timeout verdict — otherwise a single wedged component would hang every
+		// ProbeAll caller forever. The wedged probe goroutine leaks and is reaped at process exit.
+		clComponent := &ctxIgnoringComponentMock{}
+
+		p := NewHealthProber(log.TestLogger(t))
+		p.AddComponent(clComponentName, clComponent, 10*time.Millisecond, 0, 0)
+
+		probeCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		err := p.ProbeAll(probeCtx)
+		require.ErrorContains(t, err, "deadline exceeded")
+	})
+
+	t.Run("sibling cut short by early-cancel is not part of the verdict", func(t *testing.T) {
+		// The CL fails outright; its failure early-cancels the round while the EL is parked in its
+		// retry-delay. The EL's cut-short probe must contribute nothing: the verdict carries only the
+		// genuine failure and must not be classifiable as a cancellation (#2880).
+		clComponent := &componentMock{}
+		clDownErr := fmt.Errorf("some error")
+		clComponent.healthy.Store(&clDownErr)
+
+		elComponent := newGlitchyComponentMock(1) // first attempt fails -> parks in retry-delay
+
+		p := NewHealthProber(log.TestLogger(t))
+		p.AddComponent(clComponentName, clComponent, 10*time.Second, 0, 0)
+		p.AddComponent(elComponentName, elComponent, 10*time.Second, 5, 10*time.Second)
+
+		err := p.ProbeAll(ctx)
+		require.ErrorContains(t, err, clComponentName)
+		require.ErrorContains(t, err, clDownErr.Error())
+		require.NotErrorIs(t, err, context.Canceled)
+		require.NotContains(t, err.Error(), elComponentName)
 	})
 
 	t.Run("component glitches survived via retries", func(t *testing.T) {

--- a/operator/node.go
+++ b/operator/node.go
@@ -178,8 +178,12 @@ func (n *Node) Start(ctx context.Context) error {
 		return fmt.Errorf("start WS server: %w", err)
 	}
 
-	// Start the duty scheduler in modes that use it. It joins gctx so a sibling failure (e.g. the WS
-	// serve loop) tears it down too, letting the Wait in runServices return.
+	// Start the duty scheduler (modes that use it) on gctx, so it stops when the group is canceled —
+	// on shutdown, or once runServices joins the long-lived members and one fails. dutyScheduler.Start
+	// blocks (HandleInitialDuties, itself bounded to ~a slot), and the WS serve loop isn't joined until
+	// runServices, so a WS serve failure during this window is buffered in wsServeErr and surfaced once
+	// runServices joins it — same as the metrics/API serve loops in cli/operator. This is deliberate:
+	// a diagnostic-server crash shouldn't abort in-progress (resumable) startup mid-flight.
 	if n.dutyScheduler != nil {
 		if err := n.dutyScheduler.Start(gctx); err != nil {
 			return fmt.Errorf("failed to run duty scheduler: %w", err)

--- a/operator/node.go
+++ b/operator/node.go
@@ -179,11 +179,11 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 
 	// Start the duty scheduler (modes that use it) on gctx, so it stops when the group is canceled —
-	// on shutdown, or once runServices joins the long-lived members and one fails. dutyScheduler.Start
-	// blocks (HandleInitialDuties, itself bounded to ~a slot), and the WS serve loop isn't joined until
-	// runServices, so a WS serve failure during this window is buffered in wsServeErr and surfaced once
-	// runServices joins it — same as the metrics/API serve loops in cli/operator. This is deliberate:
-	// a diagnostic-server crash shouldn't abort in-progress (resumable) startup mid-flight.
+	// on shutdown, or once the long-lived members are joined below and one fails. dutyScheduler.Start
+	// blocks (HandleInitialDuties, itself bounded to ~a slot), and the WS serve loop isn't joined
+	// until after that, so a WS serve failure during this window is buffered in wsServeErr and
+	// surfaced once it's joined — same as the metrics/API serve loops in cli/operator. This is
+	// deliberate: a diagnostic-server crash shouldn't abort in-progress (resumable) startup mid-flight.
 	if n.dutyScheduler != nil {
 		if err := n.dutyScheduler.Start(gctx); err != nil {
 			return fmt.Errorf("failed to run duty scheduler: %w", err)
@@ -260,16 +260,12 @@ func (n *Node) Start(ctx context.Context) error {
 	// The p2p network is owned by its creator (cli/operator), which closes it via defer.
 	// Start() no longer closes it: closing it only on this happy path leaked the network
 	// whenever Start returned early with an error.
-	return n.runServices(g, gctx, wsServeErr)
-}
-
-// runServices joins the operator node's long-lived members — the WS server's serve loop and the
-// duty scheduler's blocking wait — into the errgroup and blocks until the first fails or gctx is
-// canceled. On a clean cancellation every member returns nil, so Start returns nil; the first
-// non-nil return cancels gctx (unwinding the others) and propagates up to cli/operator's single
-// top-level Fatal, with node.Close() running. This replaces three goroutine/blocking-tail Fatals
-// that os.Exit-ed the process directly.
-func (n *Node) runServices(g *errgroup.Group, gctx context.Context, wsServeErr <-chan error) error {
+	//
+	// Join the long-lived members — the WS serve loop and the duty scheduler's blocking wait — into
+	// the errgroup and block until the first fails or gctx is canceled (clean cancel → every member
+	// returns nil → nil). The first non-nil return cancels gctx and propagates up to cli/operator's
+	// single top-level Fatal, with node.Close() running — replacing three goroutine/blocking-tail
+	// Fatals that os.Exit-ed the process directly.
 	if wsServeErr != nil {
 		g.Go(func() error {
 			// The WS server's shutdown is bound to its constructor ctx (the node ctx), not gctx, so

--- a/operator/node.go
+++ b/operator/node.go
@@ -9,6 +9,7 @@ import (
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -170,13 +171,17 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 func (n *Node) Start(ctx context.Context) error {
 	n.logger.Info("starting operator node")
 
-	if err := n.startWSServer(); err != nil {
+	g, gctx := errgroup.WithContext(ctx)
+
+	wsServeErr, err := n.startWSServer()
+	if err != nil {
 		return fmt.Errorf("start WS server: %w", err)
 	}
 
-	// Start the duty scheduler in modes that use it.
+	// Start the duty scheduler in modes that use it. It joins gctx so a sibling failure (e.g. the WS
+	// serve loop) tears it down too, letting the Wait in runServices return.
 	if n.dutyScheduler != nil {
-		if err := n.dutyScheduler.Start(ctx); err != nil {
+		if err := n.dutyScheduler.Start(gctx); err != nil {
 			return fmt.Errorf("failed to run duty scheduler: %w", err)
 		}
 	} else {
@@ -248,21 +253,55 @@ func (n *Node) Start(ctx context.Context) error {
 
 	n.logger.Info("operator node has been started", fields.OperatorID(n.validatorOptions.OperatorDataStore.GetOperatorID()))
 
-	if n.dutyScheduler != nil {
-		if err := n.dutyScheduler.Wait(); err != nil {
-			n.logger.Fatal("duty scheduler exited with error", zap.Error(err))
-		}
-	} else {
-		if !n.exporterOptions.Enabled || n.exporterOptions.Mode != exporter.ModeStandard {
-			n.logger.Fatal("duty scheduler is nil for non-exporter-standard node")
-		}
-		<-ctx.Done()
-	}
-
 	// The p2p network is owned by its creator (cli/operator), which closes it via defer.
 	// Start() no longer closes it: closing it only on this happy path leaked the network
 	// whenever Start returned early with an error.
-	return nil
+	return n.runServices(g, gctx, wsServeErr)
+}
+
+// runServices joins the operator node's long-lived members — the WS server's serve loop and the
+// duty scheduler's blocking wait — into the errgroup and blocks until the first fails or gctx is
+// canceled. On a clean cancellation every member returns nil, so Start returns nil; the first
+// non-nil return cancels gctx (unwinding the others) and propagates up to cli/operator's single
+// top-level Fatal, with node.Close() running. This replaces three goroutine/blocking-tail Fatals
+// that os.Exit-ed the process directly.
+func (n *Node) runServices(g *errgroup.Group, gctx context.Context, wsServeErr <-chan error) error {
+	if wsServeErr != nil {
+		g.Go(func() error {
+			// The WS server's shutdown is bound to its constructor ctx (the node ctx), not gctx, so
+			// its serveErr won't close when the group is torn down by another member. Watch gctx too
+			// to avoid blocking here in that case; the WS server is then stopped by node.Close().
+			select {
+			case err := <-wsServeErr:
+				if err != nil {
+					return fmt.Errorf("WS server serve loop exited: %w", err)
+				}
+				return nil
+			case <-gctx.Done():
+				return nil
+			}
+		})
+	}
+
+	g.Go(func() error {
+		if n.dutyScheduler != nil {
+			// Wait blocks until the scheduler's tasks drain (they exit on gctx cancel). It currently
+			// always returns nil, but propagate any future error rather than swallowing it.
+			if err := n.dutyScheduler.Wait(); err != nil {
+				return fmt.Errorf("duty scheduler exited with error: %w", err)
+			}
+			return nil
+		}
+		// dutyScheduler is only nil for exporter-standard nodes; any other mode reaching here is a
+		// wiring inconsistency that must surface rather than silently idling.
+		if !n.exporterOptions.Enabled || n.exporterOptions.Mode != exporter.ModeStandard {
+			return errors.New("duty scheduler is nil for non-exporter-standard node")
+		}
+		<-gctx.Done()
+		return nil
+	})
+
+	return g.Wait()
 }
 
 // HealthCheck returns a list of issues regards the state of the operator node
@@ -430,24 +469,26 @@ func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
 	return filtered
 }
 
-func (n *Node) startWSServer() error {
-	if n.ws != nil {
-		n.logger.Info("starting WS server")
-
-		n.ws.UseQueryHandler(n.handleQueryRequests)
-
-		_, serveErr, err := n.ws.Start(fmt.Sprintf(":%d", n.wsAPIPort))
-		if err != nil {
-			return err
-		}
-		go func() {
-			if err := <-serveErr; err != nil {
-				n.logger.Fatal("WS server serve loop exited", zap.Error(err))
-			}
-		}()
+// startWSServer binds and starts the WS API server (if configured) and returns its serve-error
+// channel for the caller to join into the node's errgroup; a nil channel means no WS server is
+// configured. The serve loop's error is no longer turned into a Fatal here — it propagates via the
+// returned channel so a serve failure brings the node down gracefully (through Close) rather than
+// os.Exit-ing the process from a goroutine.
+func (n *Node) startWSServer() (<-chan error, error) {
+	if n.ws == nil {
+		return nil, nil
 	}
 
-	return nil
+	n.logger.Info("starting WS server")
+
+	n.ws.UseQueryHandler(n.handleQueryRequests)
+
+	_, serveErr, err := n.ws.Start(fmt.Sprintf(":%d", n.wsAPIPort))
+	if err != nil {
+		return nil, err
+	}
+
+	return serveErr, nil
 }
 
 func (n *Node) reportOperators() {

--- a/operator/node.go
+++ b/operator/node.go
@@ -55,7 +55,6 @@ type Options struct {
 	DutyStore           *dutystore.Store
 	ExporterRead        *exporter2.Exporter
 	WS                  api.WebSocketServer
-	WsAPIPort           int
 }
 
 type Node struct {
@@ -73,8 +72,7 @@ type Node struct {
 	dutyScheduler    *duties.Scheduler
 	feeRecipientCtrl fee_recipient.RecipientController
 
-	ws        api.WebSocketServer
-	wsAPIPort int
+	ws api.WebSocketServer
 
 	exporterRead *exporter2.Exporter
 }
@@ -151,7 +149,6 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 		feeRecipientCtrl: feeRecipientCtrl,
 
 		ws:           opts.WS,
-		wsAPIPort:    opts.WsAPIPort,
 		exporterRead: opts.ExporterRead,
 	}
 
@@ -171,25 +168,54 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 func (n *Node) Start(ctx context.Context) error {
 	n.logger.Info("starting operator node")
 
+	// On an early return, defer cancel() signals the early-joined members (the WS serve loop and the
+	// scheduler wait) to stop; it doesn't await them — they wind down alongside the caller's shutdown.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	g, gctx := errgroup.WithContext(ctx)
 
-	wsServeErr, err := n.startWSServer()
-	if err != nil {
-		return fmt.Errorf("start WS server: %w", err)
+	// The WS server's shutdown is bound to the node ctx, not gctx, so the select also watches gctx to
+	// unblock g.Wait() if another member fails first.
+	if n.ws != nil {
+		wsServeErr, err := n.startWSServer()
+		if err != nil {
+			return fmt.Errorf("start WS server: %w", err)
+		}
+		g.Go(func() error {
+			select {
+			case err := <-wsServeErr:
+				if err != nil {
+					return fmt.Errorf("WS server serve loop exited: %w", err)
+				}
+				return nil
+			case <-gctx.Done():
+				return nil
+			}
+		})
 	}
 
-	// Start the duty scheduler (modes that use it) on gctx, so it stops when the group is canceled —
-	// on shutdown, or once the long-lived members are joined below and one fails. dutyScheduler.Start
-	// blocks (HandleInitialDuties, itself bounded to ~a slot), and the WS serve loop isn't joined
-	// until after that, so a WS serve failure during this window is buffered in wsServeErr and
-	// surfaced once it's joined — same as the metrics/API serve loops in cli/operator. This is
-	// deliberate: a diagnostic-server crash shouldn't abort in-progress (resumable) startup mid-flight.
-	if n.dutyScheduler != nil {
+	// Exporter-standard runs no duties — it just stays up until shutdown. dutyScheduler is nil only for
+	// that mode; any other mode reaching the default is a wiring bug.
+	switch {
+	case n.dutyScheduler != nil:
 		if err := n.dutyScheduler.Start(gctx); err != nil {
 			return fmt.Errorf("failed to run duty scheduler: %w", err)
 		}
-	} else {
-		n.logger.Info("exporter standard mode: skipping duty scheduler")
+		g.Go(func() error {
+			// Always nil today (tasks exit on gctx cancel), but propagate any future error rather than
+			// swallowing it.
+			if err := n.dutyScheduler.Wait(); err != nil {
+				return fmt.Errorf("duty scheduler exited with error: %w", err)
+			}
+			return nil
+		})
+	case n.exporterOptions.Enabled && n.exporterOptions.Mode == exporter.ModeStandard:
+		g.Go(func() error {
+			<-gctx.Done()
+			return nil
+		})
+	default:
+		return errors.New("duty scheduler is nil for non-exporter-standard node")
 	}
 
 	n.validatorsCtrl.StartNetworkHandlers()
@@ -256,50 +282,6 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 
 	n.logger.Info("operator node has been started", fields.OperatorID(n.validatorOptions.OperatorDataStore.GetOperatorID()))
-
-	// The p2p network is owned by its creator (cli/operator), which closes it via defer.
-	// Start() no longer closes it: closing it only on this happy path leaked the network
-	// whenever Start returned early with an error.
-	//
-	// Join the long-lived members — the WS serve loop and the duty scheduler's blocking wait — into
-	// the errgroup and block until the first fails or gctx is canceled (clean cancel → every member
-	// returns nil → nil). The first non-nil return cancels gctx and propagates up to cli/operator's
-	// single top-level Fatal, with node.Close() running — replacing three goroutine/blocking-tail
-	// Fatals that os.Exit-ed the process directly.
-	if wsServeErr != nil {
-		g.Go(func() error {
-			// The WS server's shutdown is bound to its constructor ctx (the node ctx), not gctx, so
-			// its serveErr won't close when the group is torn down by another member. Watch gctx too
-			// to avoid blocking here in that case; the WS server is then stopped by node.Close().
-			select {
-			case err := <-wsServeErr:
-				if err != nil {
-					return fmt.Errorf("WS server serve loop exited: %w", err)
-				}
-				return nil
-			case <-gctx.Done():
-				return nil
-			}
-		})
-	}
-
-	g.Go(func() error {
-		if n.dutyScheduler != nil {
-			// Wait blocks until the scheduler's tasks drain (they exit on gctx cancel). It currently
-			// always returns nil, but propagate any future error rather than swallowing it.
-			if err := n.dutyScheduler.Wait(); err != nil {
-				return fmt.Errorf("duty scheduler exited with error: %w", err)
-			}
-			return nil
-		}
-		// dutyScheduler is only nil for exporter-standard nodes; any other mode reaching here is a
-		// wiring inconsistency that must surface rather than silently idling.
-		if !n.exporterOptions.Enabled || n.exporterOptions.Mode != exporter.ModeStandard {
-			return errors.New("duty scheduler is nil for non-exporter-standard node")
-		}
-		<-gctx.Done()
-		return nil
-	})
 
 	return g.Wait()
 }
@@ -469,21 +451,15 @@ func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
 	return filtered
 }
 
-// startWSServer binds and starts the WS API server (if configured) and returns its serve-error
-// channel for the caller to join into the node's errgroup; a nil channel means no WS server is
-// configured. The serve loop's error is no longer turned into a Fatal here — it propagates via the
-// returned channel so a serve failure brings the node down gracefully (through Close) rather than
-// os.Exit-ing the process from a goroutine.
+// startWSServer starts the WS API server and returns its serve-error channel for the caller to join
+// into the node's errgroup. A serve failure propagates via the channel — bringing the node down
+// gracefully through Close — rather than os.Exit-ing from a goroutine. Callers gate on n.ws != nil.
 func (n *Node) startWSServer() (<-chan error, error) {
-	if n.ws == nil {
-		return nil, nil
-	}
-
 	n.logger.Info("starting WS server")
 
 	n.ws.UseQueryHandler(n.handleQueryRequests)
 
-	_, serveErr, err := n.ws.Start(fmt.Sprintf(":%d", n.wsAPIPort))
+	_, serveErr, err := n.ws.Start()
 	if err != nil {
 		return nil, err
 	}

--- a/operator/node.go
+++ b/operator/node.go
@@ -174,23 +174,18 @@ func (n *Node) Start(ctx context.Context) error {
 	defer cancel()
 	g, gctx := errgroup.WithContext(ctx)
 
-	// The WS server's shutdown is bound to the node ctx, not gctx, so the select also watches gctx to
-	// unblock g.Wait() if another member fails first.
+	// Plain receive is safe: the WS server takes gctx (via startWSServer), so its Shutdown closes
+	// serveErr on cancel and this can't wedge g.Wait().
 	if n.ws != nil {
-		wsServeErr, err := n.startWSServer()
+		wsServeErr, err := n.startWSServer(gctx)
 		if err != nil {
 			return fmt.Errorf("start WS server: %w", err)
 		}
 		g.Go(func() error {
-			select {
-			case err := <-wsServeErr:
-				if err != nil {
-					return fmt.Errorf("WS server serve loop exited: %w", err)
-				}
-				return nil
-			case <-gctx.Done():
-				return nil
+			if err := <-wsServeErr; err != nil {
+				return fmt.Errorf("WS server serve loop exited: %w", err)
 			}
+			return nil
 		})
 	}
 
@@ -454,12 +449,12 @@ func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
 // startWSServer starts the WS API server and returns its serve-error channel for the caller to join
 // into the node's errgroup. A serve failure propagates via the channel — bringing the node down
 // gracefully through Close — rather than os.Exit-ing from a goroutine. Callers gate on n.ws != nil.
-func (n *Node) startWSServer() (<-chan error, error) {
+func (n *Node) startWSServer(ctx context.Context) (<-chan error, error) {
 	n.logger.Info("starting WS server")
 
 	n.ws.UseQueryHandler(n.handleQueryRequests)
 
-	_, serveErr, err := n.ws.Start()
+	_, serveErr, err := n.ws.Start(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/node.go
+++ b/operator/node.go
@@ -169,7 +169,7 @@ func (n *Node) Start(ctx context.Context) error {
 	n.logger.Info("starting operator node")
 
 	// On an early return, defer cancel() signals the early-joined members (the WS serve loop and the
-	// scheduler wait) to stop; it doesn't await them — they wind down alongside the caller's shutdown.
+	// scheduler wait) to stop; it doesn't await them — they unwind in the background.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	g, gctx := errgroup.WithContext(ctx)
@@ -446,9 +446,9 @@ func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
 	return filtered
 }
 
-// startWSServer starts the WS API server and returns its serve-error channel for the caller to join
-// into the node's errgroup. A serve failure propagates via the channel — bringing the node down
-// gracefully through Close — rather than os.Exit-ing from a goroutine. Callers gate on n.ws != nil.
+// startWSServer starts the WS API server and returns its serve-error channel. A serve failure
+// propagates via the channel — bringing the node down gracefully through Close — rather than
+// os.Exit-ing from a goroutine. Requires n.ws != nil.
 func (n *Node) startWSServer(ctx context.Context) (<-chan error, error) {
 	n.logger.Info("starting WS server")
 

--- a/operator/node_test.go
+++ b/operator/node_test.go
@@ -1,9 +1,14 @@
 package operator
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/exporter"
 )
@@ -45,4 +50,71 @@ func TestShouldRunDutyScheduler(t *testing.T) {
 			require.Equal(t, tc.expected, shouldRunDutyScheduler(tc.exporterOpts))
 		})
 	}
+}
+
+// TestNode_runServices_returnsNilOnCtxCancel locks in the normal-shutdown invariant for the
+// operator-package side: with the duty scheduler absent (exporter-standard) and no WS server, the
+// joined members must return nil on a plain ctx cancellation, so a clean shutdown unwinds through
+// Start as nil rather than a spurious error.
+func TestNode_runServices_returnsNilOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g, gctx := errgroup.WithContext(ctx)
+
+	n := &Node{
+		logger:          zap.NewNop(),
+		exporterOptions: exporter.Options{Enabled: true, Mode: exporter.ModeStandard},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- n.runServices(g, gctx, nil) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "runServices must return nil on a clean ctx cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runServices did not return after ctx cancellation")
+	}
+}
+
+// TestNode_runServices_propagatesWSServeError verifies a WS serve-loop failure is surfaced as a
+// returned error (not a Fatal) and cancels the group so the other members unwind. The select-on-gctx
+// join also guards against deadlock when the WS server's serveErr is tied to a different ctx.
+func TestNode_runServices_propagatesWSServeError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, gctx := errgroup.WithContext(ctx)
+
+	wsServeErr := make(chan error, 1)
+	wsServeErr <- errors.New("boom")
+
+	// Exporter-standard so the scheduler member blocks on gctx and unwinds cleanly once the WS
+	// failure cancels the group.
+	n := &Node{
+		logger:          zap.NewNop(),
+		exporterOptions: exporter.Options{Enabled: true, Mode: exporter.ModeStandard},
+	}
+
+	err := n.runServices(g, gctx, wsServeErr)
+	require.ErrorContains(t, err, "WS server serve loop exited")
+}
+
+// TestNode_runServices_schedulerNilNonExporterStandard verifies the wiring-invariant check: a node
+// without a duty scheduler that is not exporter-standard surfaces an error rather than idling
+// silently (previously a Fatal).
+func TestNode_runServices_schedulerNilNonExporterStandard(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Operator mode (exporter disabled) with a nil dutyScheduler is the inconsistent state the check
+	// guards.
+	n := &Node{
+		logger:          zap.NewNop(),
+		exporterOptions: exporter.Options{},
+	}
+
+	err := n.runServices(g, gctx, nil)
+	require.ErrorContains(t, err, "duty scheduler is nil")
 }

--- a/operator/node_test.go
+++ b/operator/node_test.go
@@ -1,14 +1,9 @@
 package operator
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/exporter"
 )
@@ -50,71 +45,4 @@ func TestShouldRunDutyScheduler(t *testing.T) {
 			require.Equal(t, tc.expected, shouldRunDutyScheduler(tc.exporterOpts))
 		})
 	}
-}
-
-// TestNode_runServices_returnsNilOnCtxCancel locks in the normal-shutdown invariant for the
-// operator-package side: with the duty scheduler absent (exporter-standard) and no WS server, the
-// joined members must return nil on a plain ctx cancellation, so a clean shutdown unwinds through
-// Start as nil rather than a spurious error.
-func TestNode_runServices_returnsNilOnCtxCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	g, gctx := errgroup.WithContext(ctx)
-
-	n := &Node{
-		logger:          zap.NewNop(),
-		exporterOptions: exporter.Options{Enabled: true, Mode: exporter.ModeStandard},
-	}
-
-	done := make(chan error, 1)
-	go func() { done <- n.runServices(g, gctx, nil) }()
-
-	cancel()
-
-	select {
-	case err := <-done:
-		require.NoError(t, err, "runServices must return nil on a clean ctx cancellation")
-	case <-time.After(5 * time.Second):
-		t.Fatal("runServices did not return after ctx cancellation")
-	}
-}
-
-// TestNode_runServices_propagatesWSServeError verifies a WS serve-loop failure is surfaced as a
-// returned error (not a Fatal) and cancels the group so the other members unwind. The select-on-gctx
-// join also guards against deadlock when the WS server's serveErr is tied to a different ctx.
-func TestNode_runServices_propagatesWSServeError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	g, gctx := errgroup.WithContext(ctx)
-
-	wsServeErr := make(chan error, 1)
-	wsServeErr <- errors.New("boom")
-
-	// Exporter-standard so the scheduler member blocks on gctx and unwinds cleanly once the WS
-	// failure cancels the group.
-	n := &Node{
-		logger:          zap.NewNop(),
-		exporterOptions: exporter.Options{Enabled: true, Mode: exporter.ModeStandard},
-	}
-
-	err := n.runServices(g, gctx, wsServeErr)
-	require.ErrorContains(t, err, "WS server serve loop exited")
-}
-
-// TestNode_runServices_schedulerNilNonExporterStandard verifies the wiring-invariant check: a node
-// without a duty scheduler that is not exporter-standard surfaces an error rather than idling
-// silently (previously a Fatal).
-func TestNode_runServices_schedulerNilNonExporterStandard(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	g, gctx := errgroup.WithContext(ctx)
-
-	// Operator mode (exporter disabled) with a nil dutyScheduler is the inconsistent state the check
-	// guards.
-	n := &Node{
-		logger:          zap.NewNop(),
-		exporterOptions: exporter.Options{},
-	}
-
-	err := n.runServices(g, gctx, nil)
-	require.ErrorContains(t, err, "duty scheduler is nil")
 }

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -336,27 +336,27 @@ type VRSubmitter struct {
 }
 
 func NewVRSubmitter(
-	ctx context.Context,
 	logger *zap.Logger,
 	beaconConfig *networkconfig.Beacon,
 	beacon beacon.BeaconNode,
 	validatorStore validatorStore,
 ) *VRSubmitter {
-	submitter := &VRSubmitter{
+	return &VRSubmitter{
 		logger:         logger,
 		beaconConfig:   beaconConfig,
 		beacon:         beacon,
 		validatorStore: validatorStore,
 		registrations:  map[phase0.BLSPubKey]*validatorRegistration{},
 	}
+}
 
-	slotTicker := slotticker.New(logger, slotticker.Config{
-		SlotDuration: beaconConfig.SlotDuration,
-		GenesisTime:  beaconConfig.GenesisTime,
+// Start runs the registration-submission loop until ctx is canceled.
+func (s *VRSubmitter) Start(ctx context.Context) {
+	slotTicker := slotticker.New(s.logger, slotticker.Config{
+		SlotDuration: s.beaconConfig.SlotDuration,
+		GenesisTime:  s.beaconConfig.GenesisTime,
 	})
-	go submitter.start(ctx, slotTicker)
-
-	return submitter
+	s.start(ctx, slotTicker)
 }
 
 // start periodically submits validator registrations of 2 types (in batches, 1 batch per slot):

--- a/protocol/v2/ssv/runner/validator_registration_test.go
+++ b/protocol/v2/ssv/runner/validator_registration_test.go
@@ -1,0 +1,37 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+// TestVRSubmitter_StartStopsOnCtxCancel pins the constructor/Start split: NewVRSubmitter returns
+// without launching anything (no ctx param, no goroutine), and Start runs the submission loop until
+// ctx is canceled. That stop-on-cancel contract is what lets the operator node spawn Start as a
+// supervised service and await it cleanly at shutdown.
+//
+// beacon and validatorStore are nil: with a realistic slot duration no tick fires within the test
+// window, so the loop blocks on ctx and never dereferences them.
+func TestVRSubmitter_StartStopsOnCtxCancel(t *testing.T) {
+	s := NewVRSubmitter(zap.NewNop(), networkconfig.TestNetwork.Beacon, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.Start(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after ctx cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Makes **"Fatal once" literal** for the operator-node boot path: every failure reachable from startup — a synchronous bind error or a long-lived background goroutine — converges on the single top-level `Fatal` in `cli/operator/start_node.go`, with `node.close()` (p2p + EL + db teardown) running on the way out. Previously these failures called `logger.Fatal` deep in goroutines, `os.Exit`-ing the process and bypassing teardown.

Implements #2867 and folds in the operator-package follow-up it deferred. Builds on the ctx-aware HTTP servers from #2866 and #2819.

## What changed

### `cli/operator` — construct vs. run

The old monolithic `runNode` is split into two peer phases, called one after another:

- **`buildNode`** constructs the node graph: validates config up front, connects the CL/EL clients, and wires everything via `newNode` — which is now **pure construction and starts no goroutines**.
- **`runNode`** owns the lifecycle: it derives a `context.WithCancelCause` root, runs every long-lived service through a `spawn` helper (the first to fail cancels the root with its error as the *cause*), blocks on the first terminal event, then tears the node down — waiting for the services to unwind, then `node.close()` — within a single grace window (`shutdownGraceTimeout`), and returns the cause. A service that ignores cancellation can't hang shutdown past the window.
- **`node.start`** is the bring-up recipe: the synchronous steps (health gate, historical contract sync, metadata sync, network) plus `spawn` of the long-lived services. The background services formerly launched *inside* `newNode` (the VRSubmitter; in exporter modes the duty-trace collector / slot-pruning) now start here through `spawn`, so they bind to the supervised root and are awaited at teardown.
- The two synchronous bind `Fatal`s (metrics, SSV-API) and the prober / event-sync `Fatal`s become returned errors that surface as the terminal cause.

### `start-node` — signal handling

A two-stage `signal.Notify` handler (not `NotifyContext`, which can't express the escape hatch): the **first** SIGINT/SIGTERM cancels the node ctx for a graceful unwind (services stop, `node.close()` runs, exit 0); a **second** one force-exits via `Fatal`. The node previously had no signal handling at all (`cmd.Context()` was `context.Background()`), so a deliberate stop terminated abruptly and never ran teardown. The top-level handler classifies off the signal ctx: a deliberate stop exits 0 (even if an error coincided), a genuine failure `Fatal`s (non-zero, so the orchestrator restarts).

### `operator.Node.Start`

Gets its own `errgroup`: the WS serve-loop and `dutyScheduler.Wait` join as members; the scheduler-nil `Fatal`s become returned errors.

### prober (`hprobe` + `cli/operator`)

- `ProbeAll` returns when every probe finishes **or** ctx expires, whichever comes first — a `Healthy` impl that ignores its ctx can no longer wedge the round (and the bring-up gate / watchdog with it).
- Fixes #2880: a real failure that early-cancels a sibling no longer satisfies `errors.Is(err, context.Canceled)` (the false-negative hazard for callers); a regression test pins the exact scenario.
- The runtime watchdog returns an error (→ graceful close, non-zero exit) instead of `Fatal`-ing from its loop.

### `protocol/v2/ssv/runner`, `exporter/api`

- `NewVRSubmitter` splits its constructor from a `Start(ctx)` method instead of launching a goroutine from the constructor — so `newNode` stays goroutine-free.
- The WS server takes its ctx at `Start(ctx)` (symmetric with the metrics/SSV-API servers) rather than at construction.

## Behavior notes

- **Graceful shutdown:** SIGINT/SIGTERM → the lifecycle ctx is canceled → every long-lived service returns → `node.close()` runs → exit 0. A genuine background-service failure brings the node down through `node.close()` with a non-zero exit, so the orchestrator restarts it.
- **Grace-bounded teardown:** the whole teardown (services unwinding + `node.close()`) is bounded; past the window the node surfaces the terminal cause rather than hanging on something ignoring cancellation (leftovers are reaped at process exit).

Closes #2867.
