### PR TITLE
fix(beacon): fetch head block root for sync-committee contributions (#2885)

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -57,7 +57,7 @@ func (gc *GoClient) SubmitAggregateSelectionProof(
 	// As specified in spec, an aggregator should wait until two thirds of the way through slot
 	// to broadcast the best aggregate to the global aggregate channel.
 	// https://github.com/ethereum/consensus-specs/blob/v0.9.3/specs/validator/0_beacon-chain-validator.md#broadcast-aggregate
-	if err := gc.waitTwoThirdsIntoSlot(ctx, slot); err != nil {
+	if err := gc.waitIntoSlot(ctx, slot, 2); err != nil {
 		return nil, 0, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
@@ -89,11 +89,13 @@ func (gc *GoClient) SubmitSignedAggregateSelectionProof(
 	return nil
 }
 
-// waitTwoThirdsIntoSlot waits until two-third of the slot has transpired (SECONDS_PER_SLOT * 2 / 3 seconds after the start of slot)
-func (gc *GoClient) waitTwoThirdsIntoSlot(ctx context.Context, slot phase0.Slot) error {
+// waitIntoSlot waits until the given number of intervals into the slot has transpired
+// (intervals * SECONDS_PER_SLOT / 3 seconds after the start of the slot): intervals=1 is
+// one-third in (attestation/contribution deadline), intervals=2 is two-thirds in
+// (aggregate broadcast deadline).
+func (gc *GoClient) waitIntoSlot(ctx context.Context, slot phase0.Slot, intervals int) error {
 	config := gc.getBeaconConfig()
-	oneInterval := config.IntervalDuration()
-	finalTime := config.SlotStartTime(slot).Add(2 * oneInterval)
+	finalTime := config.SlotStartTime(slot).Add(time.Duration(intervals) * config.IntervalDuration())
 	wait := time.Until(finalTime)
 	if wait <= 0 {
 		return nil

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -51,7 +51,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 		return nil, DataVersionNil, fmt.Errorf("mismatching number of selection proofs and subnet IDs")
 	}
 
-	if err := gc.waitOneThirdIntoSlot(ctx, slot); err != nil {
+	if err := gc.waitIntoSlot(ctx, slot, 1); err != nil {
 		return nil, DataVersionNil, fmt.Errorf("wait for 1/3 of slot: %w", err)
 	}
 
@@ -75,7 +75,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 
 	blockRoot := beaconBlockRootResp.Data
 
-	if err := gc.waitTwoThirdsIntoSlot(ctx, slot); err != nil {
+	if err := gc.waitIntoSlot(ctx, slot, 2); err != nil {
 		return nil, DataVersionNil, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
@@ -128,22 +128,4 @@ func (gc *GoClient) SubmitSignedContributionAndProof(
 	}
 
 	return nil
-}
-
-// waitOneThirdIntoSlot waits until one-third of the slot has transpired (SECONDS_PER_SLOT / 3 seconds after slot start time)
-func (gc *GoClient) waitOneThirdIntoSlot(ctx context.Context, slot phase0.Slot) error {
-	config := gc.getBeaconConfig()
-	delay := config.IntervalDuration()
-	finalTime := config.SlotStartTime(slot).Add(delay)
-	wait := time.Until(finalTime)
-	if wait <= 0 {
-		return nil
-	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(wait):
-		return nil
-	}
 }

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -80,6 +80,10 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	}
 
 	// Fetch sync committee contributions for each subnet in parallel.
+	// NOTE: this read and the head-root read above are not pinned to the same beacon
+	// node, and the multiClient does not fail over on a 4xx; if scores reorder in
+	// between, this call can land on a node that hasn't imported blockRoot and 404.
+	// Narrow (reorg/lagging-node window); tracked in ssvlabs/go-eth2-client#16.
 	var (
 		contributions = make(spectypes.Contributions, len(subnetIDs))
 		g             errgroup.Group

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -18,12 +18,11 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-// IsSyncCommitteeAggregator returns tru if aggregator
+// IsSyncCommitteeAggregator reports whether the given selection proof makes the validator
+// a sync-committee aggregator.
 func (gc *GoClient) IsSyncCommitteeAggregator(proof []byte) bool {
-	// Hash the signature.
 	hash := sha256.Sum256(proof)
 
-	// Keep the signature if it's an aggregator.
 	cfg := gc.BeaconConfig()
 
 	// as per spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#aggregation-selection
@@ -35,12 +34,13 @@ func (gc *GoClient) IsSyncCommitteeAggregator(proof []byte) bool {
 	return binary.LittleEndian.Uint64(hash[:8])%modulo == 0
 }
 
-// SyncCommitteeSubnetID returns sync committee subnet ID from subcommittee index
+// SyncCommitteeSubnetID returns the sync-committee subnet ID for the given subcommittee index.
 func (gc *GoClient) SyncCommitteeSubnetID(index phase0.CommitteeIndex) uint64 {
 	return uint64(index) / (gc.BeaconConfig().SyncCommitteeSize / gc.BeaconConfig().SyncCommitteeSubnetCount)
 }
 
-// GetSyncCommitteeContribution returns
+// GetSyncCommitteeContribution fetches one contribution per requested subnet, each paired
+// with its selection proof, all for the head block root as of the duty slot.
 func (gc *GoClient) GetSyncCommitteeContribution(
 	ctx context.Context,
 	slot phase0.Slot,
@@ -51,27 +51,32 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 		return nil, DataVersionNil, fmt.Errorf("mismatching number of selection proofs and subnet IDs")
 	}
 
-	gc.waitOneThirdIntoSlot(ctx, slot)
+	if err := gc.waitOneThirdIntoSlot(ctx, slot); err != nil {
+		return nil, DataVersionNil, fmt.Errorf("wait for 1/3 of slot: %w", err)
+	}
 
-	scDataReqStart := time.Now()
+	// Resolve the contribution root from head rather than by slot: sync-committee messages
+	// sign the head root as seen during the duty slot, which for a missed or late proposal
+	// is an earlier block's root — a by-slot lookup would 404 there and fail the duty.
+	// In the common case head matches the root the cluster's own messages signed; those
+	// sign the QBFT-decided head vote, which can diverge from a freshly-queried head under
+	// a reorg or a lagging node.
+	start := time.Now()
 	beaconBlockRootResp, err := gc.multiClient.BeaconBlockRoot(ctx, &api.BeaconBlockRootOpts{
-		Block: fmt.Sprint(slot),
+		Block: "head",
 	})
-	recordRequest(ctx, gc.log, "BeaconBlockRoot", gc.multiClient, http.MethodGet, true, time.Since(scDataReqStart), err)
+	recordRequest(ctx, gc.log, "BeaconBlockRoot", gc.multiClient, http.MethodGet, true, time.Since(start), err)
 	if err != nil {
 		return nil, DataVersionNil, errMultiClient(fmt.Errorf("fetch beacon block root: %w", err), "BeaconBlockRoot")
 	}
-	if beaconBlockRootResp == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("beacon block root response is nil"), "BeaconBlockRoot")
-	}
-	if beaconBlockRootResp.Data == nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("beacon block root response data is nil"), "BeaconBlockRoot")
+	if err := checkPtrResponse(beaconBlockRootResp, "beacon block root"); err != nil {
+		return nil, DataVersionNil, errMultiClient(err, "BeaconBlockRoot")
 	}
 
 	blockRoot := beaconBlockRootResp.Data
 
 	if err := gc.waitTwoThirdsIntoSlot(ctx, slot); err != nil {
-		return nil, 0, fmt.Errorf("wait for 2/3 of slot: %w", err)
+		return nil, DataVersionNil, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
 	// Fetch sync committee contributions for each subnet in parallel.
@@ -80,28 +85,24 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 		g             errgroup.Group
 	)
 	for i := range subnetIDs {
-		index := i
 		g.Go(func() error {
 			start := time.Now()
 			syncCommitteeContrResp, err := gc.multiClient.SyncCommitteeContribution(ctx, &api.SyncCommitteeContributionOpts{
 				Slot:              slot,
-				SubcommitteeIndex: subnetIDs[index],
+				SubcommitteeIndex: subnetIDs[i],
 				BeaconBlockRoot:   *blockRoot,
 			})
 			recordRequest(ctx, gc.log, "SyncCommitteeContribution", gc.multiClient, http.MethodGet, true, time.Since(start), err)
 			if err != nil {
 				return errMultiClient(fmt.Errorf("fetch sync committee contribution: %w", err), "SyncCommitteeContribution")
 			}
-			if syncCommitteeContrResp == nil {
-				return errMultiClient(fmt.Errorf("sync committee contribution response is nil"), "SyncCommitteeContribution")
-			}
-			if syncCommitteeContrResp.Data == nil {
-				return errMultiClient(fmt.Errorf("sync committee contribution response data is nil"), "SyncCommitteeContribution")
+			if err := checkPtrResponse(syncCommitteeContrResp, "sync committee contribution"); err != nil {
+				return errMultiClient(err, "SyncCommitteeContribution")
 			}
 
 			contribution := syncCommitteeContrResp.Data
-			contributions[index] = &spectypes.Contribution{
-				SelectionProofSig: selectionProofs[index],
+			contributions[i] = &spectypes.Contribution{
+				SelectionProofSig: selectionProofs[i],
 				Contribution:      *contribution,
 			}
 			return nil
@@ -114,7 +115,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(
 	return &contributions, spec.DataVersionAltair, nil
 }
 
-// SubmitSignedContributionAndProof broadcasts to the network
+// SubmitSignedContributionAndProof submits the signed contribution and proof to the beacon node.
 func (gc *GoClient) SubmitSignedContributionAndProof(
 	ctx context.Context,
 	contribution *altair.SignedContributionAndProof,
@@ -130,18 +131,19 @@ func (gc *GoClient) SubmitSignedContributionAndProof(
 }
 
 // waitOneThirdIntoSlot waits until one-third of the slot has transpired (SECONDS_PER_SLOT / 3 seconds after slot start time)
-func (gc *GoClient) waitOneThirdIntoSlot(ctx context.Context, slot phase0.Slot) {
+func (gc *GoClient) waitOneThirdIntoSlot(ctx context.Context, slot phase0.Slot) error {
 	config := gc.getBeaconConfig()
 	delay := config.IntervalDuration()
 	finalTime := config.SlotStartTime(slot).Add(delay)
 	wait := time.Until(finalTime)
 	if wait <= 0 {
-		return
+		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		return
+		return ctx.Err()
 	case <-time.After(wait):
+		return nil
 	}
 }

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -356,6 +356,43 @@ func TestGetSyncCommitteeContributionFetchesHeadRoot(t *testing.T) {
 	require.Equal(t, headRoot, (*contributions)[0].Contribution.BeaconBlockRoot)
 }
 
+// TestGetSyncCommitteeContributionPropagatesCanceledContext locks in the cancellation
+// path of the 1/3-into-slot wait. With a future slot (so the wait blocks instead of
+// early-returning) and an already-canceled context, GetSyncCommitteeContribution must
+// return the wrapped "wait for 1/3 of slot" error and DataVersionNil, without ever
+// querying the beacon node.
+func TestGetSyncCommitteeContributionPropagatesCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := *networkconfig.TestNetwork.Beacon
+	// A slot well into the future so waitIntoSlot blocks rather than early-returning.
+	slot := cfg.EstimatedCurrentSlot() + 1_000_000
+	selectionProofs := []phase0.BLSSignature{signatureWithFirstByte(1)}
+	subnetIDs := []uint64{7}
+
+	client := &syncCommitteeClientMock{
+		beaconBlockRootFunc: func(_ context.Context, _ *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
+			t.Error("beacon node must not be queried when the context is canceled before the wait completes")
+			return nil, errors.New("unexpected call")
+		},
+	}
+
+	goClient := &GoClient{
+		log:          zap.NewNop(),
+		beaconConfig: &cfg,
+		multiClient:  client,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, version, err := goClient.GetSyncCommitteeContribution(ctx, slot, selectionProofs, subnetIDs)
+	require.ErrorContains(t, err, "wait for 1/3 of slot")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, DataVersionNil, version)
+	require.Nil(t, got)
+}
+
 func TestIsSyncCommitteeAggregatorHandlesZeroModulo(t *testing.T) {
 	t.Parallel()
 

--- a/beacon/goclient/sync_committee_test.go
+++ b/beacon/goclient/sync_committee_test.go
@@ -3,7 +3,6 @@ package goclient
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -247,7 +246,9 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 	)
 	client := &syncCommitteeClientMock{
 		beaconBlockRootFunc: func(_ context.Context, opts *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
-			require.Equal(t, fmt.Sprint(slot), opts.Block)
+			// Must query head, not the duty slot: a by-slot lookup 404s when the slot's
+			// proposal is missed, failing the contribution duty.
+			require.Equal(t, "head", opts.Block)
 			return &api.Response[*phase0.Root]{Data: &blockRoot}, nil
 		},
 		syncCommitteeContributionFunc: func(_ context.Context, opts *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error) {
@@ -298,6 +299,61 @@ func TestGetSyncCommitteeContributionPreservesInputOrdering(t *testing.T) {
 		require.Equal(t, blockRoot, contribution.Contribution.BeaconBlockRoot)
 		require.Equal(t, slot, contribution.Contribution.Slot)
 	}
+}
+
+// TestGetSyncCommitteeContributionFetchesHeadRoot is a regression test for the
+// empty-slot 404 bug: the contribution root must be resolved from "head", never the
+// duty slot. When the slot's proposal is missed, a by-slot block-root lookup 404s and
+// terminally fails the duty for the whole cluster, whereas "head" resolves to the
+// previous block's root — in the common case the root the cluster's sync-committee
+// messages signed.
+//
+// The mock 404s any by-slot lookup and only answers "head", so this test fails if the
+// query ever regresses to the by-slot form.
+func TestGetSyncCommitteeContributionFetchesHeadRoot(t *testing.T) {
+	t.Parallel()
+
+	cfg := *networkconfig.TestNetwork.Beacon
+	headRoot := phase0.Root{4, 5, 6}
+	slot := phase0.Slot(64)
+	selectionProofs := []phase0.BLSSignature{signatureWithFirstByte(1)}
+	subnetIDs := []uint64{7}
+
+	client := &syncCommitteeClientMock{
+		beaconBlockRootFunc: func(_ context.Context, opts *api.BeaconBlockRootOpts) (*api.Response[*phase0.Root], error) {
+			if opts.Block != "head" {
+				// Emulate a missed-proposal slot: the by-slot lookup the old code used 404s.
+				return nil, errors.New("GET failed with status 404: block not found")
+			}
+			return &api.Response[*phase0.Root]{Data: &headRoot}, nil
+		},
+		syncCommitteeContributionFunc: func(_ context.Context, opts *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error) {
+			// The contribution must be requested for the head root resolved above.
+			require.Equal(t, headRoot, opts.BeaconBlockRoot)
+			return &api.Response[*altair.SyncCommitteeContribution]{
+				Data: &altair.SyncCommitteeContribution{
+					Slot:              opts.Slot,
+					BeaconBlockRoot:   opts.BeaconBlockRoot,
+					SubcommitteeIndex: opts.SubcommitteeIndex,
+				},
+			}, nil
+		},
+	}
+
+	goClient := &GoClient{
+		log:          zap.NewNop(),
+		beaconConfig: &cfg,
+		multiClient:  client,
+	}
+
+	got, version, err := goClient.GetSyncCommitteeContribution(t.Context(), slot, selectionProofs, subnetIDs)
+	require.NoError(t, err)
+	require.Equal(t, spec.DataVersionAltair, version)
+
+	contributions, ok := got.(*spectypes.Contributions)
+	require.True(t, ok)
+	require.Len(t, *contributions, len(subnetIDs))
+	require.Equal(t, headRoot, (*contributions)[0].Contribution.BeaconBlockRoot)
 }
 
 func TestIsSyncCommitteeAggregatorHandlesZeroModulo(t *testing.T) {


### PR DESCRIPTION
Bucket A of #2902 — ports stage #2885 onto `boole-fork`.

**Bug:** `GetSyncCommitteeContribution` resolves the contribution root with a by-slot block-root lookup (`Block: fmt.Sprint(slot)`), which 404s whenever the duty slot's proposal is missed or arrives late → the SYNC_COMMITTEE_CONTRIBUTION duty fails for the whole cluster.

**Fix:** query `"head"`. Sync-committee messages sign the head root as seen during the duty slot, so for an empty/late slot the correct root is the previous block's — a head query returns it, a by-slot query 404s. Mirrors the message-path fix (#839) that the contribution path was left behind by.

Follow-ons from the same upstream commit: `waitOneThirdIntoSlot` surfaces ctx cancellation as an error; `DataVersionNil` on the 2/3-wait error path; manual nil-checks → `checkPtrResponse` (added on boole in #2905); dropped an obsolete loop-var copy. Adds a regression test that 404s any by-slot lookup and only answers `head`.

**Validation:** `go build ./...` clean (except the pre-existing `spectest fixRunnerForRun`); `go test ./beacon/goclient/...` green incl. the new regression test; gofmt clean.