### PR TITLE
fix: fetch head block root for sync-committee contributions

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -59,11 +59,8 @@ func (gc *GoClient) SubmitAggregateSelectionProof(
 	if err != nil {
 		return nil, DataVersionNil, errMultiClient(fmt.Errorf("fetch aggregate attestation: %w", err), "AggregateAttestation")
 	}
-	if aggDataResp == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation response is nil"), "AggregateAttestation")
-	}
-	if aggDataResp.Data == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation response data is nil"), "AggregateAttestation")
+	if err := checkPtrResponse(aggDataResp, "aggregate attestation"); err != nil {
+		return nil, DataVersionNil, errMultiClient(err, "AggregateAttestation")
 	}
 
 	var selectionProof phase0.BLSSignature

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -54,11 +54,8 @@ func (gc *GoClient) AttesterDuties(ctx context.Context, epoch phase0.Epoch, vali
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch attester duties: %w", err), "AttesterDuties")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("attester duties response is nil"), "AttesterDuties")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("attester duties response data is nil"), "AttesterDuties")
+	if err := checkSliceResponse(resp, "attester duties"); err != nil {
+		return nil, errMultiClient(err, "AttesterDuties")
 	}
 
 	return resp.Data, nil
@@ -344,11 +341,8 @@ func (gc *GoClient) simpleAttestationData(ctx context.Context, slot phase0.Slot)
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("get attestation data: %w", err), "AttestationData")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("attestation data response is nil"), "AttestationData")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("attestation data is nil"), "AttestationData")
+	if err := checkPtrResponse(resp, "attestation data"); err != nil {
+		return nil, errMultiClient(err, "AttestationData")
 	}
 
 	logger.Debug("successfully fetched attestation data",
@@ -383,21 +377,14 @@ func (gc *GoClient) fetchWeightedAttestationData(
 		}
 		return
 	}
-	if response == nil {
+	if err := checkPtrResponse(response, "attestation data"); err != nil {
 		errCh <- &attestationDataError{
 			clientAddr: client.Address(),
-			err:        errSingleClient(fmt.Errorf("response is nil"), client.Address(), "AttestationData"),
+			err:        errSingleClient(err, client.Address(), "AttestationData"),
 		}
 		return
 	}
 	attestationData := response.Data
-	if attestationData == nil {
-		errCh <- &attestationDataError{
-			clientAddr: client.Address(),
-			err:        errSingleClient(fmt.Errorf("response data nil"), client.Address(), "AttestationData"),
-		}
-		return
-	}
 
 	logger = logger.With(fields.BlockRoot(attestationData.BeaconBlockRoot))
 

--- a/beacon/goclient/committees.go
+++ b/beacon/goclient/committees.go
@@ -34,8 +34,8 @@ func (gc *GoClient) CommitteesForEpoch(ctx context.Context, epoch phase0.Epoch) 
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch beacon committees: %w", err), "BeaconCommittees")
 	}
-	if resp == nil || resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("beacon committees response is nil"), "BeaconCommittees")
+	if err := checkSliceResponse(resp, "beacon committees"); err != nil {
+		return nil, errMultiClient(err, "BeaconCommittees")
 	}
 	if gc.committeesCache != nil {
 		gc.committeesCache.Set(epoch, resp.Data, ttlcache.DefaultTTL)

--- a/beacon/goclient/genesis.go
+++ b/beacon/goclient/genesis.go
@@ -20,11 +20,8 @@ func (gc *GoClient) genesisForClient(ctx context.Context, provider client.Servic
 	if err != nil {
 		return nil, errSingleClient(fmt.Errorf("fetch genesis: %w", err), provider.Address(), "Genesis")
 	}
-	if genesisResp == nil {
-		return nil, errSingleClient(fmt.Errorf("genesis response is nil"), provider.Address(), "Genesis")
-	}
-	if genesisResp.Data == nil {
-		return nil, errSingleClient(fmt.Errorf("genesis response data is nil"), provider.Address(), "Genesis")
+	if err := checkPtrResponse(genesisResp, "genesis"); err != nil {
+		return nil, errSingleClient(err, provider.Address(), "Genesis")
 	}
 
 	return genesisResp.Data, nil

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -501,13 +501,9 @@ func (gc *GoClient) checkNodeHealth(ctx context.Context, client Client) error {
 		recordBeaconClientStatus(ctx, statusUnknown, client.Address())
 		return errSingleClient(fmt.Errorf("fetch node syncing status: %w", err), client.Address(), "NodeSyncing")
 	}
-	if nodeSyncingResp == nil {
+	if err := checkPtrResponse(nodeSyncingResp, "node syncing"); err != nil {
 		recordBeaconClientStatus(ctx, statusUnknown, client.Address())
-		return errSingleClient(fmt.Errorf("node syncing response is nil"), client.Address(), "NodeSyncing")
-	}
-	if nodeSyncingResp.Data == nil {
-		recordBeaconClientStatus(ctx, statusUnknown, client.Address())
-		return errSingleClient(fmt.Errorf("node syncing response data is nil"), client.Address(), "NodeSyncing")
+		return errSingleClient(err, client.Address(), "NodeSyncing")
 	}
 
 	syncState := nodeSyncingResp.Data

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -39,11 +39,8 @@ func (gc *GoClient) ProposerDuties(ctx context.Context, epoch phase0.Epoch, vali
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch proposer duties: %w", err), "ProposerDuties")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("proposer duties response is nil"), "ProposerDuties")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("proposer duties response data is nil"), "ProposerDuties")
+	if err := checkSliceResponse(resp, "proposer duties"); err != nil {
+		return nil, errMultiClient(err, "ProposerDuties")
 	}
 
 	return resp.Data, nil
@@ -67,11 +64,8 @@ func (gc *GoClient) fetchProposal(
 	if err != nil {
 		return nil, errSingleClient(fmt.Errorf("fetch proposal: %w", err), client.Address(), "Proposal")
 	}
-	if resp == nil {
-		return nil, errSingleClient(fmt.Errorf("proposal response is nil"), client.Address(), "Proposal")
-	}
-	if resp.Data == nil {
-		return nil, errSingleClient(fmt.Errorf("proposal response data is nil"), client.Address(), "Proposal")
+	if err := checkPtrResponse(resp, "proposal"); err != nil {
+		return nil, errSingleClient(err, client.Address(), "Proposal")
 	}
 
 	return resp.Data, nil

--- a/beacon/goclient/response.go
+++ b/beacon/goclient/response.go
@@ -1,0 +1,37 @@
+package goclient
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/api"
+)
+
+// nilResponseErr returns the unwrapped "<subject> response[ data] is nil" error shared
+// by the typed response validators below, or nil when neither the response nor its data
+// is missing. Callers wrap the result with errMultiClient/errSingleClient to attach the
+// route name (and, for single-client calls, the client address).
+func nilResponseErr(respNil, dataNil bool, subject string) error {
+	switch {
+	case respNil:
+		return fmt.Errorf("%s response is nil", subject)
+	case dataNil:
+		return fmt.Errorf("%s response data is nil", subject)
+	default:
+		return nil
+	}
+}
+
+// checkPtrResponse returns a non-nil error if resp or its pointer Data is nil.
+func checkPtrResponse[T any](resp *api.Response[*T], subject string) error {
+	return nilResponseErr(resp == nil, resp != nil && resp.Data == nil, subject)
+}
+
+// checkSliceResponse returns a non-nil error if resp or its slice Data is nil.
+func checkSliceResponse[T any](resp *api.Response[[]T], subject string) error {
+	return nilResponseErr(resp == nil, resp != nil && resp.Data == nil, subject)
+}
+
+// checkMapResponse returns a non-nil error if resp or its map Data is nil.
+func checkMapResponse[K comparable, V any](resp *api.Response[map[K]V], subject string) error {
+	return nilResponseErr(resp == nil, resp != nil && resp.Data == nil, subject)
+}

--- a/beacon/goclient/spec.go
+++ b/beacon/goclient/spec.go
@@ -56,11 +56,8 @@ func (gc *GoClient) specForClient(ctx context.Context, provider client.Service) 
 	if err != nil {
 		return nil, errSingleClient(fmt.Errorf("fetch spec response: %w", err), provider.Address(), "Spec")
 	}
-	if specResponse == nil {
-		return nil, errSingleClient(fmt.Errorf("spec response is nil"), provider.Address(), "Spec")
-	}
-	if specResponse.Data == nil {
-		return nil, errSingleClient(fmt.Errorf("spec response data is nil"), provider.Address(), "Spec")
+	if err := checkMapResponse(specResponse, "spec"); err != nil {
+		return nil, errSingleClient(err, provider.Address(), "Spec")
 	}
 
 	return specResponse.Data, nil

--- a/beacon/goclient/sync_committee.go
+++ b/beacon/goclient/sync_committee.go
@@ -23,11 +23,8 @@ func (gc *GoClient) SyncCommitteeDuties(ctx context.Context, epoch phase0.Epoch,
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch sync committee duties: %w", err), "SyncCommitteeDuties")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("sync committee duties response is nil"), "SyncCommitteeDuties")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("sync committee duties response data is nil"), "SyncCommitteeDuties")
+	if err := checkSliceResponse(resp, "sync committee duties"); err != nil {
+		return nil, errMultiClient(err, "SyncCommitteeDuties")
 	}
 
 	return resp.Data, nil

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -58,6 +58,9 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	// Resolve the contribution root from head rather than by slot: sync-committee messages
 	// sign the head root as seen during the duty slot, which for a missed or late proposal
 	// is an earlier block's root — a by-slot lookup would 404 there and fail the duty.
+	// In the common case head matches the root the cluster's own messages signed; those
+	// sign the QBFT-decided head vote, which can diverge from a freshly-queried head under
+	// a reorg or a lagging node.
 	start := time.Now()
 	beaconBlockRootResp, err := gc.multiClient.BeaconBlockRoot(ctx, &api.BeaconBlockRootOpts{
 		Block: "head",
@@ -66,11 +69,8 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	if err != nil {
 		return nil, DataVersionNil, errMultiClient(fmt.Errorf("fetch beacon block root: %w", err), "BeaconBlockRoot")
 	}
-	if beaconBlockRootResp == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("beacon block root response is nil"), "BeaconBlockRoot")
-	}
-	if beaconBlockRootResp.Data == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("beacon block root response data is nil"), "BeaconBlockRoot")
+	if err := checkPtrResponse(beaconBlockRootResp, "beacon block root"); err != nil {
+		return nil, DataVersionNil, errMultiClient(err, "BeaconBlockRoot")
 	}
 
 	blockRoot := beaconBlockRootResp.Data
@@ -96,11 +96,8 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 			if err != nil {
 				return errMultiClient(fmt.Errorf("fetch sync committee contribution: %w", err), "SyncCommitteeContribution")
 			}
-			if syncCommitteeContrResp == nil {
-				return errMultiClient(fmt.Errorf("sync committee contribution response is nil"), "SyncCommitteeContribution")
-			}
-			if syncCommitteeContrResp.Data == nil {
-				return errMultiClient(fmt.Errorf("sync committee contribution response data is nil"), "SyncCommitteeContribution")
+			if err := checkPtrResponse(syncCommitteeContrResp, "sync committee contribution"); err != nil {
+				return errMultiClient(err, "SyncCommitteeContribution")
 			}
 
 			contribution := syncCommitteeContrResp.Data

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -18,12 +18,11 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-// IsSyncCommitteeAggregator returns tru if aggregator
+// IsSyncCommitteeAggregator reports whether the given selection proof makes the validator
+// a sync-committee aggregator.
 func (gc *GoClient) IsSyncCommitteeAggregator(proof []byte) bool {
-	// Hash the signature.
 	hash := sha256.Sum256(proof)
 
-	// Keep the signature if it's an aggregator.
 	cfg := gc.BeaconConfig()
 
 	// as per spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#aggregation-selection
@@ -35,12 +34,13 @@ func (gc *GoClient) IsSyncCommitteeAggregator(proof []byte) bool {
 	return binary.LittleEndian.Uint64(hash[:8])%modulo == 0
 }
 
-// SyncCommitteeSubnetID returns sync committee subnet ID from subcommittee index
+// SyncCommitteeSubnetID returns the sync-committee subnet ID for the given subcommittee index.
 func (gc *GoClient) SyncCommitteeSubnetID(index phase0.CommitteeIndex) uint64 {
 	return uint64(index) / (gc.BeaconConfig().SyncCommitteeSize / gc.BeaconConfig().SyncCommitteeSubnetCount)
 }
 
-// GetSyncCommitteeContribution returns
+// GetSyncCommitteeContribution fetches one contribution per requested subnet, each paired
+// with its selection proof, all for the head block root as of the duty slot.
 func (gc *GoClient) GetSyncCommitteeContribution(
 	ctx context.Context,
 	slot phase0.Slot,
@@ -51,16 +51,18 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 		return nil, DataVersionNil, fmt.Errorf("mismatching number of selection proofs and subnet IDs")
 	}
 
-	gc.waitOneThirdIntoSlot(ctx, slot)
+	if err := gc.waitOneThirdIntoSlot(ctx, slot); err != nil {
+		return nil, DataVersionNil, fmt.Errorf("wait for 1/3 of slot: %w", err)
+	}
 
-	scDataReqStart := time.Now()
 	// Resolve the contribution root from head rather than by slot: sync-committee messages
 	// sign the head root as seen during the duty slot, which for a missed or late proposal
 	// is an earlier block's root — a by-slot lookup would 404 there and fail the duty.
+	start := time.Now()
 	beaconBlockRootResp, err := gc.multiClient.BeaconBlockRoot(ctx, &api.BeaconBlockRootOpts{
 		Block: "head",
 	})
-	recordRequest(ctx, gc.log, "BeaconBlockRoot", gc.multiClient, http.MethodGet, true, time.Since(scDataReqStart), err)
+	recordRequest(ctx, gc.log, "BeaconBlockRoot", gc.multiClient, http.MethodGet, true, time.Since(start), err)
 	if err != nil {
 		return nil, DataVersionNil, errMultiClient(fmt.Errorf("fetch beacon block root: %w", err), "BeaconBlockRoot")
 	}
@@ -74,7 +76,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	blockRoot := beaconBlockRootResp.Data
 
 	if err := gc.waitTwoThirdsIntoSlot(ctx, slot); err != nil {
-		return nil, 0, fmt.Errorf("wait for 2/3 of slot: %w", err)
+		return nil, DataVersionNil, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
 	// Fetch sync committee contributions for each subnet in parallel.
@@ -83,12 +85,11 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 		g             errgroup.Group
 	)
 	for i := range subnetIDs {
-		index := i
 		g.Go(func() error {
 			start := time.Now()
 			syncCommitteeContrResp, err := gc.multiClient.SyncCommitteeContribution(ctx, &api.SyncCommitteeContributionOpts{
 				Slot:              slot,
-				SubcommitteeIndex: subnetIDs[index],
+				SubcommitteeIndex: subnetIDs[i],
 				BeaconBlockRoot:   *blockRoot,
 			})
 			recordRequest(ctx, gc.log, "SyncCommitteeContribution", gc.multiClient, http.MethodGet, true, time.Since(start), err)
@@ -103,8 +104,8 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 			}
 
 			contribution := syncCommitteeContrResp.Data
-			contributions[index] = &spectypes.Contribution{
-				SelectionProofSig: selectionProofs[index],
+			contributions[i] = &spectypes.Contribution{
+				SelectionProofSig: selectionProofs[i],
 				Contribution:      *contribution,
 			}
 			return nil
@@ -117,7 +118,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	return &contributions, spec.DataVersionAltair, nil
 }
 
-// SubmitSignedContributionAndProof broadcasts to the network
+// SubmitSignedContributionAndProof submits the signed contribution and proof to the beacon node.
 func (gc *GoClient) SubmitSignedContributionAndProof(
 	ctx context.Context,
 	contribution *altair.SignedContributionAndProof,
@@ -133,18 +134,19 @@ func (gc *GoClient) SubmitSignedContributionAndProof(
 }
 
 // waitOneThirdIntoSlot waits until one-third of the slot has transpired (SECONDS_PER_SLOT / 3 seconds after slot start time)
-func (gc *GoClient) waitOneThirdIntoSlot(ctx context.Context, slot phase0.Slot) {
+func (gc *GoClient) waitOneThirdIntoSlot(ctx context.Context, slot phase0.Slot) error {
 	config := gc.getBeaconConfig()
 	delay := config.IntervalDuration()
 	finalTime := config.SlotStartTime(slot).Add(delay)
 	wait := time.Until(finalTime)
 	if wait <= 0 {
-		return
+		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		return
+		return ctx.Err()
 	case <-time.After(wait):
+		return nil
 	}
 }

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -54,8 +54,11 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	gc.waitOneThirdIntoSlot(ctx, slot)
 
 	scDataReqStart := time.Now()
+	// Resolve the contribution root from head rather than by slot: sync-committee messages
+	// sign the head root as seen during the duty slot, which for a missed or late proposal
+	// is an earlier block's root — a by-slot lookup would 404 there and fail the duty.
 	beaconBlockRootResp, err := gc.multiClient.BeaconBlockRoot(ctx, &api.BeaconBlockRootOpts{
-		Block: fmt.Sprint(slot),
+		Block: "head",
 	})
 	recordRequest(ctx, gc.log, "BeaconBlockRoot", gc.multiClient, http.MethodGet, true, time.Since(scDataReqStart), err)
 	if err != nil {

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -247,7 +247,7 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 	client := &syncCommitteeClientMock{
 		beaconBlockRootFunc: func(_ context.Context, opts *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
 			// Must query head, not the duty slot: a by-slot lookup 404s when the slot's
-			// proposal is missed, failing the whole contribution duty.
+			// proposal is missed, failing the contribution duty.
 			require.Equal(t, "head", opts.Block)
 			return &api.Response[*phase0.Root]{Data: &blockRoot}, nil
 		},

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -305,7 +305,8 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 // empty-slot 404 bug: the contribution root must be resolved from "head", never the
 // duty slot. When the slot's proposal is missed, a by-slot block-root lookup 404s and
 // terminally fails the duty for the whole cluster, whereas "head" resolves to the
-// previous block's root — exactly what the cluster's sync-committee messages signed.
+// previous block's root — in the common case the root the cluster's sync-committee
+// messages signed.
 //
 // The mock 404s any by-slot lookup and only answers "head", so this test fails if the
 // query ever regresses to the by-slot form.

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -301,6 +301,60 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 	}
 }
 
+// TestGetSyncCommitteeContributionFetchesHeadRoot is a regression test for the
+// empty-slot 404 bug: the contribution root must be resolved from "head", never the
+// duty slot. When the slot's proposal is missed, a by-slot block-root lookup 404s and
+// terminally fails the duty for the whole cluster, whereas "head" resolves to the
+// previous block's root — exactly what the cluster's sync-committee messages signed.
+//
+// The mock 404s any by-slot lookup and only answers "head", so this test fails if the
+// query ever regresses to the by-slot form.
+func TestGetSyncCommitteeContributionFetchesHeadRoot(t *testing.T) {
+	t.Parallel()
+
+	cfg := *networkconfig.TestNetwork.Beacon
+	headRoot := phase0.Root{4, 5, 6}
+	slot := phase0.Slot(64)
+	selectionProofs := []phase0.BLSSignature{signatureWithFirstByte(1)}
+	subnetIDs := []uint64{7}
+
+	client := &syncCommitteeClientMock{
+		beaconBlockRootFunc: func(_ context.Context, opts *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
+			if opts.Block != "head" {
+				// Emulate a missed-proposal slot: the by-slot lookup the old code used 404s.
+				return nil, errors.New("GET failed with status 404: block not found")
+			}
+			return &api.Response[*phase0.Root]{Data: &headRoot}, nil
+		},
+		syncCommitteeContributionFunc: func(_ context.Context, opts *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error) {
+			// The contribution must be requested for the head root resolved above.
+			require.Equal(t, headRoot, opts.BeaconBlockRoot)
+			return &api.Response[*altair.SyncCommitteeContribution]{
+				Data: &altair.SyncCommitteeContribution{
+					Slot:              opts.Slot,
+					BeaconBlockRoot:   opts.BeaconBlockRoot,
+					SubcommitteeIndex: opts.SubcommitteeIndex,
+				},
+			}, nil
+		},
+	}
+
+	goClient := &GoClient{
+		log:          zap.NewNop(),
+		beaconConfig: &cfg,
+		multiClient:  client,
+	}
+
+	got, version, err := goClient.GetSyncCommitteeContribution(t.Context(), slot, selectionProofs, subnetIDs)
+	require.NoError(t, err)
+	require.Equal(t, spec.DataVersionAltair, version)
+
+	contributions, ok := got.(*spectypes.Contributions)
+	require.True(t, ok)
+	require.Len(t, *contributions, len(subnetIDs))
+	require.Equal(t, headRoot, (*contributions)[0].Contribution.BeaconBlockRoot)
+}
+
 func TestIsSyncCommitteeAggregatorHandlesZeroModulo(t *testing.T) {
 	t.Parallel()
 

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -3,7 +3,6 @@ package goclient
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -247,7 +246,9 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 	)
 	client := &syncCommitteeClientMock{
 		beaconBlockRootFunc: func(_ context.Context, opts *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
-			require.Equal(t, fmt.Sprint(slot), opts.Block)
+			// Must query head, not the duty slot: a by-slot lookup 404s when the slot's
+			// proposal is missed, failing the whole contribution duty.
+			require.Equal(t, "head", opts.Block)
 			return &api.Response[*phase0.Root]{Data: &blockRoot}, nil
 		},
 		syncCommitteeContributionFunc: func(_ context.Context, opts *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error) {

--- a/beacon/goclient/validator.go
+++ b/beacon/goclient/validator.go
@@ -29,11 +29,8 @@ func (gc *GoClient) GetValidatorData(
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch validators: %w", err), "Validators")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("validators response is nil"), "Validators")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("validators response data is nil"), "Validators")
+	if err := checkMapResponse(resp, "validators"); err != nil {
+		return nil, errMultiClient(err, "Validators")
 	}
 
 	return resp.Data, nil

--- a/beacon/goclient/validatorliveness.go
+++ b/beacon/goclient/validatorliveness.go
@@ -21,11 +21,8 @@ func (gc *GoClient) ValidatorLiveness(ctx context.Context, epoch phase0.Epoch, v
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("fetch validator liveness: %w", err), "ValidatorLiveness")
 	}
-	if resp == nil {
-		return nil, errMultiClient(fmt.Errorf("validator liveness response is nil"), "ValidatorLiveness")
-	}
-	if resp.Data == nil {
-		return nil, errMultiClient(fmt.Errorf("validator liveness response data is nil"), "ValidatorLiveness")
+	if err := checkSliceResponse(resp, "validator liveness"); err != nil {
+		return nil, errMultiClient(err, "ValidatorLiveness")
 	}
 
 	return resp.Data, nil


### PR DESCRIPTION
## Problem

When the duty slot's block proposal is missed (or arrives later than 1/3 into the slot), the `SYNC_COMMITTEE_CONTRIBUTION` duty fails for the entire cluster:

```
could not get sync committee contribution: multi-client request -> BeaconBlockRoot: fetch beacon block root: GET failed with status 404: {"code":404,"message":"Block not found for id '3252140'"}
```

Observed on Hoodi at slot [3252140](https://dora.hoodi.ethpandaops.io/slot/3252140) (missed proposal, finalized). `GetSyncCommitteeContribution` resolves the contribution's `beacon_block_root` via `GET /eth/v1/beacon/blocks/{slot}/root`, and the beacon API answers 404 for an empty slot — a correct and permanent answer, so the duty terminally fails whenever a cluster validator is a sync-committee aggregator for a slot with no block. The failure is deterministic across all operators (each queries its own node for a block that doesn't exist).

## Fix

Query `head` instead of the slot number. Per the consensus spec, sync-committee messages at slot N sign the head root as seen at slot N — for an empty slot that's an earlier block's root. The committee runner already behaves this way (sync messages sign the QBFT-decided beacon vote, i.e. attestation data's head vote), so in the common case `head` matches what the cluster's own messages signed — though a freshly-queried `head` can diverge from that decided root under a reorg or a lagging node. #839 made the identical change for the sync-committee message path; the contribution path kept the by-slot lookup (since #777) and was never aligned.

## Backward compatibility

Fully backward compatible — safe to roll into a live, partially-upgraded cluster with no coordinated upgrade:

- **Beacon API:** `head` and `<slot>` are both standard `block_id` values for `GET /eth/v1/beacon/blocks/{block_id}/root`; `head` is supported by every consensus client. No new endpoint or client-version requirement.
- **Mixed-version clusters (no consensus split):** the fetched contribution is wrapped in `ValidatorConsensusData` and run through QBFT, where only the leader's value is agreed and followers validate it. The contribution value-check (`syncCommitteeContributionChecker` → `checkValidatorConsensusData`) and the spec's `ValidatorConsensusData.Validate()` only verify duty type / pubkey / validator index / epoch and that the contributions decode — neither pins nor re-derives the `beacon_block_root`. A follower therefore accepts whatever root the leader proposed, whether it came from `head` or by-slot, so new and old operators interoperate either way. On an empty slot an old leader still 404s, but a QBFT round change can hand leadership to an upgraded operator — so a mixed cluster is never worse than today and gets the full fix once operators upgrade. No wire/message-format, signing-domain, or consensus-value-layout change.
- **No storage/format changes.** The only Go signature change (`waitOneThirdIntoSlot`) is unexported with a single in-package caller.

## Cleanups in the touched flow

- `waitOneThirdIntoSlot` now mirrors `waitTwoThirdsIntoSlot`: context cancellation surfaces as an error instead of letting the block-root request fire with a cancelled context.
- The 2/3-wait error path returns `DataVersionNil` rather than a literal `0` (i.e. `DataVersionUnknown`), matching the sentinel used by the function's other error paths.
- Dropped a loop-var copy made obsolete by Go 1.22 semantics.
- Completed/fixed stale doc comments in the file (truncated `GetSyncCommitteeContribution` doc, `IsSyncCommitteeAggregator` typo, vague submit doc, leftover narration comments).

## Tests

- Updated `TestGetSyncCommitteeContributionPreservesInputOrdering`, whose mock previously pinned the by-slot request shape, to assert `head`.
- Added `TestGetSyncCommitteeContributionFetchesHeadRoot`: the mock 404s any by-slot lookup and only answers `head`, so it reproduces the original failure (and fails if the query ever regresses to by-slot).

