### PR TITLE
message/validation: fix flaky pending-queued validator test + tidy test setup

### DIFF
--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -123,7 +123,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			shares.liquidated,
 			shares.inactive,
 			shares.nonUpdatedMetadata,
-			shares.nonUpdatedMetadataNextEpoch,
+			shares.nonUpdatedMetadataFutureEpoch,
 			shares.noMetadata,
 		} {
 			if bytes.Equal(share.ValidatorPubKey[:], pubKey) {
@@ -636,14 +636,14 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 	})
 
-	// Ignore messages related to a validator that in pending queued state
+	// Ignore messages related to a validator that is in pending queued state
 	t.Run("pending queued state validator", func(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
 		slot := netCfg.FirstSlotAtEpoch(1)
 
-		nonUpdatedMetadataNextEpochIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.nonUpdatedMetadataNextEpoch.ValidatorPubKey[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, nonUpdatedMetadataNextEpochIdentifier, slot)
+		nonUpdatedMetadataFutureEpochIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.nonUpdatedMetadataFutureEpoch.ValidatorPubKey[:], nonCommitteeRole)
+		signedSSVMessage := generateSignedMessage(ks, nonUpdatedMetadataFutureEpochIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.CommitteeTopicID(committeeID)[0]
@@ -653,7 +653,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 	})
 
-	// Don't ignore messages related to a validator that in pending queued state (in case metadata is not updated),
+	// Don't ignore messages related to a validator that is in pending queued state (in case metadata is not updated),
 	// but it is active (activation epoch <= current epoch)
 	t.Run("active validator with pending queued state", func(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
@@ -870,7 +870,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		msg.OperatorIDs = []spectypes.OperatorID{0}
 
 		receivedAt := netCfg.SlotStartTime(slot)
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(msg.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(context.Background(), msg, topicID, peerID, receivedAt)
 		require.ErrorIs(t, err, ErrZeroSigner)
 	})
@@ -923,7 +923,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		partialSigSSVMessage.Signatures = [][]byte{{1}}
 
 		receivedAt := netCfg.SlotStartTime(slot)
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(partialSigSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(context.Background(), partialSigSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorContains(t, err, ErrWrongRSASignatureSize.Error())
 	})
@@ -2145,12 +2145,12 @@ func cloneSSVShare(t *testing.T, original *ssvtypes.SSVShare) *ssvtypes.SSVShare
 }
 
 type shareSet struct {
-	active                      *ssvtypes.SSVShare
-	liquidated                  *ssvtypes.SSVShare
-	inactive                    *ssvtypes.SSVShare
-	nonUpdatedMetadata          *ssvtypes.SSVShare
-	nonUpdatedMetadataNextEpoch *ssvtypes.SSVShare
-	noMetadata                  *ssvtypes.SSVShare
+	active                        *ssvtypes.SSVShare
+	liquidated                    *ssvtypes.SSVShare
+	inactive                      *ssvtypes.SSVShare
+	nonUpdatedMetadata            *ssvtypes.SSVShare
+	nonUpdatedMetadataFutureEpoch *ssvtypes.SSVShare
+	noMetadata                    *ssvtypes.SSVShare
 }
 
 func generateShares(t *testing.T, ks *spectestingutils.TestKeySet, ns storage.Storage, netCfg *networkconfig.Network) shareSet {
@@ -2162,85 +2162,64 @@ func generateShares(t *testing.T, ks *spectestingutils.TestKeySet, ns storage.St
 
 	require.NoError(t, ns.Shares().Save(nil, activeShare))
 
-	liquidatedShare := &ssvtypes.SSVShare{
+	liquidatedShare := saveShareWithRandomKey(t, ns, &ssvtypes.SSVShare{
 		Share:      *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Status:     eth2apiv1.ValidatorStateActiveOngoing,
 		Liquidated: true,
-	}
+	})
 
-	liquidatedSK, err := eth2types.GenerateBLSPrivateKey()
-	require.NoError(t, err)
-
-	copy(liquidatedShare.ValidatorPubKey[:], liquidatedSK.PublicKey().Marshal())
-	require.NoError(t, ns.Shares().Save(nil, liquidatedShare))
-
-	inactiveShare := &ssvtypes.SSVShare{
+	inactiveShare := saveShareWithRandomKey(t, ns, &ssvtypes.SSVShare{
 		Share:      *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Status:     eth2apiv1.ValidatorStateUnknown,
 		Liquidated: false,
-	}
-
-	inactiveSK, err := eth2types.GenerateBLSPrivateKey()
-	require.NoError(t, err)
-
-	copy(inactiveShare.ValidatorPubKey[:], inactiveSK.PublicKey().Marshal())
-	require.NoError(t, ns.Shares().Save(nil, inactiveShare))
+	})
 
 	slot := netCfg.EstimatedCurrentSlot()
 	activationEpoch := netCfg.EstimatedEpochAtSlot(slot)
 	exitEpoch := goclient.FarFutureEpoch
 
-	nonUpdatedMetadataShare := &ssvtypes.SSVShare{
+	nonUpdatedMetadataShare := saveShareWithRandomKey(t, ns, &ssvtypes.SSVShare{
 		Share:           *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Status:          eth2apiv1.ValidatorStatePendingQueued,
 		ActivationEpoch: activationEpoch,
 		ExitEpoch:       exitEpoch,
 		Liquidated:      false,
-	}
-
-	nonUpdatedMetadataSK, err := eth2types.GenerateBLSPrivateKey()
-	require.NoError(t, err)
-
-	copy(nonUpdatedMetadataShare.ValidatorPubKey[:], nonUpdatedMetadataSK.PublicKey().Marshal())
-	require.NoError(t, ns.Shares().Save(nil, nonUpdatedMetadataShare))
+	})
 
 	// Keep this validator "pending_queued / not yet attesting" for the whole run — the
 	// "pending queued state validator" subtest asserts ErrValidatorNotAttesting. IsAttesting
 	// compares ActivationEpoch against the wall-clock epoch at validation time, so a +1 margin
 	// was flaky: a run crossing an epoch boundary before the assertion saw it as attesting.
-	nonUpdatedMetadataNextEpochShare := &ssvtypes.SSVShare{
+	nonUpdatedMetadataFutureEpochShare := saveShareWithRandomKey(t, ns, &ssvtypes.SSVShare{
 		Share:           *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Status:          eth2apiv1.ValidatorStatePendingQueued,
 		ActivationEpoch: activationEpoch + 100,
 		ExitEpoch:       exitEpoch,
 		Liquidated:      false,
-	}
+	})
 
-	nonUpdatedMetadataNextEpochSK, err := eth2types.GenerateBLSPrivateKey()
-	require.NoError(t, err)
-
-	copy(nonUpdatedMetadataNextEpochShare.ValidatorPubKey[:], nonUpdatedMetadataNextEpochSK.PublicKey().Marshal())
-	require.NoError(t, ns.Shares().Save(nil, nonUpdatedMetadataNextEpochShare))
-
-	noMetadataShare := &ssvtypes.SSVShare{
+	noMetadataShare := saveShareWithRandomKey(t, ns, &ssvtypes.SSVShare{
 		Share:      *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Liquidated: false,
-	}
-
-	noMetadataShareSK, err := eth2types.GenerateBLSPrivateKey()
-	require.NoError(t, err)
-
-	copy(noMetadataShare.ValidatorPubKey[:], noMetadataShareSK.PublicKey().Marshal())
-	require.NoError(t, ns.Shares().Save(nil, noMetadataShare))
+	})
 
 	return shareSet{
-		active:                      activeShare,
-		liquidated:                  liquidatedShare,
-		inactive:                    inactiveShare,
-		nonUpdatedMetadata:          nonUpdatedMetadataShare,
-		nonUpdatedMetadataNextEpoch: nonUpdatedMetadataNextEpochShare,
-		noMetadata:                  noMetadataShare,
+		active:                        activeShare,
+		liquidated:                    liquidatedShare,
+		inactive:                      inactiveShare,
+		nonUpdatedMetadata:            nonUpdatedMetadataShare,
+		nonUpdatedMetadataFutureEpoch: nonUpdatedMetadataFutureEpochShare,
+		noMetadata:                    noMetadataShare,
 	}
+}
+
+// saveShareWithRandomKey assigns share a fresh random validator public key, persists it, and returns it.
+func saveShareWithRandomKey(t *testing.T, ns storage.Storage, share *ssvtypes.SSVShare) *ssvtypes.SSVShare {
+	sk, err := eth2types.GenerateBLSPrivateKey()
+	require.NoError(t, err)
+	copy(share.ValidatorPubKey[:], sk.PublicKey().Marshal())
+	require.NoError(t, ns.Shares().Save(nil, share))
+	return share
 }
 
 func generateSignedMessage(

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -613,7 +613,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		liquidatedIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.liquidated.ValidatorPubKey[:], nonCommitteeRole)
 		signedSSVMessage := generateSignedMessage(ks, liquidatedIdentifier, slot)
 
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		receivedAt := netCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
 		expectedErr := ErrValidatorLiquidated
@@ -629,7 +629,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		inactiveIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.inactive.ValidatorPubKey[:], nonCommitteeRole)
 		signedSSVMessage := generateSignedMessage(ks, inactiveIdentifier, slot)
 
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		receivedAt := netCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
 		expectedErr := ErrNoShareMetadata
@@ -646,7 +646,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		signedSSVMessage := generateSignedMessage(ks, nonUpdatedMetadataNextEpochIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
 		expectedErr := ErrValidatorNotAttesting
 		expectedErr.got = eth2apiv1.ValidatorStatePendingQueued.String()
@@ -692,7 +692,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		signedSSVMessage := generateSignedMessage(ks, noMetadataIdentifier, slot)
 
 		receivedAt := netCfg.SlotStartTime(slot)
-		topicID := commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0]
+		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorIs(t, err, ErrNoShareMetadata)
 	})
@@ -2204,10 +2204,14 @@ func generateShares(t *testing.T, ks *spectestingutils.TestKeySet, ns storage.St
 	copy(nonUpdatedMetadataShare.ValidatorPubKey[:], nonUpdatedMetadataSK.PublicKey().Marshal())
 	require.NoError(t, ns.Shares().Save(nil, nonUpdatedMetadataShare))
 
+	// Keep this validator "pending_queued / not yet attesting" for the whole run — the
+	// "pending queued state validator" subtest asserts ErrValidatorNotAttesting. IsAttesting
+	// compares ActivationEpoch against the wall-clock epoch at validation time, so a +1 margin
+	// was flaky: a run crossing an epoch boundary before the assertion saw it as attesting.
 	nonUpdatedMetadataNextEpochShare := &ssvtypes.SSVShare{
 		Share:           *spectestingutils.TestingShare(ks, spectestingutils.TestingValidatorIndex),
 		Status:          eth2apiv1.ValidatorStatePendingQueued,
-		ActivationEpoch: activationEpoch + 1,
+		ActivationEpoch: activationEpoch + 100,
 		ExitEpoch:       exitEpoch,
 		Liquidated:      false,
 	}


### PR DESCRIPTION
## Summary

Fixes a low-rate flaky failure in `Test_ValidateSSVMessage/"pending queued state validator"` and folds in related test-only cleanups in the same file. **No production code is touched.**

The flake surfaces on unrelated CI (e.g. the attempt-1 unit-test job of #2876), failing with a misleading error:

```
expected: "validator is not attesting, got pending_queued"            (ErrValidatorNotAttesting)
in chain: "incorrect topic, got topic 59 / base name 59, want [114]"  (ErrIncorrectTopic)
```

## Root cause — epoch-boundary race

- `generateShares` built the share with `ActivationEpoch = currentEpoch + 1`, sampled from the wall clock **at setup time**.
- The subtest expects rejection at `getCommitteeAndValidatorIndices` → `share.IsAttesting(EstimatedCurrentEpoch())`, which compares against the wall-clock epoch **at validation time**. A `pending_queued` validator is attesting iff `ActivationEpoch <= epoch`.
- `TestNetwork`'s epoch is 6m24s (12s slot × 32). If a run crosses an epoch boundary between setup and the assertion, `EstimatedCurrentEpoch()` reaches `ActivationEpoch`, the validator counts as attesting, the not-attesting branch is skipped, and validation falls through to the topic check.
- That topic check then fails because the subtest derived the topic from the share's **random** validator pubkey (`CommitteeID(execID[16:])`) rather than its committee — producing the confusing `ErrIncorrectTopic` symptom.

## Changes

### Flaky-test fix (commit 1)
- Set `ActivationEpoch` to `currentEpoch + 100` (≈10.7h ahead, vs the 10-minute test timeout) so the validator stays `pending_queued`/not-attesting for the whole run regardless of boundary timing. Added a comment so it isn't reverted to `+1`.
- Normalized the four non-committee validator-state subtests (`liquidated`, `unknown state`, `pending queued state`, `no share metadata`) to derive the topic from `committeeID`. For a non-committee (validator-role) message the duty executor ID is the validator pubkey, so `CommitteeID(execID[16:])` is meaningless; the correct topic is the validator's committee. All four reject before the topic check, so behavior is unchanged.

### Follow-up cleanups (commit 2, no behavior change)
- **Helper:** extracted `saveShareWithRandomKey`, removing the repeated generate-key / copy-pubkey / save boilerplate from the five random-key shares in `generateShares`.
- **Topic audit:** found and normalized the two remaining non-committee subtests with the same wrong topic derivation — `partial zero signer ID` and `partial wrong RSA signature size` (both build a validator-pubkey `RoleAggregator` partial-sig message). Audited the other ~43 `CommitteeID(execID[16:])` derivations: all are committee-role messages (where `execID[16:]` genuinely is the committee ID) or the intentional `unknown committee ID` case — left as-is.
- **Rename:** `nonUpdatedMetadataNextEpoch` → `nonUpdatedMetadataFutureEpoch`, since its activation epoch is now further out than the next epoch.
- **Grammar:** "validator that in pending queued state" → "...that is in...".

## Test plan

- `go test -tags "blst_enabled lfs" -race -run 'Test_ValidateSSVMessage$' ./message/validation/ -count=5` — pass
- `go test -tags "blst_enabled lfs" -race ./message/validation/` — pass
- `go vet -tags "blst_enabled lfs" ./message/validation/` — clean
