### PR TITLE
fix: aggregate for the attestation data root the cluster attested with

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -29,24 +29,32 @@ func (gc *GoClient) SubmitAggregateSelectionProof(
 		return nil, 0, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
-	attData, _, err := gc.GetAttestationData(ctx, slot)
-	if err != nil {
-		return nil, DataVersionNil, fmt.Errorf("fetch attestation data: %w", err)
-	}
+	// Aggregate for the root of the attestation data this node actually submitted for this
+	// duty (the cluster-decided value): the beacon node then holds at least our own
+	// attestation matching it. Re-deriving the data locally can yield a root nobody
+	// attested with, which the node answers with a 404 (no matching aggregate).
+	root, found := gc.attestedDataRoot(slot, committeeIndex)
+	if !found {
+		// No record of our own attestation (it failed or hasn't landed yet) — fall back
+		// to re-deriving the root from this node's view of the slot.
+		attData, _, err := gc.GetAttestationData(ctx, slot)
+		if err != nil {
+			return nil, DataVersionNil, fmt.Errorf("fetch attestation data: %w", err)
+		}
 
-	// Explicitly set Index field as beacon nodes may return inconsistent values.
-	// EIP-7549: For Electra and later, index must always be 0, pre-Electra uses committee index.
-	config := gc.getBeaconConfig()
-	dataVersion, _ := config.ForkAtEpoch(config.EstimatedEpochAtSlot(slot))
-	attData.Index = 0
-	if dataVersion < spec.DataVersionElectra {
-		attData.Index = committeeIndex
-	}
+		// Explicitly set Index field as beacon nodes may return inconsistent values.
+		// EIP-7549: For Electra and later, index must always be 0, pre-Electra uses committee index.
+		config := gc.getBeaconConfig()
+		dataVersion, _ := config.ForkAtEpoch(config.EstimatedEpochAtSlot(slot))
+		attData.Index = 0
+		if dataVersion < spec.DataVersionElectra {
+			attData.Index = committeeIndex
+		}
 
-	// Get aggregate attestation data.
-	root, err := attData.HashTreeRoot()
-	if err != nil {
-		return nil, DataVersionNil, fmt.Errorf("fetch attestation data root: %w", err)
+		root, err = attData.HashTreeRoot()
+		if err != nil {
+			return nil, DataVersionNil, fmt.Errorf("fetch attestation data root: %w", err)
+		}
 	}
 
 	aggDataReqStart := time.Now()

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -2,6 +2,7 @@ package goclient
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -20,15 +21,32 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+// aggregatorClientMock is used both as a MultiClient (single-client path) and, when placed in
+// GoClient.clients, as a Client for the parallel-submission path.
 type aggregatorClientMock struct {
 	mock.Service
+
+	submitAttestationsFn func(context.Context, *api.SubmitAttestationsOpts) error
 }
+
+var _ Client = (*aggregatorClientMock)(nil)
 
 func (*aggregatorClientMock) SubmitProposal(context.Context, *api.SubmitProposalOpts) error {
 	return nil
 }
 
-func (*aggregatorClientMock) SubmitAttestations(context.Context, *api.SubmitAttestationsOpts) error {
+func (m *aggregatorClientMock) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
+	if m.submitAttestationsFn != nil {
+		return m.submitAttestationsFn(ctx, opts)
+	}
+	return nil
+}
+
+func (*aggregatorClientMock) NodeClient(context.Context) (*api.Response[string], error) {
+	return &api.Response[string]{Data: "mock"}, nil
+}
+
+func (*aggregatorClientMock) SubmitBlindedProposal(context.Context, *api.SubmitBlindedProposalOpts) error {
 	return nil
 }
 
@@ -263,6 +281,254 @@ func TestSubmitAggregateSelectionProof_RespectsContextCancellationWhileWaiting(t
 		require.Zero(t, attestationCalls.Load())
 		require.Zero(t, aggregateCalls.Load())
 	})
+}
+
+func TestSubmitAggregateSelectionProof_FallbackSurfacesAttestationDataError(t *testing.T) {
+	t.Parallel()
+
+	cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+	slot := cfg.FirstSlotAtEpoch(0)
+
+	var attestationCalls atomic.Int32
+	service := &aggregatorClientMock{}
+	service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+		attestationCalls.Add(1)
+		return nil, errors.New("attestation data unavailable")
+	}
+
+	client := newAggregatorTestClient(&cfg, service)
+
+	// No prior SubmitAttestations, so the attested root is unknown and the flow falls back to
+	// re-deriving it via GetAttestationData — whose error must surface to the caller.
+	_, _, err := client.SubmitAggregateSelectionProof(t.Context(), slot, 7, 128, 42, make([]byte, 96))
+	require.ErrorContains(t, err, "fetch attestation data")
+	require.EqualValues(t, 1, attestationCalls.Load())
+}
+
+func TestAttestationCommitteeIndex(t *testing.T) {
+	t.Parallel()
+
+	data := &phase0.AttestationData{
+		Slot:   100,
+		Index:  3,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+
+	t.Run("pre-electra reads the data index", func(t *testing.T) {
+		t.Parallel()
+		att := aggregatorVersionedAttestation(spec.DataVersionPhase0, data)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(3), got)
+	})
+
+	t.Run("electra reads the single committee bit", func(t *testing.T) {
+		t.Parallel()
+		att := attestedVersionedAttestation(spec.DataVersionElectra, data, 7)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(7), got)
+	})
+
+	t.Run("fulu reads the single committee bit", func(t *testing.T) {
+		t.Parallel()
+		att := attestedVersionedAttestation(spec.DataVersionFulu, data, 9)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(9), got)
+	})
+
+	t.Run("electra with no committee bit set errors", func(t *testing.T) {
+		t.Parallel()
+		att := &spec.VersionedAttestation{
+			Version: spec.DataVersionElectra,
+			Electra: &electra.Attestation{Data: data, CommitteeBits: bitfield.NewBitvector64()},
+		}
+		_, err := attestationCommitteeIndex(att, data)
+		require.ErrorContains(t, err, "exactly one committee bit")
+	})
+
+	t.Run("electra with multiple committee bits errors", func(t *testing.T) {
+		t.Parallel()
+		bits := bitfield.NewBitvector64()
+		bits.SetBitAt(1, true)
+		bits.SetBitAt(2, true)
+		att := &spec.VersionedAttestation{
+			Version: spec.DataVersionElectra,
+			Electra: &electra.Attestation{Data: data, CommitteeBits: bits},
+		}
+		_, err := attestationCommitteeIndex(att, data)
+		require.ErrorContains(t, err, "exactly one committee bit")
+	})
+
+	t.Run("electra with no inner attestation errors", func(t *testing.T) {
+		t.Parallel()
+		att := &spec.VersionedAttestation{Version: spec.DataVersionElectra}
+		_, err := attestationCommitteeIndex(att, data)
+		require.Error(t, err)
+	})
+}
+
+func TestRememberAttestedDataRoots(t *testing.T) {
+	t.Parallel()
+
+	newClient := func() *GoClient {
+		return &GoClient{
+			log:                   zap.NewNop(),
+			attestedDataRootCache: ttlcache.New[attestedDataRootKey, phase0.Root](),
+		}
+	}
+
+	preElectraData := func(slot phase0.Slot, committee phase0.CommitteeIndex, block byte) *phase0.AttestationData {
+		return &phase0.AttestationData{
+			Slot:            slot,
+			Index:           committee, // pre-Electra the committee is part of the data
+			BeaconBlockRoot: phase0.Root{block},
+			Source:          &phase0.Checkpoint{Epoch: 1},
+			Target:          &phase0.Checkpoint{Epoch: 2},
+		}
+	}
+
+	t.Run("keys remembered roots by committee", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(100)
+
+		// Pre-Electra the committee is encoded in the data, so the two committees produce
+		// distinct roots — exactly what the (slot, committee) key must keep apart.
+		dataC1 := preElectraData(slot, 1, 0x01)
+		dataC2 := preElectraData(slot, 2, 0x02)
+		rootC1 := mustHashTreeRoot(t, dataC1)
+		rootC2 := mustHashTreeRoot(t, dataC2)
+		require.NotEqual(t, rootC1, rootC2)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC1),
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC2),
+		})
+
+		got1, ok1 := gc.attestedDataRoot(slot, 1)
+		require.True(t, ok1)
+		require.Equal(t, rootC1, got1)
+
+		got2, ok2 := gc.attestedDataRoot(slot, 2)
+		require.True(t, ok2)
+		require.Equal(t, rootC2, got2)
+
+		// A committee we never attested for, and a different slot, both miss.
+		_, ok3 := gc.attestedDataRoot(slot, 3)
+		require.False(t, ok3)
+		_, okOtherSlot := gc.attestedDataRoot(slot+1, 1)
+		require.False(t, okOtherSlot)
+	})
+
+	t.Run("remembers electra roots via committee bits", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(200)
+		data := &phase0.AttestationData{Slot: slot, Source: &phase0.Checkpoint{Epoch: 1}, Target: &phase0.Checkpoint{Epoch: 2}}
+		root := mustHashTreeRoot(t, data)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			attestedVersionedAttestation(spec.DataVersionElectra, data, 4),
+		})
+
+		got, ok := gc.attestedDataRoot(slot, 4)
+		require.True(t, ok)
+		require.Equal(t, root, got)
+	})
+
+	t.Run("last submission wins for the same key", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(300)
+		committee := phase0.CommitteeIndex(5)
+
+		first := preElectraData(slot, committee, 0x01)
+		second := preElectraData(slot, committee, 0x02)
+		require.NotEqual(t, mustHashTreeRoot(t, first), mustHashTreeRoot(t, second))
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, first)})
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, second)})
+
+		got, ok := gc.attestedDataRoot(slot, committee)
+		require.True(t, ok)
+		require.Equal(t, mustHashTreeRoot(t, second), got)
+	})
+
+	t.Run("skips malformed attestations and keeps valid ones", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(400)
+		valid := preElectraData(slot, 6, 0x01)
+
+		twoBits := bitfield.NewBitvector64()
+		twoBits.SetBitAt(1, true)
+		twoBits.SetBitAt(2, true)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			// Data() fails (nil inner attestation).
+			{Version: spec.DataVersionElectra},
+			// Committee extraction fails (two committee bits).
+			{Version: spec.DataVersionElectra, Electra: &electra.Attestation{Data: valid, CommitteeBits: twoBits}},
+			// Valid — must still be remembered despite the malformed entries above.
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, valid),
+		})
+
+		got, ok := gc.attestedDataRoot(slot, 6)
+		require.True(t, ok)
+		require.Equal(t, mustHashTreeRoot(t, valid), got)
+	})
+}
+
+func TestSubmitAttestations_ParallelSubmissionRemembersRoots(t *testing.T) {
+	t.Parallel()
+
+	slot := phase0.Slot(500)
+	committee := phase0.CommitteeIndex(8)
+	data := &phase0.AttestationData{
+		Slot:   slot,
+		Index:  committee,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+	root := mustHashTreeRoot(t, data)
+
+	var failingCalls, succeedingCalls atomic.Int32
+	failing := &aggregatorClientMock{submitAttestationsFn: func(context.Context, *api.SubmitAttestationsOpts) error {
+		failingCalls.Add(1)
+		return errors.New("first client failed")
+	}}
+	succeeding := &aggregatorClientMock{submitAttestationsFn: func(context.Context, *api.SubmitAttestationsOpts) error {
+		succeedingCalls.Add(1)
+		return nil
+	}}
+
+	gc := &GoClient{
+		log:                     zap.NewNop(),
+		clients:                 []Client{failing, succeeding},
+		withParallelSubmissions: true,
+		attestedDataRootCache:   ttlcache.New[attestedDataRootKey, phase0.Root](),
+	}
+
+	require.NoError(t, gc.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+		aggregatorVersionedAttestation(spec.DataVersionPhase0, data),
+	}))
+	require.EqualValues(t, 1, failingCalls.Load())
+	require.EqualValues(t, 1, succeedingCalls.Load())
+
+	// One client failed but the other accepted the attestation, so the root is still remembered.
+	got, ok := gc.attestedDataRoot(slot, committee)
+	require.True(t, ok)
+	require.Equal(t, root, got)
+}
+
+func mustHashTreeRoot(t *testing.T, data *phase0.AttestationData) phase0.Root {
+	t.Helper()
+	root, err := data.HashTreeRoot()
+	require.NoError(t, err)
+	return root
 }
 
 func aggregatorTestBeaconConfig(genesisTime time.Time) networkconfig.Beacon {

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -524,6 +524,37 @@ func TestSubmitAttestations_ParallelSubmissionRemembersRoots(t *testing.T) {
 	require.Equal(t, root, got)
 }
 
+func TestSubmitAttestations_ParallelSubmissionNoClientsErrsWithoutRemembering(t *testing.T) {
+	t.Parallel()
+
+	slot := phase0.Slot(500)
+	committee := phase0.CommitteeIndex(8)
+	data := &phase0.AttestationData{
+		Slot:   slot,
+		Index:  committee,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+
+	// No clients to submit to. SubmitAttestations must surface an error and must NOT remember the
+	// root: nothing was submitted, so the aggregator flow would otherwise request an aggregate for
+	// a root no beacon node holds — the exact 404 this cache exists to avoid.
+	gc := &GoClient{
+		log:                     zap.NewNop(),
+		clients:                 nil,
+		withParallelSubmissions: true,
+		attestedDataRootCache:   ttlcache.New[attestedDataRootKey, phase0.Root](),
+	}
+
+	err := gc.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+		aggregatorVersionedAttestation(spec.DataVersionPhase0, data),
+	})
+	require.Error(t, err)
+
+	_, ok := gc.attestedDataRoot(slot, committee)
+	require.False(t, ok, "root must not be remembered when nothing was submitted")
+}
+
 func mustHashTreeRoot(t *testing.T, data *phase0.AttestationData) phase0.Root {
 	t.Helper()
 	root, err := data.HashTreeRoot()

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -24,6 +25,10 @@ type aggregatorClientMock struct {
 }
 
 func (*aggregatorClientMock) SubmitProposal(context.Context, *api.SubmitProposalOpts) error {
+	return nil
+}
+
+func (*aggregatorClientMock) SubmitAttestations(context.Context, *api.SubmitAttestationsOpts) error {
 	return nil
 }
 
@@ -156,6 +161,72 @@ func TestSubmitAggregateSelectionProof_UsesForkSpecificAggregateAndProof(t *test
 	}
 }
 
+func TestSubmitAggregateSelectionProof_PrefersAttestedDataRoot(t *testing.T) {
+	t.Parallel()
+
+	slotSig := make([]byte, 96)
+	validatorIndex := phase0.ValidatorIndex(42)
+	committeeIndex := phase0.CommitteeIndex(7)
+
+	testCases := []struct {
+		name    string
+		version spec.DataVersion
+		epoch   phase0.Epoch
+	}{
+		{name: "electra committee comes from committee bits", version: spec.DataVersionElectra, epoch: 5},
+		{name: "pre-electra committee comes from data index", version: spec.DataVersionPhase0, epoch: 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+			slot := cfg.FirstSlotAtEpoch(tc.epoch)
+
+			// The data the cluster decided and attested with.
+			attestedData := &phase0.AttestationData{
+				Slot:            slot,
+				BeaconBlockRoot: phase0.Root{1, 2, 3},
+				Source:          &phase0.Checkpoint{Epoch: 1},
+				Target:          &phase0.Checkpoint{Epoch: 2},
+			}
+			if tc.version < spec.DataVersionElectra {
+				attestedData.Index = committeeIndex
+			}
+			expectedRoot, err := attestedData.HashTreeRoot()
+			require.NoError(t, err)
+
+			service := &aggregatorClientMock{}
+			service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+				t.Error("attestation data must not be re-derived when the attested root is known")
+				return nil, nil
+			}
+			service.AggregateAttestationFunc = func(_ context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+				require.Equal(t, slot, opts.Slot)
+				require.Equal(t, committeeIndex, opts.CommitteeIndex)
+				require.EqualValues(t, expectedRoot, opts.AttestationDataRoot)
+
+				return &api.Response[*spec.VersionedAttestation]{
+					Data: aggregatorVersionedAttestation(tc.version, attestedData),
+				}, nil
+			}
+
+			client := newAggregatorTestClient(&cfg, service)
+
+			require.NoError(t, client.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+				attestedVersionedAttestation(tc.version, attestedData, committeeIndex),
+			}))
+
+			_, gotVersion, err := client.SubmitAggregateSelectionProof(
+				t.Context(), slot, committeeIndex, 128, validatorIndex, slotSig,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.version, gotVersion)
+		})
+	}
+}
+
 func TestSubmitAggregateSelectionProof_RespectsContextCancellationWhileWaiting(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		cfg := aggregatorTestBeaconConfig(time.Now())
@@ -205,11 +276,12 @@ func epochPtr(epoch phase0.Epoch) *phase0.Epoch {
 
 func newAggregatorTestClient(cfg *networkconfig.Beacon, service MultiClient) *GoClient {
 	client := &GoClient{
-		log:                  zap.NewNop(),
-		beaconConfig:         cfg,
-		multiClient:          service,
-		attestationDataCache: ttlcache.New[phase0.Slot, *phase0.AttestationData](),
-		headCache:            ttlcache.New[phase0.Slot, phase0.Root](),
+		log:                   zap.NewNop(),
+		beaconConfig:          cfg,
+		multiClient:           service,
+		attestationDataCache:  ttlcache.New[phase0.Slot, *phase0.AttestationData](),
+		attestedDataRootCache: ttlcache.New[attestedDataRootKey, phase0.Root](),
+		headCache:             ttlcache.New[phase0.Slot, phase0.Root](),
 	}
 	client.fetchAttestationDataFunc = client.fetchAttestationData
 	return client
@@ -234,6 +306,23 @@ func aggregatorVersionedAttestation(version spec.DataVersion, data *phase0.Attes
 	default:
 		panic("unsupported version")
 	}
+}
+
+// attestedVersionedAttestation builds an attestation the way the committee runner submits
+// it: pre-Electra the committee is the data's Index, Electra+ it's the set committee bit.
+func attestedVersionedAttestation(version spec.DataVersion, data *phase0.AttestationData, committee phase0.CommitteeIndex) *spec.VersionedAttestation {
+	att := aggregatorVersionedAttestation(version, data)
+	if version >= spec.DataVersionElectra {
+		committeeBits := bitfield.NewBitvector64()
+		committeeBits.SetBitAt(uint64(committee), true)
+		switch version {
+		case spec.DataVersionElectra:
+			att.Electra.CommitteeBits = committeeBits
+		case spec.DataVersionFulu:
+			att.Fulu.CommitteeBits = committeeBits
+		}
+	}
+	return att
 }
 
 func requireAggregateAndProof(

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -174,6 +174,7 @@ func TestSubmitAggregateSelectionProof_PrefersAttestedDataRoot(t *testing.T) {
 		epoch   phase0.Epoch
 	}{
 		{name: "electra committee comes from committee bits", version: spec.DataVersionElectra, epoch: 5},
+		{name: "fulu committee comes from committee bits", version: spec.DataVersionFulu, epoch: 6},
 		{name: "pre-electra committee comes from data index", version: spec.DataVersionPhase0, epoch: 0},
 	}
 
@@ -312,15 +313,19 @@ func aggregatorVersionedAttestation(version spec.DataVersion, data *phase0.Attes
 // it: pre-Electra the committee is the data's Index, Electra+ it's the set committee bit.
 func attestedVersionedAttestation(version spec.DataVersion, data *phase0.AttestationData, committee phase0.CommitteeIndex) *spec.VersionedAttestation {
 	att := aggregatorVersionedAttestation(version, data)
-	if version >= spec.DataVersionElectra {
-		committeeBits := bitfield.NewBitvector64()
-		committeeBits.SetBitAt(uint64(committee), true)
-		switch version {
-		case spec.DataVersionElectra:
-			att.Electra.CommitteeBits = committeeBits
-		case spec.DataVersionFulu:
-			att.Fulu.CommitteeBits = committeeBits
-		}
+	if version < spec.DataVersionElectra {
+		return att
+	}
+
+	committeeBits := bitfield.NewBitvector64()
+	committeeBits.SetBitAt(uint64(committee), true)
+	switch version {
+	case spec.DataVersionElectra:
+		att.Electra.CommitteeBits = committeeBits
+	case spec.DataVersionFulu:
+		att.Fulu.CommitteeBits = committeeBits
+	default:
+		panic("unsupported electra+ version")
 	}
 	return att
 }

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -565,17 +565,17 @@ func (gc *GoClient) SubmitAttestations(ctx context.Context, attestations []*spec
 		}); err != nil {
 			return err
 		}
-		gc.rememberAttestedDataRoots(attestations)
-		return nil
+	} else {
+		start := time.Now()
+		err := gc.multiClient.SubmitAttestations(ctx, opts)
+		recordRequest(ctx, gc.log, "SubmitAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
+		if err != nil {
+			return errMultiClient(fmt.Errorf("submit attestations: %w", err), "SubmitAttestations")
+		}
 	}
 
-	start := time.Now()
-	err := gc.multiClient.SubmitAttestations(ctx, opts)
-	recordRequest(ctx, gc.log, "SubmitAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
-	if err != nil {
-		return errMultiClient(fmt.Errorf("submit attestations: %w", err), "SubmitAttestations")
-	}
-
+	// Only reached when at least one client accepted the attestations, so the beacon node
+	// holds them — remember their data roots for the aggregator flow.
 	gc.rememberAttestedDataRoots(attestations)
 	return nil
 }
@@ -638,5 +638,6 @@ func attestationCommitteeIndex(att *spec.VersionedAttestation, data *phase0.Atte
 	if len(indices) != 1 {
 		return 0, fmt.Errorf("expected exactly one committee bit, got %d", len(indices))
 	}
-	return phase0.CommitteeIndex(indices[0]), nil
+	// A bit index is a position within a 64-bit vector, so it is always non-negative.
+	return phase0.CommitteeIndex(indices[0]), nil //nolint:gosec
 }

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -560,9 +560,13 @@ func (gc *GoClient) multiClientSubmit(
 func (gc *GoClient) SubmitAttestations(ctx context.Context, attestations []*spec.VersionedAttestation) error {
 	opts := &api.SubmitAttestationsOpts{Attestations: attestations}
 	if gc.withParallelSubmissions {
-		return gc.multiClientSubmit(ctx, "SubmitAttestations", func(ctx context.Context, client Client) error {
+		if err := gc.multiClientSubmit(ctx, "SubmitAttestations", func(ctx context.Context, client Client) error {
 			return client.SubmitAttestations(ctx, opts)
-		})
+		}); err != nil {
+			return err
+		}
+		gc.rememberAttestedDataRoots(attestations)
+		return nil
 	}
 
 	start := time.Now()
@@ -572,5 +576,67 @@ func (gc *GoClient) SubmitAttestations(ctx context.Context, attestations []*spec
 		return errMultiClient(fmt.Errorf("submit attestations: %w", err), "SubmitAttestations")
 	}
 
+	gc.rememberAttestedDataRoots(attestations)
 	return nil
+}
+
+// attestedDataRootKey identifies the attestation data a validator attested with; pre-Electra
+// each committee signs different data (the committee is part of it as Index), so the
+// committee belongs in the key.
+type attestedDataRootKey struct {
+	slot      phase0.Slot
+	committee phase0.CommitteeIndex
+}
+
+// rememberAttestedDataRoots caches the root of the attestation data that was just submitted,
+// per (slot, committee). The aggregator flow prefers this root over re-deriving the data:
+// the beacon node holds at least our own attestation matching it, so an aggregate must
+// exist, while a re-derived root may match nothing anyone attested with.
+func (gc *GoClient) rememberAttestedDataRoots(attestations []*spec.VersionedAttestation) {
+	for _, att := range attestations {
+		data, err := att.Data()
+		if err != nil {
+			gc.log.Debug("could not extract attestation data", zap.Error(err))
+			continue
+		}
+		committee, err := attestationCommitteeIndex(att, data)
+		if err != nil {
+			gc.log.Debug("could not extract attestation committee index", zap.Error(err))
+			continue
+		}
+		root, err := data.HashTreeRoot()
+		if err != nil {
+			gc.log.Debug("could not hash attestation data", zap.Error(err))
+			continue
+		}
+		key := attestedDataRootKey{slot: data.Slot, committee: committee}
+		gc.attestedDataRootCache.Set(key, root, ttlcache.DefaultTTL)
+	}
+}
+
+// attestedDataRoot returns the root of the attestation data this node submitted for the
+// given slot and committee, if known.
+func (gc *GoClient) attestedDataRoot(slot phase0.Slot, committee phase0.CommitteeIndex) (phase0.Root, bool) {
+	item := gc.attestedDataRootCache.Get(attestedDataRootKey{slot: slot, committee: committee})
+	if item == nil {
+		return phase0.Root{}, false
+	}
+	return item.Value(), true
+}
+
+// attestationCommitteeIndex extracts the committee an attestation belongs to: from the
+// committee bits for Electra and later (EIP-7549), from the data's Index field before.
+func attestationCommitteeIndex(att *spec.VersionedAttestation, data *phase0.AttestationData) (phase0.CommitteeIndex, error) {
+	if att.Version < spec.DataVersionElectra {
+		return data.Index, nil
+	}
+	bits, err := att.CommitteeBits()
+	if err != nil {
+		return 0, err
+	}
+	indices := bits.BitIndices()
+	if len(indices) != 1 {
+		return 0, fmt.Errorf("expected exactly one committee bit, got %d", len(indices))
+	}
+	return phase0.CommitteeIndex(indices[0]), nil
 }

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -525,12 +525,18 @@ func weightedAttestationDataRequestIDField(id uuid.UUID) zap.Field {
 }
 
 // multiClientSubmit is a generic function that submits data to multiple beacon clients concurrently.
-// Returns nil if at least one client successfully submitted the data.
+// Returns nil only if at least one client successfully submitted the data.
 func (gc *GoClient) multiClientSubmit(
 	ctx context.Context,
 	routeName string,
 	submitFunc func(ctx context.Context, client Client) error,
 ) error {
+	if len(gc.clients) == 0 {
+		// No clients to submit to. Guard explicitly: WithMaxGoroutines(0) below would panic, and
+		// returning nil would break the "nil only on success" contract — callers such as the
+		// attested-data-root cache would then treat a non-submission as a success.
+		return errMultiClient(fmt.Errorf("no clients available to submit"), routeName)
+	}
 	submissions := atomic.Int32{}
 	p := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(len(gc.clients))
 	for _, client := range gc.clients {
@@ -550,10 +556,9 @@ func (gc *GoClient) multiClientSubmit(
 		// At least one client has submitted successfully, so we can return without error.
 		return nil
 	}
-	if err != nil {
-		return errMultiClient(fmt.Errorf("all clients failed to submit: %w", err), routeName)
-	}
-	return nil
+	// With at least one client, zero successful submissions means every client errored, so
+	// p.Wait() returned a non-nil error.
+	return errMultiClient(fmt.Errorf("all clients failed to submit: %w", err), routeName)
 }
 
 // SubmitAttestations implements Beacon interface and sends attestations to the first client that succeeds

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -128,7 +128,9 @@ type GoClient struct {
 	// data regardless of the requested committeeIndex.
 	attestationDataCache *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
 	// attestedDataRootCache remembers the root of the attestation data this node actually
-	// submitted, per (slot, committee), for reuse by the aggregator flow.
+	// submitted (the cluster-decided value), per (slot, committee), for the aggregator flow.
+	// Unlike attestationDataCache — this node's local, pre-consensus view — this is the value
+	// the cluster attested with, which is the one an aggregate must match.
 	attestedDataRootCache *ttlcache.Cache[attestedDataRootKey, phase0.Root]
 	// domainDataReqInflight joins parallel requests for the same epoch/domain pair.
 	domainDataReqInflight singleflight.Group[domainDataCacheKey, phase0.Domain]

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -127,6 +127,9 @@ type GoClient struct {
 	// AttestationData is cached by slot only, because Beacon nodes should return the same
 	// data regardless of the requested committeeIndex.
 	attestationDataCache *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
+	// attestedDataRootCache remembers the root of the attestation data this node actually
+	// submitted, per (slot, committee), for reuse by the aggregator flow.
+	attestedDataRootCache *ttlcache.Cache[attestedDataRootKey, phase0.Root]
 	// domainDataReqInflight joins parallel requests for the same epoch/domain pair.
 	domainDataReqInflight singleflight.Group[domainDataCacheKey, phase0.Domain]
 	// domainDataCache helps reuse recently fetched domains. Domains change only at epoch boundaries,
@@ -251,6 +254,13 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 
 	// Start automatic expired item deletion for attestationDataCache.
 	go client.attestationDataCache.Start()
+
+	client.attestedDataRootCache = ttlcache.New(
+		// aggregates are requested during the duty slot (and never later),
+		// hence caching the attested roots for 2 slots is sufficient
+		ttlcache.WithTTL[attestedDataRootKey, phase0.Root](2 * config.SlotDuration),
+	)
+	go client.attestedDataRootCache.Start()
 
 	// Domain data and committee assignments change at epoch boundaries, so keep both caches
 	// for approximately two epochs.


### PR DESCRIPTION
## Problem

`AGGREGATOR` duties occasionally fail with the beacon node reporting it has nothing to aggregate:

```
failed to submit aggregate and proof: multi-client request -> AggregateAttestation: fetch aggregate attestation: GET failed with status 404: {"code":404,"message":"No aggregated attestation for slot=3252713, dataRoot=0x22f764f9d98f16164e69a1abeb030d313c678711e6227a35246962211d772585, committeeIndex=21"}
```

Observed on Hoodi at slot 3252713 — a normal, finalized slot, so the aggregate genuinely didn't exist *for the requested root*. `SubmitAggregateSelectionProof` re-derives attestation data at 2/3 of the slot via `GetAttestationData` and requests an aggregate for its root. That data is this node's local view (typically served from the attestation-data cache populated at ~1/3 of the slot) — not necessarily what the cluster's QBFT consensus decided and attested with. When head views diverge mid-slot, the re-derived root can match nothing anyone attested with, and the beacon node correctly answers 404, failing the duty for the whole cluster.

## Fix

Per the consensus spec, the aggregate must match the aggregator's **own attestation data**. The decided data already flows through goclient in `SubmitAttestations`, so:

- `SubmitAttestations` now remembers the hash-tree-root of each submitted attestation's data, keyed by (slot, committee) — the committee is in the key because pre-Electra the committee index is part of the data (post-Electra the index is 0, per EIP-7549).
- `SubmitAggregateSelectionProof` requests the aggregate for that remembered root. The beacon node holds at least our own attestation matching it, so a matching aggregate must exist.
- If no attested root is known (attestation failed or hasn't landed by 2/3 of the slot), it falls back to the previous re-derivation behavior unchanged.

Known accepted imprecision: if two clusters on the same node share a (slot, committee) and their QBFT instances decided different roots (requires diverging leader views in the same slot), last submission wins — the requested root is still one this node attested with, so an aggregate still exists.

## Tests

- New `TestSubmitAggregateSelectionProof_PrefersAttestedDataRoot` covers the Electra (committee bits) and pre-Electra (data index) paths, asserting the aggregate is requested for the submitted root without re-deriving attestation data.
- The existing fork-matrix test now exercises the fallback path (no prior submission) with unchanged assertions.

- [ ] E2E passed - [action log](put link here)