### PR TITLE
network/p2p: route go-libp2p logs through SSV logger via Libp2pTrace flag

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -33,6 +33,12 @@ p2p:
   # TcpPort: 13001
   # UdpPort: 12001
 
+  # Optionally surface networking debug logs through the SSV logger (all off by default;
+  # enable individually when troubleshooting connectivity):
+  # PubSubTrace: true      # gossipsub (pubsub) debug tracing
+  # DiscoveryTrace: true   # discv5 discovery debug tracing
+  # Libp2pTrace: true      # go-libp2p logs, swarm2 & basichost at debug (replaces GOLOG_LOG_LEVEL)
+
 # Note: Operator private key can be generated with the `generate-operator-keys` command.
 OperatorPrivateKey:
 

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/ipfs/boxo v0.35.0 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
 	github.com/ipfs/go-datastore v0.9.0 // indirect
-	github.com/ipfs/go-log/v2 v2.8.1 // indirect
+	github.com/ipfs/go-log/v2 v2.8.1
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	DiscoveryTrace bool `yaml:"DiscoveryTrace" env:"DISCOVERY_TRACE" env-description:"Enable discovery debug tracing in logs"`
 	// Libp2pTrace routes go-libp2p logs through the SSV logger at error, with the
 	// swarm2 and basichost subsystems at debug (i.e. GOLOG_LOG_LEVEL=error,swarm2=debug,basichost=debug).
+	// When enabled it owns go-log's level policy outright, overriding any GOLOG_LOG_LEVEL.
 	Libp2pTrace bool `yaml:"Libp2pTrace" env:"LIBP2P_TRACE" env-description:"Route go-libp2p logs through the SSV logger with swarm2/basichost at debug"`
 	// NetworkPrivateKey is used for network identity, MUST be injected
 	NetworkPrivateKey *ecdsa.PrivateKey

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	PubSubTrace bool `yaml:"PubSubTrace" env:"PUBSUB_TRACE" env-description:"Enable pubsub debug tracing in logs"`
 	// DiscoveryTrace is a flag to turn on/off discovery tracing in logs
 	DiscoveryTrace bool `yaml:"DiscoveryTrace" env:"DISCOVERY_TRACE" env-description:"Enable discovery debug tracing in logs"`
+	// Libp2pTrace routes go-libp2p logs through the SSV logger at error, with the
+	// swarm2 and basichost subsystems at debug (i.e. GOLOG_LOG_LEVEL=error,swarm2=debug,basichost=debug).
+	Libp2pTrace bool `yaml:"Libp2pTrace" env:"LIBP2P_TRACE" env-description:"Route go-libp2p logs through the SSV logger with swarm2/basichost at debug"`
 	// NetworkPrivateKey is used for network identity, MUST be injected
 	NetworkPrivateKey *ecdsa.PrivateKey
 	// OperatorDataStore contains own operator data including its ID

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/network/streams"
 	"github.com/ssvlabs/ssv/network/topics"
+	"github.com/ssvlabs/ssv/observability/log"
 	"github.com/ssvlabs/ssv/utils/commons"
 )
 
@@ -64,6 +65,14 @@ func (n *p2pNetwork) Setup() error {
 
 	if err := n.initCfg(); err != nil {
 		return fmt.Errorf("init config: %w", err)
+	}
+
+	if n.cfg.Libp2pTrace {
+		if err := log.HookLibp2pLogging(); err != nil {
+			logger.Warn("could not route go-libp2p logs through SSV logger", zap.Error(err))
+		} else {
+			logger.Info("routing go-libp2p logs through SSV logger (swarm2,basichost=debug)")
+		}
 	}
 
 	err := n.SetupHost()

--- a/observability/log/global.go
+++ b/observability/log/global.go
@@ -6,8 +6,10 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
+	"sync"
 	"time"
 
+	golog "github.com/ipfs/go-log/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -48,54 +50,124 @@ func SetGlobal(levelName string, levelEncoderName string, logFormat string, file
 
 	levelEncoder := parseConfigLevelEncoder(levelEncoderName)
 
-	lv := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+	encoderConfig := zapcore.EncoderConfig{
+		MessageKey:  "msg",
+		LevelKey:    "level",
+		EncodeLevel: levelEncoder,
+		TimeKey:     "time",
+		EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000000Z"))
+		},
+		CallerKey:        "caller",
+		EncodeCaller:     zapcore.ShortCallerEncoder,
+		EncodeDuration:   zapcore.StringDurationEncoder,
+		NameKey:          "name",
+		ConsoleSeparator: "\t",
+	}
+
+	var fileSyncer zapcore.WriteSyncer
+	if fileOptions != nil {
+		fileSyncer = zapcore.AddSync(fileOptions.writer(fileOptions))
+	}
+
+	stdoutLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 		return lvl >= level
 	})
 
-	cfg := zap.Config{
-		Encoding:    logFormat,
-		Level:       zap.NewAtomicLevelAt(level),
-		OutputPaths: []string{"stdout"},
-		EncoderConfig: zapcore.EncoderConfig{
-			MessageKey:  "msg",
-			LevelKey:    "level",
-			EncodeLevel: levelEncoder,
-			TimeKey:     "time",
-			EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-				enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000000Z"))
-			},
-			CallerKey:        "caller",
-			EncodeCaller:     zapcore.ShortCallerEncoder,
-			EncodeDuration:   zapcore.StringDurationEncoder,
-			NameKey:          "name",
-			ConsoleSeparator: "\t",
-		},
+	core, err := assembleCore(stdoutLevel, encoderConfig, logFormat, fileSyncer)
+	if err != nil {
+		return err
 	}
 
-	var zapCore zapcore.Core
+	globalLogConfigMu.Lock()
+	globalEncoderConfig = encoderConfig
+	globalLogFormat = logFormat
+	globalFileSyncer = fileSyncer
+	globalLogConfigMu.Unlock()
+
+	zap.ReplaceGlobals(zap.New(core))
+
+	return nil
+}
+
+// Logging config resolved by the most recent SetGlobal call, retained so
+// go-libp2p logs can be routed through a matching core (see HookLibp2pLogging).
+// Guarded by globalLogConfigMu since SetGlobal may run concurrently (e.g. tests).
+var (
+	globalLogConfigMu   sync.Mutex
+	globalEncoderConfig zapcore.EncoderConfig
+	globalLogFormat     string
+	globalFileSyncer    zapcore.WriteSyncer
+)
+
+// stdoutSyncer is shared by every core built via assembleCore so concurrent
+// writes from the SSV logger and the go-libp2p core don't interleave.
+var stdoutSyncer = zapcore.Lock(zapcore.AddSync(os.Stdout))
+
+// assembleCore builds the SSV logging core: a stdout core gated by stdoutLevel,
+// optionally tee'd with an always-on file core. The same builder is reused to
+// route go-libp2p logs through an identical sink.
+func assembleCore(stdoutLevel zapcore.LevelEnabler, encoderConfig zapcore.EncoderConfig, logFormat string, fileSyncer zapcore.WriteSyncer) (zapcore.Core, error) {
+	var stdoutEncoder zapcore.Encoder
 	switch logFormat {
 	case "console":
-		zapCore = zapcore.NewCore(zapcore.NewConsoleEncoder(cfg.EncoderConfig), os.Stdout, lv)
+		stdoutEncoder = zapcore.NewConsoleEncoder(encoderConfig)
 	case "json":
-		zapCore = zapcore.NewCore(zapcore.NewJSONEncoder(cfg.EncoderConfig), os.Stdout, lv)
+		stdoutEncoder = zapcore.NewJSONEncoder(encoderConfig)
 	default:
-		return fmt.Errorf("unknown log format: %s", logFormat)
+		return nil, fmt.Errorf("unknown log format: %s", logFormat)
 	}
 
-	if fileOptions == nil {
-		zap.ReplaceGlobals(zap.New(zapCore))
-		return nil
+	core := zapcore.NewCore(stdoutEncoder, stdoutSyncer, stdoutLevel)
+
+	if fileSyncer != nil {
+		allLevels := zap.LevelEnablerFunc(func(zapcore.Level) bool {
+			return true // file sink records all levels
+		})
+		dev := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
+		fileCore := zapcore.NewCore(dev, fileSyncer, allLevels)
+		core = zapcore.NewTee(core, fileCore)
 	}
 
-	lv2 := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return true // debug log returns all logs
+	return core, nil
+}
+
+// HookLibp2pLogging routes go-libp2p's logs (github.com/ipfs/go-log/v2) through
+// the SSV logger, with the swarm2 and basichost subsystems at debug and the rest
+// at error. It surfaces libp2p connection/host diagnostics in SSV's own log
+// format without the GOLOG_LOG_LEVEL environment variable. SetGlobal must run first.
+func HookLibp2pLogging() error {
+	globalLogConfigMu.Lock()
+	encoderConfig, logFormat, fileSyncer := globalEncoderConfig, globalLogFormat, globalFileSyncer
+	globalLogConfigMu.Unlock()
+
+	if logFormat == "" {
+		return fmt.Errorf("global logger not initialized")
+	}
+
+	// Seed go-log's per-subsystem levels and default the rest to error. Setting
+	// them via SetupLogging (rather than SetLogLevel) registers the levels even
+	// for subsystem loggers that haven't been created yet, so the policy holds
+	// regardless of package init ordering.
+	golog.SetupLogging(golog.Config{
+		Level: golog.LevelError,
+		SubsystemLevels: map[string]golog.LogLevel{
+			"swarm2":    golog.LevelDebug,
+			"basichost": golog.LevelDebug,
+		},
+		// No Stdout/Stderr/File: the core SetupLogging builds writes nowhere and
+		// is immediately replaced by the SSV core below.
 	})
 
-	dev := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
-	fileWriter := fileOptions.writer(fileOptions)
-	fileCore := zapcore.NewCore(dev, zapcore.AddSync(fileWriter), lv2)
+	// Route libp2p logs through a debug-floor core sharing the SSV logger's
+	// encoder and writers; the per-subsystem levels above do the gating.
+	allLevels := zap.LevelEnablerFunc(func(zapcore.Level) bool { return true })
+	core, err := assembleCore(allLevels, encoderConfig, logFormat, fileSyncer)
+	if err != nil {
+		return fmt.Errorf("build libp2p logging core: %w", err)
+	}
 
-	zap.ReplaceGlobals(zap.New(zapcore.NewTee(zapCore, fileCore)))
+	golog.SetPrimaryCore(core)
 
 	return nil
 }

--- a/observability/log/global.go
+++ b/observability/log/global.go
@@ -107,6 +107,10 @@ var (
 // writes from the SSV logger and the go-libp2p core don't interleave.
 var stdoutSyncer = zapcore.Lock(zapcore.AddSync(os.Stdout))
 
+// levelAll enables every level. Used where gating happens elsewhere: the always-on
+// file sink, and the go-libp2p core whose per-subsystem levels do the gating.
+var levelAll = zap.LevelEnablerFunc(func(zapcore.Level) bool { return true })
+
 // assembleCore builds the SSV logging core: a stdout core gated by stdoutLevel,
 // optionally tee'd with an always-on file core. The same builder is reused to
 // route go-libp2p logs through an identical sink.
@@ -124,11 +128,8 @@ func assembleCore(stdoutLevel zapcore.LevelEnabler, encoderConfig zapcore.Encode
 	core := zapcore.NewCore(stdoutEncoder, stdoutSyncer, stdoutLevel)
 
 	if fileSyncer != nil {
-		allLevels := zap.LevelEnablerFunc(func(zapcore.Level) bool {
-			return true // file sink records all levels
-		})
 		dev := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
-		fileCore := zapcore.NewCore(dev, fileSyncer, allLevels)
+		fileCore := zapcore.NewCore(dev, fileSyncer, levelAll) // file sink records all levels
 		core = zapcore.NewTee(core, fileCore)
 	}
 
@@ -139,6 +140,10 @@ func assembleCore(stdoutLevel zapcore.LevelEnabler, encoderConfig zapcore.Encode
 // the SSV logger, with the swarm2 and basichost subsystems at debug and the rest
 // at error. It surfaces libp2p connection/host diagnostics in SSV's own log
 // format without the GOLOG_LOG_LEVEL environment variable. SetGlobal must run first.
+//
+// go-log holds its logging state in process-global variables, so this reconfigures
+// libp2p logging for the entire process, not a single network instance. Calling it
+// more than once (e.g. a second p2p network) simply re-applies the same policy.
 func HookLibp2pLogging() error {
 	globalLogConfigMu.Lock()
 	encoderConfig, logFormat, fileSyncer := globalEncoderConfig, globalLogFormat, globalFileSyncer
@@ -165,8 +170,7 @@ func HookLibp2pLogging() error {
 
 	// Route libp2p logs through a debug-floor core sharing the SSV logger's
 	// encoder and writers; the per-subsystem levels above do the gating.
-	allLevels := zap.LevelEnablerFunc(func(zapcore.Level) bool { return true })
-	core, err := assembleCore(allLevels, encoderConfig, logFormat, fileSyncer)
+	core, err := assembleCore(levelAll, encoderConfig, logFormat, fileSyncer)
 	if err != nil {
 		return fmt.Errorf("build libp2p logging core: %w", err)
 	}

--- a/observability/log/global.go
+++ b/observability/log/global.go
@@ -67,7 +67,7 @@ func SetGlobal(levelName string, levelEncoderName string, logFormat string, file
 
 	var fileSyncer zapcore.WriteSyncer
 	if fileOptions != nil {
-		fileSyncer = zapcore.AddSync(fileOptions.writer(fileOptions))
+		fileSyncer = zapcore.AddSync(fileOptions.writer())
 	}
 
 	stdoutLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
@@ -178,11 +178,11 @@ type LogFileOptions struct {
 	MaxBackups int
 }
 
-func (o LogFileOptions) writer(options *LogFileOptions) io.Writer {
+func (o *LogFileOptions) writer() io.Writer {
 	return &lumberjack.Logger{
-		Filename:   options.FilePath,
-		MaxSize:    options.MaxSize, // megabytes
-		MaxBackups: options.MaxBackups,
+		Filename:   o.FilePath,
+		MaxSize:    o.MaxSize, // megabytes
+		MaxBackups: o.MaxBackups,
 		MaxAge:     28, // days
 		Compress:   false,
 	}

--- a/observability/log/global.go
+++ b/observability/log/global.go
@@ -65,6 +65,9 @@ func SetGlobal(levelName string, levelEncoderName string, logFormat string, file
 		ConsoleSeparator: "\t",
 	}
 
+	// Unlike stdoutSyncer, the file syncer needs no zapcore.Lock: lumberjack's
+	// Write is internally mutex-guarded, so the SSV and libp2p cores can share
+	// this one instance without interleaving.
 	var fileSyncer zapcore.WriteSyncer
 	if fileOptions != nil {
 		fileSyncer = zapcore.AddSync(fileOptions.writer())
@@ -148,7 +151,8 @@ func HookLibp2pLogging() error {
 	// Seed go-log's per-subsystem levels and default the rest to error. Setting
 	// them via SetupLogging (rather than SetLogLevel) registers the levels even
 	// for subsystem loggers that haven't been created yet, so the policy holds
-	// regardless of package init ordering.
+	// regardless of package init ordering. SetupLogging resets every subsystem
+	// level first, so this deliberately overrides any GOLOG_LOG_LEVEL.
 	golog.SetupLogging(golog.Config{
 		Level: golog.LevelError,
 		SubsystemLevels: map[string]golog.LogLevel{

--- a/observability/log/libp2p_test.go
+++ b/observability/log/libp2p_test.go
@@ -1,0 +1,25 @@
+package log
+
+import (
+	"testing"
+
+	golog "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestHookLibp2pLogging(t *testing.T) {
+	require.NoError(t, SetGlobal("info", "capital", "json", nil))
+	require.NoError(t, HookLibp2pLogging())
+
+	// swarm2 and basichost are raised to debug.
+	for _, subsystem := range []string{"swarm2", "basichost"} {
+		core := golog.Logger(subsystem).Desugar().Core()
+		require.True(t, core.Enabled(zapcore.DebugLevel), "%s should log at debug", subsystem)
+	}
+
+	// Any other subsystem stays at the error default: errors pass, debug is dropped.
+	other := golog.Logger("some-other-subsystem").Desugar().Core()
+	require.True(t, other.Enabled(zapcore.ErrorLevel))
+	require.False(t, other.Enabled(zapcore.DebugLevel))
+}

--- a/observability/log/libp2p_test.go
+++ b/observability/log/libp2p_test.go
@@ -23,3 +23,24 @@ func TestHookLibp2pLogging(t *testing.T) {
 	require.True(t, other.Enabled(zapcore.ErrorLevel))
 	require.False(t, other.Enabled(zapcore.DebugLevel))
 }
+
+// TestHookLibp2pLoggingRetrofitsExistingLogger covers the production scenario:
+// every go-libp2p/IPFS package registers its subsystem logger via a package-level
+// `var log = golog.Logger(...)` at init() time, long before p2p.Setup() calls the
+// hook. The hook must therefore retrofit an already-created logger, not merely gate
+// ones created afterward — which is the init-order independence the hook claims.
+func TestHookLibp2pLoggingRetrofitsExistingLogger(t *testing.T) {
+	// Create the subsystem logger BEFORE the hook runs, then pin it to a known
+	// non-debug level so the post-hook assertion proves the retrofit happened
+	// (independent of any level other tests in this package may have left behind).
+	core := golog.Logger("swarm2").Desugar().Core()
+	require.NoError(t, golog.SetLogLevel("swarm2", "error"))
+	require.False(t, core.Enabled(zapcore.DebugLevel), "precondition: swarm2 starts above debug")
+
+	require.NoError(t, SetGlobal("info", "capital", "json", nil))
+	require.NoError(t, HookLibp2pLogging())
+
+	// The same, already-created logger must now log at debug.
+	require.True(t, core.Enabled(zapcore.DebugLevel),
+		"hook must retrofit the pre-existing swarm2 logger to debug")
+}

--- a/observability/log/libp2p_test.go
+++ b/observability/log/libp2p_test.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	golog "github.com/ipfs/go-log/v2"
@@ -57,4 +59,32 @@ func TestHookLibp2pLoggingRetrofitsExistingLogger(t *testing.T) {
 	// The same, already-created logger must now log at debug.
 	require.True(t, core.Enabled(zapcore.DebugLevel),
 		"hook must retrofit the pre-existing swarm2 logger to debug")
+}
+
+// TestHookLibp2pLoggingWritesThroughSSVFileSink exercises the production path the
+// other tests skip — a configured file sink (production always runs with one). It
+// proves, end to end through the real sink rather than via Core.Enabled, that libp2p
+// logs are (a) rendered through the shared SSV file core in SSV's JSON format and
+// (b) still gated by the per-subsystem levels.
+func TestHookLibp2pLoggingWritesThroughSSVFileSink(t *testing.T) {
+	resetGoLog(t)
+
+	logFile := filepath.Join(t.TempDir(), "ssv.log")
+	require.NoError(t, SetGlobal("info", "capital", "json", &LogFileOptions{FilePath: logFile}))
+	require.NoError(t, HookLibp2pLogging())
+
+	// swarm2 is raised to debug: its debug line reaches the file.
+	golog.Logger("swarm2").Debug("swarm2-debug-9f3a")
+	// An un-raised subsystem stays at error: debug is dropped, error passes.
+	golog.Logger("some-other-subsystem").Debug("other-debug-9f3a")
+	golog.Logger("some-other-subsystem").Error("other-error-9f3a")
+
+	out, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	contents := string(out)
+
+	// Rendered through the shared SSV file core (dev JSON encoder, "M" message key).
+	require.Contains(t, contents, `"M":"swarm2-debug-9f3a"`, "swarm2 debug must reach the SSV file sink")
+	require.Contains(t, contents, `"M":"other-error-9f3a"`, "libp2p error logs must reach the SSV file sink")
+	require.NotContains(t, contents, "other-debug-9f3a", "debug from an un-raised subsystem must be gated out")
 }

--- a/observability/log/libp2p_test.go
+++ b/observability/log/libp2p_test.go
@@ -8,7 +8,19 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// resetGoLog restores go-log to a quiet default after the test (all subsystems
+// at error, output discarded), so the global mutations these tests make — the
+// raised subsystem levels and the replaced primary core — don't leak into other
+// tests in this package.
+func resetGoLog(t *testing.T) {
+	t.Cleanup(func() {
+		golog.SetupLogging(golog.Config{Level: golog.LevelError})
+	})
+}
+
 func TestHookLibp2pLogging(t *testing.T) {
+	resetGoLog(t)
+
 	require.NoError(t, SetGlobal("info", "capital", "json", nil))
 	require.NoError(t, HookLibp2pLogging())
 
@@ -30,6 +42,8 @@ func TestHookLibp2pLogging(t *testing.T) {
 // hook. The hook must therefore retrofit an already-created logger, not merely gate
 // ones created afterward — which is the init-order independence the hook claims.
 func TestHookLibp2pLoggingRetrofitsExistingLogger(t *testing.T) {
+	resetGoLog(t)
+
 	// Create the subsystem logger BEFORE the hook runs, then pin it to a known
 	// non-debug level so the post-hook assertion proves the retrofit happened
 	// (independent of any level other tests in this package may have left behind).


### PR DESCRIPTION
## What

Adds a `Libp2pTrace` config flag (`LIBP2P_TRACE`, default off) that hooks go-libp2p's logging (`github.com/ipfs/go-log/v2`) into the SSV `zap` logger and applies an `error,swarm2=debug,basichost=debug` level policy.

This is the SSV-config equivalent of running with `GOLOG_LOG_LEVEL=error,swarm2=debug,basichost=debug`, with two advantages:

- libp2p logs are rendered through SSV's own encoder/output (same format, same file sink) instead of go-log's default colorized stderr.
- verbosity is driven by SSV config (yaml/env), so the `GOLOG_LOG_LEVEL` environment variable is no longer needed for this.

When the flag is off, libp2p logging is left completely untouched (existing default / `GOLOG_LOG_LEVEL` behavior), mirroring how `PubSubTrace` works.

## How

`go-log/v2` is itself zap-based: every subsystem logger writes into a single shared core and is gated by a per-subsystem `AtomicLevel` via `zap.IncreaseLevel` (effective level = `max(coreLevel, subsystemLevel)`).

- `observability/log`: extracted `assembleCore` so the SSV logger and the libp2p core share the same encoder and writers (notably a single file syncer — no double log-rotation). Added `HookLibp2pLogging`, which:
  - calls `golog.SetupLogging` with `Level: error` and `SubsystemLevels: {swarm2: debug, basichost: debug}` to seed the per-subsystem levels (this registers them even for subsystem loggers not yet created, so it's init-order independent);
  - builds a debug-floor core sharing the SSV encoder/writers and installs it via `golog.SetPrimaryCore`. The per-subsystem levels do the actual gating.
- `network/p2p`: new `Libp2pTrace` field on the p2p `Config`; `Setup()` calls the hook when it's enabled.

The flip side: `go-log/v2` moves from indirect to direct in `go.mod`.

## Testing

- `TestHookLibp2pLogging` asserts `swarm2`/`basichost` log at debug while other subsystems stay error-only, exercised through the real go-log cores.
- `go build ./...`, `go vet`, and the `observability/log` package tests pass.

## Note on altitude

The hook lives in `observability/log` (keeps the core-building private and reused) and is invoked from p2p `Setup()` alongside the existing `PubSubTrace`/`TraceLog` wiring.