### PR TITLE
observability: surface silent duty failures + improve p2p logs

### DIFF
--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -504,6 +504,7 @@ func (eh *EventHandler) handleValidatorExited(txn basedb.Txn, event *contract.Co
 	}
 
 	if !share.HasBeaconMetadata() {
+		logger.Debug("share has no beacon metadata, voluntary exit duty won't be scheduled")
 		return nil, nil
 	}
 

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -8,7 +8,6 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
-	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/observability/log/fields"
@@ -175,16 +174,7 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 }
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {
-	role := messageRole(decodedMessage)
-	recordAcceptedMessage(ctx, role)
-
-	// Accepts aren't logged in general (committee/attestation traffic would be a firehose), but for
-	// the rare, one-shot quorum duties an accept line confirms a peer's partial signature reached
-	// and passed validation — the question past voluntary-exit failures couldn't answer from logs.
-	if role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration {
-		loggerFields := mv.buildLoggerFields(decodedMessage)
-		mv.logger.With(loggerFields.AsZapFields()...).Debug("accepted message")
-	}
+	recordAcceptedMessage(ctx, messageRole(decodedMessage))
 
 	return pubsub.ValidationAccept
 }

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -8,6 +8,7 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/observability/log/fields"
@@ -20,7 +21,6 @@ type Error struct {
 	want     any
 	innerErr error
 	reject   bool
-	silent   bool
 }
 
 func (e Error) Error() string {
@@ -47,10 +47,6 @@ const (
 
 func (e Error) Reject() bool {
 	return e.reject
-}
-
-func (e Error) Silent() bool {
-	return e.silent
 }
 
 func (e Error) Text() string {
@@ -168,22 +164,29 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 	}
 
 	if !valErr.Reject() {
-		if !valErr.Silent() {
-			logger.Debug("ignoring invalid message", zap.Error(valErr))
-		}
+		logger.Debug("ignoring invalid message", zap.Error(valErr))
 		recordIgnoredMessage(ctx, loggerFields.Role, valErr.Text())
 		return pubsub.ValidationIgnore
 	}
 
-	if !valErr.Silent() {
-		logger.Debug("rejecting invalid message", zap.Error(valErr))
-	}
-
+	logger.Debug("rejecting invalid message", zap.Error(valErr))
 	recordRejectedMessage(ctx, loggerFields.Role, valErr.Text())
 	return pubsub.ValidationReject
 }
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {
-	recordAcceptedMessage(ctx, messageRole(decodedMessage))
+	role := messageRole(decodedMessage)
+	recordAcceptedMessage(ctx, role)
+
+	// Accepts are metered but not logged in general — committee/attestation traffic would make it
+	// a firehose. But for the rare, one-shot quorum duties (voluntary exit, validator
+	// registration), an explicit accept line at the validation boundary lets you confirm a peer's
+	// partial signature actually reached and passed validation (with the duty id, slot and
+	// signer) — the exact question that couldn't be answered from logs in past exit failures.
+	if role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration {
+		loggerFields := mv.buildLoggerFields(decodedMessage)
+		mv.logger.With(loggerFields.AsZapFields()...).Debug("accepted message")
+	}
+
 	return pubsub.ValidationAccept
 }

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -178,11 +178,9 @@ func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decoded
 	role := messageRole(decodedMessage)
 	recordAcceptedMessage(ctx, role)
 
-	// Accepts are metered but not logged in general — committee/attestation traffic would make it
-	// a firehose. But for the rare, one-shot quorum duties (voluntary exit, validator
-	// registration), an explicit accept line at the validation boundary lets you confirm a peer's
-	// partial signature actually reached and passed validation (with the duty id, slot and
-	// signer) — the exact question that couldn't be answered from logs in past exit failures.
+	// Accepts aren't logged in general (committee/attestation traffic would be a firehose), but for
+	// the rare, one-shot quorum duties an accept line confirms a peer's partial signature reached
+	// and passed validation — the question past voluntary-exit failures couldn't answer from logs.
 	if role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration {
 		loggerFields := mv.buildLoggerFields(decodedMessage)
 		mv.logger.With(loggerFields.AsZapFields()...).Debug("accepted message")

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	p2pnet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	libp2pdiscbackoff "github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap"
 
@@ -104,7 +103,7 @@ type p2pNetwork struct {
 	// subscribedCommittees tracks committee subscription statuses for committees we've subscribed to.
 	subscribedCommittees *hashmap.Map[string, committeeSubscriptionStatus]
 
-	backoffConnector *libp2pdiscbackoff.BackoffConnector
+	backoffConnector *backoffConnector
 
 	// persistentSubnets holds subnets on node startup,
 	// these subnets should not be unsubscribed from even if all validators associated with them are removed

--- a/network/p2p/p2p_connector.go
+++ b/network/p2p/p2p_connector.go
@@ -14,28 +14,30 @@ import (
 	"github.com/ssvlabs/ssv/observability/log/fields"
 )
 
+type connCacheData struct {
+	nextTry time.Time
+	start   libp2pdiscbackoff.BackoffStrategy
+}
+
 // backoffConnector connects to proposed peers, skipping peers that are still within their backoff
 // period. It is a drop-in replacement for libp2p's discovery/backoff.BackoffConnector with one
 // difference: dial failures are logged to the node's logger. The libp2p implementation reports
 // them only to its own internal logger, so a node that cannot reach its proposed peers (firewall,
 // NAT, wrong advertised address) leaves no trace of that in SSV logs.
 type backoffConnector struct {
+	logger *zap.Logger
+
 	host       host.Host
-	logger     *zap.Logger
-	cache      *lru.TwoQueueCache[peer.ID, *connCacheData]
 	connTryDur time.Duration
 	backoff    libp2pdiscbackoff.BackoffFactory
-	mux        sync.Mutex
-}
 
-type connCacheData struct {
-	nextTry time.Time
-	strat   libp2pdiscbackoff.BackoffStrategy
+	cacheMux sync.Mutex
+	cache    *lru.TwoQueueCache[peer.ID, *connCacheData]
 }
 
 func newBackoffConnector(
-	host host.Host,
 	logger *zap.Logger,
+	host host.Host,
 	cacheSize int,
 	connTryDur time.Duration,
 	backoff libp2pdiscbackoff.BackoffFactory,
@@ -46,11 +48,11 @@ func newBackoffConnector(
 	}
 
 	return &backoffConnector{
-		host:       host,
 		logger:     logger,
-		cache:      cache,
+		host:       host,
 		connTryDur: connTryDur,
 		backoff:    backoff,
+		cache:      cache,
 	}, nil
 }
 
@@ -68,20 +70,20 @@ func (c *backoffConnector) Connect(ctx context.Context, peerCh <-chan peer.AddrI
 				continue
 			}
 
-			c.mux.Lock()
+			c.cacheMux.Lock()
 			if cached, ok := c.cache.Get(pi.ID); ok {
 				now := time.Now()
 				if now.Before(cached.nextTry) {
-					c.mux.Unlock()
+					c.cacheMux.Unlock()
 					continue
 				}
-				cached.nextTry = now.Add(cached.strat.Delay())
+				cached.nextTry = now.Add(cached.start.Delay())
 			} else {
-				cached = &connCacheData{strat: c.backoff()}
-				cached.nextTry = time.Now().Add(cached.strat.Delay())
+				cached = &connCacheData{start: c.backoff()}
+				cached.nextTry = time.Now().Add(cached.start.Delay())
 				c.cache.Add(pi.ID, cached)
 			}
-			c.mux.Unlock()
+			c.cacheMux.Unlock()
 
 			go func(pi peer.AddrInfo) {
 				ctx, cancel := context.WithTimeout(ctx, c.connTryDur)

--- a/network/p2p/p2p_connector.go
+++ b/network/p2p/p2p_connector.go
@@ -1,0 +1,102 @@
+package p2pv1
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	libp2pdiscbackoff "github.com/libp2p/go-libp2p/p2p/discovery/backoff"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/observability/log/fields"
+)
+
+// backoffConnector connects to proposed peers, skipping peers that are still within their backoff
+// period. It is a drop-in replacement for libp2p's discovery/backoff.BackoffConnector with one
+// difference: dial failures are logged to the node's logger. The libp2p implementation reports
+// them only to its own internal logger, so a node that cannot reach its proposed peers (firewall,
+// NAT, wrong advertised address) leaves no trace of that in SSV logs.
+type backoffConnector struct {
+	host       host.Host
+	logger     *zap.Logger
+	cache      *lru.TwoQueueCache[peer.ID, *connCacheData]
+	connTryDur time.Duration
+	backoff    libp2pdiscbackoff.BackoffFactory
+	mux        sync.Mutex
+}
+
+type connCacheData struct {
+	nextTry time.Time
+	strat   libp2pdiscbackoff.BackoffStrategy
+}
+
+func newBackoffConnector(
+	host host.Host,
+	logger *zap.Logger,
+	cacheSize int,
+	connTryDur time.Duration,
+	backoff libp2pdiscbackoff.BackoffFactory,
+) (*backoffConnector, error) {
+	cache, err := lru.New2Q[peer.ID, *connCacheData](cacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &backoffConnector{
+		host:       host,
+		logger:     logger,
+		cache:      cache,
+		connTryDur: connTryDur,
+		backoff:    backoff,
+	}, nil
+}
+
+// Connect attempts to connect to the peers passed in by peerCh. Will not connect to peers if they
+// are within the backoff period.
+func (c *backoffConnector) Connect(ctx context.Context, peerCh <-chan peer.AddrInfo) {
+	for {
+		select {
+		case pi, ok := <-peerCh:
+			if !ok {
+				return
+			}
+
+			if pi.ID == c.host.ID() || pi.ID == "" {
+				continue
+			}
+
+			c.mux.Lock()
+			if cached, ok := c.cache.Get(pi.ID); ok {
+				now := time.Now()
+				if now.Before(cached.nextTry) {
+					c.mux.Unlock()
+					continue
+				}
+				cached.nextTry = now.Add(cached.strat.Delay())
+			} else {
+				cached = &connCacheData{strat: c.backoff()}
+				cached.nextTry = time.Now().Add(cached.strat.Delay())
+				c.cache.Add(pi.ID, cached)
+			}
+			c.mux.Unlock()
+
+			go func(pi peer.AddrInfo) {
+				ctx, cancel := context.WithTimeout(ctx, c.connTryDur)
+				defer cancel()
+
+				if err := c.host.Connect(ctx, pi); err != nil {
+					c.logger.Debug("could not connect to discovered peer",
+						fields.PeerID(pi.ID),
+						zap.Stringers("addrs", pi.Addrs),
+						zap.Error(err))
+				}
+			}(pi)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/network/p2p/p2p_connector_test.go
+++ b/network/p2p/p2p_connector_test.go
@@ -37,7 +37,7 @@ func TestBackoffConnector(t *testing.T) {
 		backoffExponentBase,
 		rand.NewSource(1),
 	)
-	connector, err := newBackoffConnector(hostA, logger, backoffConnectorCacheSize, 5*time.Second, backoffFactory)
+	connector, err := newBackoffConnector(logger, hostA, backoffConnectorCacheSize, 5*time.Second, backoffFactory)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/network/p2p/p2p_connector_test.go
+++ b/network/p2p/p2p_connector_test.go
@@ -1,0 +1,75 @@
+package p2pv1
+
+import (
+	"context"
+	crand "crypto/rand"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	p2pnet "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	libp2pdiscbackoff "github.com/libp2p/go-libp2p/p2p/discovery/backoff"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestBackoffConnector(t *testing.T) {
+	hostA, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	defer hostA.Close()
+
+	hostB, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	defer hostB.Close()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	backoffFactory := libp2pdiscbackoff.NewExponentialDecorrelatedJitter(
+		backoffLow,
+		backoffHigh,
+		backoffExponentBase,
+		rand.NewSource(1),
+	)
+	connector, err := newBackoffConnector(hostA, logger, backoffConnectorCacheSize, 5*time.Second, backoffFactory)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peerCh := make(chan peer.AddrInfo)
+	go connector.Connect(ctx, peerCh)
+
+	// A reachable peer gets connected.
+	peerCh <- peer.AddrInfo{ID: hostB.ID(), Addrs: hostB.Addrs()}
+	require.Eventually(t, func() bool {
+		return hostA.Network().Connectedness(hostB.ID()) == p2pnet.Connected
+	}, 5*time.Second, 50*time.Millisecond)
+	require.Equal(t, 0, logs.FilterMessage("could not connect to discovered peer").Len())
+
+	// An unreachable peer produces a dial-failure log.
+	unreachablePriv, _, err := libp2pcrypto.GenerateEd25519Key(crand.Reader)
+	require.NoError(t, err)
+	unreachableID, err := peer.IDFromPrivateKey(unreachablePriv)
+	require.NoError(t, err)
+	unreachableAddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1")
+	require.NoError(t, err)
+
+	unreachable := peer.AddrInfo{ID: unreachableID, Addrs: []ma.Multiaddr{unreachableAddr}}
+	peerCh <- unreachable
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("could not connect to discovered peer").Len() == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Re-proposing the same peer within its backoff period must not trigger another dial.
+	peerCh <- unreachable
+	require.Never(t, func() bool {
+		return logs.FilterMessage("could not connect to discovered peer").Len() > 1
+	}, 1*time.Second, 100*time.Millisecond)
+}

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -32,9 +32,9 @@ const (
 	// before the node warns about it. Peers we select share our subnets (often committee
 	// partners), so consistently failing to connect to them degrades duty execution — yet the
 	// dial errors themselves are visible only at DEBUG (see backoffConnector).
-	unconnectedProposalWarnAfter = 30 * time.Minute
+	unconnectedProposalWarnAfter = 10 * time.Minute
 	// unconnectedProposalWarnInterval rate-limits the warning above.
-	unconnectedProposalWarnInterval = 10 * time.Minute
+	unconnectedProposalWarnInterval = 2 * time.Minute
 )
 
 func (s *peerSelectionPoolStats) AsLogFields() []zap.Field {

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"time"
 
-	p2pnet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/oleiade/lane/v2"
 	"go.uber.org/zap"
@@ -27,14 +26,6 @@ type peerSelectionPoolStats struct {
 const (
 	peerSelectionRetryCooldownMin = 30 * time.Second
 	peerSelectionRetryCooldownMax = 300 * time.Second
-
-	// unconnectedProposalWarnAfter is how long a repeatedly-proposed peer may remain unconnected
-	// before the node warns about it. Peers we select share our subnets (often committee
-	// partners), so consistently failing to connect to them degrades duty execution — yet the
-	// dial errors themselves are visible only at DEBUG (see backoffConnector).
-	unconnectedProposalWarnAfter = 10 * time.Minute
-	// unconnectedProposalWarnInterval rate-limits the warning above.
-	unconnectedProposalWarnInterval = 5 * time.Minute
 )
 
 func (s *peerSelectionPoolStats) AsLogFields() []zap.Field {
@@ -67,12 +58,6 @@ func (n *p2pNetwork) startDiscovery() error {
 			n.discoveredPeersPool.Set(proposal.ID, discoveredPeer)
 		}
 	}()
-
-	// proposalFirstTry records when each still-discovered peer was first proposed for connection,
-	// to surface peers that never become connections. Accessed only from the selection interval
-	// goroutine below.
-	proposalFirstTry := make(map[peer.ID]time.Time)
-	var lastUnconnectedWarn time.Time
 
 	// Spawn a goroutine to repeatedly select & connect to the best peers.
 	// To find the best set of peers to connect we'll:
@@ -185,36 +170,6 @@ func (n *p2pNetwork) startDiscovery() error {
 				LastTry:  time.Now(),
 			})
 			connector <- p.AddrInfo
-		}
-
-		// A peer we keep proposing that never becomes a connection usually means this node cannot
-		// reach it (firewall/NAT/wrong advertised address). The dial errors are logged only at
-		// DEBUG, so periodically surface the lasting condition at WARN.
-		now := time.Now()
-		for pid := range peersToConnect {
-			if _, ok := proposalFirstTry[pid]; !ok {
-				proposalFirstTry[pid] = now
-			}
-		}
-		var unconnected []string
-		for pid, firstTry := range proposalFirstTry {
-			if n.Host().Network().Connectedness(pid) == p2pnet.Connected {
-				delete(proposalFirstTry, pid)
-				continue
-			}
-			if _, stillDiscovered := n.discoveredPeersPool.Get(pid); !stillDiscovered {
-				// No longer a candidate, not worth warning about.
-				delete(proposalFirstTry, pid)
-				continue
-			}
-			if waited := now.Sub(firstTry); waited >= unconnectedProposalWarnAfter {
-				unconnected = append(unconnected, fmt.Sprintf("%s (first proposed %s ago)", pid, waited.Round(time.Minute)))
-			}
-		}
-		if len(unconnected) > 0 && now.Sub(lastUnconnectedWarn) >= unconnectedProposalWarnInterval {
-			lastUnconnectedWarn = now
-			n.logger.Warn("discovered peers sharing our subnets keep failing to connect, node may be unable to dial them (check firewall/NAT and advertised addresses)",
-				zap.Strings("unconnected_peers", unconnected))
 		}
 
 		if len(peersToConnect) == 0 {

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	p2pnet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/oleiade/lane/v2"
 	"go.uber.org/zap"
@@ -26,6 +27,14 @@ type peerSelectionPoolStats struct {
 const (
 	peerSelectionRetryCooldownMin = 30 * time.Second
 	peerSelectionRetryCooldownMax = 300 * time.Second
+
+	// unconnectedProposalWarnAfter is how long a repeatedly-proposed peer may remain unconnected
+	// before the node warns about it. Peers we select share our subnets (often committee
+	// partners), so consistently failing to connect to them degrades duty execution — yet the
+	// dial errors themselves are visible only at DEBUG (see backoffConnector).
+	unconnectedProposalWarnAfter = 30 * time.Minute
+	// unconnectedProposalWarnInterval rate-limits the warning above.
+	unconnectedProposalWarnInterval = 10 * time.Minute
 )
 
 func (s *peerSelectionPoolStats) AsLogFields() []zap.Field {
@@ -58,6 +67,12 @@ func (n *p2pNetwork) startDiscovery() error {
 			n.discoveredPeersPool.Set(proposal.ID, discoveredPeer)
 		}
 	}()
+
+	// proposalFirstTry records when each still-discovered peer was first proposed for connection,
+	// to surface peers that never become connections. Accessed only from the selection interval
+	// goroutine below.
+	proposalFirstTry := make(map[peer.ID]time.Time)
+	var lastUnconnectedWarn time.Time
 
 	// Spawn a goroutine to repeatedly select & connect to the best peers.
 	// To find the best set of peers to connect we'll:
@@ -171,6 +186,37 @@ func (n *p2pNetwork) startDiscovery() error {
 			})
 			connector <- p.AddrInfo
 		}
+
+		// A peer we keep proposing that never becomes a connection usually means this node cannot
+		// reach it (firewall/NAT/wrong advertised address). The dial errors are logged only at
+		// DEBUG, so periodically surface the lasting condition at WARN.
+		now := time.Now()
+		for pid := range peersToConnect {
+			if _, ok := proposalFirstTry[pid]; !ok {
+				proposalFirstTry[pid] = now
+			}
+		}
+		var unconnected []string
+		for pid, firstTry := range proposalFirstTry {
+			if n.Host().Network().Connectedness(pid) == p2pnet.Connected {
+				delete(proposalFirstTry, pid)
+				continue
+			}
+			if _, stillDiscovered := n.discoveredPeersPool.Get(pid); !stillDiscovered {
+				// No longer a candidate, not worth warning about.
+				delete(proposalFirstTry, pid)
+				continue
+			}
+			if waited := now.Sub(firstTry); waited >= unconnectedProposalWarnAfter {
+				unconnected = append(unconnected, fmt.Sprintf("%s (first proposed %s ago)", pid, waited.Round(time.Minute)))
+			}
+		}
+		if len(unconnected) > 0 && now.Sub(lastUnconnectedWarn) >= unconnectedProposalWarnInterval {
+			lastUnconnectedWarn = now
+			n.logger.Warn("discovered peers sharing our subnets keep failing to connect, node may be unable to dial them (check firewall/NAT and advertised addresses)",
+				zap.Strings("unconnected_peers", unconnected))
+		}
+
 		if len(peersToConnect) == 0 {
 			n.logger.Debug("no discovered peers selected for connection", append([]zap.Field{
 				zap.String("own_subnet_peers", currentSubnetPeers.String()),

--- a/network/p2p/p2p_discovery.go
+++ b/network/p2p/p2p_discovery.go
@@ -34,7 +34,7 @@ const (
 	// dial errors themselves are visible only at DEBUG (see backoffConnector).
 	unconnectedProposalWarnAfter = 10 * time.Minute
 	// unconnectedProposalWarnInterval rate-limits the warning above.
-	unconnectedProposalWarnInterval = 2 * time.Minute
+	unconnectedProposalWarnInterval = 5 * time.Minute
 )
 
 func (s *peerSelectionPoolStats) AsLogFields() []zap.Field {

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -65,11 +65,18 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		topicNames = commons.CommitteeTopicID(val.CommitteeID())
 	}
 
-	// Egress logging is scoped to the rare, one-shot quorum duties (voluntary exit, validator
-	// registration): the only ones where confirming a single message left the node matters, and
-	// where the volume is low enough to compute a per-broadcast msg-id and peer count. Keeping it
-	// off the hot path also matters because the file logger captures DEBUG regardless of level.
+	// Egress logging is scoped to the rare, one-shot quorum duties: confirming a single message
+	// left the node only matters for these, and their low volume keeps the msg-id hash and
+	// peer-count lookup off the hot path (the file logger captures DEBUG regardless of level).
 	logEgress := role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration
+
+	// gossip_msg_id is the id gossipsub itself assigns — hex-encoded to match SSV's pubsub tracer
+	// (network/topics/tracer.go) so one message can be correlated across nodes and against that
+	// trace. It hashes the payload, which is identical for every topic, so compute it once.
+	var gossipMsgID string
+	if logEgress {
+		gossipMsgID = hex.EncodeToString([]byte(topics.MsgID(encodedMsg)))
+	}
 
 	for _, topic := range topicNames {
 		if err := n.topicsCtrl.Broadcast(topic, encodedMsg, n.cfg.RequestTimeout); err != nil {
@@ -78,16 +85,12 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		}
 
 		if logEgress {
-			// gossip_msg_id is the id gossipsub itself assigns, hex-encoded to match SSV's
-			// pubsub event tracer (network/topics/tracer.go, enabled by PubSubTrace), which logs
-			// the same hex form — so a single message can be followed across nodes and against
-			// that trace. (A raw go-libp2p JSONTracer emits the id in binary and would need a
-			// hex-decode to correlate.) topic_peers surfaces a near-empty/sparse topic mesh,
-			// a prime suspect when a one-shot message fails to reach peers.
+			// topic_peers surfaces a sparse/empty mesh — a prime suspect when a one-shot message
+			// fails to reach peers.
 			topicPeers, _ := n.topicsCtrl.Peers(topic)
 			n.logger.Debug("📤 broadcast message to topic",
 				fields.MessageID(msg.SSVMessage.MsgID),
-				zap.String("gossip_msg_id", hex.EncodeToString([]byte(topics.MsgID(encodedMsg)))),
+				zap.String("gossip_msg_id", gossipMsgID),
 				fields.Topic(topic),
 				zap.Int("topic_peers", len(topicPeers)),
 			)

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
@@ -66,36 +64,20 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		topicNames = commons.CommitteeTopicID(val.CommitteeID())
 	}
 
-	// Confirm egress for every broadcast at DEBUG — without it, a message lost in transit is
-	// indistinguishable from one never sent. The level check keeps the msg-id hash and
-	// peer-count lookups off the hot path when DEBUG is disabled.
-	logEgress := n.logger.Core().Enabled(zapcore.DebugLevel)
-
-	// gossip_msg_id is the id gossipsub itself assigns — hex-encoded to match SSV's pubsub tracer
-	// (network/topics/tracer.go) so one message can be correlated across nodes and against that
-	// trace. It hashes the payload, which is identical for every topic, so compute it once.
-	var gossipMsgID string
-	if logEgress {
-		gossipMsgID = hex.EncodeToString([]byte(topics.MsgID(encodedMsg)))
-	}
-
 	for _, topic := range topicNames {
 		if err := n.topicsCtrl.Broadcast(topic, encodedMsg, n.cfg.RequestTimeout); err != nil {
 			n.logger.Debug("could not broadcast msg", fields.Topic(topic), zap.Error(err))
 			return fmt.Errorf("could not broadcast msg: %w", err)
 		}
 
-		if logEgress {
-			// topic_peers surfaces a sparse/empty mesh — a prime suspect when a one-shot message
-			// fails to reach peers.
-			topicPeers, _ := n.topicsCtrl.Peers(topic)
-			n.logger.Debug("📤 broadcast message to topic",
-				fields.MessageID(msg.SSVMessage.MsgID),
-				zap.String("gossip_msg_id", gossipMsgID),
-				fields.Topic(topic),
-				zap.Int("topic_peers", len(topicPeers)),
-			)
-		}
+		// topicPeers surfaces a sparse/empty mesh — a prime suspect when a one-shot message fails to reach peers.
+		topicPeers, _ := n.topicsCtrl.Peers(topic)
+		n.logger.Debug("📤 broadcast message to topic",
+			fields.MessageID(msg.SSVMessage.MsgID),
+			zap.String("gossip_msg_id", hex.EncodeToString([]byte(topics.MsgID(encodedMsg)))),
+			fields.Topic(topic),
+			zap.Int("topic_peers", len(topicPeers)),
+		)
 	}
 	return nil
 }

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -78,10 +78,12 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		}
 
 		if logEgress {
-			// gossip_msg_id is the id gossipsub itself assigns (and the libp2p pubsub tracer
-			// logs), so a single message can be followed across nodes and against a trace.
-			// topic_peers surfaces a near-empty/sparse topic mesh, a prime suspect when a
-			// one-shot message fails to reach peers.
+			// gossip_msg_id is the id gossipsub itself assigns, hex-encoded to match SSV's
+			// pubsub event tracer (network/topics/tracer.go, enabled by PubSubTrace), which logs
+			// the same hex form — so a single message can be followed across nodes and against
+			// that trace. (A raw go-libp2p JSONTracer emits the id in binary and would need a
+			// hex-decode to correlate.) topic_peers surfaces a near-empty/sparse topic mesh,
+			// a prime suspect when a one-shot message fails to reach peers.
 			topicPeers, _ := n.topicsCtrl.Peers(topic)
 			n.logger.Debug("📤 broadcast message to topic",
 				fields.MessageID(msg.SSVMessage.MsgID),

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/network/topics"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	p2pprotocol "github.com/ssvlabs/ssv/protocol/v2/p2p"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
@@ -51,22 +52,43 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		return fmt.Errorf("could not encode signed ssv message: %w", err)
 	}
 
-	var topics []string
+	role := msg.SSVMessage.MsgID.GetRoleType()
 
-	if msg.SSVMessage.MsgID.GetRoleType() == spectypes.RoleCommittee {
-		topics = commons.CommitteeTopicID(spectypes.CommitteeID(msg.SSVMessage.MsgID.GetDutyExecutorID()[16:]))
+	var topicNames []string
+	if role == spectypes.RoleCommittee {
+		topicNames = commons.CommitteeTopicID(spectypes.CommitteeID(msg.SSVMessage.MsgID.GetDutyExecutorID()[16:]))
 	} else {
 		val, exists := n.nodeStorage.ValidatorStore().Validator(msg.SSVMessage.MsgID.GetDutyExecutorID())
 		if !exists {
 			return fmt.Errorf("could not find share for validator %s", hex.EncodeToString(msg.SSVMessage.MsgID.GetDutyExecutorID()))
 		}
-		topics = commons.CommitteeTopicID(val.CommitteeID())
+		topicNames = commons.CommitteeTopicID(val.CommitteeID())
 	}
 
-	for _, topic := range topics {
+	// Egress logging is scoped to the rare, one-shot quorum duties (voluntary exit, validator
+	// registration): the only ones where confirming a single message left the node matters, and
+	// where the volume is low enough to compute a per-broadcast msg-id and peer count. Keeping it
+	// off the hot path also matters because the file logger captures DEBUG regardless of level.
+	logEgress := role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration
+
+	for _, topic := range topicNames {
 		if err := n.topicsCtrl.Broadcast(topic, encodedMsg, n.cfg.RequestTimeout); err != nil {
 			n.logger.Debug("could not broadcast msg", fields.Topic(topic), zap.Error(err))
 			return fmt.Errorf("could not broadcast msg: %w", err)
+		}
+
+		if logEgress {
+			// gossip_msg_id is the id gossipsub itself assigns (and the libp2p pubsub tracer
+			// logs), so a single message can be followed across nodes and against a trace.
+			// topic_peers surfaces a near-empty/sparse topic mesh, a prime suspect when a
+			// one-shot message fails to reach peers.
+			topicPeers, _ := n.topicsCtrl.Peers(topic)
+			n.logger.Debug("📤 broadcast message to topic",
+				fields.MessageID(msg.SSVMessage.MsgID),
+				zap.String("gossip_msg_id", hex.EncodeToString([]byte(topics.MsgID(encodedMsg)))),
+				fields.Topic(topic),
+				zap.Int("topic_peers", len(topicPeers)),
+			)
 		}
 	}
 	return nil

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -11,6 +11,7 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
@@ -65,10 +66,10 @@ func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedS
 		topicNames = commons.CommitteeTopicID(val.CommitteeID())
 	}
 
-	// Egress logging is scoped to the rare, one-shot quorum duties: confirming a single message
-	// left the node only matters for these, and their low volume keeps the msg-id hash and
-	// peer-count lookup off the hot path (the file logger captures DEBUG regardless of level).
-	logEgress := role == spectypes.RoleVoluntaryExit || role == spectypes.RoleValidatorRegistration
+	// Confirm egress for every broadcast at DEBUG — without it, a message lost in transit is
+	// indistinguishable from one never sent. The level check keeps the msg-id hash and
+	// peer-count lookups off the hot path when DEBUG is disabled.
+	logEgress := n.logger.Core().Enabled(zapcore.DebugLevel)
 
 	// gossip_msg_id is the id gossipsub itself assigns — hex-encoded to match SSV's pubsub tracer
 	// (network/topics/tracer.go) so one message can be correlated across nodes and against that

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -151,7 +151,7 @@ func (n *p2pNetwork) SetupHost() error {
 		backoffExponentBase,
 		rand.NewSource(time.Now().UnixNano()),
 	)
-	backoffConnector, err := libp2pdiscbackoff.NewBackoffConnector(h, backoffConnectorCacheSize, connectTimeout, backoffFactory)
+	backoffConnector, err := newBackoffConnector(h, n.logger, backoffConnectorCacheSize, connectTimeout, backoffFactory)
 	if err != nil {
 		return fmt.Errorf("could not create backoff connector: %w", err)
 	}

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -151,7 +151,7 @@ func (n *p2pNetwork) SetupHost() error {
 		backoffExponentBase,
 		rand.NewSource(time.Now().UnixNano()),
 	)
-	backoffConnector, err := newBackoffConnector(h, n.logger, backoffConnectorCacheSize, connectTimeout, backoffFactory)
+	backoffConnector, err := newBackoffConnector(n.logger, h, backoffConnectorCacheSize, connectTimeout, backoffFactory)
 	if err != nil {
 		return fmt.Errorf("could not create backoff connector: %w", err)
 	}

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -125,9 +125,9 @@ func (handler *msgIDHandler) pubsubMsgToMsgID(msg []byte) string {
 	return MsgID(msg)
 }
 
-// MsgID computes the gossipsub message-id for a raw pubsub payload, identically to the id
-// gossipsub itself assigns. Exported so the broadcast path can log the same id a receiver
-// (and the libp2p pubsub tracer) would see, enabling cross-node correlation of a single message.
+// MsgID computes the gossipsub message-id for a raw pubsub payload, identical to the id gossipsub
+// itself assigns. Exported so the broadcast path can log the same id a receiver (and the pubsub
+// tracer) sees, for cross-node correlation.
 //
 // TODO: (Alan) should we hash only the message body or what? @GalRogozinski @MatheusFranco99
 // In Alan message structure the message body can be identical for all 4 operators

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -122,12 +122,18 @@ func (handler *msgIDHandler) MsgID(logger *zap.Logger) func(pmsg *ps_pb.Message)
 }
 
 func (handler *msgIDHandler) pubsubMsgToMsgID(msg []byte) string {
-	// TODO: (Alan) should we hash only the message body or what? @GalRogozinski @MatheusFranco99
+	return MsgID(msg)
+}
 
-	// In Alan message structure the message body can be identical for all 4 operators
-	// whereas before it included a BLS signature which made it unique
-	// so we hash full message (including signer) to make it unique
-
+// MsgID computes the gossipsub message-id for a raw pubsub payload, identically to the id
+// gossipsub itself assigns. Exported so the broadcast path can log the same id a receiver
+// (and the libp2p pubsub tracer) would see, enabling cross-node correlation of a single message.
+//
+// TODO: (Alan) should we hash only the message body or what? @GalRogozinski @MatheusFranco99
+// In Alan message structure the message body can be identical for all 4 operators
+// whereas before it included a BLS signature which made it unique
+// so we hash full message (including signer) to make it unique
+func MsgID(msg []byte) string {
 	if len(msg) == 0 {
 		return ""
 	}

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -129,10 +129,14 @@ func (handler *msgIDHandler) pubsubMsgToMsgID(msg []byte) string {
 // itself assigns. Exported so the broadcast path can log the same id a receiver (and the pubsub
 // tracer) sees, for cross-node correlation.
 //
-// TODO: (Alan) should we hash only the message body or what? @GalRogozinski @MatheusFranco99
-// In Alan message structure the message body can be identical for all 4 operators
-// whereas before it included a BLS signature which made it unique
-// so we hash full message (including signer) to make it unique
+// We hash the full SignedSSVMessage, not just its body. Under the Alan message structure the body
+// can be byte-identical across a committee's operators — e.g. same-view prepare/commit messages, or
+// a decided vs. a plain commit — so a body-only id would alias their distinct messages onto a single
+// id. gossipsub marks an id "seen" before our validators run and silently drops later duplicates, so
+// that aliasing would censor all but the first operator's message to arrive and deadlock consensus.
+// Hashing the full message — which includes each operator's RSA signatures — keeps every message's id
+// distinct; as a side benefit the ids also become unpredictable to an observer, avoiding seen-cache
+// shadowing.
 func MsgID(msg []byte) string {
 	if len(msg) == 0 {
 		return ""

--- a/network/topics/tracer.go
+++ b/network/topics/tracer.go
@@ -99,58 +99,54 @@ func (pst *psTracer) log(logger *zap.Logger, evt *ps_pb.TraceEvent) {
 		if err == nil {
 			fields = append(fields, zap.String("targetPeer", pid.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil {
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		fields = appendRPCMeta(fields, msg.GetMeta())
 	case ps_pb.TraceEvent_DROP_RPC:
 		msg := evt.GetDropRPC()
 		pid, err := peer.IDFromBytes(msg.GetSendTo())
 		if err == nil {
 			fields = append(fields, zap.String("targetPeer", pid.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil {
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		fields = appendRPCMeta(fields, msg.GetMeta())
 	case ps_pb.TraceEvent_RECV_RPC:
 		msg := evt.GetRecvRPC()
 		pid, err := peer.IDFromBytes(msg.GetReceivedFrom())
 		if err == nil {
 			fields = append(fields, zap.String("receivedFrom", pid.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil {
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		fields = appendRPCMeta(fields, msg.GetMeta())
 	default:
 		return
 	}
 	logger.Debug("pubsub event", fields...)
+}
+
+// appendRPCMeta adds the RPC's payload message ids, gossip control ids (IHAVE/IWANT) and
+// subscription changes. The payload ids matter most: they record which messages were actually
+// forwarded to/by a peer, which is what lets a message's path (or the hop where it vanished) be
+// reconstructed across nodes from their traces.
+func appendRPCMeta(fields []zap.Field, meta *ps_pb.TraceEvent_RPCMeta) []zap.Field {
+	if meta == nil {
+		return fields
+	}
+	if msgs := meta.GetMessages(); len(msgs) > 0 {
+		mids := make([]string, 0, len(msgs))
+		for _, m := range msgs {
+			mids = append(mids, hex.EncodeToString(m.GetMessageID()))
+		}
+		fields = append(fields, zap.Int("msgsCount", len(mids)))
+		fields = append(fields, zap.Strings("msgIDs", mids))
+	}
+	if ctrl := meta.Control; ctrl != nil {
+		fields = appendIHave(fields, ctrl.GetIhave())
+		fields = appendIWant(fields, ctrl.GetIwant())
+	}
+	var subs []string
+	for _, sub := range meta.Subscription {
+		subs = append(subs, sub.GetTopic())
+	}
+	fields = append(fields, zap.Int("subsCount", len(subs)))
+	fields = append(fields, zap.Strings("subs", subs))
+	return fields
 }
 
 func appendIHave(fields []zap.Field, ihave []*ps_pb.TraceEvent_ControlIHaveMeta) []zap.Field {

--- a/network/topics/tracer_test.go
+++ b/network/topics/tracer_test.go
@@ -1,0 +1,97 @@
+package topics
+
+import (
+	crand "crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestPSTracer_RPCEvents locks the trace format of RPC events — in particular the payload message
+// ids, which are what allow reconstructing a message's path across nodes from their traces.
+func TestPSTracer_RPCEvents(t *testing.T) {
+	priv, _, err := libp2pcrypto.GenerateEd25519Key(crand.Reader)
+	require.NoError(t, err)
+	pid, err := peer.IDFromPrivateKey(priv)
+	require.NoError(t, err)
+
+	topic := "ssv.v2.33"
+	msgID1 := []byte{0x01, 0x02}
+	msgID2 := []byte{0x03, 0x04}
+
+	fullMeta := &ps_pb.TraceEvent_RPCMeta{
+		Messages: []*ps_pb.TraceEvent_MessageMeta{
+			{MessageID: msgID1, Topic: &topic},
+			{MessageID: msgID2, Topic: &topic},
+		},
+		Control: &ps_pb.TraceEvent_ControlMeta{
+			Ihave: []*ps_pb.TraceEvent_ControlIHaveMeta{{Topic: &topic, MessageIDs: [][]byte{msgID1}}},
+			Iwant: []*ps_pb.TraceEvent_ControlIWantMeta{{MessageIDs: [][]byte{msgID2}}},
+		},
+		Subscription: []*ps_pb.TraceEvent_SubMeta{{Topic: &topic}},
+	}
+
+	trace := func(evt *ps_pb.TraceEvent) map[string]any {
+		core, logs := observer.New(zapcore.DebugLevel)
+		newTracer(zap.New(core)).Trace(evt)
+		entries := logs.All()
+		require.Len(t, entries, 1, "expected exactly one trace log line")
+		return entries[0].ContextMap()
+	}
+
+	t.Run("SEND_RPC logs payload msg ids, control ids and subs", func(t *testing.T) {
+		fields := trace(&ps_pb.TraceEvent{
+			Type:    ps_pb.TraceEvent_SEND_RPC.Enum(),
+			SendRPC: &ps_pb.TraceEvent_SendRPC{SendTo: []byte(pid), Meta: fullMeta},
+		})
+		require.Equal(t, pid.String(), fields["targetPeer"])
+		require.Equal(t, int64(2), fields["msgsCount"])
+		require.Equal(t, []any{hex.EncodeToString(msgID1), hex.EncodeToString(msgID2)}, fields["msgIDs"])
+		require.Equal(t, []any{hex.EncodeToString(msgID1)}, fields["IHAVEmsgIDs"])
+		require.Equal(t, []any{hex.EncodeToString(msgID2)}, fields["IWANTmsgIDs"])
+		require.Equal(t, int64(1), fields["subsCount"])
+		require.Equal(t, []any{topic}, fields["subs"])
+	})
+
+	t.Run("RECV_RPC logs payload msg ids", func(t *testing.T) {
+		fields := trace(&ps_pb.TraceEvent{
+			Type: ps_pb.TraceEvent_RECV_RPC.Enum(),
+			RecvRPC: &ps_pb.TraceEvent_RecvRPC{
+				ReceivedFrom: []byte(pid),
+				Meta: &ps_pb.TraceEvent_RPCMeta{
+					Messages: []*ps_pb.TraceEvent_MessageMeta{{MessageID: msgID1, Topic: &topic}},
+				},
+			},
+		})
+		require.Equal(t, pid.String(), fields["receivedFrom"])
+		require.Equal(t, int64(1), fields["msgsCount"])
+		require.Equal(t, []any{hex.EncodeToString(msgID1)}, fields["msgIDs"])
+		require.NotContains(t, fields, "IHAVEmsgIDs")
+	})
+
+	t.Run("DROP_RPC tolerates nil meta", func(t *testing.T) {
+		fields := trace(&ps_pb.TraceEvent{
+			Type:    ps_pb.TraceEvent_DROP_RPC.Enum(),
+			DropRPC: &ps_pb.TraceEvent_DropRPC{SendTo: []byte(pid)},
+		})
+		require.Equal(t, pid.String(), fields["targetPeer"])
+		require.NotContains(t, fields, "msgsCount")
+		require.NotContains(t, fields, "subsCount")
+	})
+
+	t.Run("empty meta logs no msg ids but keeps subs fields", func(t *testing.T) {
+		fields := trace(&ps_pb.TraceEvent{
+			Type:    ps_pb.TraceEvent_SEND_RPC.Enum(),
+			SendRPC: &ps_pb.TraceEvent_SendRPC{SendTo: []byte(pid), Meta: &ps_pb.TraceEvent_RPCMeta{}},
+		})
+		require.NotContains(t, fields, "msgsCount")
+		require.Equal(t, int64(0), fields["subsCount"])
+	})
+}

--- a/observability/attributes.go
+++ b/observability/attributes.go
@@ -60,6 +60,10 @@ func DutyIDAttribute(id string) attribute.KeyValue {
 	return attribute.String("ssv.validator.duty.id", id)
 }
 
+func DutyOutcomeAttribute(outcome string) attribute.KeyValue {
+	return attribute.String("ssv.validator.duty.outcome", outcome)
+}
+
 func BeaconPeriodAttribute(period uint64) attribute.KeyValue {
 	return attribute.KeyValue{
 		Key:   "ssv.beacon.period",

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -48,6 +48,20 @@ const (
 	// time to receive the EL event and register the duty in its local dutyStore
 	// — which the inbound message-validation path checks via dutyCount.
 	//
+	// CAVEAT: that dutyCount admission check runs on every node validating the
+	// partial-sig on the gossip topic, not just on committee members. When
+	// committee operators are not direct mesh neighbors, the message must pass
+	// validation on intermediate nodes too — and an intermediary that never
+	// registered the exit silently ignores the message and does NOT forward it
+	// (dutyLimit is 0 without the dutyStore entry → ErrTooManyDutiesPerEpoch →
+	// ValidationIgnore; see dutyLimit in message/validation/common_checks.go).
+	// That is the case for nodes that run no duty scheduler at all (exporter
+	// standard mode), nodes whose EL event stream lags beyond this slack, and
+	// any node once it purges the entry an epoch after dutySlot (see
+	// processExecution). The slack cannot cover those nodes: reliable exit
+	// propagation currently assumes committee operators are mesh-connected on
+	// the topic.
+	//
 	// Independent of voluntaryExitDutySlotsToPostpone despite happening to
 	// share the same numeric value (4); see the note on that constant.
 	voluntaryExitSchedulingSlack = 4
@@ -175,6 +189,11 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				ValidatorIndex: exitDescriptor.ValidatorIndex,
 			}
 
+			// Register the duty even for validators that are not ours: inbound
+			// message validation consults this store (dutyCount), so without
+			// the entry this node would ignore — and refuse to relay — the
+			// committee's exit partial-sigs (see the CAVEAT on
+			// voluntaryExitSchedulingSlack).
 			h.duties.AddDuty(dutySlot, exitDescriptor.PubKey)
 			if !exitDescriptor.OwnValidator {
 				continue

--- a/operator/duties/voluntary_exit.go
+++ b/operator/duties/voluntary_exit.go
@@ -48,20 +48,6 @@ const (
 	// time to receive the EL event and register the duty in its local dutyStore
 	// — which the inbound message-validation path checks via dutyCount.
 	//
-	// CAVEAT: that dutyCount admission check runs on every node validating the
-	// partial-sig on the gossip topic, not just on committee members. When
-	// committee operators are not direct mesh neighbors, the message must pass
-	// validation on intermediate nodes too — and an intermediary that never
-	// registered the exit silently ignores the message and does NOT forward it
-	// (dutyLimit is 0 without the dutyStore entry → ErrTooManyDutiesPerEpoch →
-	// ValidationIgnore; see dutyLimit in message/validation/common_checks.go).
-	// That is the case for nodes that run no duty scheduler at all (exporter
-	// standard mode), nodes whose EL event stream lags beyond this slack, and
-	// any node once it purges the entry an epoch after dutySlot (see
-	// processExecution). The slack cannot cover those nodes: reliable exit
-	// propagation currently assumes committee operators are mesh-connected on
-	// the topic.
-	//
 	// Independent of voluntaryExitDutySlotsToPostpone despite happening to
 	// share the same numeric value (4); see the note on that constant.
 	voluntaryExitSchedulingSlack = 4
@@ -189,11 +175,9 @@ func (h *VoluntaryExitHandler) HandleDuties(ctx context.Context) {
 				ValidatorIndex: exitDescriptor.ValidatorIndex,
 			}
 
-			// Register the duty even for validators that are not ours: inbound
-			// message validation consults this store (dutyCount), so without
-			// the entry this node would ignore — and refuse to relay — the
-			// committee's exit partial-sigs (see the CAVEAT on
-			// voluntaryExitSchedulingSlack).
+			// Register the duty even for validators that are not ours: inbound p2p message validation consults this
+			// store (dutyCount), so without this our node would ignore a p2p message for this validator (and refuse
+			// to relay it).
 			h.duties.AddDuty(dutySlot, exitDescriptor.PubKey)
 			if !exitDescriptor.OwnValidator {
 				continue

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -102,13 +102,13 @@ func (r *AggregatorRunner) StartNewDuty(ctx context.Context, logger *zap.Logger,
 	return r.baseStartNewDuty(ctx, logger, r, validatorDuty, quorum)
 }
 
-func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -119,6 +119,14 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPreConsensus()
 	recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleAggregator)
@@ -148,7 +156,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	// to perform this aggregation duty or not
 	ok := r.IsAggregator(r.NetworkConfig.TargetAggregatorsPerCommittee, duty.CommitteeLength, fullSig)
 	if !ok {
-		r.markDutyFinished()
+		r.markDutyNotRequired()
 		r.measurements.EndDutyFlow()
 		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregator, 0)
 		return nil
@@ -280,13 +288,13 @@ func (r *AggregatorRunner) ProcessConsensus(ctx context.Context, logger *zap.Log
 	return nil
 }
 
-func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -302,6 +310,14 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleAggregator)
@@ -354,7 +370,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	span.AddEvent(submittedSignedAggregateProofEvent)
 	logger.Debug(submittedSignedAggregateProofEvent, fields.Took(time.Since(start)))
 
-	r.markDutyFinished()
+	r.markDutySucceeded()
 	r.measurements.EndDutyFlow()
 	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregator, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -510,9 +510,10 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	// (markDutySucceeded) and partial progress all return nil, so this only fires on a terminal
 	// post-quorum error — report it as failed instead of letting it fall through to a false "stuck".
 	// Unlike the consensus phase, a failure here is final: submission is the duty's last step.
-	// Shutdown (context cancellation) is left to the watcher's own ctx handling.
+	// Shutdown (context cancellation) needs no special-casing — markDutyFailed drops a context.Canceled
+	// reason, so a submission aborted by shutdown isn't recorded as a failure.
 	defer func() {
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil {
 			r.markDutyFailed(err)
 		}
 	}()

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -489,7 +489,7 @@ func (r *CommitteeRunner) signAttesterDuty(
 	return false, partialMsg, nil
 }
 
-func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
@@ -505,6 +505,17 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to submitting. Pre-quorum waiting, full success
+	// (markDutySucceeded) and partial progress all return nil, so this only fires on a terminal
+	// post-quorum error — report it as failed instead of letting it fall through to a false "stuck".
+	// Unlike the consensus phase, a failure here is final: submission is the duty's last step.
+	// Shutdown (context cancellation) is left to the watcher's own ctx handling.
+	defer func() {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleCommittee)
@@ -799,7 +810,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	}
 
 	if r.HasSubmittedAllValidatorDuties(attestationMap, committeeMap) {
-		r.markDutyFinished()
+		r.markDutySucceeded()
 		r.measurements.EndDutyFlow()
 		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleCommittee, r.State.RunningInstance.State.Round)
 		const dutyFinishedEvent = "✔️finished duty processing (100% success)"

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -367,7 +367,7 @@ func TestCommitteeRunnerProcessPostConsensus_SubmitsElectraObjectsAndDeduplicate
 		}
 	}
 
-	require.True(t, env.runner.State.Finished)
+	require.True(t, env.runner.State.Succeeded)
 	require.Len(t, env.beacon.GetBroadcastedRoots(), 2)
 
 	attesterDuty := duty.ValidatorDuties[0]
@@ -390,6 +390,6 @@ func TestCommitteeRunnerProcessPostConsensus_SubmitsElectraObjectsAndDeduplicate
 	require.ElementsMatch(t, []phase0.ValidatorIndex{attesterDuty.ValidatorIndex}, doppelganger.reports)
 
 	err = env.runner.ProcessPostConsensus(context.Background(), env.logger, postConsensusMsgs[2])
-	require.ErrorContains(t, err, ErrRunningDutyFinished.Error())
+	require.ErrorContains(t, err, ErrRunningDutySucceeded.Error())
 	require.Len(t, env.beacon.GetBroadcastedRoots(), 2)
 }

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -161,7 +161,9 @@ func newCommitteeRunnerEnv(
 func (e *committeeRunnerEnv) startAndDecideCommitteeDuty(t *testing.T, duty *spectypes.CommitteeDuty) {
 	t.Helper()
 
-	ctx := context.Background()
+	// t.Context: StartNewDuty spawns a deadline watcher that may log at slot end; the test-scoped
+	// context releases it before the zaptest logger becomes invalid.
+	ctx := t.Context()
 	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.sampleKey.Threshold))
 
 	for _, msg := range spectestingutils.CommitteeInputForDuty(duty, duty.Slot, e.keySetMap, false) {
@@ -242,7 +244,8 @@ func TestCommitteeRunnerStartNewDuty_StartsGuardAndResetsSubmissions(t *testing.
 	env.runner.RecordSubmission(spectypes.BNRoleAttester, 1)
 	env.runner.RecordSubmission(spectypes.BNRoleSyncCommittee, 2)
 
-	require.NoError(t, env.runner.StartNewDuty(context.Background(), env.logger, duty, env.sampleKey.Threshold))
+	// t.Context releases the duty deadline watcher before the zaptest logger becomes invalid.
+	require.NoError(t, env.runner.StartNewDuty(t.Context(), env.logger, duty, env.sampleKey.Threshold))
 
 	require.Len(t, guard.startCalls, 2)
 	gotRoles := make([]spectypes.BeaconRole, 0, len(guard.startCalls))

--- a/protocol/v2/ssv/runner/error.go
+++ b/protocol/v2/ssv/runner/error.go
@@ -12,9 +12,9 @@ var (
 	// ErrNoDutyAssigned means we haven't started the duty yet, while another operator already has + sent
 	// this message to us.
 	ErrNoDutyAssigned = fmt.Errorf("no duty assigned")
-	// ErrRunningDutyFinished means we have finished the duty already, while another operator hasn't finished it
-	// yet + sent this message to us.
-	ErrRunningDutyFinished = fmt.Errorf("running duty finished")
+	// ErrRunningDutySucceeded means we have successfully finished the duty already, while another operator hasn't
+	// finished it yet + sent this message to us.
+	ErrRunningDutySucceeded = fmt.Errorf("running duty already succeeded")
 	// ErrFuturePartialSigMsg means the message we've got is "from the future"; it can happen if we haven't advanced
 	// the runner to the slot the message is targeting yet, while another operator already has + sent this message
 	// to us.

--- a/protocol/v2/ssv/runner/observability.go
+++ b/protocol/v2/ssv/runner/observability.go
@@ -119,6 +119,12 @@ var (
 			observability.InstrumentName(observabilityNamespace, "submissions.failed"),
 			metric.WithUnit("{submission}"),
 			metric.WithDescription("total number of failed duty submissions")))
+
+	dutyOutcomeCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "duty.outcome"),
+			metric.WithUnit("{duty}"),
+			metric.WithDescription("total number of concluded duties, by outcome")))
 )
 
 func recordSuccessfulSubmission(ctx context.Context, count int64, epoch phase0.Epoch, role spectypes.BeaconRole) {
@@ -127,6 +133,14 @@ func recordSuccessfulSubmission(ctx context.Context, count int64, epoch phase0.E
 
 func recordFailedSubmission(ctx context.Context, role spectypes.BeaconRole) {
 	failedSubmissionCounter.Add(ctx, 1, metric.WithAttributes(observability.BeaconRoleAttribute(role)))
+}
+
+func recordDutyOutcome(ctx context.Context, role spectypes.RunnerRole, outcome dutyOutcome) {
+	dutyOutcomeCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			observability.RunnerRoleAttribute(role),
+			observability.DutyOutcomeAttribute(string(outcome)),
+		))
 }
 
 func recordPreConsensusDuration(ctx context.Context, duration time.Duration, role spectypes.RunnerRole) {

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -111,13 +111,13 @@ func (r *ProposerRunner) StartNewDuty(ctx context.Context, logger *zap.Logger, d
 	return r.baseStartNewDuty(ctx, logger, r, validatorDuty, quorum)
 }
 
-func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -128,6 +128,14 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPreConsensus()
 	recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleProposer)
@@ -330,13 +338,13 @@ func (r *ProposerRunner) ProcessConsensus(ctx context.Context, logger *zap.Logge
 	return nil
 }
 
-func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -346,6 +354,14 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleProposer)
@@ -420,7 +436,7 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	span.AddEvent(submittedBlockProposalEvent, trace.WithAttributes(submittedAttrs...))
 	logger.Info(submittedBlockProposalEvent, fields.Took(time.Since(start)))
 
-	r.markDutyFinished()
+	r.markDutySucceeded()
 	r.measurements.EndDutyFlow()
 	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleProposer, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"

--- a/protocol/v2/ssv/runner/proposer_test.go
+++ b/protocol/v2/ssv/runner/proposer_test.go
@@ -247,7 +247,7 @@ func TestProposerRunnerStartNewDutySkipsRandaoSigningWhenDoppelgangerBlocks(t *t
 	require.Equal(t, 0, beacon.getCalls)
 	require.Nil(t, runner.cachedFullBlock)
 	require.Nil(t, runner.State.RunningInstance)
-	require.False(t, runner.State.Finished)
+	require.False(t, runner.State.Succeeded)
 	require.Empty(t, dg.reportQuorum)
 }
 
@@ -282,7 +282,7 @@ func TestProposerRunnerProcessConsensusSkipsPostConsensusSigningWhenDoppelganger
 	require.NotNil(t, runner.State.DecidedValue)
 	require.Equal(t, 0, countPartialSignatureBroadcastsByType(t, network, spectypes.PostConsensusPartialSig))
 	require.Equal(t, 1, countPartialSignatureBroadcastsByType(t, network, spectypes.RandaoPartialSig))
-	require.False(t, runner.State.Finished)
+	require.False(t, runner.State.Succeeded)
 }
 
 func TestProposerRunnerProcessPostConsensusLeaderUsesCachedFullBlockWhenDecisionMatches(t *testing.T) {
@@ -306,7 +306,7 @@ func TestProposerRunnerProcessPostConsensusLeaderUsesCachedFullBlockWhenDecision
 	require.False(t, beacon.submittedBlocks[0].Blinded)
 	require.NotEqual(t, phase0.BLSSignature{}, beacon.submittedSig[0])
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.State.Finished)
+	require.True(t, runner.State.Succeeded)
 }
 
 func TestProposerRunnerProcessPostConsensusLeaderFallsBackToDecidedBlindedBlockOnCacheMismatch(t *testing.T) {
@@ -327,7 +327,7 @@ func TestProposerRunnerProcessPostConsensusLeaderFallsBackToDecidedBlindedBlockO
 	require.Len(t, beacon.submittedBlocks, 1)
 	require.True(t, beacon.submittedBlocks[0].Blinded)
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.State.Finished)
+	require.True(t, runner.State.Succeeded)
 }
 
 func TestProposerRunnerProcessPostConsensusNonLeaderKeepsDecidedBlindedBlock(t *testing.T) {
@@ -349,7 +349,7 @@ func TestProposerRunnerProcessPostConsensusNonLeaderKeepsDecidedBlindedBlock(t *
 	require.Len(t, beacon.submittedBlocks, 1)
 	require.True(t, beacon.submittedBlocks[0].Blinded)
 	require.Equal(t, []phase0.ValidatorIndex{runner.GetShare().ValidatorIndex}, dg.reportQuorum)
-	require.True(t, runner.State.Finished)
+	require.True(t, runner.State.Succeeded)
 }
 
 func newProposerRunnerForTest(

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -111,10 +111,10 @@ type BaseRunner struct {
 
 	qbftRoundTimerF ssv.QBFTRoundTimerF `json:"-"`
 
-	// dutyDeadlineDone is closed by markDutyFinished to release the duty-completion watcher.
+	// dutyFinishedOnTime is closed by markDutyFinished to release the duty-completion watcher.
 	// Set and closed only from the single message-processing goroutine (the watcher reads its
-	// own captured copy), so it needs no lock. See watchDutyDeadline.
-	dutyDeadlineDone chan struct{} `json:"-"`
+	// own captured copy), so it needs no lock. See watchDutyFinishedOnTime.
+	dutyFinishedOnTime chan struct{} `json:"-"`
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
@@ -242,7 +242,7 @@ func (b *BaseRunner) baseStartNewDuty(ctx context.Context, logger *zap.Logger, r
 
 	b.State = NewRunnerState(quorum, duty)
 
-	b.watchDutyDeadline(ctx, logger)
+	b.watchDutyFinishedOnTime(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return fmt.Errorf("failed to execute duty: %w", err)
@@ -259,7 +259,7 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 
 	b.State = NewRunnerState(quorum, duty)
 
-	b.watchDutyDeadline(ctx, logger)
+	b.watchDutyFinishedOnTime(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return err
@@ -268,30 +268,30 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 	return nil
 }
 
-// watchDutyDeadline warns once if the duty hasn't completed by the end of the current wall-clock
+// watchDutyFinishedOnTime warns once if the duty hasn't completed by the end of the current wall-clock
 // slot. It knows nothing about how duties complete: completion is signaled by markDutyFinished
-// closing dutyDeadlineDone, not by reading runner state, so it's safe alongside the single-threaded
+// closing dutyFinishedOnTime, not by reading runner state, so it's safe alongside the single-threaded
 // message loop. It MUST be started before executeDuty so a duty that completes synchronously releases
 // its own channel. Each duty gets its own channel: starting the next duty overwrites the field, and
 // the previous duty's watcher (if still pending) warns for its own duty and is reaped by its own
 // timer.
 //
-// The deadline is the end of the current wall-clock slot rather than duty.Slot's end because some
+// The "on-time" is the end of the current wall-clock slot rather than duty.Slot's end because some
 // duties are stamped with a slot in the past (a voluntary-exit envelope carries blockSlot+4 but
 // executes at blockSlot+12); for beacon duties the two coincide.
-func (b *BaseRunner) watchDutyDeadline(ctx context.Context, logger *zap.Logger) {
-	done := make(chan struct{})
-	b.dutyDeadlineDone = done
+func (b *BaseRunner) watchDutyFinishedOnTime(ctx context.Context, logger *zap.Logger) {
+	finishedOnTime := make(chan struct{})
+	b.dutyFinishedOnTime = finishedOnTime
 
-	deadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
+	onTimeDeadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
 
 	go func() {
 		select {
-		case <-done:
+		case <-finishedOnTime:
 			return // duty completed
 		case <-ctx.Done():
 			return // node/validator shutting down
-		case <-time.After(time.Until(deadline)):
+		case <-time.After(time.Until(onTimeDeadline)):
 		}
 
 		logger.Warn("⚠️ duty did not complete before slot end")
@@ -595,9 +595,9 @@ func (b *BaseRunner) markDutyFinished() {
 	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. Set b.dutyDeadlineDone
 	// to nil makes this func idempotent (it shouldn't be called twice, but it's hard to ensure that with the current
 	// code shape).
-	if b.dutyDeadlineDone != nil {
-		close(b.dutyDeadlineDone)
-		b.dutyDeadlineDone = nil
+	if b.dutyFinishedOnTime != nil {
+		close(b.dutyFinishedOnTime)
+		b.dutyFinishedOnTime = nil
 	}
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -303,7 +303,6 @@ func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap
 		// could-not-handle drop log, DEBUG), so this warning with no such preceding error means the
 		// partial-signature quorum never formed.
 		logger.Warn("⚠️ pre-consensus duty did not reach quorum or submit by deadline",
-			fields.Slot(duty.DutySlot()),
 			zap.Uint64("quorum", quorum),
 		)
 	}()
@@ -603,8 +602,9 @@ func (b *BaseRunner) hasDutyFinished() bool {
 func (b *BaseRunner) markDutyFinished() {
 	// NOTE: b.State cannot be nil at this point, by construction.
 	b.State.Finished = true
-	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. nil-ing
-	// guards against a double close; safe without a lock as this runs only on the message goroutine.
+	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. Set b.nonBeaconDeadlineDone
+	// to nil makes this func idempotent (it shouldn't be called twice, but it's hard to ensure that with the current
+	// code shape).
 	if b.nonBeaconDeadlineDone != nil {
 		close(b.nonBeaconDeadlineDone)
 		b.nonBeaconDeadlineDone = nil

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -264,7 +264,14 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 	// collect a partial-signature quorum is otherwise completely silent (the runner just stops
 	// at the !hasQuorum early-return). Watch the deadline and emit one operator-visible warning
 	// if the duty never completes.
-	b.watchNonBeaconDutyDeadline(ctx, logger, duty, quorum)
+	//
+	// Only start the watcher if the duty is still running: should executeDuty ever complete it
+	// synchronously (e.g. a single-operator setup, or a future refactor), markDutyFinished would
+	// already have run while nonBeaconDeadlineDone was still nil, so a watcher started now would
+	// never be released and would warn ~2 slots later about a duty that actually succeeded.
+	if b.hasDutyRunning() {
+		b.watchNonBeaconDutyDeadline(ctx, logger, duty, quorum)
+	}
 	return nil
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -112,9 +112,9 @@ type BaseRunner struct {
 	qbftRoundTimerF ssv.QBFTRoundTimerF `json:"-"`
 
 	// nonBeaconDeadlineDone is closed by markDutyFinished to release the deadline watcher started
-	// for a pre-consensus-only duty (voluntary exit / validator registration). It is set and
-	// closed only from the single message-processing goroutine; the watcher only reads its own
-	// captured copy. See watchNonBeaconDutyDeadline.
+	// for a pre-consensus-only duty. Set and closed only from the single message-processing
+	// goroutine (the watcher reads its own captured copy), so it needs no lock. See
+	// watchNonBeaconDutyDeadline.
 	nonBeaconDeadlineDone chan struct{} `json:"-"`
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
@@ -259,34 +259,29 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 		return err
 	}
 
-	// Pre-consensus-only duties (voluntary exit, validator registration) have no consensus or
-	// post-consensus phase and broadcast their partial signature exactly once, so a failure to
-	// collect a partial-signature quorum is otherwise completely silent (the runner just stops
-	// at the !hasQuorum early-return). Watch the deadline and emit one operator-visible warning
-	// if the duty never completes.
+	// Pre-consensus-only duties broadcast their partial signature once and have no later phase, so
+	// a failure to reach quorum is otherwise silent (the runner just stops at the !hasQuorum
+	// early-return). Watch the deadline and warn once if the duty never completes.
 	//
-	// Only start the watcher if the duty is still running: should executeDuty ever complete it
-	// synchronously (e.g. a single-operator setup, or a future refactor), markDutyFinished would
-	// already have run while nonBeaconDeadlineDone was still nil, so a watcher started now would
-	// never be released and would warn ~2 slots later about a duty that actually succeeded.
+	// Guard on hasDutyRunning so a duty completed synchronously inside executeDuty (cannot happen
+	// today) can't leave a watcher that never gets released and warns about an already-finished duty.
 	if b.hasDutyRunning() {
 		b.watchNonBeaconDutyDeadline(ctx, logger, duty, quorum)
 	}
 	return nil
 }
 
-// watchNonBeaconDutyDeadline warns if a pre-consensus-only duty has not finished (reached quorum,
-// reconstructed and submitted) by its deadline. Completion is signaled by markDutyFinished closing
-// nonBeaconDeadlineDone rather than by reading runner state, so the watcher is safe to run alongside
-// the single-threaded message-processing loop. Each duty gets its own channel, so a runner reused
-// for a later duty still reports an earlier one that never completed.
+// watchNonBeaconDutyDeadline warns if a pre-consensus-only duty hasn't finished by its deadline.
+// Completion is signaled by markDutyFinished closing nonBeaconDeadlineDone, not by reading runner
+// state, so it's safe alongside the single-threaded message loop. Each duty gets its own channel so
+// a reused runner still reports an earlier duty that never completed.
 func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty, quorum uint64) {
 	done := make(chan struct{})
 	b.nonBeaconDeadlineDone = done
 
-	// Measure the deadline from now, not from duty.Slot: a voluntary-exit envelope Slot can be
-	// several slots in the past (it stamps blockSlot+4 but broadcasts at blockSlot+12). Two slots
-	// is generous — pre-consensus quorums normally form in well under one slot.
+	// Measure from now, not duty.Slot: a voluntary-exit envelope Slot can be several slots in the
+	// past (stamped blockSlot+4 but broadcast at blockSlot+12). Two slots is generous — pre-consensus
+	// quorums normally form in well under one slot.
 	deadline := time.Now().Add(2 * b.NetworkConfig.SlotDuration)
 
 	go func() {
@@ -301,7 +296,7 @@ func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap
 		case <-timer.C:
 		}
 
-		logger.Warn("⚠️ pre-consensus duty did not complete by deadline; quorum not reached or submission failed",
+		logger.Warn("⚠️ pre-consensus duty did not reach quorum or submit by deadline",
 			fields.Slot(duty.DutySlot()),
 			zap.Uint64("quorum", quorum),
 		)
@@ -602,9 +597,8 @@ func (b *BaseRunner) hasDutyFinished() bool {
 func (b *BaseRunner) markDutyFinished() {
 	// NOTE: b.State cannot be nil at this point, by construction.
 	b.State.Finished = true
-	// Release the non-beacon deadline watcher (if any) so it doesn't warn about a duty that
-	// completed. Set and closed only from the single message-processing goroutine, so there's no
-	// race; nil-ing it guards against a double close.
+	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. nil-ing
+	// guards against a double close; safe without a lock as this runs only on the message goroutine.
 	if b.nonBeaconDeadlineDone != nil {
 		close(b.nonBeaconDeadlineDone)
 		b.nonBeaconDeadlineDone = nil

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -111,10 +111,11 @@ type BaseRunner struct {
 
 	qbftRoundTimerF ssv.QBFTRoundTimerF `json:"-"`
 
-	// dutyFinishedOnTime is closed by markDutyFinished to release the duty-completion watcher.
-	// Set and closed only from the single message-processing goroutine (the watcher reads its
-	// own captured copy), so it needs no lock. See watchDutyFinishedOnTime.
-	dutyFinishedOnTime chan struct{} `json:"-"`
+	// dutyConcluded carries a duty's terminal outcome (success / not-required / failure) from the
+	// markers to its watcher (watchDutyOutcome), which reports it exactly once. Buffered(1) so a
+	// marker never blocks even if the watcher already exited. Set and sent-on only from the single
+	// message-processing goroutine (the watcher reads its own captured copy), so it needs no lock.
+	dutyConcluded chan dutyConclusion `json:"-"`
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
@@ -242,9 +243,10 @@ func (b *BaseRunner) baseStartNewDuty(ctx context.Context, logger *zap.Logger, r
 
 	b.State = NewRunnerState(quorum, duty)
 
-	b.watchDutyFinishedOnTime(ctx, logger)
+	b.watchDutyOutcome(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
+		b.markDutyFailed(err)
 		return fmt.Errorf("failed to execute duty: %w", err)
 	}
 
@@ -259,42 +261,76 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 
 	b.State = NewRunnerState(quorum, duty)
 
-	b.watchDutyFinishedOnTime(ctx, logger)
+	b.watchDutyOutcome(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
+		b.markDutyFailed(err)
 		return err
 	}
 
 	return nil
 }
 
-// watchDutyFinishedOnTime warns once if the duty hasn't completed by the end of the current wall-clock
-// slot. It knows nothing about how duties complete: completion is signaled by markDutyFinished
-// closing dutyFinishedOnTime, not by reading runner state, so it's safe alongside the single-threaded
-// message loop. It MUST be started before executeDuty so a duty that completes synchronously releases
-// its own channel. Each duty gets its own channel: starting the next duty overwrites the field, and
-// the previous duty's watcher (if still pending) warns for its own duty and is reaped by its own
-// timer.
+// dutyOutcome classifies how a duty concluded. Every duty concludes with exactly one outcome,
+// reported once by watchDutyOutcome and recorded as the ssv.runner.duty.outcome metric.
+type dutyOutcome string
+
+const (
+	dutyOutcomeSucceeded   dutyOutcome = "succeeded"    // full successful cycle with quorum, submitted to the beacon node
+	dutyOutcomeNotRequired dutyOutcome = "not_required" // completed with nothing to submit (e.g. not selected as aggregator)
+	dutyOutcomeFailed      dutyOutcome = "failed"       // terminated by a non-recoverable error
+	dutyOutcomeStuck       dutyOutcome = "stuck"        // not concluded before the end of the current wall-clock slot
+)
+
+// dutyConclusion is handed by a marker (markDutySucceeded / markDutyNotRequired / markDutyFailed) to
+// the duty's watcher (watchDutyOutcome), which reports it.
+type dutyConclusion struct {
+	outcome dutyOutcome
+	reason  error // populated for dutyOutcomeFailed
+}
+
+// watchDutyOutcome reports a duty's terminal outcome exactly once: it records the
+// ssv.runner.duty.outcome metric and warns for the outcomes worth an operator's attention (failed
+// and stuck). It knows nothing about how duties complete — the outcome is delivered by a marker
+// over dutyConcluded, not by reading runner state — so it's safe alongside the single-threaded
+// message loop. It MUST be started before executeDuty so a duty that concludes synchronously is still
+// reported. Each duty gets its own channel: starting the next duty overwrites the field, and the
+// previous duty's watcher (if still pending) reports its own duty and is reaped by its own timer.
 //
-// The "on-time" is the end of the current wall-clock slot rather than duty.Slot's end because some
+// The deadline is the end of the current wall-clock slot rather than duty.Slot's end because some
 // duties are stamped with a slot in the past (a voluntary-exit envelope carries blockSlot+4 but
 // executes at blockSlot+12); for beacon duties the two coincide.
-func (b *BaseRunner) watchDutyFinishedOnTime(ctx context.Context, logger *zap.Logger) {
-	finishedOnTime := make(chan struct{})
-	b.dutyFinishedOnTime = finishedOnTime
+func (b *BaseRunner) watchDutyOutcome(ctx context.Context, logger *zap.Logger) {
+	concluded := make(chan dutyConclusion, 1)
+	b.dutyConcluded = concluded
 
-	onTimeDeadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
+	deadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
+
+	report := func(c dutyConclusion) {
+		recordDutyOutcome(ctx, b.GetRole(), c.outcome)
+		if c.outcome == dutyOutcomeFailed {
+			logger.Warn("⚠️ duty failed", zap.Error(c.reason))
+		}
+		if c.outcome == dutyOutcomeStuck {
+			logger.Warn("⚠️ duty did not complete before slot end (likely stuck)")
+		}
+	}
 
 	go func() {
 		select {
-		case <-finishedOnTime:
-			return // duty completed
+		case c := <-concluded:
+			report(c)
 		case <-ctx.Done():
 			return // node/validator shutting down
-		case <-time.After(time.Until(onTimeDeadline)):
+		case <-time.After(time.Until(deadline)):
+			// Prefer a conclusion that landed right at the deadline over reporting a false miss.
+			select {
+			case c := <-concluded:
+				report(c)
+			default:
+				report(dutyConclusion{outcome: dutyOutcomeStuck})
+			}
 		}
-
-		logger.Warn("⚠️ duty did not complete before slot end")
 	}()
 }
 
@@ -582,22 +618,45 @@ func (b *BaseRunner) hasDutyAssigned() bool {
 }
 
 func (b *BaseRunner) hasDutyRunning() bool {
-	return b.hasDutyAssigned() && !b.State.Finished
+	return b.hasDutyAssigned() && !b.State.Succeeded
 }
 
-func (b *BaseRunner) hasDutyFinished() bool {
-	return b.hasDutyAssigned() && b.State.Finished
+func (b *BaseRunner) hasDutySucceeded() bool {
+	return b.hasDutyAssigned() && b.State.Succeeded
 }
 
-func (b *BaseRunner) markDutyFinished() {
+// markDutySucceeded records that the duty completed its full cycle (pre-consensus, consensus and
+// post-consensus) successfully, submitting to the beacon node.
+func (b *BaseRunner) markDutySucceeded() {
 	// NOTE: b.State cannot be nil at this point, by construction.
-	b.State.Finished = true
-	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. Set b.dutyDeadlineDone
-	// to nil makes this func idempotent (it shouldn't be called twice, but it's hard to ensure that with the current
-	// code shape).
-	if b.dutyFinishedOnTime != nil {
-		close(b.dutyFinishedOnTime)
-		b.dutyFinishedOnTime = nil
+	b.State.Succeeded = true
+	b.concludeDuty(dutyOutcomeSucceeded, nil)
+}
+
+// markDutyNotRequired records that the duty completed correctly with nothing to submit — e.g. the
+// validator turned out not to be an aggregator. Like a success it is a full, correct completion
+// (State.Succeeded is set); it is reported under a distinct outcome so the two can be told apart.
+func (b *BaseRunner) markDutyNotRequired() {
+	// NOTE: b.State cannot be nil at this point, by construction.
+	b.State.Succeeded = true
+	b.concludeDuty(dutyOutcomeNotRequired, nil)
+}
+
+// markDutyFailed records that the duty terminated with a non-recoverable error. It does NOT mark the
+// duty succeeded; it only reports the outcome so the watcher classifies the duty as failed rather
+// than as a silent stall.
+func (b *BaseRunner) markDutyFailed(reason error) {
+	b.concludeDuty(dutyOutcomeFailed, reason)
+}
+
+// concludeDuty hands the duty's terminal outcome to its watcher (watchDutyOutcome), which reports it
+// exactly once. A duty concludes at most once, but nil-ing dutyConcluded after the (buffered, so
+// non-blocking) send keeps this idempotent: a second call — or one before watchDutyOutcome armed the
+// channel — must never block the single message-processing goroutine on the buffered(1) channel.
+func (b *BaseRunner) concludeDuty(outcome dutyOutcome, reason error) {
+	if b.dutyConcluded != nil {
+		b.dutyConcluded <- dutyConclusion{outcome: outcome, reason: reason}
+		b.dutyConcluded = nil
 	}
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
@@ -109,6 +110,12 @@ type BaseRunner struct {
 	ssvtypes.OperatorSigner
 
 	qbftRoundTimerF ssv.QBFTRoundTimerF `json:"-"`
+
+	// nonBeaconDeadlineDone is closed by markDutyFinished to release the deadline watcher started
+	// for a pre-consensus-only duty (voluntary exit / validator registration). It is set and
+	// closed only from the single message-processing goroutine; the watcher only reads its own
+	// captured copy. See watchNonBeaconDutyDeadline.
+	nonBeaconDeadlineDone chan struct{} `json:"-"`
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
@@ -248,7 +255,50 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 		return fmt.Errorf("can't start non-beacon duty: %w", err)
 	}
 	b.State = NewRunnerState(quorum, duty)
-	return runner.executeDuty(ctx, logger, duty)
+	if err := runner.executeDuty(ctx, logger, duty); err != nil {
+		return err
+	}
+
+	// Pre-consensus-only duties (voluntary exit, validator registration) have no consensus or
+	// post-consensus phase and broadcast their partial signature exactly once, so a failure to
+	// collect a partial-signature quorum is otherwise completely silent (the runner just stops
+	// at the !hasQuorum early-return). Watch the deadline and emit one operator-visible warning
+	// if the duty never completes.
+	b.watchNonBeaconDutyDeadline(ctx, logger, duty, quorum)
+	return nil
+}
+
+// watchNonBeaconDutyDeadline warns if a pre-consensus-only duty has not finished (reached quorum,
+// reconstructed and submitted) by its deadline. Completion is signaled by markDutyFinished closing
+// nonBeaconDeadlineDone rather than by reading runner state, so the watcher is safe to run alongside
+// the single-threaded message-processing loop. Each duty gets its own channel, so a runner reused
+// for a later duty still reports an earlier one that never completed.
+func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty, quorum uint64) {
+	done := make(chan struct{})
+	b.nonBeaconDeadlineDone = done
+
+	// Measure the deadline from now, not from duty.Slot: a voluntary-exit envelope Slot can be
+	// several slots in the past (it stamps blockSlot+4 but broadcasts at blockSlot+12). Two slots
+	// is generous — pre-consensus quorums normally form in well under one slot.
+	deadline := time.Now().Add(2 * b.NetworkConfig.SlotDuration)
+
+	go func() {
+		timer := time.NewTimer(time.Until(deadline))
+		defer timer.Stop()
+
+		select {
+		case <-done:
+			return // duty finished successfully
+		case <-ctx.Done():
+			return // node/validator shutting down
+		case <-timer.C:
+		}
+
+		logger.Warn("⚠️ pre-consensus duty did not complete by deadline; quorum not reached or submission failed",
+			fields.Slot(duty.DutySlot()),
+			zap.Uint64("quorum", quorum),
+		)
+	}()
 }
 
 // signAndBroadcastPartialSigMsgs encodes msgs into an SSVMessage, signs it with opSigner,
@@ -545,6 +595,13 @@ func (b *BaseRunner) hasDutyFinished() bool {
 func (b *BaseRunner) markDutyFinished() {
 	// NOTE: b.State cannot be nil at this point, by construction.
 	b.State.Finished = true
+	// Release the non-beacon deadline watcher (if any) so it doesn't warn about a duty that
+	// completed. Set and closed only from the single message-processing goroutine, so there's no
+	// race; nil-ing it guards against a double close.
+	if b.nonBeaconDeadlineDone != nil {
+		close(b.nonBeaconDeadlineDone)
+		b.nonBeaconDeadlineDone = nil
+	}
 }
 
 func (b *BaseRunner) ShouldProcessDuty(duty spectypes.Duty) error {

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -274,7 +274,9 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 // watchNonBeaconDutyDeadline warns if a pre-consensus-only duty hasn't finished by its deadline.
 // Completion is signaled by markDutyFinished closing nonBeaconDeadlineDone, not by reading runner
 // state, so it's safe alongside the single-threaded message loop. Each duty gets its own channel so
-// a reused runner still reports an earlier duty that never completed.
+// a reused runner still reports an earlier duty that never completed. If that earlier duty failed
+// mid-flight (markDutyFinished never ran), starting a new duty overwrites the channel and orphans
+// the earlier watcher — harmless: it warns for its own duty and is reaped by its own timer.
 func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty, quorum uint64) {
 	done := make(chan struct{})
 	b.nonBeaconDeadlineDone = done
@@ -296,6 +298,10 @@ func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap
 		case <-timer.C:
 		}
 
+		// Fires both when quorum never formed and when quorum formed but reconstruction/submission
+		// failed — the latter logs its specific error the moment it happens (the queue's
+		// could-not-handle drop log, DEBUG), so this warning with no such preceding error means the
+		// partial-signature quorum never formed.
 		logger.Warn("⚠️ pre-consensus duty did not reach quorum or submit by deadline",
 			fields.Slot(duty.DutySlot()),
 			zap.Uint64("quorum", quorum),

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -111,11 +111,10 @@ type BaseRunner struct {
 
 	qbftRoundTimerF ssv.QBFTRoundTimerF `json:"-"`
 
-	// nonBeaconDeadlineDone is closed by markDutyFinished to release the deadline watcher started
-	// for a pre-consensus-only duty. Set and closed only from the single message-processing
-	// goroutine (the watcher reads its own captured copy), so it needs no lock. See
-	// watchNonBeaconDutyDeadline.
-	nonBeaconDeadlineDone chan struct{} `json:"-"`
+	// dutyDeadlineDone is closed by markDutyFinished to release the duty-completion watcher.
+	// Set and closed only from the single message-processing goroutine (the watcher reads its
+	// own captured copy), so it needs no lock. See watchDutyDeadline.
+	dutyDeadlineDone chan struct{} `json:"-"`
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
 	highestDecidedSlot phase0.Slot
@@ -242,6 +241,7 @@ func (b *BaseRunner) baseStartNewDuty(ctx context.Context, logger *zap.Logger, r
 	}
 
 	b.State = NewRunnerState(quorum, duty)
+	b.watchDutyDeadline(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return fmt.Errorf("failed to execute duty: %w", err)
@@ -255,36 +255,30 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 		return fmt.Errorf("can't start non-beacon duty: %w", err)
 	}
 	b.State = NewRunnerState(quorum, duty)
+	b.watchDutyDeadline(ctx, logger)
+
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return err
-	}
-
-	// Pre-consensus-only duties broadcast their partial signature once and have no later phase, so
-	// a failure to reach quorum is otherwise silent (the runner just stops at the !hasQuorum
-	// early-return). Watch the deadline and warn once if the duty never completes.
-	//
-	// Guard on hasDutyRunning so a duty completed synchronously inside executeDuty (cannot happen
-	// today) can't leave a watcher that never gets released and warns about an already-finished duty.
-	if b.hasDutyRunning() {
-		b.watchNonBeaconDutyDeadline(ctx, logger, duty, quorum)
 	}
 	return nil
 }
 
-// watchNonBeaconDutyDeadline warns if a pre-consensus-only duty hasn't finished by its deadline.
-// Completion is signaled by markDutyFinished closing nonBeaconDeadlineDone, not by reading runner
-// state, so it's safe alongside the single-threaded message loop. Each duty gets its own channel so
-// a reused runner still reports an earlier duty that never completed. If that earlier duty failed
-// mid-flight (markDutyFinished never ran), starting a new duty overwrites the channel and orphans
-// the earlier watcher — harmless: it warns for its own duty and is reaped by its own timer.
-func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty, quorum uint64) {
+// watchDutyDeadline warns once if the duty hasn't completed by the end of the current wall-clock
+// slot. It knows nothing about how duties complete: completion is signaled by markDutyFinished
+// closing dutyDeadlineDone, not by reading runner state, so it's safe alongside the single-threaded
+// message loop. It is started before executeDuty so a duty that completes synchronously releases
+// its own channel. Each duty gets its own channel: starting the next duty overwrites the field, and
+// the previous duty's watcher (if still pending) warns for its own duty and is reaped by its own
+// timer.
+//
+// The deadline is the end of the current wall-clock slot rather than duty.Slot's end because some
+// duties are stamped with a slot in the past (a voluntary-exit envelope carries blockSlot+4 but
+// executes at blockSlot+12); for beacon duties the two coincide.
+func (b *BaseRunner) watchDutyDeadline(ctx context.Context, logger *zap.Logger) {
 	done := make(chan struct{})
-	b.nonBeaconDeadlineDone = done
+	b.dutyDeadlineDone = done
 
-	// Measure from now, not duty.Slot: a voluntary-exit envelope Slot can be several slots in the
-	// past (stamped blockSlot+4 but broadcast at blockSlot+12). Two slots is generous — pre-consensus
-	// quorums normally form in well under one slot.
-	deadline := time.Now().Add(2 * b.NetworkConfig.SlotDuration)
+	deadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
 
 	go func() {
 		timer := time.NewTimer(time.Until(deadline))
@@ -292,19 +286,13 @@ func (b *BaseRunner) watchNonBeaconDutyDeadline(ctx context.Context, logger *zap
 
 		select {
 		case <-done:
-			return // duty finished successfully
+			return // duty completed
 		case <-ctx.Done():
 			return // node/validator shutting down
 		case <-timer.C:
 		}
 
-		// Fires both when quorum never formed and when quorum formed but reconstruction/submission
-		// failed — the latter logs its specific error the moment it happens (the queue's
-		// could-not-handle drop log, DEBUG), so this warning with no such preceding error means the
-		// partial-signature quorum never formed.
-		logger.Warn("⚠️ pre-consensus duty did not reach quorum or submit by deadline",
-			zap.Uint64("quorum", quorum),
-		)
+		logger.Warn("⚠️ duty did not complete before slot end")
 	}()
 }
 
@@ -602,12 +590,12 @@ func (b *BaseRunner) hasDutyFinished() bool {
 func (b *BaseRunner) markDutyFinished() {
 	// NOTE: b.State cannot be nil at this point, by construction.
 	b.State.Finished = true
-	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. Set b.nonBeaconDeadlineDone
+	// Release the deadline watcher (if any) so it doesn't warn about a completed duty. Set b.dutyDeadlineDone
 	// to nil makes this func idempotent (it shouldn't be called twice, but it's hard to ensure that with the current
 	// code shape).
-	if b.nonBeaconDeadlineDone != nil {
-		close(b.nonBeaconDeadlineDone)
-		b.nonBeaconDeadlineDone = nil
+	if b.dutyDeadlineDone != nil {
+		close(b.dutyDeadlineDone)
+		b.dutyDeadlineDone = nil
 	}
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -645,7 +645,15 @@ func (b *BaseRunner) markDutyNotRequired() {
 // markDutyFailed records that the duty terminated with a non-recoverable error. It does NOT mark the
 // duty succeeded; it only reports the outcome so the watcher classifies the duty as failed rather
 // than as a silent stall.
+//
+// A context.Canceled reason is not a duty failure: a cancellation means the duty was abandoned
+// (typically node/validator shutdown), not attempted-and-failed, so "failed" stays reserved for
+// genuine, attributable failures. Filtering it here — rather than at the watcher — also means no
+// failure conclusion is ever produced to race ctx.Done() in watchDutyOutcome.
 func (b *BaseRunner) markDutyFailed(reason error) {
+	if errors.Is(reason, context.Canceled) {
+		return
+	}
 	b.concludeDuty(dutyOutcomeFailed, reason)
 }
 

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -241,11 +241,13 @@ func (b *BaseRunner) baseStartNewDuty(ctx context.Context, logger *zap.Logger, r
 	}
 
 	b.State = NewRunnerState(quorum, duty)
+
 	b.watchDutyDeadline(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return fmt.Errorf("failed to execute duty: %w", err)
 	}
+
 	return nil
 }
 
@@ -254,19 +256,22 @@ func (b *BaseRunner) baseStartNewNonBeaconDuty(ctx context.Context, logger *zap.
 	if err := b.ShouldProcessNonBeaconDuty(duty); err != nil {
 		return fmt.Errorf("can't start non-beacon duty: %w", err)
 	}
+
 	b.State = NewRunnerState(quorum, duty)
+
 	b.watchDutyDeadline(ctx, logger)
 
 	if err := runner.executeDuty(ctx, logger, duty); err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // watchDutyDeadline warns once if the duty hasn't completed by the end of the current wall-clock
 // slot. It knows nothing about how duties complete: completion is signaled by markDutyFinished
 // closing dutyDeadlineDone, not by reading runner state, so it's safe alongside the single-threaded
-// message loop. It is started before executeDuty so a duty that completes synchronously releases
+// message loop. It MUST be started before executeDuty so a duty that completes synchronously releases
 // its own channel. Each duty gets its own channel: starting the next duty overwrites the field, and
 // the previous duty's watcher (if still pending) warns for its own duty and is reaped by its own
 // timer.
@@ -281,15 +286,12 @@ func (b *BaseRunner) watchDutyDeadline(ctx context.Context, logger *zap.Logger) 
 	deadline := b.NetworkConfig.SlotStartTime(b.NetworkConfig.EstimatedCurrentSlot() + 1)
 
 	go func() {
-		timer := time.NewTimer(time.Until(deadline))
-		defer timer.Stop()
-
 		select {
 		case <-done:
 			return // duty completed
 		case <-ctx.Done():
 			return // node/validator shutting down
-		case <-timer.C:
+		case <-time.After(time.Until(deadline)):
 		}
 
 		logger.Warn("⚠️ duty did not complete before slot end")

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -36,7 +36,7 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchDutyDeadline(context.Background(), zap.New(core))
+		b.watchDutyFinishedOnTime(context.Background(), zap.New(core))
 
 		require.Eventually(t, func() bool {
 			return logs.FilterMessageSnippet(warnSnippet).Len() == 1
@@ -47,9 +47,9 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchDutyDeadline(context.Background(), zap.New(core))
+		b.watchDutyFinishedOnTime(context.Background(), zap.New(core))
 		// markDutyFinished closes this channel on duty completion.
-		close(b.dutyDeadlineDone)
+		close(b.dutyFinishedOnTime)
 
 		time.Sleep(100 * time.Millisecond) // well past the slot end
 		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn for a completed duty")
@@ -60,7 +60,7 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		b := newRunner()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		b.watchDutyDeadline(ctx, zap.New(core))
+		b.watchDutyFinishedOnTime(ctx, zap.New(core))
 		cancel()
 
 		time.Sleep(100 * time.Millisecond)

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -14,45 +13,45 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
-// TestBaseRunner_watchNonBeaconDutyDeadline covers the deadline watcher that turns a silent
-// pre-consensus-only duty failure (no quorum / failed submission) into one operator-visible warning.
-func TestBaseRunner_watchNonBeaconDutyDeadline(t *testing.T) {
-	const (
-		quorum      = uint64(3)
-		warnSnippet = "did not reach quorum or submit by deadline"
-	)
-	duty := &spectypes.ValidatorDuty{Type: spectypes.BNRoleVoluntaryExit, Slot: 100}
+// TestBaseRunner_watchDutyDeadline covers the duty-completion watcher that turns a silently
+// abandoned duty (of any kind) into one operator-visible warning at slot end.
+func TestBaseRunner_watchDutyDeadline(t *testing.T) {
+	const warnSnippet = "did not complete before slot end"
 
-	// Tiny slot duration so the ~2-slot deadline elapses in milliseconds. A fresh *Beacon is used
-	// (Network embeds *Beacon by pointer) so the shared global config isn't mutated.
+	// Genesis is set to now so the watcher starts at the beginning of slot 0 and its deadline
+	// (end of the current slot) is a full slot away. A fresh *Beacon is used (Network embeds
+	// *Beacon by pointer) so the shared global config isn't mutated.
 	newRunner := func() *BaseRunner {
 		return &BaseRunner{
 			NetworkConfig: &networkconfig.Network{
-				Beacon: &networkconfig.Beacon{SlotDuration: 5 * time.Millisecond},
+				Beacon: &networkconfig.Beacon{
+					GenesisTime:  time.Now(),
+					SlotDuration: 50 * time.Millisecond,
+				},
 			},
 		}
 	}
 
-	t.Run("warns when the duty does not complete by the deadline", func(t *testing.T) {
+	t.Run("warns when the duty does not complete before slot end", func(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchNonBeaconDutyDeadline(context.Background(), zap.New(core), duty, quorum)
+		b.watchDutyDeadline(context.Background(), zap.New(core))
 
 		require.Eventually(t, func() bool {
 			return logs.FilterMessageSnippet(warnSnippet).Len() == 1
-		}, time.Second, 2*time.Millisecond, "expected exactly one deadline warning")
+		}, time.Second, 5*time.Millisecond, "expected exactly one deadline warning")
 	})
 
-	t.Run("stays silent when the duty finishes before the deadline", func(t *testing.T) {
+	t.Run("stays silent when the duty finishes before slot end", func(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchNonBeaconDutyDeadline(context.Background(), zap.New(core), duty, quorum)
-		// markDutyFinished closes this channel on successful completion.
-		close(b.nonBeaconDeadlineDone)
+		b.watchDutyDeadline(context.Background(), zap.New(core))
+		// markDutyFinished closes this channel on duty completion.
+		close(b.dutyDeadlineDone)
 
-		time.Sleep(50 * time.Millisecond) // well past the ~10ms deadline
+		time.Sleep(100 * time.Millisecond) // well past the slot end
 		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn for a completed duty")
 	})
 
@@ -61,10 +60,10 @@ func TestBaseRunner_watchNonBeaconDutyDeadline(t *testing.T) {
 		b := newRunner()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		b.watchNonBeaconDutyDeadline(ctx, zap.New(core), duty, quorum)
+		b.watchDutyDeadline(ctx, zap.New(core))
 		cancel()
 
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn on shutdown")
 	})
 }

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,10 +14,13 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
-// TestBaseRunner_watchDutyDeadline covers the duty-completion watcher that turns a silently
-// abandoned duty (of any kind) into one operator-visible warning at slot end.
-func TestBaseRunner_watchDutyDeadline(t *testing.T) {
-	const warnSnippet = "did not complete before slot end"
+// TestBaseRunner_watchDutyOutcome covers the per-duty outcome watcher: it reports every duty's
+// terminal outcome exactly once, warning for the outcomes worth an operator's attention (a terminal
+// failure, or a duty that was silently abandoned and missed the slot deadline) and staying quiet for
+// a duty that concluded successfully.
+func TestBaseRunner_watchDutyOutcome(t *testing.T) {
+	const deadlineSnippet = "did not complete before slot end"
+	const failedSnippet = "duty failed"
 
 	// Genesis is set to now so the watcher starts at the beginning of slot 0 and its deadline
 	// (end of the current slot) is a full slot away. A fresh *Beacon is used (Network embeds
@@ -32,27 +36,39 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		}
 	}
 
-	t.Run("warns when the duty does not complete before slot end", func(t *testing.T) {
+	t.Run("warns stuck when the duty does not conclude before slot end", func(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchDutyFinishedOnTime(context.Background(), zap.New(core))
+		b.watchDutyOutcome(context.Background(), zap.New(core))
 
 		require.Eventually(t, func() bool {
-			return logs.FilterMessageSnippet(warnSnippet).Len() == 1
+			return logs.FilterMessageSnippet(deadlineSnippet).Len() == 1
 		}, time.Second, 5*time.Millisecond, "expected exactly one deadline warning")
 	})
 
-	t.Run("stays silent when the duty finishes before slot end", func(t *testing.T) {
+	t.Run("warns when the duty fails before slot end", func(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 
-		b.watchDutyFinishedOnTime(context.Background(), zap.New(core))
-		// markDutyFinished closes this channel on duty completion.
-		close(b.dutyFinishedOnTime)
+		b.watchDutyOutcome(context.Background(), zap.New(core))
+		b.dutyConcluded <- dutyConclusion{outcome: dutyOutcomeFailed, reason: errors.New("boom")}
+
+		require.Eventually(t, func() bool {
+			return logs.FilterMessageSnippet(failedSnippet).Len() == 1
+		}, time.Second, 5*time.Millisecond, "expected a failure warning")
+		require.Zero(t, logs.FilterMessageSnippet(deadlineSnippet).Len(), "a reported duty must not also warn about a deadline")
+	})
+
+	t.Run("stays silent when the duty succeeds before slot end", func(t *testing.T) {
+		core, logs := observer.New(zapcore.WarnLevel)
+		b := newRunner()
+
+		b.watchDutyOutcome(context.Background(), zap.New(core))
+		b.dutyConcluded <- dutyConclusion{outcome: dutyOutcomeSucceeded}
 
 		time.Sleep(100 * time.Millisecond) // well past the slot end
-		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn for a completed duty")
+		require.Zero(t, logs.Len(), "must not warn for a successfully concluded duty")
 	})
 
 	t.Run("stays silent when the context is canceled", func(t *testing.T) {
@@ -60,10 +76,62 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		b := newRunner()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		b.watchDutyFinishedOnTime(ctx, zap.New(core))
+		b.watchDutyOutcome(ctx, zap.New(core))
 		cancel()
 
 		time.Sleep(100 * time.Millisecond)
-		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn on shutdown")
+		require.Zero(t, logs.Len(), "must not warn on shutdown")
+	})
+}
+
+// TestBaseRunner_markDutyOutcomes pins what each marker records: succeeded/not_required are full
+// completions (State.Succeeded set) reported under distinct outcomes, failed leaves State.Succeeded
+// false and carries its reason, and a second conclusion is a no-op.
+func TestBaseRunner_markDutyOutcomes(t *testing.T) {
+	newRunner := func() *BaseRunner {
+		return &BaseRunner{
+			State:         &State{},
+			dutyConcluded: make(chan dutyConclusion, 1),
+		}
+	}
+
+	t.Run("markDutySucceeded reports succeeded and sets State.Succeeded", func(t *testing.T) {
+		b := newRunner()
+		ch := b.dutyConcluded
+
+		b.markDutySucceeded()
+
+		require.True(t, b.State.Succeeded, "duty should be marked succeeded")
+		require.Nil(t, b.dutyConcluded, "channel reference should be cleared (idempotency)")
+		require.Equal(t, dutyOutcomeSucceeded, (<-ch).outcome)
+	})
+
+	t.Run("markDutyNotRequired reports not_required and sets State.Succeeded", func(t *testing.T) {
+		b := newRunner()
+		ch := b.dutyConcluded
+
+		b.markDutyNotRequired()
+
+		require.True(t, b.State.Succeeded, "a not-required duty is still a correct completion")
+		require.Equal(t, dutyOutcomeNotRequired, (<-ch).outcome)
+	})
+
+	t.Run("markDutyFailed reports failed with reason and does not set State.Succeeded", func(t *testing.T) {
+		b := newRunner()
+		ch := b.dutyConcluded
+		boom := errors.New("boom")
+
+		b.markDutyFailed(boom)
+
+		require.False(t, b.State.Succeeded, "a failed duty must not be marked succeeded")
+		c := <-ch
+		require.Equal(t, dutyOutcomeFailed, c.outcome)
+		require.Equal(t, boom, c.reason)
+	})
+
+	t.Run("a second conclusion is a no-op", func(t *testing.T) {
+		b := newRunner()
+		b.markDutyFailed(errors.New("first"))
+		require.NotPanics(t, func() { b.markDutyFailed(errors.New("second")) }, "second conclusion must not send again")
 	})
 }

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -82,6 +83,21 @@ func TestBaseRunner_watchDutyOutcome(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		require.Zero(t, logs.Len(), "must not warn on shutdown")
 	})
+
+	t.Run("does not report a duty aborted by cancellation", func(t *testing.T) {
+		core, logs := observer.New(zapcore.WarnLevel)
+		b := newRunner()
+
+		// A duty aborted by shutdown returns context.Canceled; markDutyFailed drops it (a cancellation
+		// is not a failure), so no conclusion is produced and ctx.Done() unblocks the watcher silently.
+		ctx, cancel := context.WithCancel(context.Background())
+		b.watchDutyOutcome(ctx, zap.New(core))
+		cancel()
+		b.markDutyFailed(context.Canceled)
+
+		time.Sleep(100 * time.Millisecond)
+		require.Zero(t, logs.Len(), "a duty aborted by cancellation must not be reported")
+	})
 }
 
 // TestBaseRunner_markDutyOutcomes pins what each marker records: succeeded/not_required are full
@@ -127,6 +143,16 @@ func TestBaseRunner_markDutyOutcomes(t *testing.T) {
 		c := <-ch
 		require.Equal(t, dutyOutcomeFailed, c.outcome)
 		require.Equal(t, boom, c.reason)
+	})
+
+	t.Run("markDutyFailed drops a context.Canceled reason (a cancellation is not a failure)", func(t *testing.T) {
+		b := newRunner()
+
+		b.markDutyFailed(context.Canceled)
+		b.markDutyFailed(fmt.Errorf("submit: %w", context.Canceled)) // wrapped still matches
+
+		require.NotNil(t, b.dutyConcluded, "no conclusion should have been produced")
+		require.Empty(t, b.dutyConcluded, "a cancellation must not be recorded as a failure")
 	})
 
 	t.Run("a second conclusion is a no-op", func(t *testing.T) {

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -55,7 +55,7 @@ func TestBaseRunner_watchDutyDeadline(t *testing.T) {
 		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn for a completed duty")
 	})
 
-	t.Run("stays silent when the context is cancelled", func(t *testing.T) {
+	t.Run("stays silent when the context is canceled", func(t *testing.T) {
 		core, logs := observer.New(zapcore.WarnLevel)
 		b := newRunner()
 

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -19,7 +19,7 @@ import (
 func TestBaseRunner_watchNonBeaconDutyDeadline(t *testing.T) {
 	const (
 		quorum      = uint64(3)
-		warnSnippet = "did not complete by deadline"
+		warnSnippet = "did not reach quorum or submit by deadline"
 	)
 	duty := &spectypes.ValidatorDuty{Type: spectypes.BNRoleVoluntaryExit, Slot: 100}
 

--- a/protocol/v2/ssv/runner/runner_deadline_test.go
+++ b/protocol/v2/ssv/runner/runner_deadline_test.go
@@ -1,0 +1,70 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+// TestBaseRunner_watchNonBeaconDutyDeadline covers the deadline watcher that turns a silent
+// pre-consensus-only duty failure (no quorum / failed submission) into one operator-visible warning.
+func TestBaseRunner_watchNonBeaconDutyDeadline(t *testing.T) {
+	const (
+		quorum      = uint64(3)
+		warnSnippet = "did not complete by deadline"
+	)
+	duty := &spectypes.ValidatorDuty{Type: spectypes.BNRoleVoluntaryExit, Slot: 100}
+
+	// Tiny slot duration so the ~2-slot deadline elapses in milliseconds. A fresh *Beacon is used
+	// (Network embeds *Beacon by pointer) so the shared global config isn't mutated.
+	newRunner := func() *BaseRunner {
+		return &BaseRunner{
+			NetworkConfig: &networkconfig.Network{
+				Beacon: &networkconfig.Beacon{SlotDuration: 5 * time.Millisecond},
+			},
+		}
+	}
+
+	t.Run("warns when the duty does not complete by the deadline", func(t *testing.T) {
+		core, logs := observer.New(zapcore.WarnLevel)
+		b := newRunner()
+
+		b.watchNonBeaconDutyDeadline(context.Background(), zap.New(core), duty, quorum)
+
+		require.Eventually(t, func() bool {
+			return logs.FilterMessageSnippet(warnSnippet).Len() == 1
+		}, time.Second, 2*time.Millisecond, "expected exactly one deadline warning")
+	})
+
+	t.Run("stays silent when the duty finishes before the deadline", func(t *testing.T) {
+		core, logs := observer.New(zapcore.WarnLevel)
+		b := newRunner()
+
+		b.watchNonBeaconDutyDeadline(context.Background(), zap.New(core), duty, quorum)
+		// markDutyFinished closes this channel on successful completion.
+		close(b.nonBeaconDeadlineDone)
+
+		time.Sleep(50 * time.Millisecond) // well past the ~10ms deadline
+		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn for a completed duty")
+	})
+
+	t.Run("stays silent when the context is cancelled", func(t *testing.T) {
+		core, logs := observer.New(zapcore.WarnLevel)
+		b := newRunner()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		b.watchNonBeaconDutyDeadline(ctx, zap.New(core), duty, quorum)
+		cancel()
+
+		time.Sleep(50 * time.Millisecond)
+		require.Zero(t, logs.FilterMessageSnippet(warnSnippet).Len(), "must not warn on shutdown")
+	})
+}

--- a/protocol/v2/ssv/runner/runner_state.go
+++ b/protocol/v2/ssv/runner/runner_state.go
@@ -22,8 +22,10 @@ type State struct {
 	// CurrentDuty is the duty the node pulled locally from the beacon node, might be different
 	// from the actual duty operators will have decided upon.
 	CurrentDuty spectypes.Duty `json:"CurrentDuty,omitempty"`
-	// Finished is true when the runner has executed duty to a 100% completion successfully.
-	Finished bool
+	// Succeeded is true when the runner has executed the duty to a 100% completion successfully.
+	// It is serialized as "Finished" (see MarshalJSON/UnmarshalJSON) to stay byte-compatible with
+	// ssv-spec's State.Finished, which the spec tests compare via the post-duty-runner-state root.
+	Succeeded bool
 }
 
 func NewRunnerState(quorum uint64, duty spectypes.Duty) *State {
@@ -31,7 +33,7 @@ func NewRunnerState(quorum uint64, duty spectypes.Duty) *State {
 		PreConsensusContainer:  ssv.NewPartialSigContainer(quorum),
 		PostConsensusContainer: ssv.NewPartialSigContainer(quorum),
 		CurrentDuty:            duty,
-		Finished:               false,
+		Succeeded:              false,
 	}
 }
 
@@ -81,7 +83,7 @@ func (pcs *State) MarshalJSON() ([]byte, error) {
 		PostConsensusContainer: pcs.PostConsensusContainer,
 		RunningInstance:        pcs.RunningInstance,
 		DecidedValue:           pcs.DecidedValue,
-		Finished:               pcs.Finished,
+		Finished:               pcs.Succeeded,
 	}
 
 	// Note: pcs.CurrentDuty is not nil by construction.
@@ -119,7 +121,7 @@ func (pcs *State) UnmarshalJSON(data []byte) error {
 	pcs.PostConsensusContainer = aux.PostConsensusContainer
 	pcs.RunningInstance = aux.RunningInstance
 	pcs.DecidedValue = aux.DecidedValue
-	pcs.Finished = aux.Finished
+	pcs.Succeeded = aux.Finished
 
 	// Determine which type of duty was marshaled
 	if aux.ValidatorDuty != nil {

--- a/protocol/v2/ssv/runner/runner_validations.go
+++ b/protocol/v2/ssv/runner/runner_validations.go
@@ -23,8 +23,8 @@ func (b *BaseRunner) ValidatePreConsensusMsg(
 	if !b.hasDutyAssigned() {
 		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}
-	if b.hasDutyFinished() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutyFinished)
+	if b.hasDutySucceeded() {
+		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
 	}
 
 	currentDutySlot, err := b.currentDutySlot()
@@ -59,8 +59,8 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 	if !b.hasDutyAssigned() {
 		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}
-	if b.hasDutyFinished() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutyFinished)
+	if b.hasDutySucceeded() {
+		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
 	}
 
 	// slotIsRelevant ensures the post-consensus message is even remotely relevant (eg. we might have already

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -86,13 +86,13 @@ func (r *SyncCommitteeAggregatorRunner) StartNewDuty(ctx context.Context, logger
 	return r.baseStartNewDuty(ctx, logger, r, validatorDuty, quorum)
 }
 
-func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -104,6 +104,14 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPreConsensus()
 	recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleSyncCommitteeContribution)
@@ -148,7 +156,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	sortBySubnet(pairs)
 
 	if len(pairs) == 0 {
-		r.markDutyFinished()
+		r.markDutyNotRequired()
 		r.measurements.EndDutyFlow()
 		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleSyncCommitteeContribution, 0)
 		const dutyFinishedNoProofsEvent = "✔️successfully finished duty processing (no selection proofs)"
@@ -304,13 +312,13 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(ctx context.Context, lo
 	return nil
 }
 
-func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -321,6 +329,14 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleSyncCommitteeContribution)
@@ -413,7 +429,7 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 		fields.Took(time.Since(start)),
 	)
 
-	r.markDutyFinished()
+	r.markDutySucceeded()
 	r.measurements.EndDutyFlow()
 	recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleSyncCommitteeContribution, r.State.RunningInstance.State.Round)
 	const dutyFinishedEvent = "✔️successfully finished duty processing"

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -89,13 +89,13 @@ func (r *ValidatorRegistrationRunner) StartNewDuty(ctx context.Context, logger *
 	return r.baseStartNewNonBeaconDuty(ctx, logger, r, validatorDuty, quorum)
 }
 
-func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -107,6 +107,14 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	// only 1 root, verified in basePreConsensusMsgProcessing
 	root := roots[0]
@@ -151,7 +159,7 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 		zap.String("signature", hex.EncodeToString(specSig[:])),
 	)
 
-	r.markDutyFinished()
+	r.markDutySucceeded()
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent)
 	span.AddEvent(dutyFinishedEvent)

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -74,7 +74,7 @@ func (r *VoluntaryExitRunner) StartNewDuty(ctx context.Context, logger *zap.Logg
 
 // ProcessPreConsensus Check for quorum of partial signatures over VoluntaryExit and,
 // if has quorum, constructs SignedVoluntaryExit and submits to BeaconNode
-func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) error {
+func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Logger, signedMsg *spectypes.PartialSignatureMessages) (err error) {
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
@@ -85,8 +85,8 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	}
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutyFinished) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutyFinished error
+	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
+		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
 		// also needs to be retried.
 		err = NewRetryableError(err)
 	}
@@ -98,6 +98,14 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	if !hasQuorum {
 		return nil
 	}
+
+	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
+	// so a terminal failure below won't be retried.
+	defer func() {
+		if err != nil {
+			r.markDutyFailed(err)
+		}
+	}()
 
 	// only 1 root, verified in basePreConsensusMsgProcessing
 	root := roots[0]
@@ -130,7 +138,7 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 		zap.String("signature", hex.EncodeToString(specSig[:])),
 	)
 
-	r.markDutyFinished()
+	r.markDutySucceeded()
 	const dutyFinishedEvent = "✔️successfully finished duty processing"
 	logger.Info(dutyFinishedEvent)
 	span.AddEvent(dutyFinishedEvent)

--- a/protocol/v2/ssv/validator/committee_queue_test.go
+++ b/protocol/v2/ssv/validator/committee_queue_test.go
@@ -806,7 +806,7 @@ func TestCommitteeQueueFilteringScenarios(t *testing.T) {
 
 			// Set runner state based on hasRunningDuty parameter
 			if !tc.hasRunningDuty {
-				committeeRunner.State.Finished = true // This makes hasDutyRunning() return false
+				committeeRunner.State.Succeeded = true // This makes hasDutyRunning() return false
 			}
 
 			msgChannel := make(chan *queue.SSVMessage, len(tc.messagesTypes))

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -268,7 +268,16 @@ func (v *Validator) StartQueueConsumer(
 					}(msg, msgState, currentAttempt)
 				default:
 					var droppingMsgDueToErrorEvent = couldNotHandleMsgLogPrefix + "dropping message"
-					msgLogger.Debug(droppingMsgDueToErrorEvent, zap.Error(err))
+					// Voluntary exit and validator registration are rare, one-shot, quorum-based
+					// duties with no retry; a dropped message (failed signing/broadcast, bad
+					// partial-sig, failed submission) otherwise vanishes at DEBUG. These are
+					// operator-actionable, so surface them at WARN. Frequent duties stay at DEBUG.
+					switch msgID.GetRoleType() {
+					case spectypes.RoleVoluntaryExit, spectypes.RoleValidatorRegistration:
+						msgLogger.Warn(droppingMsgDueToErrorEvent, zap.Error(err))
+					default:
+						msgLogger.Debug(droppingMsgDueToErrorEvent, zap.Error(err))
+					}
 					msgState.span.AddEvent(droppingMsgDueToErrorEvent, trace.WithAttributes(
 						attribute.String("drop_reason", err.Error()),
 						attribute.Int64("attempt", currentAttempt),

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -268,15 +268,7 @@ func (v *Validator) StartQueueConsumer(
 					}(msg, msgState, currentAttempt)
 				default:
 					var droppingMsgDueToErrorEvent = couldNotHandleMsgLogPrefix + "dropping message"
-					// A dropped message for these rare, one-shot, no-retry duties is operator-
-					// actionable but otherwise vanishes at DEBUG, so surface it at WARN. Frequent
-					// duties stay at DEBUG.
-					switch msgID.GetRoleType() {
-					case spectypes.RoleVoluntaryExit, spectypes.RoleValidatorRegistration:
-						msgLogger.Warn(droppingMsgDueToErrorEvent, zap.Error(err))
-					default:
-						msgLogger.Debug(droppingMsgDueToErrorEvent, zap.Error(err))
-					}
+					msgLogger.Debug(droppingMsgDueToErrorEvent, zap.Error(err))
 					msgState.span.AddEvent(droppingMsgDueToErrorEvent, trace.WithAttributes(
 						attribute.String("drop_reason", err.Error()),
 						attribute.Int64("attempt", currentAttempt),

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -268,10 +268,9 @@ func (v *Validator) StartQueueConsumer(
 					}(msg, msgState, currentAttempt)
 				default:
 					var droppingMsgDueToErrorEvent = couldNotHandleMsgLogPrefix + "dropping message"
-					// Voluntary exit and validator registration are rare, one-shot, quorum-based
-					// duties with no retry; a dropped message (failed signing/broadcast, bad
-					// partial-sig, failed submission) otherwise vanishes at DEBUG. These are
-					// operator-actionable, so surface them at WARN. Frequent duties stay at DEBUG.
+					// A dropped message for these rare, one-shot, no-retry duties is operator-
+					// actionable but otherwise vanishes at DEBUG, so surface it at WARN. Frequent
+					// duties stay at DEBUG.
 					switch msgID.GetRoleType() {
 					case spectypes.RoleVoluntaryExit, spectypes.RoleValidatorRegistration:
 						msgLogger.Warn(droppingMsgDueToErrorEvent, zap.Error(err))


### PR DESCRIPTION
## Motivation

A recent cluster-wide voluntary-exit failure (validators never exiting despite repeated on-chain requests) could not be diagnosed from node logs, because the voluntary-exit duty and the partial-signature path it depends on fail **silently**:

- A pre-consensus-only duty (voluntary exit, validator registration) that never reaches a partial-signature quorum just stops at the `!hasQuorum` early-return — no log at any level.
- Broadcast egress isn't confirmed in logs, and the gossipsub message-id (needed to correlate a message across nodes and against a libp2p pubsub trace) is never logged.
- Non-retryable duty-processing failures are logged at DEBUG, so a failed exit sign/broadcast/submission is invisible at INFO.
- Message acceptance at validation is metered but not logged.

This adds low-noise log points along that path so the next such failure is diagnosable from logs alone. Per review feedback, there is **no per-role or per-path special-casing**: every log point applies uniformly to all duties. The first two gaps get dedicated log points below; the last two deliberately do not — the deadline warning is the single escalated signal (drop details remain at DEBUG), and accepts stay unlogged since arrival is already provable from the runner's "got pre-consensus message" line.

## Changes

1. **`runner` — duty-completion deadline warning, every duty.** A pure completion watcher: when any duty hasn't completed (`markDutyFinished`, which every runner already funnels through) by the end of the current wall-clock slot, emit one `WARN`. It knows nothing about quorum/consensus phases and reads no runner state (released via a channel closed by `markDutyFinished`), so it's safe alongside the single-threaded message loop and correct when a runner is reused for a later duty. For beacon duties this complements QBFT round-timeout and submission logs; for voluntary exit / validator registration it is the *only* failure signal — previously these failed with no log at any level. The deadline is wall-clock slot end (not `duty.Slot` end) because a voluntary-exit envelope is stamped several slots in the past.

2. **`network` / `topics` — broadcast egress log, every duty.** Each broadcast logs at DEBUG the gossipsub message-id (the same id a receiver and the libp2p pubsub tracer assign → cross-node correlation) and the topic peer count (surfaces a sparse/empty mesh). `topics.MsgID` is exported so the broadcast path and gossipsub compute the id identically.

**Cleanup:** removes the dead `Error.silent` suppression switch in message validation — it was never set, so `Silent()` was always false and every dropped message was already logged. Removing it makes "every drop is logged" structurally true (the guarantee these changes rely on). Behavior-preserving.

## Notes

Observability-only (logging, one exported helper, and a behavior-identical replacement of libp2p's backoff connector); no happy-path behavior changes. Designed to *complement* libp2p `PUBSUB_TRACE` — the egress msg-id (#2) is what lets node logs and a pubsub trace be correlated.


## Follow-up: gossip-path visibility (added after the trace capture)

The pubsub-trace capture for this incident found the failure outside the cluster's own logs: the four operators had **zero direct connectivity to each other** (each held exactly 2 connections, both to all-subnet relay nodes), and those relays silently refused to forward voluntary-exit partial-sigs (no `dutyStore.VoluntaryExit` entry → `dutyLimit` 0 → `ErrTooManyDutiesPerEpoch` → `ValidationIgnore`). This PR also closes the observability gaps that made that invisible and hard to confirm:

**`network/p2p` — dial failures logged.** Outbound dial errors were swallowed by libp2p's `BackoffConnector` (visible only on libp2p's internal logger), so a node that could never reach its committee partners logged nothing. Replaced with an equivalent SSV-owned connector (same backoff-cache semantics, covered by a unit test) that logs `could not connect to discovered peer` at DEBUG with peer id, addrs and error.

**`network/p2p` — WARN on persistently unreachable proposed peers.** Discovery kept proposing the committee partners every selection round for hours with nothing to show for it. The selection loop now tracks first-proposal time per still-discovered peer and emits a rate-limited WARN (default: unconnected ≥10m, warn ≤1/5m) telling the operator to check firewall/NAT/advertised addresses.

**`network/topics` — payload message ids on trace RPC events.** The pubsub tracer logged only control ids (IHAVE/IWANT) on `SEND_RPC`/`RECV_RPC`/`DROP_RPC`, so "did the sender actually hand the message to the relay" had to be inferred. RPC events now include `msgIDs` (format locked by a unit test), making a message's forwarding path (or the hop where it vanished) directly observable across nodes.

**`eth/eventhandler` — silent exit-skip logged.** A `ValidatorExited` event for a share without beacon metadata silently produced no duty; now logged at DEBUG.


## Follow-up: duty success/finality split + outcome classifier (evolves change #1)

Change #1's deadline watcher reused `markDutyFinished` / `State.Finished` as its completion signal. But `State.Finished` is ssv-spec's **success** flag — "a full successful cycle (pre, consensus and post) with quorum" — and it is serialized into the spec-test post-duty-runner-state root. Reusing it overloaded *success* to also mean *watcher-finality*, and since the watcher was released only on the success / no-op paths, a duty that **failed terminally** (e.g. a beacon-node call 404-ing on a missed slot) or **never reached pre-consensus quorum** tripped the `did not complete before slot end` WARN as if it had silently stalled. On a testnet the WARN was dominated by `AGGREGATOR` / `SYNC_COMMITTEE_CONTRIBUTION` / `VALIDATOR_REGISTRATION`, not by the core committee duties.

This splits the two concepts and turns duty completion into a definitive, single-answer classifier.

**Success vs. finality.** `State.Finished` → `State.Succeeded` (kept serialized as `"Finished"`, so the spec-test state root is byte-identical — verified by the existing spec tests). `markDutyFinished` → `markDutySucceeded`; `hasDutyFinished` → `hasDutySucceeded`.

**One outcome per duty.** A per-duty watcher (`watchDutyOutcome`) is now the single reporter of a duty's terminal outcome — it records the `ssv.runner.duty.outcome{role, outcome}` counter (Prometheus `ssv_runner_duty_outcome_total`) and warns only for the outcomes worth attention:

| outcome | meaning | log |
|---|---|---|
| `succeeded` | full cycle, submitted to the beacon node | existing per-runner success log |
| `not_required` | completed with nothing to submit (e.g. not selected as aggregator) | — |
| `failed` | terminated by a non-recoverable error (carries the reason) | `⚠️ duty failed` |
| `stuck` | not concluded before the end of the current wall-clock slot | `⚠️ duty did not complete before slot end` |

Markers (`markDutySucceeded` / `markDutyNotRequired` / `markDutyFailed`) hand the outcome to the watcher over a buffered(1) channel; the watcher is the sole reporter, so each duty is classified exactly once (no double-count; a guard prefers a conclusion that lands right at the deadline). Terminal-failure paths in the one-shot runners (`aggregator`, `sync_committee_contribution`, `proposer`, `voluntary_exit`, `validator_registration`) and `executeDuty` failures in the duty-start path now report `failed` instead of tripping the deadline WARN; the committee runner keeps its partial-progress semantics (a committee duty resolves to `succeeded` or `stuck`). `not_required` still sets `State.Succeeded`, so the state root is unchanged.

Net effect: `stuck` is now reserved for genuinely silent stalls (the voluntary-exit failure that motivated this PR), terminal failures are reported as `failed` with their reason, and "what happened to this duty?" is answerable from one metric.




