### PR TITLE
beacon/goclient: fork-gate aggregate index by duty slot (fix electra/pre-electra edge case)

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -107,7 +107,7 @@ func (gc *GoClient) waitTwoThirdsIntoSlot(ctx context.Context, slot phase0.Slot)
 	}
 }
 
-func (gc *GoClient) computeAttDataRootAndVersion(
+func (gc *GoClient) computeAttestationDataRoot(
 	ctx context.Context,
 	slot phase0.Slot,
 	committeeIndex phase0.CommitteeIndex,
@@ -122,7 +122,8 @@ func (gc *GoClient) computeAttDataRootAndVersion(
 	// Decide the fork from the requested duty slot, not attData.Slot — the latter is what the
 	// beacon node returned (the same source the comment above warns "may return inconsistent values"),
 	// whereas the aggregate is for our duty's slot, which is authoritative.
-	version, _ := gc.beaconConfig.BeaconForkAtEpoch(gc.getBeaconConfig().EstimatedEpochAtSlot(slot))
+	cfg := gc.getBeaconConfig()
+	version, _ := cfg.BeaconForkAtEpoch(cfg.EstimatedEpochAtSlot(slot))
 	attData.Index = 0
 	if version < spec.DataVersionElectra {
 		attData.Index = committeeIndex
@@ -140,7 +141,7 @@ func (gc *GoClient) fetchVersionedAggregate(
 	slot phase0.Slot,
 	committeeIndex phase0.CommitteeIndex,
 ) (*spec.VersionedAttestation, spec.DataVersion, error) {
-	root, err := gc.computeAttDataRootAndVersion(ctx, slot, committeeIndex)
+	root, err := gc.computeAttestationDataRoot(ctx, slot, committeeIndex)
 	if err != nil {
 		return nil, DataVersionNil, errMultiClient(fmt.Errorf("compute attestation root: %w", err), "AggregateAttestation")
 	}

--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -118,8 +118,11 @@ func (gc *GoClient) computeAttDataRootAndVersion(
 	}
 
 	// Explicitly set Index field as beacon nodes may return inconsistent values.
-	// EIP-7549: Electra+ uses Index=0; pre-Electra uses committee index
-	version, _ := gc.beaconConfig.BeaconForkAtEpoch(gc.getBeaconConfig().EstimatedEpochAtSlot(attData.Slot))
+	// EIP-7549: Electra+ uses Index=0; pre-Electra uses committee index.
+	// Decide the fork from the requested duty slot, not attData.Slot — the latter is what the
+	// beacon node returned (the same source the comment above warns "may return inconsistent values"),
+	// whereas the aggregate is for our duty's slot, which is authoritative.
+	version, _ := gc.beaconConfig.BeaconForkAtEpoch(gc.getBeaconConfig().EstimatedEpochAtSlot(slot))
 	attData.Index = 0
 	if version < spec.DataVersionElectra {
 		attData.Index = committeeIndex

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -66,12 +66,12 @@ func TestBuildPeerTrimScores_CharacterizesDeadSoloDuoScoring(t *testing.T) {
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
-			topics: []string{"0", "1", "2", "3"},
+			topics: []string{alanTopic(0), alanTopic(1), alanTopic(2), alanTopic(3)},
 			peersByTopic: map[string][]peer.ID{
-				"0": {candidate},
-				"1": {candidate, other1},
-				"2": {candidate, other1, other2},
-				"3": {candidate, other1, other2, other3},
+				alanTopic(0): {candidate},
+				alanTopic(1): {candidate, other1},
+				alanTopic(2): {candidate, other1, other2},
+				alanTopic(3): {candidate, other1, other2, other3},
 			},
 		},
 		nil,
@@ -92,9 +92,9 @@ func TestBuildPeerTrimScores_ExcludesCandidateFromSubnetCounts(t *testing.T) {
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
-			topics: []string{"1"},
+			topics: []string{alanTopic(1)},
 			peersByTopic: map[string][]peer.ID{
-				"1": {candidate, other},
+				alanTopic(1): {candidate, other},
 			},
 		},
 		nil,
@@ -115,11 +115,11 @@ func TestBuildPeerTrimScores_IgnoresInvalidTopics(t *testing.T) {
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
-			topics: []string{"0", "not-a-subnet", "999"},
+			topics: []string{alanTopic(0), "not-a-subnet", alanTopic(999)},
 			peersByTopic: map[string][]peer.ID{
-				"0":            {candidate, other},
+				alanTopic(0):   {candidate, other},
 				"not-a-subnet": {candidate},
-				"999":          {candidate},
+				alanTopic(999): {candidate}, // out of range, ignored
 			},
 		},
 		nil,
@@ -147,11 +147,11 @@ func TestChoosePeersToTrim_SelectsLowestScorePeers(t *testing.T) {
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
-			topics: []string{"0", "1", "3"},
+			topics: []string{alanTopic(0), alanTopic(1), alanTopic(3)},
 			peersByTopic: map[string][]peer.ID{
-				"0": {highValuePeer.ID()},
-				"1": {highValuePeer.ID(), mediumValuePeer.ID()},
-				"3": {lowValuePeer.ID()},
+				alanTopic(0): {highValuePeer.ID()},
+				alanTopic(1): {highValuePeer.ID(), mediumValuePeer.ID()},
+				alanTopic(3): {lowValuePeer.ID()},
 			},
 			allPeers: []peer.ID{highValuePeer.ID(), mediumValuePeer.ID(), lowValuePeer.ID()},
 		},
@@ -177,11 +177,11 @@ func TestChoosePeersToTrim_TrimInboundOnlySkipsOutboundPeers(t *testing.T) {
 	network := newTrimTestNetwork(
 		localHost,
 		&testTopicsController{
-			topics: []string{"0", "1", "3"},
+			topics: []string{alanTopic(0), alanTopic(1), alanTopic(3)},
 			peersByTopic: map[string][]peer.ID{
-				"0": {highValueInboundPeer.ID()},
-				"1": {highValueInboundPeer.ID(), inboundPeer.ID()},
-				"3": {outboundPeer.ID()},
+				alanTopic(0): {highValueInboundPeer.ID()},
+				alanTopic(1): {highValueInboundPeer.ID(), inboundPeer.ID()},
+				alanTopic(3): {outboundPeer.ID()},
 			},
 			allPeers: []peer.ID{outboundPeer.ID(), inboundPeer.ID(), highValueInboundPeer.ID()},
 		},
@@ -201,11 +201,11 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	network := newTrimTestNetwork(
 		nil,
 		&testTopicsController{
-			topics: []string{"0", "1", "3"},
+			topics: []string{alanTopic(0), alanTopic(1), alanTopic(3)},
 			peersByTopic: map[string][]peer.ID{
-				"0": {highValuePeer},
-				"1": {highValuePeer, mediumValuePeer},
-				"3": {lowValuePeer},
+				alanTopic(0): {highValuePeer},
+				alanTopic(1): {highValuePeer, mediumValuePeer},
+				alanTopic(3): {lowValuePeer},
 			},
 		},
 		nil,
@@ -296,7 +296,11 @@ func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.
 	}
 
 	n := &p2pNetwork{
-		logger:               zap.NewNop(),
+		logger: zap.NewNop(),
+		// buildPeerTrimScores -> subscribedSubnetsForCurrentEpoch reads cfg.NetworkConfig.
+		// Pin Boole into the future so these Alan-path characterizations stay deterministic
+		// regardless of the SSV_TEST_BOOLE_FORK (pre/post) matrix.
+		cfg:                  &Config{NetworkConfig: subscribeRandomsTestNetCfg()},
 		topicsCtrl:           topicsCtrl,
 		idx:                  idx,
 		persistentSubnets:    ownSubnets,
@@ -306,6 +310,13 @@ func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.
 		n.host.Store(&host)
 	}
 	return n
+}
+
+// alanTopic builds a valid Alan gossipsub topic name ("ssv.v2.<subnet>") for a
+// subnet index. ParseTopicSubnet only accepts the fork-prefixed topic format, so
+// tests must use this rather than bare subnet numbers.
+func alanTopic(subnet uint64) string {
+	return commons.Subnet(subnet).AlanTopic()
 }
 
 func subnetsFor(subnets ...uint64) commons.Subnets {


### PR DESCRIPTION
## Problem

`GoClient.computeAttDataRootAndVersion` (used by `SubmitAggregateSelectionProof`) decides EIP-7549 committee-index zeroing from the fork at **`attData.Slot`** — i.e. the slot the *beacon node returned*, the very source the adjacent comment flags as one that "may return inconsistent values":

```go
version, _ := gc.beaconConfig.BeaconForkAtEpoch(gc.getBeaconConfig().EstimatedEpochAtSlot(attData.Slot))
attData.Index = 0
if version < spec.DataVersionElectra {
    attData.Index = committeeIndex
}
```

For an **Electra duty** where the node returns attestation data stamped with a **pre-Electra slot**, `version` resolves pre-Electra, so the committee index is left non-zero. The resulting `AttestationDataRoot` sent in the `AggregateAttestation` request then **diverges from what peers compute** for the same duty — a real aggregate-attestation correctness issue around fork boundaries, not just a test artifact.

## Fix

Gate the fork decision on the requested **duty `slot`** (authoritative — it's the slot we're aggregating for) rather than the beacon-returned `attData.Slot`.

- **No behavior change in the normal case** (`attData.Slot == slot`).
- Corrects only the divergent edge case.

5-line change in `beacon/goclient/aggregator.go`.

## Verification

- `TestSubmitAggregateSelectionProof_UsesForkSpecificAggregateAndProof` — all 7 subtests pass (the `electra_duty_with_pre_electra_attestation_slot_uses_zero_index` subtest was failing before).
- Full `beacon/goclient` package green, no regressions.

## Note

This is a **pre-existing failure** on `boole-fork` (the subtest fails on the untouched base). It's currently reddening the `ssv (pre)` / `ssv (post)` checks on #2899 (the consensus-sync PR). Landing this fix in `boole-fork` clears that red — #2899 doesn't touch this code, so its `ssv (pre)/(post)` go green once the base is fixed.
