### PR TITLE
fix(beacon): aggregate for the root the cluster attested with (#2888)

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -146,14 +146,14 @@ func (gc *GoClient) fetchVersionedAggregate(
 	// aggregate must exist. Re-deriving the data locally can yield a root nobody attested with,
 	// which the beacon node answers with a 404 (no matching aggregate).
 	//
-	// NOTE (boole adaptation): fetchVersionedAggregate is shared by both SubmitAggregateSelectionProof
-	// (AggregatorRunner) and GetAggregateAttestation (AggregatorCommitteeRunner). Both paths have the
-	// identical 404 risk, so injecting here fixes both — stage's #2888 only fixed the submit path.
+	// A cache hit only guarantees that *some* beacon node accepted the attestation. The
+	// AggregateAttestation request below is routed to the single highest-scored client and does
+	// not fail over on 4xx, so it can still 404 if that node hasn't ingested the attestation yet
+	// (gossip backfill before 2/3 of the slot makes this rare).
 	root, found := gc.attestedDataRoot(slot, committeeIndex)
 	if !found {
 		// No record of our own attestation (it failed or hasn't landed yet) — fall back to
-		// re-deriving the root from this node's view of the slot. computeAttestationDataRoot
-		// preserves #2900's authoritative-slot fork-gating (BeaconForkAtEpoch(EstimatedEpochAtSlot(slot))).
+		// re-deriving the root from this node's view of the slot, fork-gated by the duty slot.
 		var err error
 		root, err = gc.computeAttestationDataRoot(ctx, slot, committeeIndex)
 		if err != nil {

--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -141,9 +141,24 @@ func (gc *GoClient) fetchVersionedAggregate(
 	slot phase0.Slot,
 	committeeIndex phase0.CommitteeIndex,
 ) (*spec.VersionedAttestation, spec.DataVersion, error) {
-	root, err := gc.computeAttestationDataRoot(ctx, slot, committeeIndex)
-	if err != nil {
-		return nil, DataVersionNil, errMultiClient(fmt.Errorf("compute attestation root: %w", err), "AggregateAttestation")
+	// Prefer the root of the attestation data this node actually submitted (the cluster-decided
+	// value): the beacon node holds at least our own attestation matching it, so a matching
+	// aggregate must exist. Re-deriving the data locally can yield a root nobody attested with,
+	// which the beacon node answers with a 404 (no matching aggregate).
+	//
+	// NOTE (boole adaptation): fetchVersionedAggregate is shared by both SubmitAggregateSelectionProof
+	// (AggregatorRunner) and GetAggregateAttestation (AggregatorCommitteeRunner). Both paths have the
+	// identical 404 risk, so injecting here fixes both — stage's #2888 only fixed the submit path.
+	root, found := gc.attestedDataRoot(slot, committeeIndex)
+	if !found {
+		// No record of our own attestation (it failed or hasn't landed yet) — fall back to
+		// re-deriving the root from this node's view of the slot. computeAttestationDataRoot
+		// preserves #2900's authoritative-slot fork-gating (BeaconForkAtEpoch(EstimatedEpochAtSlot(slot))).
+		var err error
+		root, err = gc.computeAttestationDataRoot(ctx, slot, committeeIndex)
+		if err != nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("compute attestation root: %w", err), "AggregateAttestation")
+		}
 	}
 
 	start := time.Now()

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -314,71 +314,6 @@ func TestSubmitAggregateSelectionProof_FallbackSurfacesAttestationDataError(t *t
 	require.EqualValues(t, 1, attestationCalls.Load())
 }
 
-func TestAttestationCommitteeIndex(t *testing.T) {
-	t.Parallel()
-
-	data := &phase0.AttestationData{
-		Slot:   100,
-		Index:  3,
-		Source: &phase0.Checkpoint{Epoch: 1},
-		Target: &phase0.Checkpoint{Epoch: 2},
-	}
-
-	t.Run("pre-electra reads the data index", func(t *testing.T) {
-		t.Parallel()
-		att := aggregatorVersionedAttestation(spec.DataVersionPhase0, data)
-		got, err := attestationCommitteeIndex(att, data)
-		require.NoError(t, err)
-		require.Equal(t, phase0.CommitteeIndex(3), got)
-	})
-
-	t.Run("electra reads the single committee bit", func(t *testing.T) {
-		t.Parallel()
-		att := attestedVersionedAttestation(spec.DataVersionElectra, data, 7)
-		got, err := attestationCommitteeIndex(att, data)
-		require.NoError(t, err)
-		require.Equal(t, phase0.CommitteeIndex(7), got)
-	})
-
-	t.Run("fulu reads the single committee bit", func(t *testing.T) {
-		t.Parallel()
-		att := attestedVersionedAttestation(spec.DataVersionFulu, data, 9)
-		got, err := attestationCommitteeIndex(att, data)
-		require.NoError(t, err)
-		require.Equal(t, phase0.CommitteeIndex(9), got)
-	})
-
-	t.Run("electra with no committee bit set errors", func(t *testing.T) {
-		t.Parallel()
-		att := &spec.VersionedAttestation{
-			Version: spec.DataVersionElectra,
-			Electra: &electra.Attestation{Data: data, CommitteeBits: bitfield.NewBitvector64()},
-		}
-		_, err := attestationCommitteeIndex(att, data)
-		require.ErrorContains(t, err, "exactly one committee bit")
-	})
-
-	t.Run("electra with multiple committee bits errors", func(t *testing.T) {
-		t.Parallel()
-		bits := bitfield.NewBitvector64()
-		bits.SetBitAt(1, true)
-		bits.SetBitAt(2, true)
-		att := &spec.VersionedAttestation{
-			Version: spec.DataVersionElectra,
-			Electra: &electra.Attestation{Data: data, CommitteeBits: bits},
-		}
-		_, err := attestationCommitteeIndex(att, data)
-		require.ErrorContains(t, err, "exactly one committee bit")
-	})
-
-	t.Run("electra with no inner attestation errors", func(t *testing.T) {
-		t.Parallel()
-		att := &spec.VersionedAttestation{Version: spec.DataVersionElectra}
-		_, err := attestationCommitteeIndex(att, data)
-		require.Error(t, err)
-	})
-}
-
 func TestRememberAttestedDataRoots(t *testing.T) {
 	t.Parallel()
 
@@ -412,7 +347,7 @@ func TestRememberAttestedDataRoots(t *testing.T) {
 		rootC2 := mustHashTreeRoot(t, dataC2)
 		require.NotEqual(t, rootC1, rootC2)
 
-		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+		gc.rememberAttestedDataRoots(t.Context(), []*spec.VersionedAttestation{
 			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC1),
 			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC2),
 		})
@@ -439,7 +374,7 @@ func TestRememberAttestedDataRoots(t *testing.T) {
 		data := &phase0.AttestationData{Slot: slot, Source: &phase0.Checkpoint{Epoch: 1}, Target: &phase0.Checkpoint{Epoch: 2}}
 		root := mustHashTreeRoot(t, data)
 
-		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+		gc.rememberAttestedDataRoots(t.Context(), []*spec.VersionedAttestation{
 			attestedVersionedAttestation(spec.DataVersionElectra, data, 4),
 		})
 
@@ -458,8 +393,8 @@ func TestRememberAttestedDataRoots(t *testing.T) {
 		second := preElectraData(slot, committee, 0x02)
 		require.NotEqual(t, mustHashTreeRoot(t, first), mustHashTreeRoot(t, second))
 
-		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, first)})
-		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, second)})
+		gc.rememberAttestedDataRoots(t.Context(), []*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, first)})
+		gc.rememberAttestedDataRoots(t.Context(), []*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, second)})
 
 		got, ok := gc.attestedDataRoot(slot, committee)
 		require.True(t, ok)
@@ -476,7 +411,7 @@ func TestRememberAttestedDataRoots(t *testing.T) {
 		twoBits.SetBitAt(1, true)
 		twoBits.SetBitAt(2, true)
 
-		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+		gc.rememberAttestedDataRoots(t.Context(), []*spec.VersionedAttestation{
 			// Data() fails (nil inner attestation).
 			{Version: spec.DataVersionElectra},
 			// Committee extraction fails (two committee bits).

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -2,6 +2,7 @@ package goclient
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -13,17 +14,39 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+// aggregatorClientMock is used both as a MultiClient (single-client path) and, when placed in
+// GoClient.clients, as a Client for the parallel-submission path.
 type aggregatorClientMock struct {
 	mock.Service
+
+	submitAttestationsFn func(context.Context, *api.SubmitAttestationsOpts) error
 }
 
+var _ Client = (*aggregatorClientMock)(nil)
+
 func (*aggregatorClientMock) SubmitProposal(context.Context, *api.SubmitProposalOpts) error {
+	return nil
+}
+
+func (m *aggregatorClientMock) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
+	if m.submitAttestationsFn != nil {
+		return m.submitAttestationsFn(ctx, opts)
+	}
+	return nil
+}
+
+func (*aggregatorClientMock) NodeClient(context.Context) (*api.Response[string], error) {
+	return &api.Response[string]{Data: "mock"}, nil
+}
+
+func (*aggregatorClientMock) SubmitBlindedProposal(context.Context, *api.SubmitBlindedProposalOpts) error {
 	return nil
 }
 
@@ -156,6 +179,398 @@ func TestSubmitAggregateSelectionProof_UsesForkSpecificAggregateAndProof(t *test
 	}
 }
 
+func TestSubmitAggregateSelectionProof_PrefersAttestedDataRoot(t *testing.T) {
+	t.Parallel()
+
+	slotSig := make([]byte, 96)
+	validatorIndex := phase0.ValidatorIndex(42)
+	committeeIndex := phase0.CommitteeIndex(7)
+
+	testCases := []struct {
+		name    string
+		version spec.DataVersion
+		epoch   phase0.Epoch
+	}{
+		{name: "electra committee comes from committee bits", version: spec.DataVersionElectra, epoch: 5},
+		{name: "fulu committee comes from committee bits", version: spec.DataVersionFulu, epoch: 6},
+		{name: "pre-electra committee comes from data index", version: spec.DataVersionPhase0, epoch: 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+			slot := cfg.FirstSlotAtEpoch(tc.epoch)
+
+			// The data the cluster decided and attested with.
+			attestedData := &phase0.AttestationData{
+				Slot:            slot,
+				BeaconBlockRoot: phase0.Root{1, 2, 3},
+				Source:          &phase0.Checkpoint{Epoch: 1},
+				Target:          &phase0.Checkpoint{Epoch: 2},
+			}
+			if tc.version < spec.DataVersionElectra {
+				attestedData.Index = committeeIndex
+			}
+			expectedRoot, err := attestedData.HashTreeRoot()
+			require.NoError(t, err)
+
+			service := &aggregatorClientMock{}
+			service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+				t.Error("attestation data must not be re-derived when the attested root is known")
+				return nil, nil
+			}
+			service.AggregateAttestationFunc = func(_ context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+				require.Equal(t, slot, opts.Slot)
+				require.Equal(t, committeeIndex, opts.CommitteeIndex)
+				require.EqualValues(t, expectedRoot, opts.AttestationDataRoot)
+
+				return &api.Response[*spec.VersionedAttestation]{
+					Data: aggregatorVersionedAttestation(tc.version, attestedData),
+				}, nil
+			}
+
+			client := newAggregatorTestClient(&cfg, service)
+
+			require.NoError(t, client.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+				attestedVersionedAttestation(tc.version, attestedData, committeeIndex),
+			}))
+
+			_, gotVersion, err := client.SubmitAggregateSelectionProof(
+				t.Context(), slot, committeeIndex, 128, validatorIndex, slotSig,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.version, gotVersion)
+		})
+	}
+}
+
+func TestGetAggregateAttestation_PrefersAttestedDataRoot(t *testing.T) {
+	t.Parallel()
+
+	// Electra is representative: the boole-specific adaptation fixes both SubmitAggregateSelectionProof
+	// (AggregatorRunner) and GetAggregateAttestation (AggregatorCommitteeRunner) via the shared
+	// fetchVersionedAggregate injection point. This test exercises that second path.
+	cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+	committeeIndex := phase0.CommitteeIndex(7)
+	epoch := phase0.Epoch(5)
+	slot := cfg.FirstSlotAtEpoch(epoch)
+
+	attestedData := &phase0.AttestationData{
+		Slot:            slot,
+		BeaconBlockRoot: phase0.Root{4, 5, 6},
+		Source:          &phase0.Checkpoint{Epoch: 1},
+		Target:          &phase0.Checkpoint{Epoch: 2},
+	}
+	expectedRoot, err := attestedData.HashTreeRoot()
+	require.NoError(t, err)
+
+	service := &aggregatorClientMock{}
+	service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+		t.Error("attestation data must not be re-derived when the attested root is known")
+		return nil, nil
+	}
+	service.AggregateAttestationFunc = func(_ context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+		require.Equal(t, slot, opts.Slot)
+		require.Equal(t, committeeIndex, opts.CommitteeIndex)
+		require.EqualValues(t, expectedRoot, opts.AttestationDataRoot)
+
+		return &api.Response[*spec.VersionedAttestation]{
+			Data: aggregatorVersionedAttestation(spec.DataVersionElectra, attestedData),
+		}, nil
+	}
+
+	client := newAggregatorTestClient(&cfg, service)
+
+	require.NoError(t, client.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+		attestedVersionedAttestation(spec.DataVersionElectra, attestedData, committeeIndex),
+	}))
+
+	_, gotVersion, err := client.GetAggregateAttestation(t.Context(), slot, committeeIndex)
+	require.NoError(t, err)
+	require.Equal(t, spec.DataVersionElectra, gotVersion)
+}
+
+func TestSubmitAggregateSelectionProof_FallbackSurfacesAttestationDataError(t *testing.T) {
+	t.Parallel()
+
+	cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+	slot := cfg.FirstSlotAtEpoch(0)
+
+	var attestationCalls atomic.Int32
+	service := &aggregatorClientMock{}
+	service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+		attestationCalls.Add(1)
+		return nil, errors.New("attestation data unavailable")
+	}
+
+	client := newAggregatorTestClient(&cfg, service)
+
+	// No prior SubmitAttestations, so the attested root is unknown and the flow falls back to
+	// re-deriving it via GetAttestationData — whose error must surface to the caller.
+	_, _, err := client.SubmitAggregateSelectionProof(t.Context(), slot, 7, 128, 42, make([]byte, 96))
+	require.ErrorContains(t, err, "fetch attestation data")
+	require.EqualValues(t, 1, attestationCalls.Load())
+}
+
+func TestAttestationCommitteeIndex(t *testing.T) {
+	t.Parallel()
+
+	data := &phase0.AttestationData{
+		Slot:   100,
+		Index:  3,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+
+	t.Run("pre-electra reads the data index", func(t *testing.T) {
+		t.Parallel()
+		att := aggregatorVersionedAttestation(spec.DataVersionPhase0, data)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(3), got)
+	})
+
+	t.Run("electra reads the single committee bit", func(t *testing.T) {
+		t.Parallel()
+		att := attestedVersionedAttestation(spec.DataVersionElectra, data, 7)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(7), got)
+	})
+
+	t.Run("fulu reads the single committee bit", func(t *testing.T) {
+		t.Parallel()
+		att := attestedVersionedAttestation(spec.DataVersionFulu, data, 9)
+		got, err := attestationCommitteeIndex(att, data)
+		require.NoError(t, err)
+		require.Equal(t, phase0.CommitteeIndex(9), got)
+	})
+
+	t.Run("electra with no committee bit set errors", func(t *testing.T) {
+		t.Parallel()
+		att := &spec.VersionedAttestation{
+			Version: spec.DataVersionElectra,
+			Electra: &electra.Attestation{Data: data, CommitteeBits: bitfield.NewBitvector64()},
+		}
+		_, err := attestationCommitteeIndex(att, data)
+		require.ErrorContains(t, err, "exactly one committee bit")
+	})
+
+	t.Run("electra with multiple committee bits errors", func(t *testing.T) {
+		t.Parallel()
+		bits := bitfield.NewBitvector64()
+		bits.SetBitAt(1, true)
+		bits.SetBitAt(2, true)
+		att := &spec.VersionedAttestation{
+			Version: spec.DataVersionElectra,
+			Electra: &electra.Attestation{Data: data, CommitteeBits: bits},
+		}
+		_, err := attestationCommitteeIndex(att, data)
+		require.ErrorContains(t, err, "exactly one committee bit")
+	})
+
+	t.Run("electra with no inner attestation errors", func(t *testing.T) {
+		t.Parallel()
+		att := &spec.VersionedAttestation{Version: spec.DataVersionElectra}
+		_, err := attestationCommitteeIndex(att, data)
+		require.Error(t, err)
+	})
+}
+
+func TestRememberAttestedDataRoots(t *testing.T) {
+	t.Parallel()
+
+	newClient := func() *GoClient {
+		return &GoClient{
+			log:                   zap.NewNop(),
+			attestedDataRootCache: ttlcache.New[attestedDataRootKey, phase0.Root](),
+		}
+	}
+
+	preElectraData := func(slot phase0.Slot, committee phase0.CommitteeIndex, block byte) *phase0.AttestationData {
+		return &phase0.AttestationData{
+			Slot:            slot,
+			Index:           committee, // pre-Electra the committee is part of the data
+			BeaconBlockRoot: phase0.Root{block},
+			Source:          &phase0.Checkpoint{Epoch: 1},
+			Target:          &phase0.Checkpoint{Epoch: 2},
+		}
+	}
+
+	t.Run("keys remembered roots by committee", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(100)
+
+		// Pre-Electra the committee is encoded in the data, so the two committees produce
+		// distinct roots — exactly what the (slot, committee) key must keep apart.
+		dataC1 := preElectraData(slot, 1, 0x01)
+		dataC2 := preElectraData(slot, 2, 0x02)
+		rootC1 := mustHashTreeRoot(t, dataC1)
+		rootC2 := mustHashTreeRoot(t, dataC2)
+		require.NotEqual(t, rootC1, rootC2)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC1),
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, dataC2),
+		})
+
+		got1, ok1 := gc.attestedDataRoot(slot, 1)
+		require.True(t, ok1)
+		require.Equal(t, rootC1, got1)
+
+		got2, ok2 := gc.attestedDataRoot(slot, 2)
+		require.True(t, ok2)
+		require.Equal(t, rootC2, got2)
+
+		// A committee we never attested for, and a different slot, both miss.
+		_, ok3 := gc.attestedDataRoot(slot, 3)
+		require.False(t, ok3)
+		_, okOtherSlot := gc.attestedDataRoot(slot+1, 1)
+		require.False(t, okOtherSlot)
+	})
+
+	t.Run("remembers electra roots via committee bits", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(200)
+		data := &phase0.AttestationData{Slot: slot, Source: &phase0.Checkpoint{Epoch: 1}, Target: &phase0.Checkpoint{Epoch: 2}}
+		root := mustHashTreeRoot(t, data)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			attestedVersionedAttestation(spec.DataVersionElectra, data, 4),
+		})
+
+		got, ok := gc.attestedDataRoot(slot, 4)
+		require.True(t, ok)
+		require.Equal(t, root, got)
+	})
+
+	t.Run("last submission wins for the same key", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(300)
+		committee := phase0.CommitteeIndex(5)
+
+		first := preElectraData(slot, committee, 0x01)
+		second := preElectraData(slot, committee, 0x02)
+		require.NotEqual(t, mustHashTreeRoot(t, first), mustHashTreeRoot(t, second))
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, first)})
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{aggregatorVersionedAttestation(spec.DataVersionPhase0, second)})
+
+		got, ok := gc.attestedDataRoot(slot, committee)
+		require.True(t, ok)
+		require.Equal(t, mustHashTreeRoot(t, second), got)
+	})
+
+	t.Run("skips malformed attestations and keeps valid ones", func(t *testing.T) {
+		t.Parallel()
+		gc := newClient()
+		slot := phase0.Slot(400)
+		valid := preElectraData(slot, 6, 0x01)
+
+		twoBits := bitfield.NewBitvector64()
+		twoBits.SetBitAt(1, true)
+		twoBits.SetBitAt(2, true)
+
+		gc.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			// Data() fails (nil inner attestation).
+			{Version: spec.DataVersionElectra},
+			// Committee extraction fails (two committee bits).
+			{Version: spec.DataVersionElectra, Electra: &electra.Attestation{Data: valid, CommitteeBits: twoBits}},
+			// Valid — must still be remembered despite the malformed entries above.
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, valid),
+		})
+
+		got, ok := gc.attestedDataRoot(slot, 6)
+		require.True(t, ok)
+		require.Equal(t, mustHashTreeRoot(t, valid), got)
+	})
+}
+
+func TestSubmitAttestations_ParallelSubmissionRemembersRoots(t *testing.T) {
+	t.Parallel()
+
+	slot := phase0.Slot(500)
+	committee := phase0.CommitteeIndex(8)
+	data := &phase0.AttestationData{
+		Slot:   slot,
+		Index:  committee,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+	root := mustHashTreeRoot(t, data)
+
+	var failingCalls, succeedingCalls atomic.Int32
+	failing := &aggregatorClientMock{submitAttestationsFn: func(context.Context, *api.SubmitAttestationsOpts) error {
+		failingCalls.Add(1)
+		return errors.New("first client failed")
+	}}
+	succeeding := &aggregatorClientMock{submitAttestationsFn: func(context.Context, *api.SubmitAttestationsOpts) error {
+		succeedingCalls.Add(1)
+		return nil
+	}}
+
+	gc := &GoClient{
+		log:                     zap.NewNop(),
+		clients:                 []Client{failing, succeeding},
+		withParallelSubmissions: true,
+		attestedDataRootCache:   ttlcache.New[attestedDataRootKey, phase0.Root](),
+	}
+
+	require.NoError(t, gc.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+		aggregatorVersionedAttestation(spec.DataVersionPhase0, data),
+	}))
+	require.EqualValues(t, 1, failingCalls.Load())
+	require.EqualValues(t, 1, succeedingCalls.Load())
+
+	// One client failed but the other accepted the attestation, so the root is still remembered.
+	got, ok := gc.attestedDataRoot(slot, committee)
+	require.True(t, ok)
+	require.Equal(t, root, got)
+}
+
+func TestSubmitAttestations_ParallelSubmissionNoClientsErrsWithoutRemembering(t *testing.T) {
+	t.Parallel()
+
+	slot := phase0.Slot(500)
+	committee := phase0.CommitteeIndex(8)
+	data := &phase0.AttestationData{
+		Slot:   slot,
+		Index:  committee,
+		Source: &phase0.Checkpoint{Epoch: 1},
+		Target: &phase0.Checkpoint{Epoch: 2},
+	}
+
+	// No clients to submit to. SubmitAttestations must surface an error and must NOT remember the
+	// root: nothing was submitted, so the aggregator flow would otherwise request an aggregate for
+	// a root no beacon node holds — the exact 404 this cache exists to avoid.
+	gc := &GoClient{
+		log:                     zap.NewNop(),
+		clients:                 nil,
+		withParallelSubmissions: true,
+		attestedDataRootCache:   ttlcache.New[attestedDataRootKey, phase0.Root](),
+	}
+
+	err := gc.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+		aggregatorVersionedAttestation(spec.DataVersionPhase0, data),
+	})
+	require.Error(t, err)
+
+	_, ok := gc.attestedDataRoot(slot, committee)
+	require.False(t, ok, "root must not be remembered when nothing was submitted")
+}
+
+func mustHashTreeRoot(t *testing.T, data *phase0.AttestationData) phase0.Root {
+	t.Helper()
+	root, err := data.HashTreeRoot()
+	require.NoError(t, err)
+	return root
+}
+
 func TestSubmitAggregateSelectionProof_RespectsContextCancellationWhileWaiting(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		cfg := aggregatorTestBeaconConfig(time.Now())
@@ -205,11 +620,12 @@ func epochPtr(epoch phase0.Epoch) *phase0.Epoch {
 
 func newAggregatorTestClient(cfg *networkconfig.Beacon, service MultiClient) *GoClient {
 	client := &GoClient{
-		log:                  zap.NewNop(),
-		beaconConfig:         cfg,
-		multiClient:          service,
-		attestationDataCache: ttlcache.New[phase0.Slot, *phase0.AttestationData](),
-		headCache:            ttlcache.New[phase0.Slot, phase0.Root](),
+		log:                   zap.NewNop(),
+		beaconConfig:          cfg,
+		multiClient:           service,
+		attestationDataCache:  ttlcache.New[phase0.Slot, *phase0.AttestationData](),
+		attestedDataRootCache: ttlcache.New[attestedDataRootKey, phase0.Root](),
+		headCache:             ttlcache.New[phase0.Slot, phase0.Root](),
 	}
 	client.fetchAttestationDataFunc = client.fetchAttestationData
 	return client
@@ -234,6 +650,27 @@ func aggregatorVersionedAttestation(version spec.DataVersion, data *phase0.Attes
 	default:
 		panic("unsupported version")
 	}
+}
+
+// attestedVersionedAttestation builds an attestation the way the committee runner submits
+// it: pre-Electra the committee is the data's Index, Electra+ it's the set committee bit.
+func attestedVersionedAttestation(version spec.DataVersion, data *phase0.AttestationData, committee phase0.CommitteeIndex) *spec.VersionedAttestation {
+	att := aggregatorVersionedAttestation(version, data)
+	if version < spec.DataVersionElectra {
+		return att
+	}
+
+	committeeBits := bitfield.NewBitvector64()
+	committeeBits.SetBitAt(uint64(committee), true)
+	switch version {
+	case spec.DataVersionElectra:
+		att.Electra.CommitteeBits = committeeBits
+	case spec.DataVersionFulu:
+		att.Fulu.CommitteeBits = committeeBits
+	default:
+		panic("unsupported electra+ version")
+	}
+	return att
 }
 
 func requireAggregateAndProof(

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -581,7 +581,7 @@ func (gc *GoClient) SubmitAttestations(ctx context.Context, attestations []*spec
 
 	// Only reached when at least one client accepted the attestations, so the beacon node
 	// holds them — remember their data roots for the aggregator flow.
-	gc.rememberAttestedDataRoots(attestations)
+	gc.rememberAttestedDataRoots(ctx, attestations)
 	return nil
 }
 
@@ -597,24 +597,38 @@ type attestedDataRootKey struct {
 // per (slot, committee). The aggregator flow prefers this root over re-deriving the data:
 // the beacon node holds at least our own attestation matching it, so an aggregate must
 // exist, while a re-derived root may match nothing anyone attested with.
-func (gc *GoClient) rememberAttestedDataRoots(attestations []*spec.VersionedAttestation) {
+//
+// The committee runner submits one attestation per validator, and validators in the same
+// committee share a single AttestationData (for Electra it is identical across all committees),
+// so we dedupe per distinct (slot, committee) to hash and store each root only once.
+func (gc *GoClient) rememberAttestedDataRoots(ctx context.Context, attestations []*spec.VersionedAttestation) {
+	seen := make(map[attestedDataRootKey]struct{}, len(attestations))
 	for _, att := range attestations {
 		data, err := att.Data()
 		if err != nil {
-			gc.log.Debug("could not extract attestation data", zap.Error(err))
+			// We just submitted this attestation successfully, so extraction should not fail; a
+			// silent miss would degrade the aggregator flow to the 404-prone re-derivation.
+			gc.log.Warn("could not extract attestation data to remember its root", zap.Error(err))
+			attestedDataRootRememberFailedCounter.Add(ctx, 1)
 			continue
 		}
-		committee, err := attestationCommitteeIndex(att, data)
+		committee, err := att.CommitteeIndex()
 		if err != nil {
-			gc.log.Debug("could not extract attestation committee index", zap.Error(err))
+			gc.log.Warn("could not extract attestation committee index to remember its root", zap.Error(err))
+			attestedDataRootRememberFailedCounter.Add(ctx, 1)
+			continue
+		}
+		key := attestedDataRootKey{slot: data.Slot, committee: committee}
+		if _, ok := seen[key]; ok {
 			continue
 		}
 		root, err := data.HashTreeRoot()
 		if err != nil {
-			gc.log.Debug("could not hash attestation data", zap.Error(err))
+			gc.log.Warn("could not hash attestation data to remember its root", zap.Error(err))
+			attestedDataRootRememberFailedCounter.Add(ctx, 1)
 			continue
 		}
-		key := attestedDataRootKey{slot: data.Slot, committee: committee}
+		seen[key] = struct{}{}
 		gc.attestedDataRootCache.Set(key, root, ttlcache.DefaultTTL)
 	}
 }
@@ -627,22 +641,4 @@ func (gc *GoClient) attestedDataRoot(slot phase0.Slot, committee phase0.Committe
 		return phase0.Root{}, false
 	}
 	return item.Value(), true
-}
-
-// attestationCommitteeIndex extracts the committee an attestation belongs to: from the
-// committee bits for Electra and later (EIP-7549), from the data's Index field before.
-func attestationCommitteeIndex(att *spec.VersionedAttestation, data *phase0.AttestationData) (phase0.CommitteeIndex, error) {
-	if att.Version < spec.DataVersionElectra {
-		return data.Index, nil
-	}
-	bits, err := att.CommitteeBits()
-	if err != nil {
-		return 0, err
-	}
-	indices := bits.BitIndices()
-	if len(indices) != 1 {
-		return 0, fmt.Errorf("expected exactly one committee bit, got %d", len(indices))
-	}
-	// A bit index is a position within a 64-bit vector, so it is always non-negative.
-	return phase0.CommitteeIndex(indices[0]), nil //nolint:gosec
 }

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -525,12 +525,18 @@ func weightedAttestationDataRequestIDField(id uuid.UUID) zap.Field {
 }
 
 // multiClientSubmit is a generic function that submits data to multiple beacon clients concurrently.
-// Returns nil if at least one client successfully submitted the data.
+// Returns nil only if at least one client successfully submitted the data.
 func (gc *GoClient) multiClientSubmit(
 	ctx context.Context,
 	routeName string,
 	submitFunc func(ctx context.Context, client Client) error,
 ) error {
+	if len(gc.clients) == 0 {
+		// No clients to submit to. Guard explicitly: WithMaxGoroutines(0) below would panic, and
+		// returning nil would break the "nil only on success" contract — callers such as the
+		// attested-data-root cache would then treat a non-submission as a success.
+		return errMultiClient(fmt.Errorf("no clients available to submit"), routeName)
+	}
 	submissions := atomic.Int32{}
 	p := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(len(gc.clients))
 	for _, client := range gc.clients {
@@ -550,27 +556,93 @@ func (gc *GoClient) multiClientSubmit(
 		// At least one client has submitted successfully, so we can return without error.
 		return nil
 	}
-	if err != nil {
-		return errMultiClient(fmt.Errorf("all clients failed to submit: %w", err), routeName)
-	}
-	return nil
+	// With at least one client, zero successful submissions means every client errored, so
+	// p.Wait() returned a non-nil error.
+	return errMultiClient(fmt.Errorf("all clients failed to submit: %w", err), routeName)
 }
 
 // SubmitAttestations implements Beacon interface and sends attestations to the first client that succeeds
 func (gc *GoClient) SubmitAttestations(ctx context.Context, attestations []*spec.VersionedAttestation) error {
 	opts := &api.SubmitAttestationsOpts{Attestations: attestations}
 	if gc.withParallelSubmissions {
-		return gc.multiClientSubmit(ctx, "SubmitAttestations", func(ctx context.Context, client Client) error {
+		if err := gc.multiClientSubmit(ctx, "SubmitAttestations", func(ctx context.Context, client Client) error {
 			return client.SubmitAttestations(ctx, opts)
-		})
+		}); err != nil {
+			return err
+		}
+	} else {
+		start := time.Now()
+		err := gc.multiClient.SubmitAttestations(ctx, opts)
+		recordRequest(ctx, gc.log, "SubmitAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
+		if err != nil {
+			return errMultiClient(fmt.Errorf("submit attestations: %w", err), "SubmitAttestations")
+		}
 	}
 
-	start := time.Now()
-	err := gc.multiClient.SubmitAttestations(ctx, opts)
-	recordRequest(ctx, gc.log, "SubmitAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
-	if err != nil {
-		return errMultiClient(fmt.Errorf("submit attestations: %w", err), "SubmitAttestations")
-	}
-
+	// Only reached when at least one client accepted the attestations, so the beacon node
+	// holds them — remember their data roots for the aggregator flow.
+	gc.rememberAttestedDataRoots(attestations)
 	return nil
+}
+
+// attestedDataRootKey identifies the attestation data a validator attested with; pre-Electra
+// each committee signs different data (the committee is part of it as Index), so the
+// committee belongs in the key.
+type attestedDataRootKey struct {
+	slot      phase0.Slot
+	committee phase0.CommitteeIndex
+}
+
+// rememberAttestedDataRoots caches the root of the attestation data that was just submitted,
+// per (slot, committee). The aggregator flow prefers this root over re-deriving the data:
+// the beacon node holds at least our own attestation matching it, so an aggregate must
+// exist, while a re-derived root may match nothing anyone attested with.
+func (gc *GoClient) rememberAttestedDataRoots(attestations []*spec.VersionedAttestation) {
+	for _, att := range attestations {
+		data, err := att.Data()
+		if err != nil {
+			gc.log.Debug("could not extract attestation data", zap.Error(err))
+			continue
+		}
+		committee, err := attestationCommitteeIndex(att, data)
+		if err != nil {
+			gc.log.Debug("could not extract attestation committee index", zap.Error(err))
+			continue
+		}
+		root, err := data.HashTreeRoot()
+		if err != nil {
+			gc.log.Debug("could not hash attestation data", zap.Error(err))
+			continue
+		}
+		key := attestedDataRootKey{slot: data.Slot, committee: committee}
+		gc.attestedDataRootCache.Set(key, root, ttlcache.DefaultTTL)
+	}
+}
+
+// attestedDataRoot returns the root of the attestation data this node submitted for the
+// given slot and committee, if known.
+func (gc *GoClient) attestedDataRoot(slot phase0.Slot, committee phase0.CommitteeIndex) (phase0.Root, bool) {
+	item := gc.attestedDataRootCache.Get(attestedDataRootKey{slot: slot, committee: committee})
+	if item == nil {
+		return phase0.Root{}, false
+	}
+	return item.Value(), true
+}
+
+// attestationCommitteeIndex extracts the committee an attestation belongs to: from the
+// committee bits for Electra and later (EIP-7549), from the data's Index field before.
+func attestationCommitteeIndex(att *spec.VersionedAttestation, data *phase0.AttestationData) (phase0.CommitteeIndex, error) {
+	if att.Version < spec.DataVersionElectra {
+		return data.Index, nil
+	}
+	bits, err := att.CommitteeBits()
+	if err != nil {
+		return 0, err
+	}
+	indices := bits.BitIndices()
+	if len(indices) != 1 {
+		return 0, fmt.Errorf("expected exactly one committee bit, got %d", len(indices))
+	}
+	// A bit index is a position within a 64-bit vector, so it is always non-negative.
+	return phase0.CommitteeIndex(indices[0]), nil //nolint:gosec
 }

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -127,6 +127,11 @@ type GoClient struct {
 	// AttestationData is cached by slot only, because Beacon nodes should return the same
 	// data regardless of the requested committeeIndex.
 	attestationDataCache *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
+	// attestedDataRootCache remembers the root of the attestation data this node actually
+	// submitted (the cluster-decided value), per (slot, committee), for the aggregator flow.
+	// Unlike attestationDataCache — this node's local, pre-consensus view — this is the value
+	// the cluster attested with, which is the one an aggregate must match.
+	attestedDataRootCache *ttlcache.Cache[attestedDataRootKey, phase0.Root]
 	// domainDataReqInflight joins parallel requests for the same epoch/domain pair.
 	domainDataReqInflight singleflight.Group[domainDataCacheKey, phase0.Domain]
 	// domainDataCache helps reuse recently fetched domains. Domains change only at epoch boundaries,
@@ -251,6 +256,13 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 
 	// Start automatic expired item deletion for attestationDataCache.
 	go client.attestationDataCache.Start()
+
+	client.attestedDataRootCache = ttlcache.New(
+		// aggregates are requested during the duty slot (and never later),
+		// hence caching the attested roots for 2 slots is sufficient
+		ttlcache.WithTTL[attestedDataRootKey, phase0.Root](2 * config.SlotDuration),
+	)
+	go client.attestedDataRootCache.Start()
 
 	// Domain data and committee assignments change at epoch boundaries, so keep both caches
 	// for approximately two epochs.

--- a/beacon/goclient/observability.go
+++ b/beacon/goclient/observability.go
@@ -130,6 +130,14 @@ var (
 			observability.InstrumentName(observabilityNamespace, "proposal.parent_mismatch"),
 			metric.WithUnit("{mismatch}"),
 			metric.WithDescription("proposal parent root did not match cached HeadEvent")))
+
+	// Counts attestations we submitted successfully but could not remember the data root for, so
+	// the aggregator flow silently degrades to the 404-prone re-derivation. Should stay at zero.
+	attestedDataRootRememberFailedCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "attestation_data.remember_root_failed"),
+			metric.WithUnit("{failure}"),
+			metric.WithDescription("submitted attestations whose data root could not be remembered for the aggregator flow")))
 )
 
 func recordRequest(


### PR DESCRIPTION
Bucket A of #2902 — ports stage #2888 onto `boole-fork`, reconciled with boole's #2900.

**Bug:** the aggregator re-derives attestation data at 2/3 of the slot and requests the aggregate for *that* root — this node's local view, not necessarily what the cluster's QBFT decided and attested with. On head divergence the re-derived root matches nothing anyone attested with → beacon node **404 → the whole cluster's AGGREGATOR duty fails** (lost rewards, intermittent).

**Fix:** remember the root of the attestation data this node actually submitted (`SubmitAttestations`), keyed by `(slot, committee)`, and request the aggregate for that root — the beacon node holds at least our own attestation matching it, so an aggregate must exist. Fall back to re-deriving when uncached (attestation failed / not landed yet).

**Boole reconciliation (the part that differs from stage):**
- The attested-root preference is injected in `fetchVersionedAggregate`, which boole shares between `SubmitAggregateSelectionProof` (AggregatorRunner) **and** `GetAggregateAttestation` (boole's `AggregatorCommitteeRunner`). So **both** boole aggregator paths are fixed — stage's #2888 only covered the submit path.
- `computeAttestationDataRoot` keeps **#2900**'s duty-slot fork-gating untouched, as the fallback.
- Guards `multiClientSubmit` against zero clients (would panic on `WithMaxGoroutines(0)` / silently return nil and cache a never-submitted root).

**Review:** deep-reviewed (consensus-correctness) — APPROVE, no must/should-fix; committee-index cache keying traced end-to-end. Ported the full upstream regression suite + added `TestGetAggregateAttestation_PrefersAttestedDataRoot` for boole's second path. #2900's `UsesForkSpecificAggregateAndProof` test still green. `go build/test/vet/gofmt` clean (except pre-existing `spectest fixRunnerForRun`).