### PR TITLE
fix(duties): retry-capable sync-committee duty-fetching (#2769)

### DIFF
--- a/networkconfig/beacon.go
+++ b/networkconfig/beacon.go
@@ -99,8 +99,10 @@ func (b *Beacon) FirstEpochOfSyncPeriod(period uint64) phase0.Epoch {
 	return phase0.Epoch(period * b.EpochsPerSyncCommitteePeriod)
 }
 
-// LastSlotOfSyncPeriod calculates the first epoch of the given sync period.
-func (b *Beacon) LastSlotOfSyncPeriod(period uint64) phase0.Slot {
+// LastActionableSlotOfSyncPeriod calculates the last slot of the given sync period for which
+// producing a sync committee message still makes sense. Note this is one slot before the period's
+// literal last slot (a message produced during that final slot would never be included).
+func (b *Beacon) LastActionableSlotOfSyncPeriod(period uint64) phase0.Slot {
 	lastEpoch := b.FirstEpochOfSyncPeriod(period+1) - 1
 	// If we are in the sync committee that ends at slot x we do not generate a message during slot x-1
 	// as it will never be included, hence -1.

--- a/networkconfig/beacon_test.go
+++ b/networkconfig/beacon_test.go
@@ -134,3 +134,49 @@ func TestForkAtEpoch(t *testing.T) {
 		require.Equal(t, tc.fork, *fork, "Wrong fork")
 	}
 }
+
+func TestSyncCommitteePeriodHelpers(t *testing.T) {
+	config := &Beacon{
+		SlotsPerEpoch:                32,
+		EpochsPerSyncCommitteePeriod: 8, // 8 * 32 = 256 slots per period
+	}
+
+	tests := []struct {
+		name               string
+		period             uint64
+		firstEpoch         phase0.Epoch
+		lastActionableSlot phase0.Slot
+		firstNextSlot      phase0.Slot
+	}{
+		{
+			name:               "first period",
+			period:             0,
+			firstEpoch:         0,
+			firstNextSlot:      256,
+			lastActionableSlot: 254,
+		},
+		{
+			name:               "second period",
+			period:             1,
+			firstEpoch:         8,
+			firstNextSlot:      512,
+			lastActionableSlot: 510,
+		},
+		{
+			name:               "third period",
+			period:             2,
+			firstEpoch:         16,
+			firstNextSlot:      768,
+			lastActionableSlot: 766,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.firstEpoch, config.FirstEpochOfSyncPeriod(tc.period))
+			require.Equal(t, tc.firstNextSlot, config.FirstSlotAtEpoch(config.FirstEpochOfSyncPeriod(tc.period+1)))
+			require.Equal(t, tc.lastActionableSlot, config.LastActionableSlotOfSyncPeriod(tc.period))
+			require.Equal(t, tc.firstNextSlot-2, config.LastActionableSlotOfSyncPeriod(tc.period))
+		})
+	}
+}

--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -124,7 +124,15 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 					delete(h.dutyFetchIntents, currentEpoch-1)
 				}
 
-				// 2. Process validator indices changes (if any). We want to process it on the current slot only
+				// 2. Schedule the next-epoch duty-fetch intent (only if absent, so a pending or fulfilled one is
+				// left untouched). We register it before the indices-change handling below, which can return early
+				// on tickCtx.Done - so even a tick that overruns its deadline still records the intent, and the
+				// next-epoch pre-fetch can't be deferred indefinitely at an epoch boundary under sustained slowness.
+				if _, ok := h.dutyFetchIntents[nextEpoch]; !ok {
+					h.dutyFetchIntents[nextEpoch] = false
+				}
+
+				// 3. Process validator indices changes (if any). We want to process it on the current slot only
 				// if we are still early into the slot (1 slot-interval is just a guesstimate), otherwise we might
 				// be delaying the next tick (the duties that need to be executed on the next slot).
 
@@ -134,10 +142,10 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 					logger.Info("🔁 indices change received")
 
 					// 1) Declare intents.
-					// Some validator-related state has updated, means we need to re-fetch the duties for the current
-					// and next epoch to ensure we have the up-to-date duties for all validators for both epochs.
-					h.dutyFetchIntents[nextEpoch] = false
+					// Some validator-related state has changed, so re-fetch the duties for the current and next
+					// epoch to keep them up to date for all validators.
 					h.dutyFetchIntents[currentEpoch] = false
+					h.dutyFetchIntents[nextEpoch] = false
 
 					// 2) Process certain intents immediately.
 					// When at epoch boundary, we only care about pre-fetching & preparing the duties for the next
@@ -153,12 +161,6 @@ func (h *AttesterHandler) HandleDuties(ctx context.Context) {
 					// It's too late(risky) to handle indices change on the current slot, we'll do it on the next slot.
 				case <-tickCtx.Done():
 					return
-				}
-
-				// 3. Schedule the duty-fetch for the next epoch, but only if it hasn't been scheduled already (also,
-				// already fulfilled intents need not be re-scheduled).
-				if _, ok := h.dutyFetchIntents[nextEpoch]; !ok {
-					h.dutyFetchIntents[nextEpoch] = false
 				}
 			}()
 

--- a/operator/duties/base_handler.go
+++ b/operator/duties/base_handler.go
@@ -82,7 +82,13 @@ func (h *baseHandler) shouldFetchNextEpoch(currentSlot phase0.Slot) bool {
 	return uint64(currentSlot)%slotsPerEpoch > slotsPerEpoch/2-2
 }
 
+// atLastSlotOfCurrentEpoch returns true if the currentSlot is the latest slot of the current epoch.
 func (h *baseHandler) atLastSlotOfCurrentEpoch(currentSlot phase0.Slot) bool {
 	slotsPerEpoch := h.netCfg.SlotsPerEpoch
 	return uint64(currentSlot+1)%slotsPerEpoch == 0
+}
+
+// atLastSlotOrPastCurrentPeriod returns true if the currentSlot is at or past the last actionable slot of the currentPeriod.
+func (h *baseHandler) atLastSlotOrPastCurrentPeriod(currentSlot phase0.Slot, currentPeriod uint64) bool {
+	return currentSlot >= h.netCfg.LastActionableSlotOfSyncPeriod(currentPeriod)
 }

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -360,17 +360,19 @@ func TestScheduler_Committee_Indices_Changed_Attester_Only(t *testing.T) {
 		})
 		scheduler.indicesChgCh <- struct{}{}
 		waitForDuties.Set(true)
-		// wait for attester duties to be fetched in slot 0
+		// Two fetches happen here: one for the attester handler and one for the sync-committee handler.
+		// The sync-committee handler's indicesChangeCh is now consumed inside the slot-tick closure
+		// (not the outer select), so it also triggers a re-fetch on the same tick as the attester.
+		// The test name says "Attester_Only" because no sync-committee duties are assigned — the
+		// sync-committee handler still re-fetches (period intent reset), but finds no duties.
+		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		// no other fetching or execution should happen in slot 0
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: wait for attester duties to be fetched in slot 1
+		// STEP 3: wait for no action to be taken in slot 1
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
 		ticker.Send(phase0.Slot(1))
-		// wait for committee duties to be fetched in slot 1
-		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
-		// no other fetching or execution should happen in slot 1
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
 		// STEP 4: wait for committee duties to be executed in slot 2
@@ -437,17 +439,15 @@ func TestScheduler_Committee_Indices_Changed_Attester_Only_2(t *testing.T) {
 		})
 		scheduler.indicesChgCh <- struct{}{}
 		waitForDuties.Set(true)
-		// wait for attester duties to be fetched in slot 0
+		// wait for attester and sync committee duties to be fetched in slot 0
+		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		// no other fetching or execution should happen in slot 0
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: wait for attester duties to be fetched in slot 1
+		// STEP 3: wait for no action to be taken in slot 1
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
 		ticker.Send(phase0.Slot(1))
-		// wait for committee duties to be fetched in slot 1
-		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
-		// no other fetching or execution should happen in slot 1
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
 		// STEP 4: wait for committee duties to be executed in slot 2
@@ -512,17 +512,15 @@ func TestScheduler_Committee_Indices_Changed_Attester_Only_3(t *testing.T) {
 		})
 		scheduler.indicesChgCh <- struct{}{}
 		waitForDuties.Set(true)
-		// wait for attester duties to be fetched in slot 0
+		// wait for attester and sync committee duties to be fetched in slot 0
+		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
 		// no other fetching or execution should happen in slot 0
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: wait for attester duties to be fetched in slot 1
+		// STEP 3: wait for no action to be taken in slot 1
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
 		ticker.Send(phase0.Slot(1))
-		// wait for committee duties to be fetched in slot 1
-		waitForDutiesFetchCommittee(t, fetchDutiesCall, executeDutiesCall, timeout)
-		// no other fetching or execution should happen in slot 1
 		waitForNoActionCommittee(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
 		// STEP 4: wait for committee duties to be executed in slot 2

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -114,7 +114,15 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 					delete(h.dutyFetchIntents, currentEpoch-1)
 				}
 
-				// 2. Process validator indices changes (if any). We want to process it on the current slot only
+				// 2. Schedule the next-epoch duty-fetch intent (only if absent, so a pending or fulfilled one is
+				// left untouched). We register it before the indices-change handling below, which can return early
+				// on tickCtx.Done - so even a tick that overruns its deadline still records the intent, and the
+				// next-epoch pre-fetch can't be deferred indefinitely at an epoch boundary under sustained slowness.
+				if _, ok := h.dutyFetchIntents[nextEpoch]; !ok {
+					h.dutyFetchIntents[nextEpoch] = false
+				}
+
+				// 3. Process validator indices changes (if any). We want to process it on the current slot only
 				// if we are still early into the slot (1 slot-interval is just a guesstimate), otherwise we might
 				// be delaying the next tick (the duties that need to be executed on the next slot).
 
@@ -124,10 +132,10 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 					logger.Info("🔁 indices change received")
 
 					// 1) Declare intents.
-					// Some validator-related state has updated, means we need to re-fetch the duties for the current
-					// and next epoch to ensure we have the up-to-date duties for all validators for both epochs.
-					h.dutyFetchIntents[nextEpoch] = false
+					// Some validator-related state has changed, so re-fetch the duties for the current and next
+					// epoch to keep them up to date for all validators.
 					h.dutyFetchIntents[currentEpoch] = false
+					h.dutyFetchIntents[nextEpoch] = false
 
 					// 2) Process certain intents immediately.
 					// When at epoch boundary, we only care about pre-fetching & preparing the duties for the next
@@ -143,12 +151,6 @@ func (h *ProposerHandler) HandleDuties(ctx context.Context) {
 					// It's too late(risky) to handle indices change on the current slot, we'll do it on the next slot.
 				case <-tickCtx.Done():
 					return
-				}
-
-				// 3. Schedule the duty-fetch for the next epoch, but only if it hasn't been scheduled already (also,
-				// already fulfilled intents need not be re-scheduled).
-				if _, ok := h.dutyFetchIntents[nextEpoch]; !ok {
-					h.dutyFetchIntents[nextEpoch] = false
 				}
 			}()
 

--- a/operator/duties/sync_committee.go
+++ b/operator/duties/sync_committee.go
@@ -27,12 +27,9 @@ type SyncCommitteeHandler struct {
 
 	duties *dutystore.SyncCommitteeDuties
 
-	// fetchCurrentPeriod stores the intent to fetch duties for the current period, while
-	// processFetching func uses this value to decide on whether the fetch is needed.
-	fetchCurrentPeriod bool
-	// fetchNextPeriod stores the intent to fetch duties for the next period, while
-	// processFetching func uses this value to decide on whether the fetch is needed.
-	fetchNextPeriod bool
+	// dutyFetchIntents stores the intents to fetch duties for some target periods, the bool indicates whether the
+	// intent has already been fulfilled.
+	dutyFetchIntents map[uint64]bool
 
 	// preparationSlots is the number of slots ahead of the sync committee
 	// period change at which to prepare the relevant duties.
@@ -46,8 +43,9 @@ type SyncCommitteeHandler struct {
 
 func NewSyncCommitteeHandler(duties *dutystore.SyncCommitteeDuties, exporterMode bool) *SyncCommitteeHandler {
 	h := &SyncCommitteeHandler{
-		duties:       duties,
-		exporterMode: exporterMode,
+		duties:           duties,
+		dutyFetchIntents: make(map[uint64]bool),
+		exporterMode:     exporterMode,
 	}
 	return h
 }
@@ -63,23 +61,22 @@ func (h *SyncCommitteeHandler) WaitShutdown() {
 // HandleDuties manages the duty lifecycle, handling different cases:
 //
 // On First Run:
-//  1. Fetch duties for the current period.
+//  1. If necessary, fetch duties for the current period.
 //  2. If necessary, fetch duties for the next period.
-//  3. Execute duties.
+//  3. Duties will be executed on the very next slot-tick.
 //
 // On Re-org:
-//  1. Execute duties.
-//  2. If necessary, fetch duties for the next period.
-//
-// On Indices Change:
-//  1. Execute duties.
-//  2. EraseEpochData duties for the current period.
-//  3. Fetch duties for the current period.
-//  4. If necessary, fetch duties for the next period.
+//  1. If the current duty dependent root changed, declare the intent to fetch duties for the next period
+//     (the current period's sync committee membership is fixed a full period in advance, so it is unaffected).
+//  2. If necessary, pre-fetch the next period's duties so they can be processed on the next slot-tick.
+//  3. Duties will be executed on the very next slot-tick.
 //
 // On Ticker event:
-//  1. Execute duties.
-//  2. If necessary, fetch duties for the next period.
+//  1. If necessary, fetch duties for the current period.
+//  2. Execute duties.
+//  3. If necessary, fetch duties for the next period.
+//  4. If necessary, process validator-indices changes by declaring the intents to fetch duties for the periods
+//     affected by it, also potentially pre-fetching duties so they are ready for processing on the next slot-tick.
 func (h *SyncCommitteeHandler) HandleDuties(ctx context.Context) {
 	h.logger.Info("starting duty handler")
 	defer h.logger.Info("duty handler exited")
@@ -92,13 +89,21 @@ func (h *SyncCommitteeHandler) HandleDuties(ctx context.Context) {
 
 		case <-next:
 			currentSlot := h.ticker.Slot()
-			next = h.ticker.Next()
+			next = h.ticker.Next() // advances h.ticker
 			currentEpoch := h.netCfg.EstimatedEpochAtSlot(currentSlot)
 			currentPeriod := h.netCfg.EstimatedSyncCommitteePeriodAtEpoch(currentEpoch)
+			nextPeriod := currentPeriod + 1
 
 			slotNumber := uint64(currentSlot)%h.netCfg.SlotsPerEpoch + 1
 			buildStr := fmt.Sprintf("p%v-e%v-s%v-#%v", currentPeriod, currentEpoch, currentSlot, slotNumber)
-			h.logger.Debug("🛠 ticker event", zap.String("period_epoch_slot_pos", buildStr))
+			logger := h.logger.With(
+				zap.String("period_epoch_slot_pos", buildStr),
+				zap.Uint64("current_period", currentPeriod),
+				zap.Uint64("current_epoch", uint64(currentEpoch)),
+				zap.Uint64("current_slot", uint64(currentSlot)),
+			)
+
+			logger.Debug("🛠 ticker event")
 
 			func() {
 				// tickCtx ensures we never take too long to process ticks (otherwise we might not be able to catch up
@@ -107,111 +112,221 @@ func (h *SyncCommitteeHandler) HandleDuties(ctx context.Context) {
 				tickCtx, cancel := context.WithDeadline(ctx, h.netCfg.SlotStartTime(currentSlot+1))
 				defer cancel()
 
+				// 1. Process the duty execution & fetching.
+
+				// Process intents (if any): fetch & prepare the duties for the current period.
+				h.prepareCurrentPeriod(tickCtx, logger, currentPeriod, currentEpoch, currentSlot, true)
+
 				if !h.netCfg.BooleForkAtSlot(currentSlot) {
-					// Before Boole fork: execute Alan sync committee contribution flow and fetch duties.
+					// Before Boole fork: execute Alan sync committee contribution flow.
 					h.processExecution(tickCtx, currentPeriod, currentSlot)
 				}
 
 				// After Boole fork: keep fetching duties (to pass them to both Committee and AggregatorCommittee handlers),
 				// but skip Alan execution, as the aggregator committee handler will be responsible for executing them.
-				h.processFetching(tickCtx, currentEpoch, currentPeriod, true)
+				// Process intents (if any): fetch & prepare the duties for the next period.
+				h.prepareNextPeriod(tickCtx, logger, currentPeriod, currentEpoch, currentSlot, true)
+
+				// Clean up the irrelevant data to prevent infinite memory growth at the very 1st slot of the epoch.
+				// Note, it doesn't have to be "the very 1st slot" exactly - it's just the most natural time to do it.
+				if slotNumber == 1 && currentPeriod >= 1 {
+					h.duties.Reset(currentPeriod - 1)
+					delete(h.dutyFetchIntents, currentPeriod-1)
+				}
+
+				// 2. Schedule the next-period duty-fetch intent (only if absent, so a pending or fulfilled one is
+				// left untouched). We register it before the indices-change handling below, which can return early
+				// on tickCtx.Done - so even a tick that overruns its deadline still records the intent, and the
+				// next-period pre-fetch can't be deferred indefinitely at a period boundary under sustained slowness.
+				if _, ok := h.dutyFetchIntents[nextPeriod]; !ok {
+					h.dutyFetchIntents[nextPeriod] = false
+				}
+
+				// 3. Process validator indices changes (if any). We want to process it on the current slot only
+				// if we are still early into the slot (1 slot-interval is just a guesstimate), otherwise we might
+				// be delaying the next tick (the duties that need to be executed on the next slot).
+
+				indicesChangeDeadline := h.netCfg.SlotStartTime(currentSlot).Add(h.netCfg.IntervalDuration())
+				select {
+				case <-h.indicesChangeCh:
+					logger.Info("🔁 indices change received")
+
+					// 1) Declare intents.
+					// Some validator-related state has changed, so re-fetch the duties for the current and next
+					// period to keep them up to date for all validators.
+					h.dutyFetchIntents[currentPeriod] = false
+					h.dutyFetchIntents[nextPeriod] = false
+
+					// 2) Process certain intents immediately.
+					// When at period boundary, we only care about pre-fetching & preparing the duties for the next
+					// period (the current period will have been passed upon the next slot-tick). Otherwise, pre-fetch &
+					// prepare the duties for the current period.
+					if h.atLastSlotOrPastCurrentPeriod(currentSlot, currentPeriod) {
+						delete(h.dutyFetchIntents, currentPeriod) // optimization: prune irrelevant intent
+						h.prepareNextPeriod(tickCtx, logger, currentPeriod, currentEpoch, currentSlot, true)
+					} else {
+						h.prepareCurrentPeriod(tickCtx, logger, currentPeriod, currentEpoch, currentSlot, true)
+					}
+				case <-time.After(time.Until(indicesChangeDeadline)):
+					// It's too late(risky) to handle indices change on the current slot, we'll do it on the next slot.
+				case <-tickCtx.Done():
+					return
+				}
 			}()
-
-			// if we have reached the preparation slots -1, prepare the next period duties in the next slot.
-			periodSlots := h.slotsPerPeriod()
-			if uint64(currentSlot)%periodSlots == periodSlots-h.preparationSlots-1 {
-				h.fetchNextPeriod = true
-			}
-
-			// last slot of period
-			if currentSlot == h.netCfg.LastSlotOfSyncPeriod(currentPeriod) {
-				h.duties.Reset(currentPeriod - 1)
-			}
 
 		case reorgEvent := <-h.reorgEventsCh:
 			currentSlot := h.netCfg.EstimatedCurrentSlot()
 			currentEpoch := h.netCfg.EstimatedEpochAtSlot(currentSlot)
 			currentPeriod := h.netCfg.EstimatedSyncCommitteePeriodAtEpoch(currentEpoch)
+			nextPeriod := currentPeriod + 1
 
 			slotNumber := uint64(currentSlot)%h.netCfg.SlotsPerEpoch + 1
 			buildStr := fmt.Sprintf("p%v-e%v-s%v-#%v", currentPeriod, currentEpoch, currentSlot, slotNumber)
-			h.logger.Info("🔀 reorg event received", zap.String("period_epoch_slot_pos", buildStr), zap.Any("event", reorgEvent))
+			logger := h.logger.With(
+				zap.String("period_epoch_slot_pos", buildStr),
+				zap.Uint64("current_period", currentPeriod),
+				zap.Uint64("current_epoch", uint64(currentEpoch)),
+				zap.Uint64("current_slot", uint64(currentSlot)),
+			)
 
-			// reset current epoch duties
-			if reorgEvent.CurrentDutyDependentRootChanged && h.shouldFetchNextPeriod(currentSlot) {
-				h.duties.Reset(currentPeriod + 1)
-				h.fetchNextPeriod = true
-			}
+			// Sync committee membership for the current period is fixed a full period in advance, so a reorg can
+			// only affect the next period's duties (and only when the current duty dependent root changed).
+			refetchNextPeriod := reorgEvent.CurrentDutyDependentRootChanged
 
-		case <-h.indicesChangeCh:
-			currentSlot := h.netCfg.EstimatedCurrentSlot()
-			currentEpoch := h.netCfg.EstimatedEpochAtSlot(currentSlot)
-			currentPeriod := h.netCfg.EstimatedSyncCommitteePeriodAtEpoch(currentEpoch)
+			logger.Info("🔀 reorg event received",
+				zap.Any("event", reorgEvent),
+				zap.Bool("refetch_next_period_duties", refetchNextPeriod),
+			)
 
-			slotNumber := uint64(currentSlot)%h.netCfg.SlotsPerEpoch + 1
-			buildStr := fmt.Sprintf("p%v-e%v-s%v-#%v", currentPeriod, currentEpoch, currentSlot, slotNumber)
-			h.logger.Info("🔁 indices change received", zap.String("period_epoch_slot_pos", buildStr))
+			func() {
+				// reorgCtx ensures we never take too long to process the reorg (we don't want to prevent the
+				// slot-ticker from executing duties even if some of them might not be up to date). Since the
+				// reorg can happen closer to the end of the current slot we wouldn't want to set the deadline
+				// to currentSlot+1 as that might be too short (hence setting it to currentSlot+2).
+				reorgCtx, cancel := context.WithDeadline(ctx, h.netCfg.SlotStartTime(currentSlot+2))
+				defer cancel()
 
-			h.fetchCurrentPeriod = true
+				if !refetchNextPeriod {
+					return
+				}
 
-			// reset next period duties if in appropriate slot range
-			if h.shouldFetchNextPeriod(currentSlot) {
-				h.fetchNextPeriod = true
-			}
+				// 1) Declare intent.
+				// We deliberately do NOT Reset the existing next-period duties before re-fetching: if the re-fetch
+				// fails we keep serving the previously fetched (possibly stale) duties and retry on later ticks,
+				// rather than dropping a whole period's duties on a transient error. A successful re-fetch overwrites them.
+				h.dutyFetchIntents[nextPeriod] = false
+
+				// 2) Process the intent immediately (when it's a "good time") so the duties are ready for the
+				// next slot-tick.
+				h.prepareNextPeriod(reorgCtx, logger, currentPeriod, currentEpoch, currentSlot, true)
+			}()
 		}
 	}
 }
 
-// HandleInitialDuties fetches duties for the current and next periods.
-// Fetching duties for the next period is necessary if we are starting close to epoch-boundary because
-// our ticker might "miss" that rollover otherwise.
+// HandleInitialDuties fetches & prepares the duties for the current and next periods.
 func (h *SyncCommitteeHandler) HandleInitialDuties(ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, h.netCfg.SlotDuration)
+	initCtx, cancel := context.WithTimeout(ctx, h.netCfg.SlotDuration)
 	defer cancel()
 
-	h.fetchCurrentPeriod = true
-
-	// Prepare relevant duties 1.5 epochs (48 slots) ahead of the sync committee period change.
-	// The 1.5 epochs timing helps ensure setup occurs when the beacon node is likely less busy.
+	// Prepare the next-period duties 1.5 epochs ahead of the period change, when the beacon node is likely less busy.
 	h.preparationSlots = h.netCfg.SlotsPerEpoch * 3 / 2
 
-	if h.shouldFetchNextPeriod(h.netCfg.EstimatedCurrentSlot()) {
-		h.fetchNextPeriod = true
-	}
-
-	currentEpoch := h.netCfg.EstimatedCurrentEpoch()
+	currentSlot := h.netCfg.EstimatedCurrentSlot()
+	currentEpoch := h.netCfg.EstimatedEpochAtSlot(currentSlot)
 	currentPeriod := h.netCfg.EstimatedSyncCommitteePeriodAtEpoch(currentEpoch)
-	h.processFetching(ctx, currentEpoch, currentPeriod, false)
+	nextPeriod := currentPeriod + 1
+
+	slotNumber := uint64(currentSlot)%h.netCfg.SlotsPerEpoch + 1
+	buildStr := fmt.Sprintf("p%v-e%v-s%v-#%v", currentPeriod, currentEpoch, currentSlot, slotNumber)
+	logger := h.logger.With(
+		zap.String("period_epoch_slot_pos", buildStr),
+		zap.Uint64("current_period", currentPeriod),
+		zap.Uint64("current_epoch", uint64(currentEpoch)),
+		zap.Uint64("current_slot", uint64(currentSlot)),
+	)
+
+	// 1) Declare intents.
+	h.dutyFetchIntents[currentPeriod] = false
+	h.dutyFetchIntents[nextPeriod] = false
+
+	// 2) Process certain intents immediately.
+	// At the last slot of current period we don't fetch duties for the current period because we likely won't
+	// have enough time to process those duties anyway ... but we do want to fetch the duties for the next period
+	// right away in that case since we'll need to be able to execute those duties on the next tick - the tick
+	// corresponding to the 1st slot of the next period.
+	if h.atLastSlotOrPastCurrentPeriod(currentSlot, currentPeriod) {
+		delete(h.dutyFetchIntents, currentPeriod) // optimization: prune irrelevant intent
+		h.prepareNextPeriod(initCtx, logger, currentPeriod, currentEpoch, currentSlot, false)
+	} else {
+		h.prepareCurrentPeriod(initCtx, logger, currentPeriod, currentEpoch, currentSlot, false)
+	}
 }
 
-func (h *SyncCommitteeHandler) processFetching(ctx context.Context, epoch phase0.Epoch, period uint64, waitForInitial bool) {
+func (h *SyncCommitteeHandler) prepareCurrentPeriod(
+	ctx context.Context,
+	logger *zap.Logger,
+	currentPeriod uint64,
+	currentEpoch phase0.Epoch,
+	currentSlot phase0.Slot,
+	waitForInit bool,
+) {
 	ctx, span := tracer.Start(ctx,
-		observability.InstrumentName(observabilityNamespace, "sync_committee_contribution.fetch"),
+		observability.InstrumentName(observabilityNamespace, "sync_committee.prepare_current_period"),
 		trace.WithAttributes(
-			observability.BeaconEpochAttribute(epoch),
-			observability.BeaconPeriodAttribute(period),
-			observability.BeaconRoleAttribute(spectypes.BNRoleSyncCommitteeContribution),
+			observability.BeaconPeriodAttribute(currentPeriod),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleSyncCommittee),
 		))
 	defer span.End()
 
-	if h.fetchCurrentPeriod {
-		span.AddEvent("fetching current period duties")
-		if err := h.fetchAndProcessDuties(ctx, epoch, period, waitForInitial); err != nil {
-			h.logger.Error("failed to fetch duties for current period", zap.Error(err))
+	if fulfilled, ok := h.dutyFetchIntents[currentPeriod]; ok && !fulfilled {
+		logger.Debug("fetching duties for the current period")
+
+		err := h.fetchAndProcessDuties(ctx, logger, currentPeriod, currentEpoch, currentSlot, waitForInit)
+		if err != nil {
+			logger.Error("fetching duties for the current period failed", zap.Error(err))
 			span.SetStatus(codes.Error, err.Error())
 			return
 		}
-		h.fetchCurrentPeriod = false
+		h.dutyFetchIntents[currentPeriod] = true
+
+		logger.Debug("fetching duties for the current period succeeded")
 	}
 
-	if h.fetchNextPeriod {
-		span.AddEvent("fetching next period duties")
-		if err := h.fetchAndProcessDuties(ctx, epoch, period+1, waitForInitial); err != nil {
-			h.logger.Error("failed to fetch duties for next period", zap.Error(err))
+	span.SetStatus(codes.Ok, "")
+}
+
+func (h *SyncCommitteeHandler) prepareNextPeriod(
+	ctx context.Context,
+	logger *zap.Logger,
+	currentPeriod uint64,
+	currentEpoch phase0.Epoch,
+	currentSlot phase0.Slot,
+	waitForInit bool,
+) {
+	ctx, span := tracer.Start(ctx,
+		observability.InstrumentName(observabilityNamespace, "sync_committee.prepare_next_period"),
+		trace.WithAttributes(
+			observability.BeaconPeriodAttribute(currentPeriod+1),
+			observability.BeaconSlotAttribute(currentSlot),
+			observability.BeaconRoleAttribute(spectypes.BNRoleSyncCommittee),
+		))
+	defer span.End()
+
+	// Delaying the duty fetch until it's a "good time" allows us to do it when the beacon node should be less busy.
+	if fulfilled, ok := h.dutyFetchIntents[currentPeriod+1]; ok && !fulfilled && h.shouldFetchNextPeriod(currentSlot) {
+		logger.Debug("fetching duties for the next period")
+
+		err := h.fetchAndProcessDuties(ctx, logger, currentPeriod+1, currentEpoch, currentSlot, waitForInit)
+		if err != nil {
+			logger.Error("fetching duties for the next period failed", zap.Error(err))
 			span.SetStatus(codes.Error, err.Error())
 			return
 		}
-		h.fetchNextPeriod = false
+		h.dutyFetchIntents[currentPeriod+1] = true
+
+		logger.Debug("fetching duties for the next period succeeded")
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -256,17 +371,24 @@ func (h *SyncCommitteeHandler) processExecution(ctx context.Context, period uint
 	span.SetStatus(codes.Ok, "")
 }
 
-// Period can be current or future.
-// If the period passed is the current period – the sync committee target epoch should be the current epoch.
-// If the period passed is a future period – the sync committee target epoch should be the first epoch of that future period.
-// The epoch passed is always the current epoch.
-func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch phase0.Epoch, period uint64, waitForInitial bool) error {
+// fetchAndProcessDuties fetches & stores the sync committee duties for the given period (current or future).
+// The passed epoch must be the current epoch; for a future period the target epoch is resolved to that
+// period's first epoch.
+func (h *SyncCommitteeHandler) fetchAndProcessDuties(
+	ctx context.Context,
+	logger *zap.Logger,
+	period uint64,
+	epoch phase0.Epoch,
+	currentSlot phase0.Slot,
+	waitForInit bool,
+) error {
 	start := time.Now()
 	ctx, span := tracer.Start(ctx,
 		observability.InstrumentName(observabilityNamespace, "sync_committee.fetch_and_store"),
 		trace.WithAttributes(
-			observability.BeaconEpochAttribute(epoch),
 			observability.BeaconPeriodAttribute(period),
+			observability.BeaconEpochAttribute(epoch),
+			observability.BeaconSlotAttribute(currentSlot),
 			observability.BeaconRoleAttribute(spectypes.BNRoleSyncCommittee),
 		))
 	defer span.End()
@@ -276,14 +398,18 @@ func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch 
 	}
 
 	span.SetAttributes(observability.BeaconEpochAttribute(epoch))
+	logger = logger.With(
+		zap.Uint64("target_period", period),
+		zap.Uint64("target_epoch", uint64(epoch)),
+	)
 
-	eligibleIndices := h.validatorController.FilterIndices(waitForInitial, func(s *types.SSVShare) bool {
+	eligibleIndices := h.validatorController.FilterIndices(waitForInit, func(s *types.SSVShare) bool {
 		return s.IsParticipating(h.netCfg.Beacon, epoch)
 	})
 
 	if len(eligibleIndices) == 0 {
 		const eventMsg = "no eligible validators for period"
-		h.logger.Debug(eventMsg, fields.Epoch(epoch), zap.Uint64("period", period))
+		logger.Debug(eventMsg)
 		span.AddEvent(eventMsg)
 		span.SetStatus(codes.Ok, "")
 		return nil
@@ -315,7 +441,7 @@ func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch 
 	span.AddEvent("storing duties", trace.WithAttributes(observability.DutyCountAttribute(len(storeDuties))))
 	h.duties.Set(period, storeDuties)
 
-	h.prepareDutiesResultLog(period, duties, start)
+	h.logDutiesFetched(logger, period, duties, start)
 
 	// Further processing is not needed in exporter mode, terminate early
 	// avoiding CL subscriptions saves some CPU & Network resources
@@ -325,7 +451,7 @@ func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch 
 		return nil
 	}
 
-	// lastEpoch + 1 due to the fact that we need to subscribe "until" the end of the period
+	// lastEpoch + 1 because the subscription's "until" epoch is exclusive
 	lastEpoch := h.netCfg.FirstEpochOfSyncPeriod(period+1) - 1
 	subscriptions := calculateSubscriptions(lastEpoch+1, duties)
 
@@ -357,7 +483,12 @@ func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch 
 	return nil
 }
 
-func (h *SyncCommitteeHandler) prepareDutiesResultLog(period uint64, duties []*eth2apiv1.SyncCommitteeDuty, start time.Time) {
+func (h *SyncCommitteeHandler) logDutiesFetched(
+	logger *zap.Logger,
+	period uint64,
+	duties []*eth2apiv1.SyncCommitteeDuty,
+	start time.Time,
+) {
 	var b strings.Builder
 	if h.exporterMode {
 		// too many duties to log individually
@@ -371,7 +502,7 @@ func (h *SyncCommitteeHandler) prepareDutiesResultLog(period uint64, duties []*e
 			b.WriteString(tmp)
 		}
 	}
-	h.logger.Debug("👥 got duties",
+	logger.Debug("👥 got duties",
 		fields.Count(len(duties)),
 		zap.String("period", fmt.Sprintf("p%v", period)),
 		zap.Any("duties", b.String()),

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -78,7 +78,7 @@ func setupSyncCommitteeDutiesMockWithFetcher(
 
 	if fetcher == nil {
 		fetcher = func(_ context.Context, epoch phase0.Epoch, _ []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-			period := s.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+			period := s.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 			duties, _ := dutiesMap.Get(period)
 			return duties, nil
 		}
@@ -105,7 +105,7 @@ func setupSyncCommitteeDutiesMockWithFetcher(
 								ValidatorIndex: duty.ValidatorIndex,
 							},
 						}
-						firstEpoch := s.netCfg.Beacon.FirstEpochOfSyncPeriod(period)
+						firstEpoch := s.netCfg.FirstEpochOfSyncPeriod(period)
 						if firstEpoch < minEpoch {
 							minEpoch = firstEpoch
 							ssvShare.SetMinParticipationEpoch(firstEpoch)
@@ -764,7 +764,7 @@ func TestScheduler_SyncCommittee_Reorg_Previous_Epoch_Transition(t *testing.T) {
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				fetchedPeriods <- period
 				duties, _ := dutiesMap.Get(period)
 				return duties, nil
@@ -851,7 +851,7 @@ func TestScheduler_SyncCommittee_Retry_Current_Period_Fetch_On_Next_Tick(t *test
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				duties, _ := dutiesMap.Get(period)
 				if period == 0 && currentPeriodFetches.Add(1) <= 3 {
 					return nil, errors.New("failed to fetch sync committee duties")
@@ -952,7 +952,7 @@ func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Mid_Period
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				fetchedPeriods <- period
 				duties, _ := dutiesMap.Get(period)
 				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
@@ -1026,7 +1026,7 @@ func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Period_Tra
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				fetchedPeriods <- period
 				duties, _ := dutiesMap.Get(period)
 				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
@@ -1104,7 +1104,7 @@ func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Period_Tra
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				fetchedPeriods <- period
 				duties, _ := dutiesMap.Get(period)
 				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
@@ -1179,7 +1179,7 @@ func TestScheduler_SyncCommittee_Reorg_Retry_Next_Period_Fetch_On_Next_Tick(t *t
 			dutiesMap,
 			waitForDuties,
 			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
-				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				period := scheduler.netCfg.EstimatedSyncCommitteePeriodAtEpoch(epoch)
 				fetchedPeriods <- period
 				if period == 1 && failNextPeriodFetch.Load() {
 					return nil, errors.New("failed to fetch sync committee duties")

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -3,6 +3,8 @@ package duties
 import (
 	"bytes"
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -57,6 +59,16 @@ func setupSyncCommitteeDutiesMock(
 	dutiesMap *hashmap.Map[uint64, []*v1.SyncCommitteeDuty],
 	waitForDuties *SafeValue[bool],
 ) (chan struct{}, chan []*spectypes.ValidatorDuty) {
+	return setupSyncCommitteeDutiesMockWithFetcher(s, activeShares, dutiesMap, waitForDuties, nil)
+}
+
+func setupSyncCommitteeDutiesMockWithFetcher(
+	s *Scheduler,
+	activeShares []*ssvtypes.SSVShare,
+	dutiesMap *hashmap.Map[uint64, []*v1.SyncCommitteeDuty],
+	waitForDuties *SafeValue[bool],
+	fetcher func(context.Context, phase0.Epoch, []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error),
+) (chan struct{}, chan []*spectypes.ValidatorDuty) {
 	// fetchDutiesCall relays/signals duty-fetch calls, it is buffered so that our test code can run in a single
 	// go-routine (so that we don't need to worry about draining this channel to let the execution proceed). The
 	// buffer size of 2 covers the current and the next periods.
@@ -64,17 +76,23 @@ func setupSyncCommitteeDutiesMock(
 	// executeDutiesCall is similar to fetchDutiesCall but signals the duty-executions.
 	executeDutiesCall := make(chan []*spectypes.ValidatorDuty, 100)
 
+	if fetcher == nil {
+		fetcher = func(_ context.Context, epoch phase0.Epoch, _ []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+			period := s.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+			duties, _ := dutiesMap.Get(period)
+			return duties, nil
+		}
+	}
+
 	s.beaconNode.(*MockBeaconNode).EXPECT().SyncCommitteeDuties(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
 			if waitForDuties.Get() {
 				fetchDutiesCall <- struct{}{}
 			}
-			period := s.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
-			duties, _ := dutiesMap.Get(period)
-			return duties, nil
+			return fetcher(ctx, epoch, indices)
 		}).AnyTimes()
 
-	s.validatorProvider.(*MockValidatorProvider).EXPECT().SelfParticipatingValidators(gomock.Any()).Return(activeShares).MinTimes(1)
+	s.validatorProvider.(*MockValidatorProvider).EXPECT().SelfParticipatingValidators(gomock.Any()).Return(activeShares).AnyTimes()
 	s.validatorProvider.(*MockValidatorProvider).EXPECT().Validator(gomock.Any()).DoAndReturn(
 		func(pubKey []byte) (*ssvtypes.SSVShare, bool) {
 			var ssvShare *ssvtypes.SSVShare
@@ -128,6 +146,23 @@ func expectedExecutedSyncCommitteeDuties(handler *SyncCommitteeHandler, duties [
 		expectedDuties = append(expectedDuties, handler.toSpecDuty(d, slot, spectypes.BNRoleSyncCommitteeContribution))
 	}
 	return expectedDuties
+}
+
+func waitForFetchedSyncCommitteePeriod(
+	t *testing.T,
+	fetchDutiesCall chan struct{},
+	fetchedPeriods chan uint64,
+	timeout time.Duration,
+	expectedPeriod uint64,
+) {
+	waitForDutiesFetch(t, fetchDutiesCall, timeout)
+
+	select {
+	case period := <-fetchedPeriods:
+		require.Equal(t, expectedPeriod, period)
+	case <-time.After(timeout):
+		require.FailNow(t, "timed out waiting for fetched sync committee period")
+	}
 }
 
 func TestScheduler_SyncCommittee_Same_Period(t *testing.T) {
@@ -292,10 +327,9 @@ func TestScheduler_SyncCommittee_Indices_Changed(t *testing.T) {
 			},
 		})
 
-		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current and next periods
+		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current period only
 		waitForDuties.Set(true)
 		require.NoError(t, scheduler.Start(ctx))
-		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
 		// STEP 2: trigger a change in active indices
@@ -307,11 +341,13 @@ func TestScheduler_SyncCommittee_Indices_Changed(t *testing.T) {
 		}))
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: wait for sync committee duties to be re-fetched
+		// STEP 3: wait for sync committee duties to be re-fetched twice:
+		// once for the regular next-period prefetch and once while handling the indices change.
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-2))
 		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 2))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
 		// STEP 4: no action should be taken
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-1))
@@ -424,10 +460,9 @@ func TestScheduler_SyncCommittee_Reorg_Current(t *testing.T) {
 			},
 		})
 
-		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current and next periods
+		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current period only
 		waitForDuties.Set(true)
 		require.NoError(t, scheduler.Start(ctx))
-		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
 		// STEP 2: trigger head event
@@ -440,12 +475,13 @@ func TestScheduler_SyncCommittee_Reorg_Current(t *testing.T) {
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: Ticker with no action
+		// STEP 3: ticker pre-fetches duties for the next period
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-2))
 		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 2))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 4: trigger reorg
+		// STEP 4: trigger reorg, the current slot re-fetches duties for the next period
 		e = &v1.Event{
 			Data: &v1.HeadEvent{
 				Slot:                     testEpochsPerSCPeriod*testSlotsPerEpoch - 2,
@@ -459,12 +495,13 @@ func TestScheduler_SyncCommittee_Reorg_Current(t *testing.T) {
 			},
 		})
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 5: wait for sync committee duties to be re-fetched for the current epoch
+		// STEP 5: wait for no action to be taken
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-1))
 		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 1))
-		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
 		// STEP 6: The first assigned duty should not be executed, but the second one should
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
@@ -505,10 +542,9 @@ func TestScheduler_SyncCommittee_Reorg_Current_Indices_Changed(t *testing.T) {
 			},
 		})
 
-		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current and next periods
+		// STEP 1: (on startup) wait for sync committee duties to be fetched for the current period only
 		waitForDuties.Set(true)
 		require.NoError(t, scheduler.Start(ctx))
-		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 
 		// STEP 2: trigger head event
@@ -521,12 +557,13 @@ func TestScheduler_SyncCommittee_Reorg_Current_Indices_Changed(t *testing.T) {
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: Ticker with no action
+		// STEP 3: ticker pre-fetches duties for the next period
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-2))
 		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 2))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 4: trigger reorg
+		// STEP 4: trigger reorg, the current slot re-fetches duties for the next period
 		e = &v1.Event{
 			Data: &v1.HeadEvent{
 				Slot:                     testEpochsPerSCPeriod*testSlotsPerEpoch - 2,
@@ -540,9 +577,10 @@ func TestScheduler_SyncCommittee_Reorg_Current_Indices_Changed(t *testing.T) {
 			},
 		})
 		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 3: trigger a change in active indices
+		// STEP 5: trigger a change in active indices in the same slot
 		scheduler.indicesChgCh <- struct{}{}
 		duties, _ := dutiesMap.Get(1)
 		dutiesMap.Set(1, append(duties, &v1.SyncCommitteeDuty{
@@ -551,13 +589,15 @@ func TestScheduler_SyncCommittee_Reorg_Current_Indices_Changed(t *testing.T) {
 		}))
 		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 5: wait for sync committee duties to be re-fetched for the current epoch
+		// STEP 6: the boundary tick re-fetches duties for the next period due to the indices change.
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-1))
 		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 1))
 		waitForDutiesFetch(t, fetchDutiesCall, timeout)
-		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
 
-		// STEP 6: The first assigned duty should not be executed, but the second and the new from indices change should
+		// STEP 7: The first assigned duty should not be executed, but the second and the new from indices change should.
+		// With the period-boundary check applying on slot 46+, the indices change at slot 47 already refreshed p1,
+		// so entering the new period executes without an additional fetch.
 		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
 		duties, _ = dutiesMap.Get(1)
 		expected := expectedExecutedSyncCommitteeDuties(handler, duties, testEpochsPerSCPeriod*testSlotsPerEpoch)
@@ -631,6 +671,655 @@ func TestScheduler_SyncCommittee_Early_Block(t *testing.T) {
 		require.Greater(t, time.Since(startTime), time.Duration(float64(scheduler.netCfg.SlotDuration/3)*0.90))
 
 		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Indices_Changed_Too_Late_In_Slot(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler       = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap     = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties = &SafeValue[bool]{}
+			activeShares  = eligibleShares()
+		)
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		scheduler, ticker := setupSchedulerAndMocks(ctx, t, []dutyHandler{handler})
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMock(scheduler, activeShares, dutiesMap, waitForDuties)
+		require.NoError(t, scheduler.Start(ctx))
+
+		// STEP 1: slot 0 has no duties and no action.
+		ticker.Send(phase0.Slot(0))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 2: arrange for indices change to arrive too late for slot 0 processing.
+		waitForDuties.Set(true)
+		dutiesMap.Set(0, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+		go func() {
+			time.Sleep(scheduler.netCfg.IntervalDuration() + 1*time.Millisecond)
+			scheduler.indicesChgCh <- struct{}{}
+		}()
+
+		// No fetching should happen on slot 0 because the indices change arrived too late in the slot.
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: on slot 1 the deferred indices change is processed and duties are fetched.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
+		ticker.Send(phase0.Slot(1))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: on slot 2 the fetched duty executes.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(2))
+		duties, _ := dutiesMap.Get(0)
+		expected := expectedExecutedSyncCommitteeDuties(handler, duties, phase0.Slot(2))
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(2))
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Reorg_Previous_Epoch_Transition(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler       = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap     = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties = &SafeValue[bool]{}
+			activeShares  = eligibleShares()
+		)
+
+		initialPeriod1Duties := []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		}
+		dutiesMap.Set(1, initialPeriod1Duties)
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		startSlot := phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 2)
+		scheduler, ticker := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot)
+		fetchedPeriods := make(chan uint64, 100)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				fetchedPeriods <- period
+				duties, _ := dutiesMap.Get(period)
+				return duties, nil
+			},
+		)
+
+		// STEP 1: startup at the last slot fetches duties for the next period.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+
+		// STEP 2: establish the baseline head state for the current period.
+		e := &v1.Event{
+			Data: &v1.HeadEvent{
+				Slot:                      startSlot,
+				Block:                     phase0.Root{0x03},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
+				PreviousDutyDependentRoot: phase0.Root{0x01},
+			},
+		}
+		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: slot 47 has no action because the period duties were already prefetched.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-1))
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 1))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: previous-duty-dependent-root changes on the period transition.
+		// Sync committee duties should ignore it and keep using the already fetched current-period duties.
+		dutiesMap.Set(1, append(initialPeriod1Duties, &v1.SyncCommitteeDuty{
+			PubKey:         phase0.BLSPubKey{4, 5, 6},
+			ValidatorIndex: phase0.ValidatorIndex(2),
+		}))
+		e = &v1.Event{
+			Data: &v1.HeadEvent{
+				Slot:                      phase0.Slot(testEpochsPerSCPeriod * testSlotsPerEpoch),
+				Block:                     phase0.Root{0x05},
+				CurrentDutyDependentRoot:  phase0.Root{0x02},
+				PreviousDutyDependentRoot: phase0.Root{0x04},
+			},
+		}
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 5: enter the new period. The originally fetched duties still execute, proving there was no refetch.
+		expected := expectedExecutedSyncCommitteeDuties(handler, initialPeriod1Duties, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod * testSlotsPerEpoch))
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Retry_Current_Period_Fetch_On_Next_Tick(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler              = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap            = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties        = &SafeValue[bool]{}
+			currentPeriodFetches atomic.Int32
+			activeShares         = eligibleShares()
+		)
+		dutiesMap.Set(0, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		scheduler, ticker := setupSchedulerAndMocks(ctx, t, []dutyHandler{handler})
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				duties, _ := dutiesMap.Get(period)
+				if period == 0 && currentPeriodFetches.Add(1) <= 3 {
+					return nil, errors.New("failed to fetch sync committee duties")
+				}
+				return duties, nil
+			},
+		)
+
+		// STEP 1: fail the initial current-period fetch.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+
+		// STEP 2: fail the retry on slot 0.
+		ticker.Send(phase0.Slot(0))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: fail the retry on slot 1.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
+		ticker.Send(phase0.Slot(1))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: retry again on slot 2, succeed, and execute duties in the same slot.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(2))
+		duties, _ := dutiesMap.Get(0)
+		expected := expectedExecutedSyncCommitteeDuties(handler, duties, phase0.Slot(2))
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(2))
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_No_Eligible_Validators_Does_Not_Retry_Current_Period_Fetch(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler       = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap     = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties = &SafeValue[bool]{}
+		)
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		scheduler, ticker := setupSchedulerAndMocks(ctx, t, []dutyHandler{handler})
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMock(scheduler, nil, dutiesMap, waitForDuties)
+
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+
+		// Startup fetch completes as a successful no-op because there are no eligible validators.
+		require.True(t, handler.dutyFetchIntents[0])
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// The next tick must not retry the current-period fetch.
+		ticker.Send(phase0.Slot(0))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Mid_Period(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler           = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap         = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties     = &SafeValue[bool]{}
+			nextPeriodFetches atomic.Int32
+			activeShares      = eligibleShares()
+		)
+		dutiesMap.Set(1, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		scheduler, ticker := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, phase0.Slot(29))
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(29))
+		fetchedPeriods := make(chan uint64, 100)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				fetchedPeriods <- period
+				duties, _ := dutiesMap.Get(period)
+				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
+					return nil, errors.New("failed to fetch sync committee duties")
+				}
+				return duties, nil
+			},
+		)
+
+		// STEP 1: on startup, fetch duties for the current period successfully.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 0)
+
+		// STEP 2: on the first tick, fail to fetch duties for the next period.
+		ticker.Send(phase0.Slot(29))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: retry on the next tick and fail again.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(30))
+		ticker.Send(phase0.Slot(30))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: retry on the next tick and fail again.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(31))
+		ticker.Send(phase0.Slot(31))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 5: retry on the next tick and succeed.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(32))
+		ticker.Send(phase0.Slot(32))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Period_Transition(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler           = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap         = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties     = &SafeValue[bool]{}
+			nextPeriodFetches atomic.Int32
+			activeShares      = eligibleShares()
+		)
+		dutiesMap.Set(1, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		startSlot := phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 3)
+		scheduler, ticker := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot)
+		fetchedPeriods := make(chan uint64, 100)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				fetchedPeriods <- period
+				duties, _ := dutiesMap.Get(period)
+				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
+					return nil, errors.New("failed to fetch sync committee duties")
+				}
+				return duties, nil
+			},
+		)
+
+		// STEP 1: on startup, fetch duties for the current period successfully.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 0)
+
+		// STEP 2: on the first tick, fail to fetch duties for the next period.
+		ticker.Send(startSlot)
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: retry on the next tick and fail again.
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot+1)
+		ticker.Send(startSlot + 1)
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: retry on the next tick and fail again.
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot+2)
+		ticker.Send(startSlot + 2)
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 5: on the next tick, the previously next period becomes current, fetch succeeds, and duties execute.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		duties, _ := dutiesMap.Get(1)
+		expected := expectedExecutedSyncCommitteeDuties(handler, duties, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod * testSlotsPerEpoch))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+func TestScheduler_SyncCommittee_Retry_Next_Period_Fetch_On_Next_Tick_Period_Transition_Start_At_Last_Slot_Of_Current_Period(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler           = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			dutiesMap         = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			waitForDuties     = &SafeValue[bool]{}
+			nextPeriodFetches atomic.Int32
+			activeShares      = eligibleShares()
+		)
+		dutiesMap.Set(1, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		startSlot := phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 2)
+		scheduler, ticker := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot)
+		fetchedPeriods := make(chan uint64, 100)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				fetchedPeriods <- period
+				duties, _ := dutiesMap.Get(period)
+				if period == 1 && nextPeriodFetches.Add(1) <= 3 {
+					return nil, errors.New("failed to fetch sync committee duties")
+				}
+				return duties, nil
+			},
+		)
+
+		// STEP 1: starting at the last slot of the current period fetches the next period immediately, and it fails.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+
+		// STEP 2: one more retry happens on slot 47 while the period is still current, and it fails.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch-1))
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 1))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: on the period transition tick, retry the previously next period as the now current period and fail.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod * testSlotsPerEpoch))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: retry on the next tick, succeed, and execute duties in the same slot.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch+1))
+		duties, _ := dutiesMap.Get(1)
+		expected := expectedExecutedSyncCommitteeDuties(handler, duties, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch+1))
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch + 1))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+// A reorg-triggered next-period re-fetch that fails must not drop the duties: the intent stays unfulfilled
+// and is retried on later ticks. Regression guard for the reorg path, which is distinct from the ticker path.
+func TestScheduler_SyncCommittee_Reorg_Retry_Next_Period_Fetch_On_Next_Tick(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler             = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			waitForDuties       = &SafeValue[bool]{}
+			dutiesMap           = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			activeShares        = eligibleShares()
+			failNextPeriodFetch atomic.Bool
+		)
+		dutiesMap.Set(1, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		// Duty executor expects deadline to be set on the parent context (see "parent-context has no deadline set").
+		// This deadline needs to be large enough to not prevent tests from executing their intended flow.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		startSlot := phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch - 3)
+		scheduler, ticker := setupSchedulerAndMocksWithStartSlot(ctx, t, []dutyHandler{handler}, startSlot)
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot)
+		fetchedPeriods := make(chan uint64, 100)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMockWithFetcher(
+			scheduler,
+			activeShares,
+			dutiesMap,
+			waitForDuties,
+			func(ctx context.Context, epoch phase0.Epoch, indices []phase0.ValidatorIndex) ([]*v1.SyncCommitteeDuty, error) {
+				period := scheduler.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(epoch)
+				fetchedPeriods <- period
+				if period == 1 && failNextPeriodFetch.Load() {
+					return nil, errors.New("failed to fetch sync committee duties")
+				}
+				duties, _ := dutiesMap.Get(period)
+				return duties, nil
+			},
+		)
+
+		// STEP 1: on startup, fetch duties for the current period.
+		waitForDuties.Set(true)
+		require.NoError(t, scheduler.Start(ctx))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 0)
+
+		// STEP 2: record the baseline dependent root via a head event (no reorg detected yet).
+		e := &v1.Event{
+			Data: &v1.HeadEvent{
+				Slot:                     startSlot,
+				CurrentDutyDependentRoot: phase0.Root{0x01},
+			},
+		}
+		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: the ticker pre-fetches the next-period duties successfully.
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot+1)
+		ticker.Send(startSlot + 1)
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 4: a reorg (current dependent root changed) re-fetches the next period, but the fetch fails. The
+		// intent must stay unfulfilled (duties are not dropped) rather than being cleared.
+		failNextPeriodFetch.Store(true)
+		e = &v1.Event{
+			Data: &v1.HeadEvent{
+				Slot:                     startSlot + 1,
+				CurrentDutyDependentRoot: phase0.Root{0x02},
+			},
+		}
+		scheduler.HandleHeadEvent()(t.Context(), e.Data.(*v1.HeadEvent))
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// The failed re-fetch must not drop the previously-fetched next-period duties - they stay available
+		// (a successful re-fetch overwrites them; a failed one leaves them intact). Asserting here, between the
+		// failed re-fetch and the STEP 5 retry, is what makes "duties are not dropped" observable: the retry
+		// would otherwise repopulate them regardless.
+		keptDuties := handler.duties.CommitteePeriodDuties(1)
+		require.Len(t, keptDuties, 1, "next-period duties must survive a failed reorg re-fetch")
+		require.Equal(t, phase0.ValidatorIndex(1), keptDuties[0].ValidatorIndex)
+
+		// STEP 5: the next tick retries the failed next-period fetch and succeeds.
+		failNextPeriodFetch.Store(false)
+		waitForSlotN(scheduler.netCfg.Beacon, startSlot+2)
+		ticker.Send(startSlot + 2)
+		waitForFetchedSyncCommitteePeriod(t, fetchDutiesCall, fetchedPeriods, timeout, 1)
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 6: on the period-transition tick the duties for the (now current) period are executed.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(testEpochsPerSCPeriod*testSlotsPerEpoch))
+		duties, _ := dutiesMap.Get(1)
+		expected := expectedExecutedSyncCommitteeDuties(handler, duties, testEpochsPerSCPeriod*testSlotsPerEpoch)
+		setExecuteDutyFunc(scheduler, executeDutiesCall, len(expected))
+
+		ticker.Send(phase0.Slot(testEpochsPerSCPeriod * testSlotsPerEpoch))
+		waitForDutiesExecution(t, fetchDutiesCall, executeDutiesCall, timeout, expected)
+
+		// Stop scheduler & wait for graceful exit.
+		cancel()
+		require.NoError(t, scheduler.Wait())
+		ticker.WaitShutdown()
+	})
+}
+
+// setupSchedulerAndMocksWithBoole creates a scheduler whose Forks.Boole = 0, making
+// BooleForkAtSlot true for every slot. This exercises the post-Boole code path where
+// the sync-committee handler fetches & stores duties but skips processExecution.
+func setupSchedulerAndMocksWithBoole(
+	ctx context.Context,
+	t *testing.T,
+	handlers []dutyHandler,
+) (*Scheduler, *mockSlotTickerService) {
+	s, ticker := setupSchedulerAndMocksWithParams(ctx, t, handlers, time.Now(), slotDuration)
+	// Activate Boole at epoch 0 so BooleForkAtSlot is true for all test slots.
+	s.netCfg.SSV.Forks.Boole = 0
+	return s, ticker
+}
+
+// TestScheduler_SyncCommittee_Boole_Fork_Fetches_But_Does_Not_Execute guards the
+// BooleForkAtSlot gate in HandleDuties: post-fork the handler must still FETCH and STORE
+// sync-committee duties but must NOT emit BNRoleSyncCommitteeContribution via ExecuteDuty.
+//
+// Secondary assertion (duties visible to the AggregatorCommittee handler) is skipped —
+// wiring that handler into the test harness is a significant lift tracked separately.
+func TestScheduler_SyncCommittee_Boole_Fork_Fetches_But_Does_Not_Execute(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			handler       = NewSyncCommitteeHandler(dutystore.NewSyncCommitteeDuties(), false)
+			waitForDuties = &SafeValue[bool]{}
+			dutiesMap     = hashmap.New[uint64, []*v1.SyncCommitteeDuty]()
+			activeShares  = eligibleShares()
+		)
+		dutiesMap.Set(0, []*v1.SyncCommitteeDuty{
+			{
+				PubKey:         phase0.BLSPubKey{1, 2, 3},
+				ValidatorIndex: phase0.ValidatorIndex(1),
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+		// Use the Boole-enabled scheduler: BooleForkAtSlot is always true.
+		scheduler, ticker := setupSchedulerAndMocksWithBoole(ctx, t, []dutyHandler{handler})
+
+		// Signal all fetches from the start so we can detect them.
+		waitForDuties.Set(true)
+		fetchDutiesCall, executeDutiesCall := setupSyncCommitteeDutiesMock(scheduler, activeShares, dutiesMap, waitForDuties)
+
+		// ExecuteDuty is NOT registered on the mock. Any unexpected call will cause gomock to
+		// fail the test, confirming that the BooleForkAtSlot gate suppresses Alan execution.
+		require.NoError(t, scheduler.Start(ctx))
+
+		// STEP 1: HandleInitialDuties fetches & stores period-0 duties.
+		waitForDutiesFetch(t, fetchDutiesCall, timeout)
+		stored := handler.duties.CommitteePeriodDuties(0)
+		require.NotEmpty(t, stored, "duties must be stored after HandleInitialDuties")
+
+		// STEP 2: tick slot 0. prepareCurrentPeriod skips the fetch (intent already fulfilled).
+		// processExecution is gated by BooleForkAtSlot — it must NOT fire, so no ExecuteDuty call.
+		ticker.Send(phase0.Slot(0))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// STEP 3: tick slot 1 — the gate must hold on subsequent ticks too.
+		waitForSlotN(scheduler.netCfg.Beacon, phase0.Slot(1))
+		ticker.Send(phase0.Slot(1))
+		waitForNoAction(t, fetchDutiesCall, executeDutiesCall, noActionTimeout)
+
+		// Duties remain stored (fetch side intact, execution side suppressed).
+		stored = handler.duties.CommitteePeriodDuties(0)
+		require.Len(t, stored, 1, "duties must still be stored after Boole-gated ticks")
+
 		cancel()
 		require.NoError(t, scheduler.Wait())
 		ticker.WaitShutdown()


### PR DESCRIPTION
Bucket A of #2902 — ports stage #2769 onto `boole-fork` (hand-port onto boole's diverged sync-committee handler).

**Bug:** the sync-committee handler used `fetchCurrentPeriod`/`fetchNextPeriod` boolean flags. A single transient beacon-node error at a sync-committee period boundary could drop a **whole period (~256 epochs) of duties**.

**Fix:** replace the booleans with a per-period `dutyFetchIntents` map (period → fulfilled). An unfulfilled intent is retried on later slot-ticks, so a transient error no longer drops the period. This mirrors the intent model boole's `attester`/`proposer` handlers already use.

**Boole reconciliation (the part not in upstream):**
- Boole's `BooleForkAtSlot` gate is preserved: **pre-fork** runs the Alan `processExecution`; **post-fork** it only fetches + stores duties and feeds **both** the Committee and AggregatorCommittee handlers (which own execution). Kept boole's `netCfg` naming.
- Reorg re-fetches **only** the next period (current-period membership is fixed a period ahead) and does **not** Reset before re-fetch (serve stale + retry rather than drop on a failed re-fetch — strictly safer than the old code).

**Supporting:** `base_handler` gains `atLastSlotOrPastCurrentPeriod`; `attester`/`proposer` register the next-epoch intent **before** the indices-change select (a deadline-overrunning tick still records it); `networkconfig` rename `LastSlotOfSyncPeriod`→`LastActionableSlotOfSyncPeriod` (name/doc only, semantics unchanged).

**Review:** deep-reviewed for duty-scheduling correctness — **APPROVE**; the reviewer traced retry/transition/reorg/cleanup/deadline paths and confirmed no duty can be dropped, duplicated, or mis-timed. Ported the upstream retry/reorg/indices test suite + added `TestScheduler_SyncCommittee_Boole_Fork_Fetches_But_Does_Not_Execute` to guard the boole post-fork gate (previously uncovered — the whole duties suite ran pre-Boole). `go build/test/vet/gofmt` clean (except pre-existing `spectest fixRunnerForRun`).