### PR TITLE
observability/el: demote benign & self-healing log-fetch noise to debug, clarify recovery warning

### DIFF
--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -66,10 +66,11 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 			// were dropped by the EL — this is not a bloom false positive. This is the
 			// actionable signal: the execution client returned incomplete logs, which
 			// would have been silently skipped without this cross-check.
-			ec.logger.Warn("recovered contract logs the execution client omitted on first request: events were not lost, but this indicates a buggy or unhealthy EL (e.g. known geth log-dropping bug) — consider updating or checking your execution client",
+			ec.logger.Warn("recovered contract logs the execution client omitted on first request",
 				fields.BlockNumber(blockNum),
 				zap.Int("recovered_events", len(blockLogs)),
 				zap.String("contract", ec.contractAddress.Hex()),
+				zap.String("recommendation", "events were not lost, but the EL returned incomplete logs (e.g. known geth log-dropping bug) — consider updating or checking your execution client"),
 			)
 			recordBloomRecovery(ctx)
 			logs = append(logs, blockLogs...)
@@ -116,7 +117,9 @@ func (ec *ExecutionClient) retryBlockLogs(ctx context.Context, blockNumber uint6
 
 		logs, err := ec.FilterLogs(ctx, query)
 		if err != nil {
-			ec.logger.Warn("bloom retry: FilterLogs failed",
+			// Transient RPC failure the retry usually absorbs. The final attempt returns
+			// this error, which the streaming retry loop logs at error level — so debug here.
+			ec.logger.Debug("bloom retry: FilterLogs failed",
 				fields.BlockNumber(blockNumber),
 				zap.Int("attempt", attempt),
 				zap.Error(err),

--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -44,8 +44,13 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 			continue // bloom says no SSV events in this block — genuine empty
 		}
 
-		// Bloom matched but FilterLogs returned nothing — suspected EL bug.
-		ec.logger.Warn("bloom filter mismatch during block-logs fetching: block bloom matches contract but EL returned no logs for this block, gonna retry to fetch block-logs for this specific block",
+		// Bloom matched but FilterLogs returned nothing. This is inconclusive on its
+		// own: it happens routinely as a benign bloom false positive (the filter is
+		// probabilistic and other logs in the block can set the contract's bits), and
+		// only occasionally because the EL actually dropped logs. We therefore log it
+		// at debug and let the retry below decide — a successful recovery is what gets
+		// promoted to a warning.
+		ec.logger.Debug("bloom matched contract but EL returned no logs for block, retrying to confirm",
 			fields.BlockNumber(blockNum),
 			zap.String("contract", ec.contractAddress.Hex()),
 		)
@@ -56,9 +61,15 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 		}
 
 		if len(blockLogs) > 0 {
-			ec.logger.Warn("bloom cross-check recovered missing events",
+			// The retry recovered logs the EL had omitted from the original response.
+			// The block bloom is consensus-verified, so these events are genuine and
+			// were dropped by the EL — this is not a bloom false positive. This is the
+			// actionable signal: the execution client returned incomplete logs, which
+			// would have been silently skipped without this cross-check.
+			ec.logger.Warn("recovered contract logs the execution client omitted on first request: events were not lost, but this indicates a buggy or unhealthy EL (e.g. known geth log-dropping bug) — consider updating or checking your execution client",
 				fields.BlockNumber(blockNum),
 				zap.Int("recovered_events", len(blockLogs)),
+				zap.String("contract", ec.contractAddress.Hex()),
 			)
 			recordBloomRecovery(ctx)
 			logs = append(logs, blockLogs...)

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -279,7 +279,9 @@ func (ec *ExecutionClient) subdivideLogFetch(ctx context.Context, q ethereum.Fil
 			return nil, fmt.Errorf("insufficient blocks to subdivide (fromBlock: %d, toBlock: %d): %w", fromBlock, toBlock, err)
 		}
 
-		ec.logger.Warn("execution client query limit exceeded, subdividing query",
+		// Query-limit subdivision is an expected, self-healing fallback that recurses,
+		// so log at debug; a genuine failure to fetch surfaces as an error upstream.
+		ec.logger.Debug("execution client query limit exceeded, subdividing query",
 			zap.String("method", "eth_getLogs"),
 			fields.FromBlock(fromBlock),
 			fields.ToBlock(toBlock),
@@ -310,7 +312,7 @@ func (ec *ExecutionClient) subdivideLogFetch(ctx context.Context, q ethereum.Fil
 		combinedLogs = append(combinedLogs, leftLogs...)
 		combinedLogs = append(combinedLogs, rightLogs...)
 
-		ec.logger.Info("successfully fetched logs after subdivision",
+		ec.logger.Debug("successfully fetched logs after subdivision",
 			fields.FromBlock(fromBlock),
 			fields.ToBlock(toBlock),
 			zap.Int("total_logs", totalLogs))


### PR DESCRIPTION
## Summary

Follow-up to the bloom cross-check introduced in #2722. Several log lines in the EL log-fetch path were emitting at WARN/INFO for conditions that are either **benign** (probabilistic bloom false positives) or **self-healing** (automatic retry / query subdivision), producing operator-facing noise near the chain tip that isn't actionable on its own. This PR demotes those to `DEBUG` and keeps — and clarifies — the one `WARN` that genuinely indicates a problem.

## Changes

**Bloom cross-check (`eth/executionclient/bloom.go`)**

- **Pre-retry "mismatch" message → `DEBUG`.** It fired on *every* block whose header bloom matched the contract but for which `eth_getLogs` returned nothing — a condition dominated by benign bloom false positives (`logsBloom` is a probabilistic 2048-bit filter, so unrelated logs in a busy block routinely set the contract's bits). It's inconclusive before the retry runs, so it shouldn't be a warning.
- **Recovery message stays `WARN`, reworded and slimmed.** A successful retry of the same *consensus-verified* block proves the EL dropped logs (not a false positive) — this is the actionable signal. The diagnosis/remediation prose now lives in a `recommendation` field so the message itself stays concise.
- **Per-attempt retry `FilterLogs` failures → `DEBUG`.** These are transient RPC failures the retry usually absorbs; the terminal failure already returns an error that the streaming retry loop logs at `ERROR` (block number preserved in the wrapped chain), so warning per-attempt was noisy and redundant.

**Query-limit subdivision (`eth/executionclient/execution_client.go`)**

- **"query limit exceeded, subdividing" (`WARN`) and "fetched after subdivision" (`INFO`) → `DEBUG`.** Query-limit subdivision is an expected, self-healing fallback that *recurses*, so each split level emitted its own line for a single logical fetch. Genuine failures to fetch still surface at `ERROR` upstream.

## Net effect

The only line left at `WARN` in this path is the bloom recovery message — the one that actually tells an operator their EL returned incomplete logs and should be checked/updated. Everything benign or self-healing is now `DEBUG`. No behavior change beyond log levels and wording; the retry / recovery / subdivision logic and metrics (`ssv.el.bloom.checks{outcome=recovery|false_positive}`) are untouched.

## Testing

- `go build ./eth/executionclient/`
- `go vet ./eth/executionclient/`
- `go test ./eth/executionclient/ -count=1` — pass (no test asserts on these message strings or levels)
