### PR TITLE
fix(p2p): address highlighted-peer observability review feedback

### DIFF
--- a/cli/operator/network.go
+++ b/cli/operator/network.go
@@ -55,8 +55,7 @@ func setupSSVNetwork(logger *zap.Logger, cfg *config) (*networkconfig.SSV, error
 
 		// Shallow-copy here before updating DomainType below — otherwise the update mutates the underlying global
 		// value ssvConfig is pointing to.
-		cfgCopy := *ssvConfig
-		ssvConfig = &cfgCopy
+		ssvConfig = new(*ssvConfig)
 		// https://github.com/ssvlabs/ssv/pull/1808 incremented the post-fork domain type by 1, so we have to maintain the compatibility.
 		postForkDomain := binary.BigEndian.Uint32(domainBytes) + 1
 		binary.BigEndian.PutUint32(ssvConfig.DomainType[:], postForkDomain)

--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/goccy/go-yaml v1.12.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -264,7 +264,7 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
+	golang.org/x/time v0.12.0
 	golang.org/x/tools v0.38.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -43,6 +43,10 @@ func (e Error) Error() string {
 const (
 	validationTimeoutReason  = "validation_timeout"
 	validationCanceledReason = "validation_canceled"
+	// validationUnexpectedErrorReason keeps the highlighted-peer metric reason
+	// bounded for errors that are not validation Errors; the raw error text is
+	// still attached to the observed event itself.
+	validationUnexpectedErrorReason = "unexpected_error"
 )
 
 func (e Error) Reject() bool {
@@ -165,7 +169,7 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 	var valErr Error
 	if !errors.As(err, &valErr) {
 		recordIgnoredMessage(ctx, loggerFields.Role, err.Error())
-		mv.observeSSVValidation(ctx, peerID, loggerFields, SSVValidationIgnored, err.Error(), err)
+		mv.observeSSVValidation(ctx, peerID, loggerFields, SSVValidationIgnored, validationUnexpectedErrorReason, err)
 		logger.Debug("ignoring invalid message", zap.Error(err))
 		return pubsub.ValidationIgnore
 	}
@@ -190,7 +194,9 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, peerID peer.ID, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {
 	recordAcceptedMessage(ctx, messageRole(decodedMessage))
-	if mv.observer == nil {
+	// Accepted messages are the hot path, so don't even build the logger fields
+	// unless this message's peer is actually observed.
+	if mv.observer == nil || !mv.observer.Interested(peerID) {
 		return pubsub.ValidationAccept
 	}
 	mv.observeSSVValidation(ctx, peerID, mv.buildLoggerFields(decodedMessage), SSVValidationAccepted, "valid", nil)
@@ -205,7 +211,7 @@ func (mv *messageValidator) observeSSVValidation(
 	reason string,
 	err error,
 ) {
-	if mv.observer == nil {
+	if mv.observer == nil || !mv.observer.Interested(peerID) {
 		return
 	}
 	if loggerFields == nil {
@@ -221,10 +227,7 @@ func (mv *messageValidator) observeSSVValidation(
 		Slot:           loggerFields.Slot,
 		DutyExecutorID: loggerFields.DutyExecutorID,
 		Signers:        loggerFields.Signers,
-	}
-	if loggerFields.Consensus != nil {
-		consensus := *loggerFields.Consensus
-		event.Consensus = &consensus
+		Consensus:      loggerFields.Consensus,
 	}
 	if err != nil {
 		event.Error = err.Error()

--- a/message/validation/observer.go
+++ b/message/validation/observer.go
@@ -18,6 +18,8 @@ const (
 
 // SSVValidationEvent describes the SSV-level validation decision before it
 // is reduced to libp2p's accept/reject/ignore validation result.
+// Its pointer and slice fields are shared with the validator, so the event is
+// only valid for the duration of the ObserveSSVValidation call.
 type SSVValidationEvent struct {
 	PeerID         peer.ID
 	Outcome        string
@@ -33,5 +35,9 @@ type SSVValidationEvent struct {
 
 // SSVValidationObserver receives SSV-level validation decisions.
 type SSVValidationObserver interface {
+	// Interested reports whether the observer wants events for messages received
+	// from the given peer. It must be cheap: it gates event construction on the
+	// message validation hot path.
+	Interested(peer.ID) bool
 	ObserveSSVValidation(context.Context, *zap.Logger, SSVValidationEvent)
 }

--- a/message/validation/observer_test.go
+++ b/message/validation/observer_test.go
@@ -1,14 +1,22 @@
 package validation
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 )
 
 type stubSSVValidationObserver struct {
@@ -21,6 +29,14 @@ func (s *stubSSVValidationObserver) Interested(peer.ID) bool {
 }
 
 func (s *stubSSVValidationObserver) ObserveSSVValidation(_ context.Context, _ *zap.Logger, event SSVValidationEvent) {
+	// The event's reference fields are shared with the validator and only valid
+	// for the duration of this call, so clone them before retaining the event.
+	event.DutyExecutorID = slices.Clone(event.DutyExecutorID)
+	event.Signers = slices.Clone(event.Signers)
+	if event.Consensus != nil {
+		consensus := *event.Consensus
+		event.Consensus = &consensus
+	}
 	s.events = append(s.events, event)
 }
 
@@ -29,15 +45,34 @@ func TestHandleValidationErrorReportsOutcomeToObserver(t *testing.T) {
 	mv := &messageValidator{logger: zap.NewNop(), observer: observer}
 	pid := peer.ID("highlighted")
 
-	require.Equal(t, pubsub.ValidationReject, mv.handleValidationError(t.Context(), pid, nil, ErrZeroRound))
+	dutyExecutorID := bytes.Repeat([]byte{0xab}, 48)
+	decoded := &queue.SSVMessage{
+		SSVMessage: &spectypes.SSVMessage{
+			MsgType: spectypes.SSVConsensusMsgType,
+			MsgID:   spectypes.NewMsgID(spectypes.DomainType{1, 2, 3, 4}, dutyExecutorID, spectypes.RoleProposer),
+		},
+		SignedSSVMessage: &spectypes.SignedSSVMessage{OperatorIDs: []spectypes.OperatorID{1, 2}},
+		Body:             &specqbft.Message{MsgType: specqbft.PrepareMsgType, Height: 10, Round: 2},
+	}
+
+	require.Equal(t, pubsub.ValidationReject, mv.handleValidationError(t.Context(), pid, decoded, ErrZeroRound))
 	require.Equal(t, pubsub.ValidationIgnore, mv.handleValidationError(t.Context(), pid, nil, Error{text: "stale message"}))
 	require.Equal(t, pubsub.ValidationIgnore, mv.handleValidationError(t.Context(), pid, nil, errors.New("boom")))
 
 	require.Len(t, observer.events, 3)
 
-	require.Equal(t, SSVValidationRejected, observer.events[0].Outcome)
-	require.Equal(t, ErrZeroRound.Text(), observer.events[0].Reason)
-	require.Equal(t, pid, observer.events[0].PeerID)
+	rejected := observer.events[0]
+	require.Equal(t, SSVValidationRejected, rejected.Outcome)
+	require.Equal(t, ErrZeroRound.Text(), rejected.Reason)
+	require.Equal(t, pid, rejected.PeerID)
+	require.Equal(t, spectypes.RoleProposer, rejected.Role)
+	require.Equal(t, spectypes.SSVConsensusMsgType, rejected.SSVMessageType)
+	require.Equal(t, phase0.Slot(10), rejected.Slot)
+	require.Equal(t, dutyExecutorID, rejected.DutyExecutorID)
+	require.Equal(t, []spectypes.OperatorID{1, 2}, rejected.Signers)
+	require.NotNil(t, rejected.Consensus)
+	require.Equal(t, specqbft.Round(2), rejected.Consensus.Round)
+	require.Equal(t, specqbft.PrepareMsgType, rejected.Consensus.QBFTMessageType)
 
 	require.Equal(t, SSVValidationIgnored, observer.events[1].Outcome)
 	require.Equal(t, "stale message", observer.events[1].Reason)

--- a/message/validation/observer_test.go
+++ b/message/validation/observer_test.go
@@ -1,0 +1,79 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type stubSSVValidationObserver struct {
+	interested bool
+	events     []SSVValidationEvent
+}
+
+func (s *stubSSVValidationObserver) Interested(peer.ID) bool {
+	return s.interested
+}
+
+func (s *stubSSVValidationObserver) ObserveSSVValidation(_ context.Context, _ *zap.Logger, event SSVValidationEvent) {
+	s.events = append(s.events, event)
+}
+
+func TestHandleValidationErrorReportsOutcomeToObserver(t *testing.T) {
+	observer := &stubSSVValidationObserver{interested: true}
+	mv := &messageValidator{logger: zap.NewNop(), observer: observer}
+	pid := peer.ID("highlighted")
+
+	require.Equal(t, pubsub.ValidationReject, mv.handleValidationError(t.Context(), pid, nil, ErrZeroRound))
+	require.Equal(t, pubsub.ValidationIgnore, mv.handleValidationError(t.Context(), pid, nil, Error{text: "stale message"}))
+	require.Equal(t, pubsub.ValidationIgnore, mv.handleValidationError(t.Context(), pid, nil, errors.New("boom")))
+
+	require.Len(t, observer.events, 3)
+
+	require.Equal(t, SSVValidationRejected, observer.events[0].Outcome)
+	require.Equal(t, ErrZeroRound.Text(), observer.events[0].Reason)
+	require.Equal(t, pid, observer.events[0].PeerID)
+
+	require.Equal(t, SSVValidationIgnored, observer.events[1].Outcome)
+	require.Equal(t, "stale message", observer.events[1].Reason)
+
+	require.Equal(t, SSVValidationIgnored, observer.events[2].Outcome)
+	require.Equal(t, validationUnexpectedErrorReason, observer.events[2].Reason)
+	require.Equal(t, "boom", observer.events[2].Error)
+}
+
+func TestHandleValidationSuccessReportsAcceptedToObserver(t *testing.T) {
+	observer := &stubSSVValidationObserver{interested: true}
+	mv := &messageValidator{logger: zap.NewNop(), observer: observer}
+	pid := peer.ID("highlighted")
+
+	require.Equal(t, pubsub.ValidationAccept, mv.handleValidationSuccess(t.Context(), pid, nil))
+
+	require.Len(t, observer.events, 1)
+	require.Equal(t, SSVValidationAccepted, observer.events[0].Outcome)
+	require.Equal(t, "valid", observer.events[0].Reason)
+	require.Equal(t, pid, observer.events[0].PeerID)
+}
+
+func TestSSVValidationObserverSkippedForUninterestingPeer(t *testing.T) {
+	observer := &stubSSVValidationObserver{interested: false}
+	mv := &messageValidator{logger: zap.NewNop(), observer: observer}
+	pid := peer.ID("regular")
+
+	require.Equal(t, pubsub.ValidationAccept, mv.handleValidationSuccess(t.Context(), pid, nil))
+	require.Equal(t, pubsub.ValidationReject, mv.handleValidationError(t.Context(), pid, nil, ErrZeroRound))
+
+	require.Empty(t, observer.events)
+}
+
+func TestSSVValidationWithoutObserverDoesNotPanic(t *testing.T) {
+	mv := &messageValidator{logger: zap.NewNop()}
+
+	require.Equal(t, pubsub.ValidationAccept, mv.handleValidationSuccess(t.Context(), "peer", nil))
+	require.Equal(t, pubsub.ValidationReject, mv.handleValidationError(t.Context(), "peer", nil, ErrZeroRound))
+}

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	// DiscoveryTrace is a flag to turn on/off discovery tracing in logs
 	DiscoveryTrace bool `yaml:"DiscoveryTrace" env:"DISCOVERY_TRACE" env-description:"Enable discovery debug tracing in logs"`
 	// HighlightedPeers is a list of libp2p peer IDs that should be highlighted in p2p logs and metrics.
-	HighlightedPeers string `yaml:"HighlightedPeers" env:"P2P_HIGHLIGHTED_PEERS" env-default:"" env-description:"Comma, semicolon, or whitespace-separated libp2p peer IDs to highlight in p2p logs and metrics. 0x-prefixed secp256k1 public keys are still accepted for backwards compatibility, but P2P_HIGHLIGHTED_PEER_KEYS is preferred for keys"`
+	HighlightedPeers string `yaml:"HighlightedPeers" env:"P2P_HIGHLIGHTED_PEERS" env-default:"" env-description:"Comma, semicolon, or whitespace-separated libp2p peer IDs to highlight in p2p logs and metrics. 0x-prefixed secp256k1 public keys are also accepted for convenience, but P2P_HIGHLIGHTED_PEER_KEYS is preferred for keys"`
 	// HighlightedPeerKeys is a list of secp256k1 public identity keys whose derived libp2p peers should be highlighted in p2p logs and metrics.
 	HighlightedPeerKeys string `yaml:"HighlightedPeerKeys" env:"P2P_HIGHLIGHTED_PEER_KEYS" env-default:"" env-description:"Comma, semicolon, or whitespace-separated 0x-prefixed secp256k1 public identity keys to highlight in p2p logs and metrics"`
 	// HighlightedPeerLabel is attached to every highlighted peer log and metric.

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -65,7 +65,8 @@ type Config struct {
 	HighlightedPeerKeys string `yaml:"HighlightedPeerKeys" env:"P2P_HIGHLIGHTED_PEER_KEYS" env-default:"" env-description:"Comma, semicolon, or whitespace-separated 0x-prefixed secp256k1 public identity keys to highlight in p2p logs and metrics"`
 	// HighlightedPeerLabel is attached to every highlighted peer log and metric.
 	HighlightedPeerLabel string `yaml:"HighlightedPeerLabel" env:"P2P_HIGHLIGHTED_PEER_LABEL" env-default:"highlighted-peer" env-description:"Label attached to highlighted peer logs and metrics"`
-	// PeerObserver observes traffic for highlighted peers. If unset, it is built from HighlightedPeers and HighlightedPeerKeys.
+	// PeerObserver observes traffic for highlighted peers. The operator setup builds it
+	// from HighlightedPeers and HighlightedPeerKeys; nil disables highlighting.
 	PeerObserver *peertrace.Observer `yaml:"-"`
 	// NetworkPrivateKey is used for network identity, MUST be injected
 	NetworkPrivateKey *ecdsa.PrivateKey

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -137,19 +137,6 @@ func New(
 	cfg *Config,
 ) (*p2pNetwork, error) {
 	ctx, cancel := context.WithCancel(cfg.Ctx)
-	peerObserver := cfg.PeerObserver
-	if peerObserver == nil {
-		var err error
-		peerObserver, err = peertrace.New(peertrace.Config{
-			Label:    cfg.HighlightedPeerLabel,
-			Peers:    cfg.HighlightedPeers,
-			PeerKeys: cfg.HighlightedPeerKeys,
-		})
-		if err != nil {
-			cancel()
-			return nil, fmt.Errorf("could not parse highlighted peers: %w", err)
-		}
-	}
 
 	n := &p2pNetwork{
 		parentCtx:            cfg.Ctx,
@@ -163,12 +150,12 @@ func New(
 		subscribedCommittees: hashmap.New[string, committeeSubscriptionStatus](),
 		nodeStorage:          cfg.NodeStorage,
 		operatorDataStore:    cfg.OperatorDataStore,
-		peerObserver:         peerObserver,
+		peerObserver:         cfg.PeerObserver,
 		discoveredPeersPool:  ttl.New[peer.ID, discovery.DiscoveredPeer](ctx, 30*time.Minute, 3*time.Minute),
 		trimmedRecently:      ttl.New[peer.ID, struct{}](ctx, 30*time.Minute, 3*time.Minute),
 	}
-	if peerObserver.Enabled() {
-		n.logger.Info("p2p highlighted peer observer configured", zap.Int("peer_count", peerObserver.Count()))
+	if n.peerObserver.Enabled() {
+		n.logger.Info("p2p highlighted peer observer configured", zap.Int("peer_count", n.peerObserver.Count()))
 	}
 	if err := n.parseTrustedPeers(); err != nil {
 		cancel() // release the ctx-bound ttl goroutines started above before bailing out

--- a/network/peers/connections/conn_gater.go
+++ b/network/peers/connections/conn_gater.go
@@ -221,7 +221,9 @@ func (n *connGater) observeDecision(
 	_, highlighted := n.peerObserver.Match(id)
 	recordConnectionGaterDecision(ctx, phase, decision, reason, direction, highlighted)
 
-	if id == "" {
+	// Only highlighted peers consume the log fields below; gating decisions fire
+	// for every dial/accept, so skip the field building for everyone else.
+	if !highlighted {
 		return
 	}
 

--- a/network/peers/connections/conn_gater.go
+++ b/network/peers/connections/conn_gater.go
@@ -213,13 +213,8 @@ func (n *connGater) observeDecision(
 	direction libp2pnetwork.Direction,
 	extraFields ...zap.Field,
 ) {
-	ctx := n.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	_, highlighted := n.peerObserver.Match(id)
-	recordConnectionGaterDecision(ctx, phase, decision, reason, direction, highlighted)
+	recordConnectionGaterDecision(n.ctx, phase, decision, reason, direction, highlighted)
 
 	// Only highlighted peers consume the log fields below; gating decisions fire
 	// for every dial/accept, so skip the field building for everyone else.
@@ -235,12 +230,5 @@ func (n *connGater) observeDecision(
 		zap.String("conn_direction", direction.String()),
 	)
 	logFields = append(logFields, extraFields...)
-	n.peerObserver.Observe(ctx, n.loggerOrNop(), "connection_gater_decision", id, logFields...)
-}
-
-func (n *connGater) loggerOrNop() *zap.Logger {
-	if n.logger == nil {
-		return zap.NewNop()
-	}
-	return n.logger
+	n.peerObserver.Observe(n.ctx, n.logger, "connection_gater_decision", id, logFields...)
 }

--- a/network/peers/connections/conn_gater_test.go
+++ b/network/peers/connections/conn_gater_test.go
@@ -24,6 +24,7 @@ const (
 
 func TestConnGaterInterceptAddrDial(t *testing.T) {
 	gater := &connGater{
+		ctx:             t.Context(),
 		logger:          zap.NewNop(),
 		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
@@ -35,6 +36,7 @@ func TestConnGaterInterceptAddrDial(t *testing.T) {
 
 func TestConnGaterInterceptPeerDial(t *testing.T) {
 	gater := &connGater{
+		ctx:             t.Context(),
 		logger:          zap.NewNop(),
 		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: ttl.New[peer.ID, struct{}](t.Context(), time.Minute, time.Minute),
@@ -47,6 +49,7 @@ func TestConnGaterInterceptPeerDial(t *testing.T) {
 func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
 	t.Run("disabled bypasses limits", func(t *testing.T) {
 		gater := &connGater{
+			ctx:             t.Context(),
 			logger:          zap.NewNop(),
 			disable:         true,
 			atMaxPeersLimit: func() bool { return true },
@@ -59,6 +62,7 @@ func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
 
 	t.Run("rejects at inbound limit", func(t *testing.T) {
 		gater := &connGater{
+			ctx:             t.Context(),
 			logger:          zap.NewNop(),
 			atMaxPeersLimit: func() bool { return false },
 			atInboundLimit:  func() bool { return true },
@@ -70,6 +74,7 @@ func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
 
 	t.Run("rejects at max peers limit after a valid dial", func(t *testing.T) {
 		gater := &connGater{
+			ctx:             t.Context(),
 			logger:          zap.NewNop(),
 			atMaxPeersLimit: func() bool { return true },
 			atInboundLimit:  func() bool { return false },
@@ -83,6 +88,7 @@ func TestConnGaterInterceptAcceptHonorsLimits(t *testing.T) {
 
 func TestConnGaterInterceptAcceptRateLimitsByIP(t *testing.T) {
 	gater := &connGater{
+		ctx:             t.Context(),
 		logger:          zap.NewNop(),
 		atMaxPeersLimit: func() bool { return false },
 		atInboundLimit:  func() bool { return false },
@@ -122,6 +128,7 @@ func TestConnGaterValidateDialReturnsReason(t *testing.T) {
 
 func TestConnGaterInterceptAcceptRejectsDNSAddresses(t *testing.T) {
 	gater := &connGater{
+		ctx:             t.Context(),
 		logger:          zap.NewNop(),
 		atMaxPeersLimit: func() bool { return false },
 		atInboundLimit:  func() bool { return false },
@@ -137,6 +144,7 @@ func TestConnGaterInterceptSecured(t *testing.T) {
 	trimmedRecently.Set(trimmedPeerID, struct{}{})
 
 	gater := &connGater{
+		ctx:             t.Context(),
 		logger:          zap.NewNop(),
 		isBadPeer:       func(id peer.ID) bool { return id == badPeerID },
 		trimmedRecently: trimmedRecently,

--- a/network/peers/connections/conn_handler.go
+++ b/network/peers/connections/conn_handler.go
@@ -71,9 +71,13 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 		errClose := net.ClosePeer(id)
 		if errClose == nil {
 			recordFiltered(ch.ctx, conn.Stat().Direction)
-			ch.peerObserver.Observe(ch.ctx, logger, "connection_filtered", id,
-				zap.String("conn_dir", conn.Stat().Direction.String()),
-			)
+			// Match before Observe: variadic fields are evaluated at the call site,
+			// so the check keeps regular connections free of highlight-only work.
+			if _, ok := ch.peerObserver.Match(id); ok {
+				ch.peerObserver.Observe(ch.ctx, logger, "connection_filtered", id,
+					zap.String("conn_dir", conn.Stat().Direction.String()),
+				)
+			}
 		}
 	}
 
@@ -208,10 +212,12 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 				recordConnected(ch.ctx, conn.Stat().Direction)
 
 				ch.peerInfos.SetState(conn.RemotePeer(), peers.StateConnected)
-				ch.peerObserver.Observe(ch.ctx, logger, "connection_connected", conn.RemotePeer(),
-					zap.String("remote_addr", conn.RemoteMultiaddr().String()),
-					zap.String("conn_dir", conn.Stat().Direction.String()),
-				)
+				if _, ok := ch.peerObserver.Match(conn.RemotePeer()); ok {
+					ch.peerObserver.Observe(ch.ctx, logger, "connection_connected", conn.RemotePeer(),
+						zap.String("remote_addr", conn.RemoteMultiaddr().String()),
+						zap.String("conn_dir", conn.Stat().Direction.String()),
+					)
+				}
 				logger.Debug("peer connected")
 
 				// if this connection is the one we found through discovery - remove it from discoveredPeersPool
@@ -238,10 +244,12 @@ func (ch *connHandler) Handle() *libp2pnetwork.NotifyBundle {
 			ch.peerInfos.SetState(conn.RemotePeer(), peers.StateDisconnected)
 
 			logger := connLogger(conn)
-			ch.peerObserver.Observe(ch.ctx, logger, "connection_disconnected", conn.RemotePeer(),
-				zap.String("remote_addr", conn.RemoteMultiaddr().String()),
-				zap.String("conn_dir", conn.Stat().Direction.String()),
-			)
+			if _, ok := ch.peerObserver.Match(conn.RemotePeer()); ok {
+				ch.peerObserver.Observe(ch.ctx, logger, "connection_disconnected", conn.RemotePeer(),
+					zap.String("remote_addr", conn.RemoteMultiaddr().String()),
+					zap.String("conn_dir", conn.Stat().Direction.String()),
+				)
+			}
 			logger.Debug("peer disconnected")
 		},
 	}

--- a/network/peers/peertrace/observer.go
+++ b/network/peers/peertrace/observer.go
@@ -73,12 +73,12 @@ type Observer struct {
 	logLimiter *rate.Limiter
 }
 
+// New builds an observer from cfg. It never returns a nil observer: with no
+// peers configured the observer is disabled (Enabled reports false) and every
+// observation method is a no-op.
 func New(cfg Config) (*Observer, error) {
 	peerTokens := splitPeerList(cfg.Peers)
 	keyTokens := splitPeerList(cfg.PeerKeys)
-	if len(peerTokens)+len(keyTokens) == 0 {
-		return nil, nil
-	}
 
 	label := strings.TrimSpace(cfg.Label)
 	if label == "" {

--- a/network/peers/peertrace/observer.go
+++ b/network/peers/peertrace/observer.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/metrics"
@@ -19,6 +20,13 @@ import (
 
 const (
 	defaultLabel = "highlighted-peer"
+
+	// Highlighted peers are typically observed exactly when they flood the node
+	// (attack simulations), so log emission is rate-limited to keep the node
+	// responsive and its logs readable. Counters are never rate-limited, so
+	// metrics stay exact while logs degrade to a sample.
+	logsPerSecond = 10
+	logsBurst     = 100
 
 	observabilityName      = "github.com/ssvlabs/ssv/network/peers/peertrace"
 	observabilityNamespace = "ssv.p2p.highlighted_peer"
@@ -44,9 +52,9 @@ var (
 type Config struct {
 	// Label is attached to every log and metric for this observer.
 	Label string
-	// Peers is a comma, semicolon, or whitespace separated list of libp2p peer IDs
-	// or secp256k1 public keys encoded as hex. Hex public keys are accepted here
-	// for backwards compatibility; prefer PeerKeys for new key-based configuration.
+	// Peers is a comma, semicolon, or whitespace separated list of libp2p peer IDs.
+	// 0x-prefixed hex secp256k1 public keys are also accepted here for convenience;
+	// prefer PeerKeys for key-based configuration.
 	Peers string
 	// PeerKeys is a comma, semicolon, or whitespace separated list of secp256k1
 	// public identity keys encoded as hex.
@@ -60,13 +68,15 @@ type Peer struct {
 }
 
 type Observer struct {
-	label string
-	peers map[peer.ID]Peer
+	label      string
+	peers      map[peer.ID]Peer
+	logLimiter *rate.Limiter
 }
 
 func New(cfg Config) (*Observer, error) {
-	tokens := splitPeerList(strings.Join([]string{cfg.Peers, cfg.PeerKeys}, " "))
-	if len(tokens) == 0 {
+	peerTokens := splitPeerList(cfg.Peers)
+	keyTokens := splitPeerList(cfg.PeerKeys)
+	if len(peerTokens)+len(keyTokens) == 0 {
 		return nil, nil
 	}
 
@@ -76,13 +86,21 @@ func New(cfg Config) (*Observer, error) {
 	}
 
 	observer := &Observer{
-		label: label,
-		peers: make(map[peer.ID]Peer, len(tokens)),
+		label:      label,
+		peers:      make(map[peer.ID]Peer, len(peerTokens)+len(keyTokens)),
+		logLimiter: rate.NewLimiter(logsPerSecond, logsBurst),
 	}
-	for _, token := range tokens {
+	for _, token := range peerTokens {
 		tracedPeer, err := parsePeer(token)
 		if err != nil {
 			return nil, fmt.Errorf("parse highlighted peer %q: %w", token, err)
+		}
+		observer.peers[tracedPeer.ID] = tracedPeer
+	}
+	for _, token := range keyTokens {
+		tracedPeer, err := parsePublicKey(token)
+		if err != nil {
+			return nil, fmt.Errorf("parse highlighted peer key %q: %w", token, err)
 		}
 		observer.peers[tracedPeer.ID] = tracedPeer
 	}
@@ -121,6 +139,16 @@ func (o *Observer) Observe(ctx context.Context, logger *zap.Logger, event string
 	if !ok {
 		return
 	}
+
+	highlightedPeerEventsCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("ssv.p2p.highlight.label", o.label),
+		attribute.String("ssv.p2p.highlight.event", event),
+		attribute.String("ssv.p2p.peer.id", match.ID.String()),
+	))
+
+	if !o.AllowLog() {
+		return
+	}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -137,12 +165,13 @@ func (o *Observer) Observe(ctx context.Context, logger *zap.Logger, event string
 	}
 	highlightFields = append(highlightFields, fields...)
 	logger.Info("p2p highlighted peer event", highlightFields...)
+}
 
-	highlightedPeerEventsCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("ssv.p2p.highlight.label", o.label),
-		attribute.String("ssv.p2p.highlight.event", event),
-		attribute.String("ssv.p2p.peer.id", match.ID.String()),
-	))
+// AllowLog reports whether a highlighted-peer log line may be emitted now.
+// It rate-limits log volume (a highlighted peer is expected to flood the node
+// during attack simulations); counters stay exact regardless.
+func (o *Observer) AllowLog() bool {
+	return o != nil && o.logLimiter.Allow()
 }
 
 func (o *Observer) ObserveValidation(

--- a/network/peers/peertrace/observer_test.go
+++ b/network/peers/peertrace/observer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
+	"golang.org/x/time/rate"
 )
 
 const attackSimulatorPublicKey = "0x02006c0a9a7e965cb22399987a5a748e90bcc4cb76c461b5d62643c2f2f112055e"
@@ -82,6 +83,31 @@ func TestNew_EmptyConfigDisablesObserver(t *testing.T) {
 	observer, err := New(Config{})
 	require.NoError(t, err)
 	require.Nil(t, observer)
+}
+
+func TestNew_RejectsPeerIDInPeerKeys(t *testing.T) {
+	_, err := New(Config{PeerKeys: "12D3KooWGRZpEouTWybB5jDKsVLqYXn3hXyzuTNxti4ghui6u5HE"})
+	require.Error(t, err)
+}
+
+func TestObserveRateLimitsLogsButNotMatches(t *testing.T) {
+	observer, err := New(Config{Peers: attackSimulatorPublicKey})
+	require.NoError(t, err)
+
+	var pid peer.ID
+	for highlightedPeer := range observer.peers {
+		pid = highlightedPeer
+	}
+
+	observer.logLimiter = rate.NewLimiter(0, 2) // 2 logs allowed, then dry
+
+	core, logs := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(core)
+	for range 5 {
+		observer.Observe(t.Context(), logger, "test_event", pid)
+	}
+
+	require.Len(t, logs.All(), 2)
 }
 
 func TestObserveValidation_LogsHighlightedPeerAndFields(t *testing.T) {

--- a/network/peers/peertrace/observer_test.go
+++ b/network/peers/peertrace/observer_test.go
@@ -82,7 +82,11 @@ func TestNew_DeduplicatesPeerKeysAcrossConfigFields(t *testing.T) {
 func TestNew_EmptyConfigDisablesObserver(t *testing.T) {
 	observer, err := New(Config{})
 	require.NoError(t, err)
-	require.Nil(t, observer)
+	require.NotNil(t, observer)
+	require.False(t, observer.Enabled())
+
+	_, ok := observer.Match("some-peer")
+	require.False(t, ok)
 }
 
 func TestNew_RejectsPeerIDInPeerKeys(t *testing.T) {

--- a/network/peers/peertrace/ssvvalidation/observer.go
+++ b/network/peers/peertrace/ssvvalidation/observer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -42,6 +43,12 @@ func New(peerObserver *peertrace.Observer) validation.SSVValidationObserver {
 	return &Observer{peerObserver: peerObserver}
 }
 
+// Interested reports whether messages from this peer are highlighted.
+func (o *Observer) Interested(pid peer.ID) bool {
+	_, ok := o.peerObserver.Match(pid)
+	return ok
+}
+
 func (o *Observer) ObserveSSVValidation(ctx context.Context, logger *zap.Logger, event validation.SSVValidationEvent) {
 	if o == nil || !o.peerObserver.Enabled() {
 		return
@@ -50,12 +57,31 @@ func (o *Observer) ObserveSSVValidation(ctx context.Context, logger *zap.Logger,
 	if !ok {
 		return
 	}
+
+	label := o.peerObserver.Label()
+	messageType := ssvmessage.MsgTypeToString(event.SSVMessageType)
+	qbftMessageType := ""
+	if event.Consensus != nil {
+		qbftMessageType = ssvmessage.QBFTMsgTypeToString(event.Consensus.QBFTMessageType)
+	}
+
+	highlightedPeerSSVValidationsCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("ssv.p2p.highlight.label", label),
+		attribute.String("ssv.p2p.ssv_validation.result", event.Outcome),
+		attribute.String("ssv.p2p.ssv_validation.reason", event.Reason),
+		attribute.String("ssv.p2p.message.role", event.Role.String()),
+		attribute.String("ssv.p2p.message.type", messageType),
+		attribute.String("ssv.p2p.qbft.message.type", qbftMessageType),
+		attribute.String("ssv.p2p.peer.id", match.ID.String()),
+	))
+
+	if !o.peerObserver.AllowLog() {
+		return
+	}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	label := o.peerObserver.Label()
-	messageType := ssvmessage.MsgTypeToString(event.SSVMessageType)
 	logFields := []zap.Field{
 		zap.Bool("p2p_highlight", true),
 		zap.String("p2p_highlight_label", label),
@@ -71,9 +97,7 @@ func (o *Observer) ObserveSSVValidation(ctx context.Context, logger *zap.Logger,
 		zap.String("duty_executor_id", hex.EncodeToString(event.DutyExecutorID)),
 		zap.Any("signers", event.Signers),
 	}
-	qbftMessageType := ""
 	if event.Consensus != nil {
-		qbftMessageType = ssvmessage.QBFTMsgTypeToString(event.Consensus.QBFTMessageType)
 		logFields = append(logFields,
 			zap.Uint64("qbft_round", uint64(event.Consensus.Round)),
 			zap.String("qbft_message_type", qbftMessageType),
@@ -86,14 +110,4 @@ func (o *Observer) ObserveSSVValidation(ctx context.Context, logger *zap.Logger,
 		logFields = append(logFields, zap.String("ssv_validation_error", event.Error))
 	}
 	logger.Info("p2p highlighted peer ssv validation", logFields...)
-
-	highlightedPeerSSVValidationsCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("ssv.p2p.highlight.label", label),
-		attribute.String("ssv.p2p.ssv_validation.result", event.Outcome),
-		attribute.String("ssv.p2p.ssv_validation.reason", event.Reason),
-		attribute.String("ssv.p2p.message.role", event.Role.String()),
-		attribute.String("ssv.p2p.message.type", messageType),
-		attribute.String("ssv.p2p.qbft.message.type", qbftMessageType),
-		attribute.String("ssv.p2p.peer.id", match.ID.String()),
-	))
 }

--- a/network/peers/peertrace/ssvvalidation/observer_test.go
+++ b/network/peers/peertrace/ssvvalidation/observer_test.go
@@ -21,6 +21,19 @@ func TestNewDisabledObserverReturnsNilInterface(t *testing.T) {
 	require.Nil(t, New(observer))
 }
 
+func TestInterestedReportsOnlyHighlightedPeers(t *testing.T) {
+	pid, err := peer.Decode(highlightedPeerID)
+	require.NoError(t, err)
+	regularPID, err := peer.Decode("12D3KooWAVdZV4v1YKiB8icTQmeqHvRsVSVNqZ3iJ1Ls5C1xe6NC")
+	require.NoError(t, err)
+	peerObserver, err := peertrace.New(peertrace.Config{Peers: highlightedPeerID})
+	require.NoError(t, err)
+
+	observer := New(peerObserver)
+	require.True(t, observer.Interested(pid))
+	require.False(t, observer.Interested(regularPID))
+}
+
 func TestObserveSSVValidation_UsesProvidedLogger(t *testing.T) {
 	pid, err := peer.Decode(highlightedPeerID)
 	require.NoError(t, err)

--- a/network/streams/controller.go
+++ b/network/streams/controller.go
@@ -66,10 +66,14 @@ func (n *streamCtrl) Request(logger *zap.Logger, peerID peer.ID, protocol protoc
 	s := NewStream(stream)
 
 	requestsSentCounter.Add(n.ctx, 1, metric.WithAttributes(protocolIDAttribute(s.Protocol())))
-	n.peerObserver.Observe(n.ctx, logger, "stream_request_sent", peerID,
-		zap.String(fields.FieldProtocolID, string(s.Protocol())),
-		zap.Int("payload_size", len(data)),
-	)
+	// Match before Observe: variadic fields are evaluated at the call site, so
+	// the check keeps regular stream traffic free of highlight-only allocations.
+	if _, ok := n.peerObserver.Match(peerID); ok {
+		n.peerObserver.Observe(n.ctx, logger, "stream_request_sent", peerID,
+			zap.String(fields.FieldProtocolID, string(s.Protocol())),
+			zap.Int("payload_size", len(data)),
+		)
+	}
 
 	defer func() {
 		if err := s.Close(); err != nil && !errors.Is(err, libp2pnetwork.ErrReset) {
@@ -92,10 +96,12 @@ func (n *streamCtrl) Request(logger *zap.Logger, peerID peer.ID, protocol protoc
 	}
 
 	responsesReceivedCounter.Add(n.ctx, 1, metric.WithAttributes(protocolIDAttribute(s.Protocol())))
-	n.peerObserver.Observe(n.ctx, logger, "stream_response_received", peerID,
-		zap.String(fields.FieldProtocolID, string(s.Protocol())),
-		zap.Int("payload_size", len(res)),
-	)
+	if _, ok := n.peerObserver.Match(peerID); ok {
+		n.peerObserver.Observe(n.ctx, logger, "stream_response_received", peerID,
+			zap.String(fields.FieldProtocolID, string(s.Protocol())),
+			zap.Int("payload_size", len(res)),
+		)
+	}
 	return res, nil
 }
 
@@ -119,10 +125,12 @@ func (n *streamCtrl) HandleStream(logger *zap.Logger, stream core.Stream) ([]byt
 		}
 		return nil, nil, done, fmt.Errorf("could not read stream msg: %w", err)
 	}
-	n.peerObserver.Observe(n.ctx, logger, "stream_request_received", s.Conn().RemotePeer(),
-		zap.String(fields.FieldProtocolID, string(s.Protocol())),
-		zap.Int("payload_size", len(data)),
-	)
+	if _, ok := n.peerObserver.Match(s.Conn().RemotePeer()); ok {
+		n.peerObserver.Observe(n.ctx, logger, "stream_request_received", s.Conn().RemotePeer(),
+			zap.String(fields.FieldProtocolID, string(s.Protocol())),
+			zap.Int("payload_size", len(data)),
+		)
+	}
 
 	return data, func(res []byte) error {
 		cp := make([]byte, len(res))
@@ -132,10 +140,12 @@ func (n *streamCtrl) HandleStream(logger *zap.Logger, stream core.Stream) ([]byt
 		}
 
 		responsesSentCounter.Add(n.ctx, 1, metric.WithAttributes(protocolIDAttribute(s.Protocol())))
-		n.peerObserver.Observe(n.ctx, logger, "stream_response_sent", s.Conn().RemotePeer(),
-			zap.String(fields.FieldProtocolID, string(s.Protocol())),
-			zap.Int("payload_size", len(res)),
-		)
+		if _, ok := n.peerObserver.Match(s.Conn().RemotePeer()); ok {
+			n.peerObserver.Observe(n.ctx, logger, "stream_response_sent", s.Conn().RemotePeer(),
+				zap.String(fields.FieldProtocolID, string(s.Protocol())),
+				zap.Int("payload_size", len(res)),
+			)
+		}
 		return nil
 	}, done, nil
 }
@@ -152,8 +162,10 @@ func (n *streamCtrl) observeOversizedPayload(logger *zap.Logger, peerID peer.ID,
 		zap.String(fields.FieldProtocolID, string(protocolID)),
 		zap.String("direction", direction),
 	)
-	n.peerObserver.Observe(n.ctx, logger, "stream_oversized_payload", peerID,
-		zap.String(fields.FieldProtocolID, string(protocolID)),
-		zap.String("direction", direction),
-	)
+	if _, ok := n.peerObserver.Match(peerID); ok {
+		n.peerObserver.Observe(n.ctx, logger, "stream_oversized_payload", peerID,
+			zap.String(fields.FieldProtocolID, string(protocolID)),
+			zap.String("direction", direction),
+		)
+	}
 }

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -290,11 +290,15 @@ func (ctrl *topicsCtrl) listen(sub *pubsub.Subscription) error {
 				messageTopicAttribute(topicNameFull),
 				messageTypeAttribute(uint64(m.MsgType)),
 			))
-			ctrl.peerObserver.Observe(ctrl.ctx, logger, "pubsub_message_delivered", msg.ReceivedFrom,
-				zap.String("topic", topicNameFull),
-				zap.Uint64("message_type", uint64(m.MsgType)),
-				zap.Int("payload_size", len(msg.Data)),
-			)
+			// Variadic args are evaluated before Observe no-ops internally, so match
+			// first to keep regular message delivery free of highlight-only work.
+			if _, ok := ctrl.peerObserver.Match(msg.ReceivedFrom); ok {
+				ctrl.peerObserver.Observe(ctrl.ctx, logger, "pubsub_message_delivered", msg.ReceivedFrom,
+					zap.String("topic", topicNameFull),
+					zap.Uint64("message_type", uint64(m.MsgType)),
+					zap.Int("payload_size", len(msg.Data)),
+				)
+			}
 		default:
 			logger.Warn("unknown message type", zap.Any("message", m))
 		}
@@ -320,7 +324,7 @@ func (ctrl *topicsCtrl) setupTopicValidator(name string) error {
 		validator := ctrl.msgValidator.ValidatorForTopic(name)
 		wrappedValidator := func(ctx context.Context, p peer.ID, pmsg *pubsub.Message) pubsub.ValidationResult {
 			result := validator(ctx, p, pmsg)
-			if ctrl.peerObserver.Enabled() {
+			if _, ok := ctrl.peerObserver.Match(p); ok {
 				ctrl.peerObserver.ObserveValidation(ctx, ctrl.logger, p, name, validationResultString(result), len(pmsg.Data),
 					zap.Int("validation_result_code", int(result)),
 				)

--- a/network/topics/tracer.go
+++ b/network/topics/tracer.go
@@ -43,10 +43,41 @@ func (pst *psTracer) log(logger *zap.Logger, evt *ps_pb.TraceEvent) {
 	if evt == nil {
 		return
 	}
+	eventPeer := tracedEventPeer(evt)
+	_, highlighted := pst.peerObserver.Match(eventPeer)
+	// Building the fields below is not free, so skip it entirely when nothing
+	// would consume them (highlighted-peer-only mode, event from a regular peer).
+	if !pst.traceLog && !highlighted {
+		return
+	}
 	fields := []zap.Field{
 		zap.String("type", evt.GetType().String()),
 	}
-	var highlightedPeer peer.ID
+	// appendRPCMeta keeps the long-standing trace-log schema (IHAVE/IWANT and
+	// subscriptions) for every peer and adds the more verbose message/GRAFT/PRUNE
+	// metadata only for highlighted peers.
+	appendRPCMeta := func(meta *ps_pb.TraceEvent_RPCMeta) {
+		if meta == nil {
+			return
+		}
+		if highlighted {
+			fields = appendMessages(fields, meta.GetMessages())
+		}
+		if ctrl := meta.Control; ctrl != nil {
+			fields = appendIHave(fields, ctrl.GetIhave())
+			fields = appendIWant(fields, ctrl.GetIwant())
+			if highlighted {
+				fields = appendGraft(fields, ctrl.GetGraft())
+				fields = appendPrune(fields, ctrl.GetPrune())
+			}
+		}
+		var subs []string
+		for _, sub := range meta.Subscription {
+			subs = append(subs, sub.GetTopic())
+		}
+		fields = append(fields, zap.Int("subsCount", len(subs)))
+		fields = append(fields, zap.Strings("subs", subs))
+	}
 	switch evt.GetType() {
 	case ps_pb.TraceEvent_PUBLISH_MESSAGE:
 		msg := evt.GetPublishMessage()
@@ -54,144 +85,107 @@ func (pst *psTracer) log(logger *zap.Logger, evt *ps_pb.TraceEvent) {
 		fields = append(fields, zap.String("topic", msg.GetTopic()))
 	case ps_pb.TraceEvent_REJECT_MESSAGE:
 		msg := evt.GetRejectMessage()
-		pid, err := peer.IDFromBytes(msg.GetReceivedFrom())
-		if err == nil {
-			fields = append(fields, zap.String("receivedFrom", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("receivedFrom", eventPeer.String()))
 		}
 		fields = append(fields, zap.String("msgID", hex.EncodeToString(msg.GetMessageID())))
 		fields = append(fields, zap.String("topic", msg.GetTopic()))
 		fields = append(fields, zap.String("reason", msg.GetReason()))
 	case ps_pb.TraceEvent_DUPLICATE_MESSAGE:
 		msg := evt.GetDuplicateMessage()
-		pid, err := peer.IDFromBytes(msg.GetReceivedFrom())
-		if err == nil {
-			fields = append(fields, zap.String("receivedFrom", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("receivedFrom", eventPeer.String()))
 		}
 		fields = append(fields, zap.String("msgID", hex.EncodeToString(msg.GetMessageID())))
 		fields = append(fields, zap.String("topic", msg.GetTopic()))
 	case ps_pb.TraceEvent_DELIVER_MESSAGE:
 		msg := evt.GetDeliverMessage()
-		pid, err := peer.IDFromBytes(msg.GetReceivedFrom())
-		if err == nil {
-			fields = append(fields, zap.String("receivedFrom", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("receivedFrom", eventPeer.String()))
 		}
 		fields = append(fields, zap.String("msgID", hex.EncodeToString(msg.GetMessageID())))
 		fields = append(fields, zap.String("topic", msg.GetTopic()))
 	case ps_pb.TraceEvent_ADD_PEER:
-		pid, err := peer.IDFromBytes(evt.GetAddPeer().GetPeerID())
-		if err == nil {
-			fields = append(fields, zap.String("targetPeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("targetPeer", eventPeer.String()))
 		}
 	case ps_pb.TraceEvent_REMOVE_PEER:
-		pid, err := peer.IDFromBytes(evt.GetRemovePeer().GetPeerID())
-		if err == nil {
-			fields = append(fields, zap.String("targetPeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("targetPeer", eventPeer.String()))
 		}
 	case ps_pb.TraceEvent_JOIN:
 		fields = append(fields, zap.String("topic", evt.GetJoin().GetTopic()))
 	case ps_pb.TraceEvent_LEAVE:
 		fields = append(fields, zap.String("topic", evt.GetLeave().GetTopic()))
 	case ps_pb.TraceEvent_GRAFT:
-		msg := evt.GetGraft()
-		pid, err := peer.IDFromBytes(msg.GetPeerID())
-		if err == nil {
-			fields = append(fields, zap.String("graftPeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("graftPeer", eventPeer.String()))
 		}
-		fields = append(fields, zap.String("topic", msg.GetTopic()))
+		fields = append(fields, zap.String("topic", evt.GetGraft().GetTopic()))
 	case ps_pb.TraceEvent_PRUNE:
-		msg := evt.GetPrune()
-		pid, err := peer.IDFromBytes(msg.GetPeerID())
-		if err == nil {
-			fields = append(fields, zap.String("prunePeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("prunePeer", eventPeer.String()))
 		}
-		fields = append(fields, zap.String("topic", msg.GetTopic()))
+		fields = append(fields, zap.String("topic", evt.GetPrune().GetTopic()))
 	case ps_pb.TraceEvent_SEND_RPC:
-		msg := evt.GetSendRPC()
-		pid, err := peer.IDFromBytes(msg.GetSendTo())
-		if err == nil {
-			fields = append(fields, zap.String("targetPeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("targetPeer", eventPeer.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil && pst.highlighted(highlightedPeer) {
-			fields = appendMessages(fields, meta.GetMessages())
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-				fields = appendGraft(fields, ctrl.GetGraft())
-				fields = appendPrune(fields, ctrl.GetPrune())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		appendRPCMeta(evt.GetSendRPC().GetMeta())
 	case ps_pb.TraceEvent_DROP_RPC:
-		msg := evt.GetDropRPC()
-		pid, err := peer.IDFromBytes(msg.GetSendTo())
-		if err == nil {
-			fields = append(fields, zap.String("targetPeer", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("targetPeer", eventPeer.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil && pst.highlighted(highlightedPeer) {
-			fields = appendMessages(fields, meta.GetMessages())
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-				fields = appendGraft(fields, ctrl.GetGraft())
-				fields = appendPrune(fields, ctrl.GetPrune())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		appendRPCMeta(evt.GetDropRPC().GetMeta())
 	case ps_pb.TraceEvent_RECV_RPC:
-		msg := evt.GetRecvRPC()
-		pid, err := peer.IDFromBytes(msg.GetReceivedFrom())
-		if err == nil {
-			fields = append(fields, zap.String("receivedFrom", pid.String()))
-			highlightedPeer = pid
+		if eventPeer != "" {
+			fields = append(fields, zap.String("receivedFrom", eventPeer.String()))
 		}
-		if meta := msg.GetMeta(); meta != nil && pst.highlighted(highlightedPeer) {
-			fields = appendMessages(fields, meta.GetMessages())
-			if ctrl := meta.Control; ctrl != nil {
-				fields = appendIHave(fields, ctrl.GetIhave())
-				fields = appendIWant(fields, ctrl.GetIwant())
-				fields = appendGraft(fields, ctrl.GetGraft())
-				fields = appendPrune(fields, ctrl.GetPrune())
-			}
-			var subs []string
-			for _, sub := range meta.Subscription {
-				subs = append(subs, sub.GetTopic())
-			}
-			fields = append(fields, zap.Int("subsCount", len(subs)))
-			fields = append(fields, zap.Strings("subs", subs))
-		}
+		appendRPCMeta(evt.GetRecvRPC().GetMeta())
 	default:
 		return
 	}
-	if highlightedPeer != "" {
-		pst.peerObserver.Observe(pst.context(), logger, "pubsub_trace_"+strings.ToLower(evt.GetType().String()), highlightedPeer, fields...)
+	if highlighted {
+		pst.peerObserver.Observe(pst.context(), logger, "pubsub_trace_"+strings.ToLower(evt.GetType().String()), eventPeer, fields...)
 	}
 	if pst.traceLog {
 		logger.Debug("pubsub event", fields...)
 	}
 }
 
-func (pst *psTracer) highlighted(pid peer.ID) bool {
-	_, ok := pst.peerObserver.Match(pid)
-	return ok
+// tracedEventPeer extracts the remote peer a trace event relates to, if any.
+func tracedEventPeer(evt *ps_pb.TraceEvent) peer.ID {
+	var raw []byte
+	switch evt.GetType() {
+	case ps_pb.TraceEvent_REJECT_MESSAGE:
+		raw = evt.GetRejectMessage().GetReceivedFrom()
+	case ps_pb.TraceEvent_DUPLICATE_MESSAGE:
+		raw = evt.GetDuplicateMessage().GetReceivedFrom()
+	case ps_pb.TraceEvent_DELIVER_MESSAGE:
+		raw = evt.GetDeliverMessage().GetReceivedFrom()
+	case ps_pb.TraceEvent_ADD_PEER:
+		raw = evt.GetAddPeer().GetPeerID()
+	case ps_pb.TraceEvent_REMOVE_PEER:
+		raw = evt.GetRemovePeer().GetPeerID()
+	case ps_pb.TraceEvent_GRAFT:
+		raw = evt.GetGraft().GetPeerID()
+	case ps_pb.TraceEvent_PRUNE:
+		raw = evt.GetPrune().GetPeerID()
+	case ps_pb.TraceEvent_SEND_RPC:
+		raw = evt.GetSendRPC().GetSendTo()
+	case ps_pb.TraceEvent_DROP_RPC:
+		raw = evt.GetDropRPC().GetSendTo()
+	case ps_pb.TraceEvent_RECV_RPC:
+		raw = evt.GetRecvRPC().GetReceivedFrom()
+	}
+	if len(raw) == 0 {
+		return ""
+	}
+	pid, err := peer.IDFromBytes(raw)
+	if err != nil {
+		return ""
+	}
+	return pid
 }
 
 func (pst *psTracer) context() context.Context {

--- a/network/topics/tracer.go
+++ b/network/topics/tracer.go
@@ -146,7 +146,7 @@ func (pst *psTracer) log(logger *zap.Logger, evt *ps_pb.TraceEvent) {
 		return
 	}
 	if highlighted {
-		pst.peerObserver.Observe(pst.context(), logger, "pubsub_trace_"+strings.ToLower(evt.GetType().String()), eventPeer, fields...)
+		pst.peerObserver.Observe(pst.ctx, logger, "pubsub_trace_"+strings.ToLower(evt.GetType().String()), eventPeer, fields...)
 	}
 	if pst.traceLog {
 		logger.Debug("pubsub event", fields...)
@@ -177,6 +177,8 @@ func tracedEventPeer(evt *ps_pb.TraceEvent) peer.ID {
 		raw = evt.GetDropRPC().GetSendTo()
 	case ps_pb.TraceEvent_RECV_RPC:
 		raw = evt.GetRecvRPC().GetReceivedFrom()
+	default:
+		return ""
 	}
 	if len(raw) == 0 {
 		return ""
@@ -186,13 +188,6 @@ func tracedEventPeer(evt *ps_pb.TraceEvent) peer.ID {
 		return ""
 	}
 	return pid
-}
-
-func (pst *psTracer) context() context.Context {
-	if pst.ctx == nil {
-		return context.Background()
-	}
-	return pst.ctx
 }
 
 func appendMessages(fields []zap.Field, messages []*ps_pb.TraceEvent_MessageMeta) []zap.Field {

--- a/network/topics/tracer_test.go
+++ b/network/topics/tracer_test.go
@@ -22,6 +22,7 @@ func TestPsTracerLogRecvRPCMetadataForHighlightedPeer(t *testing.T) {
 
 	tracer := &psTracer{
 		logger:       zap.New(core),
+		ctx:          t.Context(),
 		traceLog:     true,
 		peerObserver: observer,
 	}
@@ -52,6 +53,7 @@ func TestPsTracerLogRecvRPCKeepsStandardTraceMetadataForRegularPeer(t *testing.T
 	core, logs := zapobserver.New(zap.DebugLevel)
 	tracer := &psTracer{
 		logger:   zap.New(core),
+		ctx:      t.Context(),
 		traceLog: true,
 	}
 
@@ -84,6 +86,7 @@ func TestPsTracerSkipsRegularPeerEventsWithoutTraceLog(t *testing.T) {
 
 	tracer := &psTracer{
 		logger:       zap.New(core),
+		ctx:          t.Context(),
 		traceLog:     false,
 		peerObserver: observer,
 	}

--- a/network/topics/tracer_test.go
+++ b/network/topics/tracer_test.go
@@ -48,7 +48,7 @@ func TestPsTracerLogRecvRPCMetadataForHighlightedPeer(t *testing.T) {
 	require.Equal(t, int64(2), fields["prunePeerCount"])
 }
 
-func TestPsTracerLogRecvRPCKeepsTraceLogMetadataSmallForRegularPeer(t *testing.T) {
+func TestPsTracerLogRecvRPCKeepsStandardTraceMetadataForRegularPeer(t *testing.T) {
 	core, logs := zapobserver.New(zap.DebugLevel)
 	tracer := &psTracer{
 		logger:   zap.New(core),
@@ -63,11 +63,36 @@ func TestPsTracerLogRecvRPCKeepsTraceLogMetadataSmallForRegularPeer(t *testing.T
 	fields := logs.All()[0].ContextMap()
 	require.Equal(t, ps_pb.TraceEvent_RECV_RPC.String(), fields["type"])
 	require.Equal(t, pid.String(), fields["receivedFrom"])
+	// The pre-highlighting trace schema stays intact for regular peers...
+	require.Equal(t, int64(1), fields["ihaveCount"])
+	require.Equal(t, int64(1), fields["iwantCount"])
+	require.Equal(t, int64(1), fields["subsCount"])
+	// ...while the more verbose highlighted-peer-only metadata is left out.
 	require.NotContains(t, fields, "messageCount")
 	require.NotContains(t, fields, "messageTopics")
 	require.NotContains(t, fields, "messageIDs")
 	require.NotContains(t, fields, "graftCount")
 	require.NotContains(t, fields, "prunePeerCount")
+}
+
+func TestPsTracerSkipsRegularPeerEventsWithoutTraceLog(t *testing.T) {
+	core, logs := zapobserver.New(zap.DebugLevel)
+	highlightedPID, err := peer.Decode("12D3KooWAVdZV4v1YKiB8icTQmeqHvRsVSVNqZ3iJ1Ls5C1xe6NC")
+	require.NoError(t, err)
+	observer, err := peertrace.New(peertrace.Config{Peers: highlightedPID.String()})
+	require.NoError(t, err)
+
+	tracer := &psTracer{
+		logger:       zap.New(core),
+		traceLog:     false,
+		peerObserver: observer,
+	}
+
+	regularPID, err := peer.Decode("12D3KooWGRZpEouTWybB5jDKsVLqYXn3hXyzuTNxti4ghui6u5HE")
+	require.NoError(t, err)
+	tracer.Trace(recvRPCTraceEvent(regularPID))
+
+	require.Empty(t, logs.All())
 }
 
 func TestAppendTraceMetadataSkipsEmptyInputs(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements the feedback from my review of #2854. Based on `attack-sim-observability-clean` and targeting it, so merging this PR folds the fixes into the highlighted-peer observability change before it lands in `stage`.

## What changed

**Hot-path cost for regular traffic**

- `network/topics/controller.go`: the `pubsub_message_delivered` observation and the wrapped topic validator now match the peer before building zap fields. Variadic args are evaluated before `Observe`/`ObserveValidation` no-op internally, so previously every delivered/validated message allocated highlight-only fields — on every node in the delivery case, observer configured or not.
- `network/streams/controller.go` and `network/peers/connections/conn_handler.go`: the same match-before-Observe gate on stream request/response and connection connected/disconnected/filtered events.
- `message/validation`: `SSVValidationObserver` gains a cheap `Interested(peer.ID)` check, so `buildLoggerFields` (which can include a validator-store lookup at debug level) and event construction are skipped for peers nobody observes. Previously, with highlighting enabled, every accepted message from every peer paid that cost.
- `network/topics/tracer.go`: the tracer extracts the event peer first and returns early when trace logging is off and the peer is not highlighted, instead of building log fields for every pubsub event of every peer in highlighted-peer-only mode.
- `network/peers/connections/conn_gater.go`: `observeDecision` skips building log fields for non-highlighted peers (the metric is still recorded for every decision).

**Trace-log schema regression for `PubsubTrace` users**

- RPC trace entries regain the pre-highlighting IHAVE/IWANT/subscription metadata for regular peers — gating the *new* metadata behind the highlighted-peer check had accidentally taken the long-standing fields with it. The verbose message/GRAFT/PRUNE metadata stays highlighted-only, as intended by the earlier review round.

**Log volume under attack traffic**

- `peertrace.Observer` rate-limits highlighted-peer log emission (10/s, burst 100) while counters stay exact. The whole point of highlighting is to watch a peer that floods the node, so unbounded per-event Info logging would bottleneck exactly during the experiment; metrics keep reporting full volume when logs degrade to a sample.

**Observer construction contract**

- `peertrace.New` never returns nil anymore: with no peers configured it returns a disabled observer (`Enabled()` is false, all methods no-op). The previous typed-nil-as-disabled contract would silently defeat nil checks the moment the pointer landed in an interface-typed variable.
- With the operator setup always injecting the observer, the duplicate fallback construction in `p2p.New` had no production caller left and is removed — the highlighted-peers config is now parsed in exactly one place. A nil `PeerObserver` in directly built configs (tests) still disables highlighting via the nil-safe methods.
- Dropped the nil-context/nil-logger fallbacks in the conn gater and pubsub tracer that were only reachable from hand-built test structs; the tests set a context now.

**Config/parsing polish**

- `HighlightedPeerKeys` tokens are parsed strictly as secp256k1 public keys (a peer ID there is now a startup error instead of being silently accepted), and the "backwards compatibility" wording is dropped from a freshly introduced option.
- The highlighted-peer metric reason for non-validation errors is bounded to `unexpected_error` instead of raw `err.Error()` text (unbounded label cardinality); the raw text still travels on the event and shows up in the log line.
- Dropped the unrelated rewrite of the Go 1.26 `new(expr)` shallow copy in `cli/operator/network.go`.
- `go.mod`: `golang.org/x/time` (newly used) and `github.com/gogo/protobuf` (already imported directly by the tracer test) are marked as direct dependencies; versions unchanged.

**Tests**

- New coverage for the validator-observer wiring (accepted/ignored/rejected outcomes, interest gating, nil observer), tracer early-exit and restored regular-peer schema, log rate limiting, strict `PeerKeys` parsing, and `Interested`.

## Validation

- `go build ./...` clean
- `golangci-lint run ./...` (via `go tool -modfile=tool.mod`, matching `make golangci-lint`): 0 issues — includes the `exhaustive` finding CI reported on `tracedEventPeer`, fixed with an explicit `default`
- `./scripts/deadcode.sh`: no unused code found
- `go test ./network/topics ./network/peers/peertrace/... ./network/peers/connections ./network/streams ./message/validation` — all pass except `TestTopicManager`, which fails identically on the base branch in my environment (mdns/multicast restrictions), i.e. unrelated to this change
- `gofmt -s -l` / `goimports -local github.com/ssvlabs/ssv -l` clean on touched files
