### PR TITLE
feat(exporter): remove standard mode, add optional duty-trace retention

### DIFF
--- a/cli/operator/config.go
+++ b/cli/operator/config.go
@@ -68,9 +68,8 @@ const maxSafeProposerDelay = 1000 * time.Millisecond
 type nodeMode int
 
 const (
-	modeOperator         nodeMode = iota // not an exporter
-	modeExporterStandard                 // exporter, standard tracing
-	modeExporterArchive                  // exporter, archive tracing (pre-consensus + consensus)
+	modeOperator nodeMode = iota // not an exporter
+	modeExporter                 // exporter (full duty tracing: pre-consensus + consensus + post-consensus)
 )
 
 // resolved carries config-derived state computed by resolveAndValidate (not operator-provided):
@@ -136,11 +135,7 @@ func (c *config) resolveAndValidate(logger *zap.Logger) (resolved, error) {
 
 	// Resolve the operating mode last so a doubly-misconfigured node still surfaces the signing
 	// or proposer-delay error first.
-	m, err := resolveMode(c.ExporterOptions)
-	if err != nil {
-		return resolved{}, err
-	}
-	res.mode = m
+	res.mode = resolveMode(c.ExporterOptions)
 
 	return res, nil
 }
@@ -218,21 +213,14 @@ func (c *config) resolveSigning() (resolved, error) {
 	return res, nil
 }
 
-// resolveMode derives the node's operating mode from the exporter options, rejecting an
-// unrecognized EXPORTER_MODE up front (fail-fast). A non-exporter node is always modeOperator,
-// regardless of the (then-irrelevant) EXPORTER_MODE.
-func resolveMode(opts exporter.Options) (nodeMode, error) {
+// resolveMode derives the node's operating mode from the exporter options. An enabled exporter
+// always runs in full duty-tracing mode; a non-exporter node is modeOperator. (The legacy
+// standard/archive EXPORTER_MODE distinction was removed — exporters are always full tracers.)
+func resolveMode(opts exporter.Options) nodeMode {
 	if !opts.Enabled {
-		return modeOperator, nil
+		return modeOperator
 	}
-	switch opts.Mode {
-	case exporter.ModeStandard:
-		return modeExporterStandard, nil
-	case exporter.ModeArchive:
-		return modeExporterArchive, nil
-	default:
-		return modeOperator, fmt.Errorf("invalid exporter mode %q (must be %q or %q)", opts.Mode, exporter.ModeStandard, exporter.ModeArchive)
-	}
+	return modeExporter
 }
 
 // warnExporterSigning warns when signing configuration is provided in exporter mode (where it

--- a/cli/operator/config.go
+++ b/cli/operator/config.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
@@ -64,7 +65,7 @@ const maxSafeProposerDelay = 1000 * time.Millisecond
 
 // nodeMode is the resolved operating mode of the node, derived once from ExporterOptions by
 // resolveAndValidate so startup can dispatch on a typed value instead of re-deriving the mode
-// from ExporterOptions.Enabled / .Mode at each site.
+// from ExporterOptions.Enabled at each site.
 type nodeMode int
 
 const (
@@ -136,6 +137,9 @@ func (c *config) resolveAndValidate(logger *zap.Logger) (resolved, error) {
 	// Resolve the operating mode last so a doubly-misconfigured node still surfaces the signing
 	// or proposer-delay error first.
 	res.mode = resolveMode(c.ExporterOptions)
+	if res.mode != modeOperator {
+		warnDeprecatedExporterEnv(logger)
+	}
 
 	return res, nil
 }
@@ -221,6 +225,19 @@ func resolveMode(opts exporter.Options) nodeMode {
 		return modeOperator
 	}
 	return modeExporter
+}
+
+// warnDeprecatedExporterEnv flags removed exporter env vars (set via a pre-existing deployment) so
+// operators notice a stale value is now ignored: exporters always run full duty tracing, and
+// retention moved from slots to EXPORTER_RETAIN_EPOCHS. Best-effort — only env vars are checked,
+// not equivalent YAML keys (cleanenv silently drops unknown fields).
+func warnDeprecatedExporterEnv(logger *zap.Logger) {
+	for _, env := range []string{"EXPORTER_MODE", "EXPORTER_RETAIN_SLOTS"} {
+		if v, ok := os.LookupEnv(env); ok {
+			logger.Warn("ignoring removed exporter config option; exporters always run full duty tracing — use EXPORTER_RETAIN_EPOCHS for retention",
+				zap.String("env", env), zap.String("value", v))
+		}
+	}
 }
 
 // warnExporterSigning warns when signing configuration is provided in exporter mode (where it

--- a/cli/operator/config_test.go
+++ b/cli/operator/config_test.go
@@ -419,6 +419,19 @@ func Test_resolveMode(t *testing.T) {
 	require.Equal(t, modeExporter, resolveMode(exporter.Options{Enabled: true}))
 }
 
+// Test_warnDeprecatedExporterEnv verifies a stale, now-removed exporter env var is flagged rather
+// than silently ignored.
+func Test_warnDeprecatedExporterEnv(t *testing.T) {
+	t.Setenv("EXPORTER_MODE", "archive")
+	t.Setenv("EXPORTER_RETAIN_SLOTS", "50400")
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	warnDeprecatedExporterEnv(zap.New(core))
+
+	require.Equal(t, 1, logs.FilterField(zap.String("env", "EXPORTER_MODE")).Len())
+	require.Equal(t, 1, logs.FilterField(zap.String("env", "EXPORTER_RETAIN_SLOTS")).Len())
+}
+
 func Test_warnIfSSVAPIAddressUnset(t *testing.T) {
 	t.Parallel()
 

--- a/cli/operator/config_test.go
+++ b/cli/operator/config_test.go
@@ -118,8 +118,9 @@ func Test_resolveAndValidate_signingErrorContext(t *testing.T) {
 	}
 }
 
-// Test_resolveAndValidate_mode verifies the operating mode is resolved into the result and that
-// an invalid EXPORTER_MODE fails validation up front.
+// Test_resolveAndValidate_mode verifies the operating mode is resolved into the result: a
+// non-exporter is modeOperator, and an enabled exporter is modeExporter (full duty tracing). The
+// legacy standard/archive EXPORTER_MODE validation was removed along with the mode itself.
 func Test_resolveAndValidate_mode(t *testing.T) {
 	t.Run("non-exporter -> modeOperator", func(t *testing.T) {
 		c := config{}

--- a/cli/operator/config_test.go
+++ b/cli/operator/config_test.go
@@ -22,10 +22,6 @@ import (
 const (
 	testSignerEndpoint = "http://signer:9000"
 	testOperatorKey    = "super-secret-operator-key"
-
-	// substring of resolveMode's error for an unrecognized EXPORTER_MODE (kept as a const so
-	// the repeated assertion doesn't trip goconst).
-	msgInvalidExporterMode = "invalid exporter mode"
 )
 
 func Test_config_load(t *testing.T) {
@@ -133,22 +129,12 @@ func Test_resolveAndValidate_mode(t *testing.T) {
 		require.Equal(t, modeOperator, res.mode)
 	})
 
-	t.Run("exporter archive -> modeExporterArchive", func(t *testing.T) {
+	t.Run("exporter -> modeExporter", func(t *testing.T) {
 		c := config{}
 		c.ExporterOptions.Enabled = true
-		c.ExporterOptions.Mode = exporter.ModeArchive
 		res, err := c.resolveAndValidate(zap.NewNop())
 		require.NoError(t, err)
-		require.Equal(t, modeExporterArchive, res.mode)
-	})
-
-	t.Run("invalid exporter mode -> error", func(t *testing.T) {
-		c := config{}
-		c.ExporterOptions.Enabled = true
-		c.ExporterOptions.Mode = "bogus"
-		_, err := c.resolveAndValidate(zap.NewNop())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), msgInvalidExporterMode)
+		require.Equal(t, modeExporter, res.mode)
 	})
 }
 
@@ -425,36 +411,11 @@ func Test_resolveSigning(t *testing.T) {
 	}
 }
 
-// Test_resolveMode covers operating-mode resolution and the fail-fast rejection of an
-// unrecognized EXPORTER_MODE.
+// Test_resolveMode covers operating-mode resolution: an enabled exporter resolves to modeExporter
+// (full duty tracing), everything else to modeOperator.
 func Test_resolveMode(t *testing.T) {
-	tests := []struct {
-		name    string
-		enabled bool
-		mode    string
-		want    nodeMode
-		wantErr string
-	}{
-		{name: "not exporter -> operator", enabled: false, mode: "", want: modeOperator},
-		{name: "not exporter ignores mode -> operator", enabled: false, mode: exporter.ModeArchive, want: modeOperator},
-		{name: "exporter standard", enabled: true, mode: exporter.ModeStandard, want: modeExporterStandard},
-		{name: "exporter archive", enabled: true, mode: exporter.ModeArchive, want: modeExporterArchive},
-		{name: "exporter invalid -> error", enabled: true, mode: "bogus", wantErr: msgInvalidExporterMode},
-		{name: "exporter empty mode -> error", enabled: true, mode: "", wantErr: msgInvalidExporterMode},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveMode(exporter.Options{Enabled: tt.enabled, Mode: tt.mode})
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
+	require.Equal(t, modeOperator, resolveMode(exporter.Options{Enabled: false}))
+	require.Equal(t, modeExporter, resolveMode(exporter.Options{Enabled: true}))
 }
 
 func Test_warnIfSSVAPIAddressUnset(t *testing.T) {

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -381,7 +381,7 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 	// subset.) RetainEpochs bounds on-disk trace history; 0 (default) retains indefinitely.
 	var collector *dutytracer.Collector
 	if res.isExporter() {
-		retainSlots := cfg.ExporterOptions.RetainEpochs * networkConfig.Beacon.SlotsPerEpoch
+		retainSlots := cfg.ExporterOptions.RetainEpochs * networkConfig.SlotsPerEpoch
 		logger.Info("exporter enabled (full duty tracing)",
 			zap.Uint64("retain_epochs", cfg.ExporterOptions.RetainEpochs),
 			zap.Uint64("retain_slots", retainSlots))

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -8,10 +8,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
@@ -359,12 +357,6 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 		})
 	}
 
-	if res.mode == modeExporterStandard {
-		retain := cfg.ExporterOptions.RetainSlots
-		threshold := networkConfig.EstimatedCurrentSlot()
-		initSlotPruning(ctx, storageMap, slotTickerProvider, threshold, retain)
-	}
-
 	fixedSubnets, err := networkcommons.SubnetsFromString(cfg.P2pNetworkConfig.Subnets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse fixed subnets: %w", err)
@@ -383,12 +375,16 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 		metadata.WithSyncInterval(cfg.SSVOptions.ValidatorOptions.MetadataUpdateInterval),
 	)
 
-	// Exporter duty tracing. An invalid EXPORTER_MODE is rejected up front by resolveAndValidate,
-	// so res.mode here is always one of the known modes.
+	// Exporter duty tracing. Exporters always run full duty tracing — collecting pre-consensus,
+	// consensus, and post-consensus steps and serving them via the read API. (The legacy
+	// standard/archive EXPORTER_MODE distinction was removed; "standard" was a strict, and broken,
+	// subset.) RetainEpochs bounds on-disk trace history; 0 (default) retains indefinitely.
 	var collector *dutytracer.Collector
-	switch res.mode {
-	case modeExporterArchive:
-		logger.Info("exporter mode: archive")
+	if res.isExporter() {
+		retainSlots := cfg.ExporterOptions.RetainEpochs * networkConfig.Beacon.SlotsPerEpoch
+		logger.Info("exporter enabled (full duty tracing)",
+			zap.Uint64("retain_epochs", cfg.ExporterOptions.RetainEpochs),
+			zap.Uint64("retain_slots", retainSlots))
 		dstore := &dutytracer.DutyTraceStoreMetrics{
 			Store: dutytracestore.New(db),
 		}
@@ -397,12 +393,8 @@ func newNode(ctx context.Context, cfg *config, logger *zap.Logger, res resolved,
 			dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 			dutyStore)
 
-		go collector.Start(ctx, slotTickerProvider)
+		go collector.Start(ctx, slotTickerProvider, retainSlots)
 		cfg.SSVOptions.ExporterRead = exporter2.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
-	case modeExporterStandard:
-		logger.Info("exporter mode: standard")
-	case modeOperator:
-		// not an exporter: no duty-trace collector
 	}
 
 	doppelgangerHandler := buildDoppelganger(logger, cfg, res, networkConfig.Beacon, consensusClient, validatorProvider, slotTickerProvider)
@@ -597,7 +589,7 @@ func (n *node) start() error {
 				Shares: n.nodeStorage.Shares(),
 			},
 			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore()),
-			n.mode == modeExporterArchive,
+			n.mode == modeExporter,
 		)
 		_, apiServeErr, err := apiServer.Start(n.ctx)
 		if err != nil {
@@ -662,30 +654,6 @@ func setupOperatorDataStore(
 	}
 
 	return operatordatastore.New(operatorData), nil
-}
-
-func initSlotPruning(ctx context.Context, stores *ibftstorage.ParticipantStores, slotTickerProvider slotticker.Provider, slot phase0.Slot, retain uint64) {
-	var wg sync.WaitGroup
-
-	threshold := slot - phase0.Slot(retain)
-
-	// async perform initial slot gc
-	_ = stores.Each(func(_ spectypes.BeaconRole, store ibftstorage.ParticipantStore) error {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			store.Prune(ctx, threshold)
-		}()
-		return nil
-	})
-
-	wg.Wait()
-
-	// start background job for removing old slots on every tick
-	_ = stores.Each(func(_ spectypes.BeaconRole, store ibftstorage.ParticipantStore) error {
-		go store.PruneContinuously(ctx, slotTickerProvider, phase0.Slot(retain))
-		return nil
-	})
 }
 
 // buildDoppelganger returns the node's doppelganger-protection provider: a no-op for exporter nodes

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ssvlabs/ssv/doppelganger"
 	"github.com/ssvlabs/ssv/eth/executionclient"
-	"github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/hprobe"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -126,19 +125,15 @@ func Test_newNode_wiresOperatorNode(t *testing.T) {
 	}
 }
 
-// Test_newNode_wiresExporterNode mirrors the operator smoke test for the exporter paths: with no
-// signing identity, it asserts newNode() wires the graph for both exporter modes and that the
-// mode-specific divergences hold — no key manager in either, and a duty-trace collector only in
-// archive mode.
+// Test_newNode_wiresExporterNode mirrors the operator smoke test for the exporter path: with no
+// signing identity, it asserts newNode() wires the graph for an exporter node — no key manager,
+// and a duty-trace collector (exporters always run full duty tracing).
 func Test_newNode_wiresExporterNode(t *testing.T) {
 	for _, tc := range []struct {
-		name          string
-		mode          nodeMode
-		exporterMode  string
-		wantCollector bool
+		name string
+		mode nodeMode
 	}{
-		{name: "standard", mode: modeExporterStandard, exporterMode: exporter.ModeStandard, wantCollector: false},
-		{name: "archive", mode: modeExporterArchive, exporterMode: exporter.ModeArchive, wantCollector: true},
+		{name: "exporter", mode: modeExporter},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -152,7 +147,6 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 			cfg := &config{}
 			cfg.DBOptions.Path = t.TempDir()
 			cfg.ExporterOptions.Enabled = true
-			cfg.ExporterOptions.Mode = tc.exporterMode
 			cfg.MetricsAPIPort = 0
 			cfg.SSVAPIPort = 0
 			cfg.WsAPIPort = 0
@@ -170,11 +164,7 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 			require.NotNil(t, a.operatorNode)
 			require.Nil(t, a.keyManager, "exporter nodes have no key manager")
 
-			if tc.wantCollector {
-				require.NotNil(t, a.collector, "archive mode wires a duty-trace collector")
-			} else {
-				require.Nil(t, a.collector, "standard mode has no duty-trace collector")
-			}
+			require.NotNil(t, a.collector, "exporter wires a duty-trace collector")
 
 			require.NoError(t, a.Close())
 		})

--- a/exporter/opts.go
+++ b/exporter/opts.go
@@ -1,12 +1,6 @@
 package exporter
 
 type Options struct {
-	Enabled     bool   `yaml:"Enabled" env:"EXPORTER" env-default:"false" env-description:"Enable exporter mode to track post-consensus participations"`
-	Mode        string `yaml:"Mode" env:"EXPORTER_MODE" env-default:"standard" env-description:"Set to 'archive' to also track pre-consensus and consensus steps. Defaults to 'standard'"`
-	RetainSlots uint64 `yaml:"RetainSlots" env:"EXPORTER_RETAIN_SLOTS" env-default:"50400" env-description:"Number of slots to retain in export data"`
+	Enabled      bool   `yaml:"Enabled" env:"EXPORTER" env-default:"false" env-description:"Enable exporter mode to track validator duties and network consensus participation (full duty tracing)"`
+	RetainEpochs uint64 `yaml:"RetainEpochs" env:"EXPORTER_RETAIN_EPOCHS" env-default:"0" env-description:"Number of epochs of duty-trace history to retain; 0 (default) retains indefinitely"`
 }
-
-const (
-	ModeArchive  = "archive"
-	ModeStandard = "standard"
-)

--- a/exporter/opts.go
+++ b/exporter/opts.go
@@ -2,5 +2,5 @@ package exporter
 
 type Options struct {
 	Enabled      bool   `yaml:"Enabled" env:"EXPORTER" env-default:"false" env-description:"Enable exporter mode to track validator duties and network consensus participation (full duty tracing)"`
-	RetainEpochs uint64 `yaml:"RetainEpochs" env:"EXPORTER_RETAIN_EPOCHS" env-default:"0" env-description:"Number of epochs of duty-trace history to retain; 0 (default) retains indefinitely"`
+	RetainEpochs uint64 `yaml:"RetainEpochs" env:"EXPORTER_RETAIN_EPOCHS" env-default:"0" env-description:"Best-effort retention: prune on-disk duty traces older than this many epochs. 0 (default) retains indefinitely. Enforced forward from process start — history that ages out while the node is down is not reclaimed after a restart"`
 }

--- a/exporter/store/store.go
+++ b/exporter/store/store.go
@@ -369,8 +369,8 @@ func (s *DutyTraceStore) PruneSlot(slot phase0.Slot) error {
 	if err := s.db.DropPrefix(s.makeValidatorCommitteePrefix(slot)); err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("prune validator-committee links (slot=%d): %w", slot, err))
 	}
-	if err := s.DeleteScheduledSlot(slot); err != nil {
-		errs = multierror.Append(errs, err)
+	if err := s.db.DropPrefix(s.makeScheduledSlotPrefix(slot)); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("prune scheduled duties (slot=%d): %w", slot, err))
 	}
 	return errs.ErrorOrNil()
 }
@@ -478,6 +478,14 @@ func (s *DutyTraceStore) makeCommitteePrefix(slot phase0.Slot, id spectypes.Comm
 func (s *DutyTraceStore) makeValidatorCommitteePrefix(slot phase0.Slot) []byte {
 	prefix := make([]byte, 0, len(validatorCommitteeIndexKey)+4)
 	prefix = append(prefix, []byte(validatorCommitteeIndexKey)...)
+	return append(prefix, slotToByteSlice(slot)...)
+}
+
+// makeScheduledSlotPrefix returns the "sd"+slot prefix covering every role's scheduled bitmap for a
+// slot, so a slot's scheduled data is dropped in a single prefix delete during pruning.
+func (s *DutyTraceStore) makeScheduledSlotPrefix(slot phase0.Slot) []byte {
+	prefix := make([]byte, 0, len(scheduledDutyKey)+slotKeyLen)
+	prefix = append(prefix, []byte(scheduledDutyKey)...)
 	return append(prefix, slotToByteSlice(slot)...)
 }
 

--- a/exporter/store/store.go
+++ b/exporter/store/store.go
@@ -354,6 +354,27 @@ func (s *DutyTraceStore) DeleteScheduledSlot(slot phase0.Slot) error {
 	return errs.ErrorOrNil()
 }
 
+// PruneSlot removes all duty-trace data for a single slot: validator duties (all roles/indices),
+// committee duties (all committees), validator->committee links, and scheduled-role bitmaps. It
+// backs the exporter's optional retention window (EXPORTER_RETAIN_EPOCHS). Keys are slot-prefixed,
+// so each group is removed with a single prefix drop.
+func (s *DutyTraceStore) PruneSlot(slot phase0.Slot) error {
+	var errs *multierror.Error
+	if err := s.db.DropPrefix(s.makeValidatorSlotPrefix(slot)); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("prune validator duties (slot=%d): %w", slot, err))
+	}
+	if err := s.db.DropPrefix(s.makeCommitteeSlotPrefix(slot)); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("prune committee duties (slot=%d): %w", slot, err))
+	}
+	if err := s.db.DropPrefix(s.makeValidatorCommitteePrefix(slot)); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("prune validator-committee links (slot=%d): %w", slot, err))
+	}
+	if err := s.DeleteScheduledSlot(slot); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+	return errs.ErrorOrNil()
+}
+
 // SaveScheduled stores a compact map (validator index -> role mask) for a slot.
 func (s *DutyTraceStore) SaveScheduled(slot phase0.Slot, schedule map[phase0.ValidatorIndex]rolemask.Mask) error {
 	if len(schedule) == 0 {
@@ -429,6 +450,14 @@ func (s *DutyTraceStore) makeValidatorPrefix(slot phase0.Slot, role spectypes.Be
 		prefix = append(prefix, uInt64ToByteSlice(uint64(index[0]))...)
 	}
 	return prefix
+}
+
+// makeValidatorSlotPrefix returns the "vd"+slot prefix covering all roles and validator indices
+// for a slot (used to drop an entire slot's validator duties at once during pruning).
+func (s *DutyTraceStore) makeValidatorSlotPrefix(slot phase0.Slot) []byte {
+	prefix := make([]byte, 0, len(validatorDutyTraceKey)+slotKeyLen)
+	prefix = append(prefix, []byte(validatorDutyTraceKey)...)
+	return append(prefix, slotToByteSlice(slot)...)
 }
 
 func (s *DutyTraceStore) makeCommitteeSlotPrefix(slot phase0.Slot) []byte {

--- a/exporter/store/store_test.go
+++ b/exporter/store/store_test.go
@@ -298,6 +298,18 @@ func TestPruneSlot(t *testing.T) {
 	require.Len(t, sched, 1)
 }
 
+// TestPruneSlot_DBError exercises PruneSlot's error aggregation: a closed DB makes every prefix
+// drop fail, and PruneSlot must surface a (combined) error rather than silently succeeding.
+func TestPruneSlot_DBError(t *testing.T) {
+	logger := zap.NewNop()
+	db, err := kv.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+	require.NoError(t, db.Close()) // subsequent DropPrefix/Delete calls now fail
+
+	s := store.New(db)
+	require.Error(t, s.PruneSlot(1))
+}
+
 func TestAddScheduledRole_UnionsIndices(t *testing.T) {
 	logger := zap.NewNop()
 	db, err := kv.NewInMemory(logger, basedb.Options{})

--- a/exporter/store/store_test.go
+++ b/exporter/store/store_test.go
@@ -240,19 +240,31 @@ func TestPruneSlot(t *testing.T) {
 	const prune = phase0.Slot(1)
 	const keep = phase0.Slot(2)
 
+	// Validator duties span multiple roles/indices so we prove the whole "vd"+slot keyspace is
+	// dropped, not just the attester example.
+	roles := []spectypes.BeaconRole{spectypes.BNRoleAttester, spectypes.BNRoleProposer, spectypes.BNRoleSyncCommittee}
+
 	// Populate every trace kind at both the slot to prune and an adjacent slot to keep.
 	for _, slot := range []phase0.Slot{prune, keep} {
-		require.NoError(t, s.SaveValidatorDuty(makeVTrace(slot)))
+		for i, role := range roles {
+			require.NoError(t, s.SaveValidatorDuty(&exporter.ValidatorDutyTrace{
+				Slot: slot, Role: role, Validator: phase0.ValidatorIndex(100 + i),
+			}))
+		}
 		require.NoError(t, s.SaveCommitteeDuty(makeCTrace(slot, 'a')))
+		require.NoError(t, s.SaveCommitteeDuty(makeCTrace(slot, 'b')))
 		require.NoError(t, s.SaveCommitteeDutyLinks(slot, map[phase0.ValidatorIndex]spectypes.CommitteeID{1: {1, 1, 1}}))
-		require.NoError(t, s.SaveScheduled(slot, map[phase0.ValidatorIndex]rolemask.Mask{1: rolemask.BitAttester}))
+		require.NoError(t, s.SaveScheduled(slot, map[phase0.ValidatorIndex]rolemask.Mask{1: rolemask.BitAttester | rolemask.BitProposer}))
 	}
 
 	require.NoError(t, s.PruneSlot(prune))
 
-	// Pruned slot: every trace kind is gone.
-	_, err = s.GetValidatorDuty(prune, spectypes.BNRoleAttester, phase0.ValidatorIndex(39393))
-	require.Error(t, err, "validator duty should be pruned")
+	// Pruned slot: every trace kind is gone, across all validator roles.
+	for _, role := range roles {
+		vds, err := s.GetValidatorDuties(role, prune)
+		require.NoError(t, err)
+		require.Empty(t, vds, "validator duties for role %v should be pruned", role)
+	}
 
 	cds, err := s.GetCommitteeDuties(prune)
 	require.NoError(t, err)
@@ -266,13 +278,16 @@ func TestPruneSlot(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, sched, "scheduled duties should be pruned")
 
-	// Adjacent slot is untouched.
-	_, err = s.GetValidatorDuty(keep, spectypes.BNRoleAttester, phase0.ValidatorIndex(39393))
-	require.NoError(t, err)
+	// Adjacent slot is untouched, across all validator roles.
+	for _, role := range roles {
+		vds, err := s.GetValidatorDuties(role, keep)
+		require.NoError(t, err)
+		require.Len(t, vds, 1, "validator duties for role %v should be retained", role)
+	}
 
 	cds, err = s.GetCommitteeDuties(keep)
 	require.NoError(t, err)
-	require.Len(t, cds, 1)
+	require.Len(t, cds, 2)
 
 	links, err = s.GetCommitteeDutyLinks(keep)
 	require.NoError(t, err)

--- a/exporter/store/store_test.go
+++ b/exporter/store/store_test.go
@@ -229,6 +229,60 @@ func TestSaveScheduledDuties(t *testing.T) {
 	assert.ElementsMatch(t, []phase0.ValidatorIndex{2}, syncers)
 }
 
+func TestPruneSlot(t *testing.T) {
+	logger := zap.NewNop()
+	db, err := kv.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := store.New(db)
+
+	const prune = phase0.Slot(1)
+	const keep = phase0.Slot(2)
+
+	// Populate every trace kind at both the slot to prune and an adjacent slot to keep.
+	for _, slot := range []phase0.Slot{prune, keep} {
+		require.NoError(t, s.SaveValidatorDuty(makeVTrace(slot)))
+		require.NoError(t, s.SaveCommitteeDuty(makeCTrace(slot, 'a')))
+		require.NoError(t, s.SaveCommitteeDutyLinks(slot, map[phase0.ValidatorIndex]spectypes.CommitteeID{1: {1, 1, 1}}))
+		require.NoError(t, s.SaveScheduled(slot, map[phase0.ValidatorIndex]rolemask.Mask{1: rolemask.BitAttester}))
+	}
+
+	require.NoError(t, s.PruneSlot(prune))
+
+	// Pruned slot: every trace kind is gone.
+	_, err = s.GetValidatorDuty(prune, spectypes.BNRoleAttester, phase0.ValidatorIndex(39393))
+	require.Error(t, err, "validator duty should be pruned")
+
+	cds, err := s.GetCommitteeDuties(prune)
+	require.NoError(t, err)
+	require.Empty(t, cds, "committee duties should be pruned")
+
+	links, err := s.GetCommitteeDutyLinks(prune)
+	require.NoError(t, err)
+	require.Empty(t, links, "committee links should be pruned")
+
+	sched, err := s.GetScheduled(prune)
+	require.NoError(t, err)
+	require.Empty(t, sched, "scheduled duties should be pruned")
+
+	// Adjacent slot is untouched.
+	_, err = s.GetValidatorDuty(keep, spectypes.BNRoleAttester, phase0.ValidatorIndex(39393))
+	require.NoError(t, err)
+
+	cds, err = s.GetCommitteeDuties(keep)
+	require.NoError(t, err)
+	require.Len(t, cds, 1)
+
+	links, err = s.GetCommitteeDutyLinks(keep)
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+
+	sched, err = s.GetScheduled(keep)
+	require.NoError(t, err)
+	require.Len(t, sched, 1)
+}
+
 func TestAddScheduledRole_UnionsIndices(t *testing.T) {
 	logger := zap.NewNop()
 	db, err := kv.NewInMemory(logger, basedb.Options{})

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -95,10 +95,6 @@ type SchedulerOptions struct {
 	// executing duties (e.g., validator registration). When true, scheduler
 	// still fetches/stores duties for all validators but does not execute them.
 	ExporterMode bool
-	// ArchiveMode indicates this is an archive-mode exporter that needs the Attester handler
-	// for duty tracing. Only meaningful when ExporterMode is true; standard-mode exporters skip
-	// the Attester handler to avoid fetching duties for all network validators.
-	ArchiveMode bool
 }
 
 type Scheduler struct {
@@ -169,26 +165,20 @@ func NewScheduler(logger *zap.Logger, opts *SchedulerOptions) *Scheduler {
 
 	s.exporterMode = opts.ExporterMode
 
-	// Proposer, SyncCommittee, and VoluntaryExit are needed in all modes.
-	// Proposer and SyncCommittee populate dutyStore entries consulted by message validation on all
-	// node types. VoluntaryExit populates the per-(slot,pk) duty count also consulted by validation.
-	// In exporter mode, exit descriptors always have OwnValidator=false (no owned validators), so
-	// the handler never queues exits for execution; VoluntaryExitHandler.processExecution also
-	// guards explicitly against execution in exporter mode as a second line of defense.
+	// Attester, Proposer, SyncCommittee, and VoluntaryExit are needed in all modes (operator and
+	// exporter). Proposer and SyncCommittee populate dutyStore entries consulted by message
+	// validation on all node types; VoluntaryExit populates the per-(slot,pk) duty count also
+	// consulted by validation; Attester is needed for duty execution (operator) and full duty
+	// tracing (exporter). In exporter mode, exit descriptors always have OwnValidator=false (no
+	// owned validators), so the handler never queues exits for execution; VoluntaryExitHandler.
+	// processExecution also guards explicitly against execution in exporter mode as a second line
+	// of defense.
 	s.dutyHandlers = append(s.dutyHandlers,
 		NewProposerHandler(dutyStore.Proposer, opts.ExporterMode),
 		NewSyncCommitteeHandler(dutyStore.SyncCommittee, opts.ExporterMode),
 		NewVoluntaryExitHandler(dutyStore.VoluntaryExit, opts.ValidatorExitCh, opts.ExporterMode),
+		NewAttesterHandler(dutyStore.Attester, opts.ExporterMode),
 	)
-
-	// Attester is needed for duty execution (operator) and duty tracing (archive exporter).
-	// Standard-mode exporter skips it: the attester store is not checked by message validation,
-	// and fetching duties for all network validators is expensive without the tracing benefit.
-	if !opts.ExporterMode || opts.ArchiveMode {
-		s.dutyHandlers = append(s.dutyHandlers,
-			NewAttesterHandler(dutyStore.Attester, opts.ExporterMode),
-		)
-	}
 
 	// These handlers only execute duties and are not needed in exporter mode.
 	if !opts.ExporterMode {

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -700,29 +700,19 @@ func TestNewScheduler_HandlerRegistration(t *testing.T) {
 	tests := []struct {
 		name         string
 		exporterMode bool
-		archiveMode  bool
 		wantHandlers []string
 	}{
 		{
 			name:         "operator mode",
 			exporterMode: false,
-			archiveMode:  false,
 			wantHandlers: []string{"PROPOSER", "SYNC_COMMITTEE", "VOLUNTARY_EXIT", "ATTESTER", "CLUSTER", "VALIDATOR_REGISTRATION"},
 		},
 		{
-			name:         "standard exporter",
+			name:         "exporter mode",
 			exporterMode: true,
-			archiveMode:  false,
-			// VoluntaryExit is included so the dutyStore is populated for message validation;
-			// Attester is excluded because the standard exporter does not trace duties.
-			wantHandlers: []string{"PROPOSER", "SYNC_COMMITTEE", "VOLUNTARY_EXIT"},
-		},
-		{
-			name:         "archive exporter",
-			exporterMode: true,
-			archiveMode:  true,
-			// Archive exporter needs Attester for full duty tracing but still skips
-			// execution-only handlers (CLUSTER, VALIDATOR_REGISTRATION).
+			// Exporters run full duty tracing: Proposer/SyncCommittee/VoluntaryExit populate the
+			// stores message validation consults, and Attester is needed for duty tracing. Only the
+			// execution-only handlers (CLUSTER, VALIDATOR_REGISTRATION) are skipped.
 			wantHandlers: []string{"PROPOSER", "SYNC_COMMITTEE", "VOLUNTARY_EXIT", "ATTESTER"},
 		},
 	}
@@ -736,7 +726,6 @@ func TestNewScheduler_HandlerRegistration(t *testing.T) {
 
 			s := NewScheduler(zap.NewNop(), &SchedulerOptions{
 				ExporterMode: tc.exporterMode,
-				ArchiveMode:  tc.archiveMode,
 				SlotTickerProvider: func() slotticker.SlotTicker {
 					return NewMockSlotTicker(ctx)
 				},

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -127,9 +127,7 @@ func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provide
 	// Start a single worker to process schedule writes asynchronously.
 	go c.runScheduleWorker(ctx)
 
-	// lastPrunedSlot tracks retention progress; seeded lazily on the first eligible tick so we
-	// enforce retention going forward without an expensive backfill of pre-existing history.
-	var lastPrunedSlot phase0.Slot
+	pruner := &tracePruner{store: c.store, logger: c.logger}
 	for {
 		select {
 		case <-ctx.Done():
@@ -137,42 +135,59 @@ func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provide
 		case <-ticker.Next():
 			currentSlot := ticker.Slot()
 			c.evict(currentSlot)
-			if retainSlots > 0 {
-				lastPrunedSlot = c.pruneExpired(currentSlot, phase0.Slot(retainSlots), lastPrunedSlot)
-			}
+			pruner.prune(currentSlot, phase0.Slot(retainSlots))
 		}
 	}
 }
 
-// pruneExpired deletes trace data for slots that have fallen outside the retention window. It
-// prunes only the slots that newly expired since the previous call (normally one per tick),
-// capping per-tick work so a long downtime gap cannot stall the loop. On the first eligible call
-// it seeds the cursor at the current boundary, so enabling retention does not retroactively purge
-// older history — retention is enforced from that point forward. Returns the updated cursor (the
-// lowest slot not yet pruned).
-func (c *Collector) pruneExpired(currentSlot, retainSlots, lastPruned phase0.Slot) phase0.Slot {
-	if currentSlot <= retainSlots {
-		return lastPruned // not enough history accumulated to prune anything yet
+// maxPrunePerTick bounds the slots a single tick may prune, so a large jump in the window boundary
+// (e.g. after a processing pause) cannot stall the eviction loop; the remainder is reclaimed on
+// subsequent ticks.
+const maxPrunePerTick = 64
+
+// tracePruner enforces the duty-trace retention window. It advances a cursor over expired slots so
+// the per-slot eviction loop reclaims exactly the slots that age out, while staying robust to the
+// edge cases of a long-lived chain.
+type tracePruner struct {
+	store  DutyTraceStore
+	logger *zap.Logger
+	cursor phase0.Slot // next slot to prune; meaningful once seeded
+	seeded bool
+}
+
+// prune deletes trace data for slots that have aged out of the retention window
+// [currentSlot-retainSlots, currentSlot]. Safeguards:
+//   - retainSlots == 0 disables retention (retain indefinitely — the default);
+//   - the currentSlot <= retainSlots guard avoids unsigned slot underflow early in the chain's life;
+//   - on first activation the cursor seeds at the window boundary, so enabling retention does not
+//     trigger an unbounded backfill of the chain's entire pre-existing history;
+//   - per-tick work is capped (maxPrunePerTick) so a large boundary jump cannot stall eviction;
+//   - the cursor lets a coalesced/late tick reclaim every skipped slot rather than leaking it.
+//
+// The cursor is in-memory, so slots that expire while the node is down are not reclaimed after a
+// restart (retention re-seeds forward). That is an accepted bound for a best-effort disk-retention
+// feature — trace reads never depend on pruned data.
+func (p *tracePruner) prune(currentSlot, retainSlots phase0.Slot) {
+	if retainSlots == 0 || currentSlot <= retainSlots {
+		return
 	}
 	boundary := currentSlot - retainSlots // slots strictly below boundary are expired
-	if lastPruned == 0 {
-		return boundary // first run: enforce going forward, no backfill sweep
+	if !p.seeded {
+		p.cursor, p.seeded = boundary, true
+		return
 	}
 
-	const maxPerTick = 64
-	pruned := 0
-	for s := lastPruned; s < boundary && pruned < maxPerTick; s++ {
-		if err := c.store.PruneSlot(s); err != nil {
-			c.logger.Warn("failed to prune expired duty traces", fields.Slot(s), zap.Error(err))
+	var pruned int
+	for ; p.cursor < boundary && pruned < maxPrunePerTick; pruned++ {
+		if err := p.store.PruneSlot(p.cursor); err != nil {
+			p.logger.Warn("failed to prune expired duty traces", fields.Slot(p.cursor), zap.Error(err))
 		}
-		pruned++
-		lastPruned = s + 1
+		p.cursor++
 	}
 	if pruned > 0 {
-		c.logger.Debug("pruned expired duty traces",
-			fields.Slot(lastPruned-1), zap.Int("count", pruned))
+		p.logger.Debug("pruned expired duty traces",
+			zap.Uint64("through_slot", uint64(p.cursor-1)), zap.Int("count", pruned))
 	}
-	return lastPruned
 }
 
 const slotTTL = 4

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -73,6 +73,10 @@ type Collector struct {
 	// scheduleJobs is a bounded queue for async schedule computation to avoid
 	// blocking the hot path and DB with synchronous writes.
 	scheduleJobs chan phase0.Slot
+
+	// retention enforces the optional duty-trace retention window (EXPORTER_RETAIN_EPOCHS) and is
+	// the single source of truth for the retained-slot floor consulted by the collection paths.
+	retention *retentionState
 }
 
 type DomainDataProvider interface {
@@ -106,6 +110,7 @@ func New(
 		duties:                         duties,
 		scheduleJobs:                   make(chan phase0.Slot, 32),
 	}
+	collector.retention = &retentionState{store: store, logger: collector.logger}
 
 	return collector
 }
@@ -127,7 +132,6 @@ func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provide
 	// Start a single worker to process schedule writes asynchronously.
 	go c.runScheduleWorker(ctx)
 
-	pruner := &tracePruner{store: c.store, logger: c.logger}
 	for {
 		select {
 		case <-ctx.Done():
@@ -135,58 +139,74 @@ func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provide
 		case <-ticker.Next():
 			currentSlot := ticker.Slot()
 			c.evict(currentSlot)
-			pruner.prune(currentSlot, phase0.Slot(retainSlots))
+			c.retention.advance(currentSlot, phase0.Slot(retainSlots))
 		}
 	}
 }
 
-// maxPrunePerTick bounds the slots a single tick may prune, so a large jump in the window boundary
+// maxPrunePerTick bounds the slots a single tick may prune, so a large jump in the window floor
 // (e.g. after a processing pause) cannot stall the eviction loop; the remainder is reclaimed on
 // subsequent ticks.
 const maxPrunePerTick = 64
 
-// tracePruner enforces the duty-trace retention window. It advances a cursor over expired slots so
-// the per-slot eviction loop reclaims exactly the slots that age out, while staying robust to the
-// edge cases of a long-lived chain.
-type tracePruner struct {
+// retentionState is the single source of truth for the duty-trace retention window. The eviction
+// loop advances it once per slot; the message-collection and schedule-write paths consult expired()
+// so they never (re)create trace data for a slot that has already aged out of the window — without
+// it, a late message or schedule job could resurrect a slot just deleted from disk.
+type retentionState struct {
 	store  DutyTraceStore
 	logger *zap.Logger
-	cursor phase0.Slot // next slot to prune; meaningful once seeded
+
+	// floor is the lowest slot still inside the retention window; slots strictly below it are
+	// expired. 0 means retention is disabled (retain indefinitely — the default). Read concurrently
+	// from collection goroutines, written only from the eviction loop.
+	floor atomic.Uint64
+
+	// cursor is the next slot to delete from disk; meaningful once seeded. Accessed only from the
+	// single eviction-loop goroutine.
+	cursor phase0.Slot
 	seeded bool
 }
 
-// prune deletes trace data for slots that have aged out of the retention window
-// [currentSlot-retainSlots, currentSlot]. Safeguards:
+// expired reports whether slot has aged out of the retention window and must not be (re)written.
+func (r *retentionState) expired(slot phase0.Slot) bool {
+	floor := r.floor.Load()
+	return floor > 0 && uint64(slot) < floor
+}
+
+// advance moves the retention window to currentSlot and deletes a bounded batch of newly-expired
+// slots from disk. Safeguards:
 //   - retainSlots == 0 disables retention (retain indefinitely — the default);
 //   - the currentSlot <= retainSlots guard avoids unsigned slot underflow early in the chain's life;
-//   - on first activation the cursor seeds at the window boundary, so enabling retention does not
+//   - on first activation the cursor seeds at the window floor, so enabling retention does not
 //     trigger an unbounded backfill of the chain's entire pre-existing history;
-//   - per-tick work is capped (maxPrunePerTick) so a large boundary jump cannot stall eviction;
+//   - per-tick work is capped (maxPrunePerTick) so a large floor jump cannot stall eviction;
 //   - the cursor lets a coalesced/late tick reclaim every skipped slot rather than leaking it.
 //
-// The cursor is in-memory, so slots that expire while the node is down are not reclaimed after a
-// restart (retention re-seeds forward). That is an accepted bound for a best-effort disk-retention
-// feature — trace reads never depend on pruned data.
-func (p *tracePruner) prune(currentSlot, retainSlots phase0.Slot) {
+// The cursor is in-memory, so retention is best-effort and forward-only across restarts: slots that
+// expire while the node is down are not reclaimed afterwards (see EXPORTER_RETAIN_EPOCHS docs).
+// Trace reads never depend on pruned data.
+func (r *retentionState) advance(currentSlot, retainSlots phase0.Slot) {
 	if retainSlots == 0 || currentSlot <= retainSlots {
 		return
 	}
-	boundary := currentSlot - retainSlots // slots strictly below boundary are expired
-	if !p.seeded {
-		p.cursor, p.seeded = boundary, true
+	floor := currentSlot - retainSlots // slots strictly below floor are expired
+	r.floor.Store(uint64(floor))
+	if !r.seeded {
+		r.cursor, r.seeded = floor, true
 		return
 	}
 
 	var pruned int
-	for ; p.cursor < boundary && pruned < maxPrunePerTick; pruned++ {
-		if err := p.store.PruneSlot(p.cursor); err != nil {
-			p.logger.Warn("failed to prune expired duty traces", fields.Slot(p.cursor), zap.Error(err))
+	for ; r.cursor < floor && pruned < maxPrunePerTick; pruned++ {
+		if err := r.store.PruneSlot(r.cursor); err != nil {
+			r.logger.Warn("failed to prune expired duty traces", fields.Slot(r.cursor), zap.Error(err))
 		}
-		p.cursor++
+		r.cursor++
 	}
 	if pruned > 0 {
-		p.logger.Debug("pruned expired duty traces",
-			zap.Uint64("through_slot", uint64(p.cursor-1)), zap.Int("count", pruned))
+		r.logger.Debug("pruned expired duty traces",
+			zap.Uint64("through_slot", uint64(r.cursor-1)), zap.Int("count", pruned))
 	}
 }
 
@@ -220,6 +240,11 @@ func (c *Collector) evict(currentSlot phase0.Slot) {
 }
 
 func (c *Collector) getOrCreateValidatorTrace(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex) (*validatorDutyTrace, bool, error) {
+	// Drop traces for slots already pruned out of the retention window so a late message cannot
+	// resurrect them on disk.
+	if c.retention.expired(slot) {
+		return nil, false, errExpiredSlot
+	}
 	// check late arrival
 	if uint64(slot) <= c.lastEvictedSlot.Load() {
 		if _, found := c.inFlightValidator.GetOrSet(index, struct{}{}); found {
@@ -273,7 +298,17 @@ func (c *Collector) getOrCreateValidatorTrace(slot phase0.Slot, role spectypes.B
 
 var errInFlight = errors.New("in flight")
 
+// errExpiredSlot signals that a message is for a slot already outside the retention window. The
+// collection path drops such messages silently so retention can't be defeated by a late write
+// resurrecting a slot that was just pruned from disk.
+var errExpiredSlot = errors.New("slot outside retention window")
+
 func (c *Collector) getOrCreateCommitteeTrace(slot phase0.Slot, committeeID spectypes.CommitteeID) (*committeeDutyTrace, bool, error) {
+	// Drop traces for slots already pruned out of the retention window so a late message cannot
+	// resurrect them on disk.
+	if c.retention.expired(slot) {
+		return nil, false, errExpiredSlot
+	}
 	// check late arrival
 	if uint64(slot) <= c.lastEvictedSlot.Load() {
 		if _, found := c.inFlightCommittee.GetOrSet(committeeID, struct{}{}); found {
@@ -579,6 +614,9 @@ func (c *Collector) Collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 		go c.collectLateMessage(ctx, msg, verifySig)
 		return nil
 	}
+	if errors.Is(err, errExpiredSlot) {
+		return nil // message is for a slot outside the retention window; drop silently
+	}
 	return err
 }
 
@@ -599,6 +637,10 @@ func (c *Collector) collectLateMessage(ctx context.Context, msg *queue.SSVMessag
 	// if another late message is in flight (for the same ID) - try `maxRetryCount` times before giving up
 	for tries < maxRetryCount {
 		err = c.collect(ctx, msg, verifySig)
+		if errors.Is(err, errExpiredSlot) {
+			err = nil // slot aged out of the retention window while retrying; drop silently
+			return
+		}
 		if !errors.Is(err, errInFlight) {
 			return
 		}
@@ -1452,6 +1494,9 @@ func (c *Collector) runScheduleWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case s := <-c.scheduleJobs:
+			if c.retention.expired(s) {
+				continue // slot outside the retention window; don't recreate its scheduled data
+			}
 			if err := c.computeAndPersistScheduleForSlot(s); err != nil {
 				c.logger.Debug("schedule worker compute/persist", fields.Slot(s), zap.Error(err))
 			}

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -1494,12 +1494,18 @@ func (c *Collector) runScheduleWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case s := <-c.scheduleJobs:
-			if c.retention.expired(s) {
-				continue // slot outside the retention window; don't recreate its scheduled data
-			}
-			if err := c.computeAndPersistScheduleForSlot(s); err != nil {
-				c.logger.Debug("schedule worker compute/persist", fields.Slot(s), zap.Error(err))
-			}
+			c.processScheduleJob(s)
 		}
+	}
+}
+
+// processScheduleJob persists the per-slot scheduled-role map, unless the slot has already aged out
+// of the retention window — recreating its scheduled data would defeat pruning.
+func (c *Collector) processScheduleJob(s phase0.Slot) {
+	if c.retention.expired(s) {
+		return // slot outside the retention window; don't recreate its scheduled data
+	}
+	if err := c.computeAndPersistScheduleForSlot(s); err != nil {
+		c.logger.Debug("schedule worker compute/persist", fields.Slot(s), zap.Error(err))
 	}
 }

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -116,13 +116,20 @@ type scRootKey struct {
 	blockRoot phase0.Root
 }
 
-func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provider) {
-	c.logger.Info("start duty tracer cache to disk evictor")
+// Start runs the duty-tracer background loop: it evicts in-memory traces to disk each slot and,
+// when retainSlots > 0, prunes on-disk trace history older than the retention window. retainSlots
+// of 0 disables pruning (retain indefinitely — the default).
+func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provider, retainSlots uint64) {
+	c.logger.Info("start duty tracer cache to disk evictor", zap.Uint64("retain_slots", retainSlots))
 	ticker := tickerProvider()
 	// Start schedule filler in a separate goroutine to avoid blocking eviction.
 	go c.startScheduleFiller(ctx, tickerProvider)
 	// Start a single worker to process schedule writes asynchronously.
 	go c.runScheduleWorker(ctx)
+
+	// lastPrunedSlot tracks retention progress; seeded lazily on the first eligible tick so we
+	// enforce retention going forward without an expensive backfill of pre-existing history.
+	var lastPrunedSlot phase0.Slot
 	for {
 		select {
 		case <-ctx.Done():
@@ -130,8 +137,42 @@ func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provide
 		case <-ticker.Next():
 			currentSlot := ticker.Slot()
 			c.evict(currentSlot)
+			if retainSlots > 0 {
+				lastPrunedSlot = c.pruneExpired(currentSlot, phase0.Slot(retainSlots), lastPrunedSlot)
+			}
 		}
 	}
+}
+
+// pruneExpired deletes trace data for slots that have fallen outside the retention window. It
+// prunes only the slots that newly expired since the previous call (normally one per tick),
+// capping per-tick work so a long downtime gap cannot stall the loop. On the first eligible call
+// it seeds the cursor at the current boundary, so enabling retention does not retroactively purge
+// older history — retention is enforced from that point forward. Returns the updated cursor (the
+// lowest slot not yet pruned).
+func (c *Collector) pruneExpired(currentSlot, retainSlots, lastPruned phase0.Slot) phase0.Slot {
+	if currentSlot <= retainSlots {
+		return lastPruned // not enough history accumulated to prune anything yet
+	}
+	boundary := currentSlot - retainSlots // slots strictly below boundary are expired
+	if lastPruned == 0 {
+		return boundary // first run: enforce going forward, no backfill sweep
+	}
+
+	const maxPerTick = 64
+	pruned := 0
+	for s := lastPruned; s < boundary && pruned < maxPerTick; s++ {
+		if err := c.store.PruneSlot(s); err != nil {
+			c.logger.Warn("failed to prune expired duty traces", fields.Slot(s), zap.Error(err))
+		}
+		pruned++
+		lastPruned = s + 1
+	}
+	if pruned > 0 {
+		c.logger.Debug("pruned expired duty traces",
+			fields.Slot(lastPruned-1), zap.Int("count", pruned))
+	}
+	return lastPruned
 }
 
 const slotTTL = 4

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -1829,54 +1829,85 @@ func (m *mockDutyTraceStore) PruneSlot(slot phase0.Slot) error {
 	return m.err
 }
 
-func TestTracePruner(t *testing.T) {
+func TestRetentionState(t *testing.T) {
 	const retain = phase0.Slot(100)
 
 	t.Run("disabled when retainSlots is zero", func(t *testing.T) {
 		st := &mockDutyTraceStore{}
-		p := &tracePruner{store: st, logger: zap.NewNop()}
-		p.prune(1_000_000, 0)
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(1_000_000, 0)
 		require.Empty(t, st.prunedSlots)
-		require.False(t, p.seeded)
+		require.False(t, r.seeded)
+		require.False(t, r.expired(0), "nothing is expired when retention is disabled")
 	})
 
 	t.Run("no underflow before the window fills", func(t *testing.T) {
 		st := &mockDutyTraceStore{}
-		p := &tracePruner{store: st, logger: zap.NewNop()}
-		p.prune(50, retain) // currentSlot < retain
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(50, retain) // currentSlot < retain
 		require.Empty(t, st.prunedSlots)
-		require.False(t, p.seeded)
+		require.False(t, r.seeded)
+		require.False(t, r.expired(0))
 	})
 
-	t.Run("first activation seeds forward without backfilling old history", func(t *testing.T) {
+	t.Run("first activation seeds the floor forward without backfilling old history", func(t *testing.T) {
 		st := &mockDutyTraceStore{}
-		p := &tracePruner{store: st, logger: zap.NewNop()}
-		p.prune(1_000_000, retain) // boundary is huge; must NOT prune from slot 0
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(1_000_000, retain) // floor is huge; must NOT prune from slot 0
 		require.Empty(t, st.prunedSlots)
-		require.True(t, p.seeded)
-		require.Equal(t, phase0.Slot(1_000_000-100), p.cursor)
+		require.True(t, r.seeded)
+		require.Equal(t, phase0.Slot(1_000_000-100), r.cursor)
+		// floor guards the collection path immediately, even before the cursor prunes anything
+		require.True(t, r.expired(1_000_000-101))
+		require.False(t, r.expired(1_000_000-100))
 	})
 
 	t.Run("prunes exactly the slot that ages out each advancing tick", func(t *testing.T) {
 		st := &mockDutyTraceStore{}
-		p := &tracePruner{store: st, logger: zap.NewNop()}
-		p.prune(150, retain) // seed: cursor=50
-		p.prune(151, retain) // prune 50
-		p.prune(152, retain) // prune 51
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(150, retain) // seed: floor/cursor=50
+		r.advance(151, retain) // prune 50
+		r.advance(152, retain) // prune 51
 		require.Equal(t, []phase0.Slot{50, 51}, st.prunedSlots)
-		require.Equal(t, phase0.Slot(52), p.cursor)
+		require.Equal(t, phase0.Slot(52), r.cursor)
 	})
 
 	t.Run("catches up skipped slots but caps work per tick", func(t *testing.T) {
 		st := &mockDutyTraceStore{}
-		p := &tracePruner{store: st, logger: zap.NewNop()}
-		p.prune(150, retain) // seed: cursor=50
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(150, retain) // seed: floor/cursor=50
 		st.prunedSlots = nil
-		p.prune(150+1000, retain) // boundary jumps to 1050; must cap, not stall
+		r.advance(150+1000, retain) // floor jumps to 1050; must cap, not stall
 		require.Len(t, st.prunedSlots, maxPrunePerTick)
 		require.Equal(t, phase0.Slot(50), st.prunedSlots[0])
-		require.Equal(t, phase0.Slot(50+maxPrunePerTick), p.cursor)
+		require.Equal(t, phase0.Slot(50+maxPrunePerTick), r.cursor)
 	})
+
+	t.Run("expired tracks the current floor", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		r := &retentionState{store: st, logger: zap.NewNop()}
+		r.advance(150, retain) // floor=50
+		require.True(t, r.expired(49))
+		require.False(t, r.expired(50))
+		require.False(t, r.expired(51))
+	})
+}
+
+// TestCollector_dropsExpiredSlot verifies the collection hot path refuses to (re)create traces for
+// a slot below the retention floor, so a late message cannot resurrect a slot already pruned.
+func TestCollector_dropsExpiredSlot(t *testing.T) {
+	c := New(zap.NewNop(), nil, nil, &mockDutyTraceStore{}, networkconfig.TestNetwork.Beacon, nil, nil)
+	c.retention.floor.Store(100) // slots < 100 are expired
+
+	_, _, err := c.getOrCreateValidatorTrace(50, spectypes.BNRoleAttester, 1)
+	require.ErrorIs(t, err, errExpiredSlot)
+
+	_, _, err = c.getOrCreateCommitteeTrace(50, spectypes.CommitteeID{})
+	require.ErrorIs(t, err, errExpiredSlot)
+
+	// A slot inside the window is not dropped by the guard.
+	_, _, err = c.getOrCreateValidatorTrace(150, spectypes.BNRoleAttester, 1)
+	require.NotErrorIs(t, err, errExpiredSlot)
 }
 
 func (m *mockDutyTraceStore) SaveCommitteeDutyLink(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error {

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter/rolemask"
 	"github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/operator/slotticker"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/registry/storage"
@@ -1908,6 +1909,94 @@ func TestCollector_dropsExpiredSlot(t *testing.T) {
 	// A slot inside the window is not dropped by the guard.
 	_, _, err = c.getOrCreateValidatorTrace(150, spectypes.BNRoleAttester, 1)
 	require.NotErrorIs(t, err, errExpiredSlot)
+}
+
+// fakeSlotTicker fires a single pre-loaded tick and reports a fixed slot.
+type fakeSlotTicker struct {
+	ch   chan time.Time
+	slot phase0.Slot
+}
+
+func (f *fakeSlotTicker) Next() <-chan time.Time { return f.ch }
+func (f *fakeSlotTicker) Slot() phase0.Slot      { return f.slot }
+
+// TestCollector_Start_advancesRetention drives the eviction loop one tick and asserts it advances
+// the retention window (sets the floor). Only the main loop's ticker fires; the schedule filler's
+// ticker stays silent so the worker doesn't run with the test's empty deps.
+func TestCollector_Start_advancesRetention(t *testing.T) {
+	c := New(zap.NewNop(), nil, nil, &mockDutyTraceStore{}, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	var calls int
+	provider := func() slotticker.SlotTicker {
+		calls++
+		ch := make(chan time.Time, 1)
+		if calls == 1 { // the main eviction loop is the first to ask for a ticker
+			ch <- time.Now()
+		}
+		return &fakeSlotTicker{ch: ch, slot: 1_000_000}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { c.Start(ctx, provider, 100); close(done) }()
+
+	require.Eventually(t, func() bool { return c.retention.floor.Load() > 0 },
+		2*time.Second, 5*time.Millisecond, "Start should advance the retention floor on a tick")
+	require.Equal(t, uint64(1_000_000-100), c.retention.floor.Load())
+
+	cancel()
+	<-done
+}
+
+// TestCollector_processScheduleJob_skipsExpired verifies the schedule worker drops jobs for slots
+// outside the retention window (so they cannot recreate pruned scheduled data). With nil duties,
+// only the guard's early return keeps computeAndPersistScheduleForSlot from being reached.
+func TestCollector_processScheduleJob_skipsExpired(t *testing.T) {
+	c := New(zap.NewNop(), nil, nil, &mockDutyTraceStore{}, networkconfig.TestNetwork.Beacon, nil, nil)
+	c.retention.floor.Store(100)
+	require.NotPanics(t, func() { c.processScheduleJob(50) }, "expired slot must be skipped before persist")
+}
+
+// TestCollector_Collect_dropsExpiredSlot drives a real message for a slot below the retention floor
+// through Collect end-to-end and asserts it is dropped silently — proving a late message cannot
+// resurrect a pruned slot.
+func TestCollector_Collect_dropsExpiredSlot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	const slot = phase0.Slot(1)
+	vIndex := phase0.ValidatorIndex(55)
+	identifier := spectypes.NewMsgID([4]byte{}, []byte("pk"), spectypes.RoleAggregator)
+
+	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
+	validators.EXPECT().ValidatorIndex(gomock.Any()).Return(vIndex, true).AnyTimes()
+
+	c := New(zap.NewNop(), validators, nil, &mockDutyTraceStore{}, networkconfig.TestNetwork.Beacon, nil, nil)
+	c.retention.floor.Store(100) // slot 1 is far outside the retention window
+
+	psm := spectypes.PartialSignatureMessages{
+		Type: spectypes.PostConsensusPartialSig,
+		Slot: slot,
+		Messages: []*spectypes.PartialSignatureMessage{
+			{ValidatorIndex: vIndex, Signer: 99, PartialSignature: make([]byte, 96), SigningRoot: [32]byte{1}},
+		},
+	}
+	data, err := psm.Encode()
+	require.NoError(t, err)
+
+	require.NoError(t, c.Collect(t.Context(), buildPartialSigMessage(identifier, data), dummyVerify))
+}
+
+// TestDutyTraceStoreMetrics_PruneSlot covers the metrics wrapper used in production (node.go wraps
+// the store in DutyTraceStoreMetrics).
+func TestDutyTraceStoreMetrics_PruneSlot(t *testing.T) {
+	db, err := kv.NewInMemory(zap.NewNop(), basedb.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	m := &DutyTraceStoreMetrics{Store: store.New(db)}
+	require.NoError(t, m.PruneSlot(123))
 }
 
 func (m *mockDutyTraceStore) SaveCommitteeDutyLink(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error {

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -1829,32 +1829,54 @@ func (m *mockDutyTraceStore) PruneSlot(slot phase0.Slot) error {
 	return m.err
 }
 
-func TestCollector_pruneExpired(t *testing.T) {
-	st := &mockDutyTraceStore{}
-	c := &Collector{logger: zap.NewNop(), store: st}
+func TestTracePruner(t *testing.T) {
 	const retain = phase0.Slot(100)
 
-	// Not enough history accumulated yet: nothing pruned, cursor unchanged.
-	require.Equal(t, phase0.Slot(0), c.pruneExpired(50, retain, 0))
-	require.Empty(t, st.prunedSlots)
+	t.Run("disabled when retainSlots is zero", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		p := &tracePruner{store: st, logger: zap.NewNop()}
+		p.prune(1_000_000, 0)
+		require.Empty(t, st.prunedSlots)
+		require.False(t, p.seeded)
+	})
 
-	// First eligible tick seeds the cursor at the retention boundary without sweeping old history.
-	cur := c.pruneExpired(150, retain, 0) // boundary = 150-100 = 50
-	require.Equal(t, phase0.Slot(50), cur)
-	require.Empty(t, st.prunedSlots)
+	t.Run("no underflow before the window fills", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		p := &tracePruner{store: st, logger: zap.NewNop()}
+		p.prune(50, retain) // currentSlot < retain
+		require.Empty(t, st.prunedSlots)
+		require.False(t, p.seeded)
+	})
 
-	// Next tick prunes exactly the one slot that just fell outside the window.
-	cur = c.pruneExpired(151, retain, cur) // boundary = 51
-	require.Equal(t, phase0.Slot(51), cur)
-	require.Equal(t, []phase0.Slot{50}, st.prunedSlots)
+	t.Run("first activation seeds forward without backfilling old history", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		p := &tracePruner{store: st, logger: zap.NewNop()}
+		p.prune(1_000_000, retain) // boundary is huge; must NOT prune from slot 0
+		require.Empty(t, st.prunedSlots)
+		require.True(t, p.seeded)
+		require.Equal(t, phase0.Slot(1_000_000-100), p.cursor)
+	})
 
-	// A large gap (e.g. after downtime) is capped at maxPerTick per call so the loop can't stall.
-	st.prunedSlots = nil
-	cur = c.pruneExpired(10000, retain, 51) // boundary = 9900, but capped to 64 slots
-	require.Equal(t, phase0.Slot(51+64), cur)
-	require.Len(t, st.prunedSlots, 64)
-	require.Equal(t, phase0.Slot(51), st.prunedSlots[0])
-	require.Equal(t, phase0.Slot(114), st.prunedSlots[63])
+	t.Run("prunes exactly the slot that ages out each advancing tick", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		p := &tracePruner{store: st, logger: zap.NewNop()}
+		p.prune(150, retain) // seed: cursor=50
+		p.prune(151, retain) // prune 50
+		p.prune(152, retain) // prune 51
+		require.Equal(t, []phase0.Slot{50, 51}, st.prunedSlots)
+		require.Equal(t, phase0.Slot(52), p.cursor)
+	})
+
+	t.Run("catches up skipped slots but caps work per tick", func(t *testing.T) {
+		st := &mockDutyTraceStore{}
+		p := &tracePruner{store: st, logger: zap.NewNop()}
+		p.prune(150, retain) // seed: cursor=50
+		st.prunedSlots = nil
+		p.prune(150+1000, retain) // boundary jumps to 1050; must cap, not stall
+		require.Len(t, st.prunedSlots, maxPrunePerTick)
+		require.Equal(t, phase0.Slot(50), st.prunedSlots[0])
+		require.Equal(t, phase0.Slot(50+maxPrunePerTick), p.cursor)
+	})
 }
 
 func (m *mockDutyTraceStore) SaveCommitteeDutyLink(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error {

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -1817,10 +1817,44 @@ type mockDutyTraceStore struct {
 	committeeDutyTrace      *exporter.CommitteeDutyTrace
 	saveCommitteeDutyLinkFn func(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error
 	scheduled               map[phase0.Slot]map[phase0.ValidatorIndex]rolemask.Mask
+	prunedSlots             []phase0.Slot
 }
 
 func (m *mockDutyTraceStore) SaveCommitteeDuties(slot phase0.Slot, duties []*exporter.CommitteeDutyTrace) error {
 	return m.err
+}
+
+func (m *mockDutyTraceStore) PruneSlot(slot phase0.Slot) error {
+	m.prunedSlots = append(m.prunedSlots, slot)
+	return m.err
+}
+
+func TestCollector_pruneExpired(t *testing.T) {
+	st := &mockDutyTraceStore{}
+	c := &Collector{logger: zap.NewNop(), store: st}
+	const retain = phase0.Slot(100)
+
+	// Not enough history accumulated yet: nothing pruned, cursor unchanged.
+	require.Equal(t, phase0.Slot(0), c.pruneExpired(50, retain, 0))
+	require.Empty(t, st.prunedSlots)
+
+	// First eligible tick seeds the cursor at the retention boundary without sweeping old history.
+	cur := c.pruneExpired(150, retain, 0) // boundary = 150-100 = 50
+	require.Equal(t, phase0.Slot(50), cur)
+	require.Empty(t, st.prunedSlots)
+
+	// Next tick prunes exactly the one slot that just fell outside the window.
+	cur = c.pruneExpired(151, retain, cur) // boundary = 51
+	require.Equal(t, phase0.Slot(51), cur)
+	require.Equal(t, []phase0.Slot{50}, st.prunedSlots)
+
+	// A large gap (e.g. after downtime) is capped at maxPerTick per call so the loop can't stall.
+	st.prunedSlots = nil
+	cur = c.pruneExpired(10000, retain, 51) // boundary = 9900, but capped to 64 slots
+	require.Equal(t, phase0.Slot(51+64), cur)
+	require.Len(t, st.prunedSlots, 64)
+	require.Equal(t, phase0.Slot(51), st.prunedSlots[0])
+	require.Equal(t, phase0.Slot(114), st.prunedSlots[63])
 }
 
 func (m *mockDutyTraceStore) SaveCommitteeDutyLink(slot phase0.Slot, index phase0.ValidatorIndex, id spectypes.CommitteeID) error {

--- a/operator/dutytracer/store.go
+++ b/operator/dutytracer/store.go
@@ -42,6 +42,9 @@ type DutyTraceStore interface {
 	// Compact scheduled duties I/O
 	SaveScheduled(slot phase0.Slot, schedule map[phase0.ValidatorIndex]rolemask.Mask) error
 	GetScheduled(slot phase0.Slot) (map[phase0.ValidatorIndex]rolemask.Mask, error)
+
+	// PruneSlot removes all trace data for a slot, backing the optional retention window.
+	PruneSlot(slot phase0.Slot) error
 }
 
 func (c *Collector) GetCommitteeID(slot phase0.Slot, index phase0.ValidatorIndex) (spectypes.CommitteeID, error) {

--- a/operator/dutytracer/store_metrics.go
+++ b/operator/dutytracer/store_metrics.go
@@ -47,6 +47,14 @@ func (d *DutyTraceStoreMetrics) SaveCommitteeDutyLink(slot phase0.Slot, index ph
 	return d.Store.SaveCommitteeDutyLink(slot, index, id)
 }
 
+func (d *DutyTraceStoreMetrics) PruneSlot(slot phase0.Slot) error {
+	start := time.Now()
+	defer func() {
+		record("prune", "prune_slot", start)
+	}()
+	return d.Store.PruneSlot(slot)
+}
+
 func (d *DutyTraceStoreMetrics) GetCommitteeDutyLink(slot phase0.Slot, index phase0.ValidatorIndex) (spectypes.CommitteeID, error) {
 	start := time.Now()
 	defer func() {

--- a/operator/node.go
+++ b/operator/node.go
@@ -126,7 +126,6 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 		SlotTickerProvider:      slotTickerProvider,
 		P2PNetwork:              opts.P2PNetwork,
 		ExporterMode:            exporterOpts.Enabled,
-		ArchiveMode:             exporterOpts.Mode == exporter.ModeArchive,
 	})
 
 	node := &Node{

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -388,12 +388,13 @@ func (c *Controller) handleWorkerMessages(ctx context.Context, msg network.Decod
 		ncv = item.Value()
 	}
 
-	if c.validatorCommonOpts.ExporterOptions.Mode == exporter.ModeArchive {
-		// use new exporter functionality
+	if c.traceCollector != nil {
+		// Exporter nodes run full duty tracing via the collector. The collector is wired only for
+		// exporter nodes (see cli/operator/node.go), so a non-nil collector means this is an exporter.
 		return c.traceCollector.Collect(c.ctx, ssvMsg, ncv.VerifySig)
 	}
 
-	// use old exporter functionality
+	// Operator nodes record post-consensus participation via the legacy participant store.
 	return c.handleNonCommitteeMessages(ctx, ssvMsg, ncv)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2892. Removes the exporter's **standard** mode — exporters now always run **full duty tracing** (the former *archive* behavior) — and adds an optional, default-off retention window for the on-disk duty-trace store.

> Stacked on #2892 (`fix/exporter-duty-store-blackhole`) so the archive voluntary-exit fix is included. Base will retarget to `stage` once #2892 merges.

## Why

`EXPORTER_MODE` defaulted to `standard`, yet standard was a strict — and historically broken — subset of archive:
- It served only the participant-store-backed `/v1/exporter/decideds` endpoint (no trace endpoints).
- It was the source of the gossip-message blackhole in #2886 (proposer/sync/exit messages dropped because no duty scheduler ran).

Every deployed exporter (prod mainnet, stage mainnet, all hoodi exporters) already runs `archive`. Verified live: the production mainnet exporter handles all duty classes archive does; archive is a **functional superset** of standard (same `decideds` endpoint + the trace endpoints). So removing standard deletes a real footgun (a default that silently blackholes) without losing any capability.

## What changed

- **`exporter.Options`**: drop `Mode` / `ModeStandard` / `ModeArchive`. Replace the standard-only `RetainSlots` with **`RetainEpochs`** (`EXPORTER_RETAIN_EPOCHS`, default `0` = retain indefinitely — matches today's archive behavior).
- **`cli/operator`**: node-mode enum collapses to `operator` / `exporter`; `resolveMode` can no longer fail; the duty-trace collector + read API are always wired for exporters; the standard-only participant-store pruning is removed.
- **`duties.Scheduler`**: drop the `ArchiveMode` option — the Attester handler is registered for every exporter (full tracing), unchanged for operators.
- **`validator.Controller`**: route non-committee messages to the trace collector whenever one is wired (exporter), else the legacy participant path (operator) — nil-safe via `traceCollector != nil`.
- **`dutytracer`**: new `DutyTraceStore.PruneSlot(slot)` (single prefix-drop per key group) and a retention loop in `Collector.Start` that prunes trace data older than `RetainEpochs`. Pruning is capped per tick and **seeds forward on first run** — enabling retention does not retroactively sweep pre-existing history.

## Compatibility

- A stale `EXPORTER_MODE` / `RetainSlots` in existing configs is simply ignored (unknown fields), so nodes keep booting.
- The effective default flips from the (broken) `standard` to full tracing — which is what the fleet already runs.
- Out of scope (deliberately): the operator/legacy participant-store path and its `/v1/exporter/decideds` handler are untouched; only the **exporter** stops using standard mode.

## Tests

- Updated: handler-registration (`operator/duties`), mode resolution + exporter wiring (`cli/operator`).
- Added: `TestPruneSlot` (store removes all trace kinds for a slot, leaves adjacent slots intact) and `TestCollector_pruneExpired` (retention cursor: seed-forward, per-tick advance, per-tick cap).
- `go build ./...`, `go vet`, and affected unit suites pass.

## Verification status

Unit-tested and built clean. Live deploy verification on a stage exporter is **pending** (vnet tunnel was down at PR-creation time) — will confirm boot (full tracing), trace endpoints, health, and that the now-ignored `EXPORTER_MODE` in the deploy template still boots cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)