### PR TITLE
fix(ssvsigner): pin fixed-fork signing domains for the remote signer (#2875)

### DIFF
--- a/networkconfig/beacon.go
+++ b/networkconfig/beacon.go
@@ -166,6 +166,11 @@ func (b *Beacon) BeaconForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase
 	return version, &fork
 }
 
+func (b *Beacon) ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool) {
+	fork, ok := b.Forks[version]
+	return fork, ok
+}
+
 func (b *Beacon) AssertSame(other *Beacon) error {
 	if b.Name != other.Name {
 		return fmt.Errorf("different Name")

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -169,7 +169,7 @@ func (r *VoluntaryExitRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRo
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *VoluntaryExitRunner) expectedPostConsensusRootsAndDomain(context.Context) ([]ssz.HashRoot, phase0.DomainType, error) {
-	return nil, [4]byte{}, errors.New("no post consensus roots for voluntary exit")
+	return nil, spectypes.DomainError, errors.New("no post consensus roots for voluntary exit")
 }
 
 func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) error {
@@ -198,7 +198,9 @@ func (r *VoluntaryExitRunner) executeDuty(ctx context.Context, logger *zap.Logge
 		spectypes.DomainVoluntaryExit,
 	)
 	if err != nil {
-		return fmt.Errorf("could not sign VoluntaryExit object: %w", err)
+		// EIP-7044 pins exits to the Capella domain, so a signer that disagrees on the fork
+		// rejects exits while other duties still sign (e.g. a remote Web3Signer with the wrong --network).
+		return fmt.Errorf("could not sign voluntary exit (if signing remotely, check the signer config, e.g. the Web3Signer --network): %w", err)
 	}
 
 	msgs := &spectypes.PartialSignatureMessages{

--- a/ssvsigner/e2e/signing/validator_registration_test.go
+++ b/ssvsigner/e2e/signing/validator_registration_test.go
@@ -1,0 +1,87 @@
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/ssvlabs/ssv/ssvsigner/e2e"
+)
+
+// ValidatorRegistrationSigningTestSuite covers validator-registration signing. Like
+// voluntary exit, the registration (application builder) domain is derived from a fixed
+// fork - the genesis fork version - rather than the current one, so a node/signer fork
+// disagreement would surface here.
+type ValidatorRegistrationSigningTestSuite struct {
+	e2e.E2ETestSuite
+}
+
+// TestValidatorRegistrationSigningConsistency verifies that LocalKeyManager,
+// RemoteKeyManager (via SSV-Signer + Web3Signer), and Web3Signer-direct all produce the
+// same validator-registration signature over the application-builder domain, even though
+// "now" is in the Fulu era and the current fork differs from genesis. This extends the
+// voluntary-exit consistency check to the other fixed-fork domain.
+func (s *ValidatorRegistrationSigningTestSuite) TestValidatorRegistrationSigningConsistency() {
+	// Place the chain clock in the Fulu era (mainnet Fulu @ epoch 411392) so the current
+	// fork is well past genesis; the application-builder domain must still be computed
+	// over the genesis fork version regardless.
+	testCurrentEpoch := phase0.Epoch(411392 + 256)
+	s.GetEnv().SetTestCurrentEpoch(testCurrentEpoch)
+
+	ctx, cancel := context.WithTimeout(s.GetContext(), 60*time.Second)
+	defer cancel()
+
+	validatorKeyPair := s.AddValidator(ctx)
+
+	slot := s.GetEnv().GetBeaconConfig().FirstSlotAtEpoch(testCurrentEpoch)
+
+	registration := &eth2apiv1.ValidatorRegistration{
+		FeeRecipient: bellatrix.ExecutionAddress{0x01, 0x02, 0x03},
+		GasLimit:     30_000_000,
+		Timestamp:    time.Unix(1_700_000_000, 0),
+		Pubkey:       validatorKeyPair.BLSPubKey,
+	}
+
+	// The application-builder domain uses the genesis fork version, not the current fork.
+	domain, err := s.CalculateValidatorRegistrationDomain()
+	s.Require().NoError(err, "Failed to calculate validator registration domain")
+
+	s.T().Logf("Signing validator registration (current fork = Fulu) over the genesis builder domain")
+
+	localSig, localRoot, err := s.GetEnv().GetLocalKeyManager().SignBeaconObject(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Local key manager failed to sign validator registration")
+	s.Require().NotEmpty(localSig)
+	s.Require().NotEmpty(localRoot)
+
+	remoteSig, remoteRoot, err := s.GetEnv().GetRemoteKeyManager().SignBeaconObject(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Remote key manager failed to sign validator registration")
+	s.Require().NotEmpty(remoteSig)
+	s.Require().NotEmpty(remoteRoot)
+
+	web3Sig, web3Root, err := s.SignWeb3Signer(
+		ctx, registration, domain, validatorKeyPair.BLSPubKey, slot, spectypes.DomainApplicationBuilder)
+	s.Require().NoError(err, "Web3Signer failed to sign validator registration")
+	s.Require().NotEmpty(web3Sig)
+	s.Require().NotEmpty(web3Root)
+
+	// All three paths must agree on both the (genesis builder) signing root and the signature.
+	s.Require().Equal(localRoot, remoteRoot, "local vs remote signing root should match")
+	s.Require().Equal(remoteRoot, web3Root, "remote vs web3signer signing root should match")
+	s.Require().Equal(localSig, remoteSig, "local vs remote signature should match")
+	s.Require().Equal(remoteSig, web3Sig, "remote vs web3signer signature should match")
+
+	s.T().Logf("All signers agree on the genesis-builder-domain validator registration signature")
+}
+
+// TestValidatorRegistrationSigning runs the validator registration signing test suite.
+func TestValidatorRegistrationSigning(t *testing.T) {
+	suite.Run(t, new(ValidatorRegistrationSigningTestSuite))
+}

--- a/ssvsigner/e2e/signing/voluntary_exit_test.go
+++ b/ssvsigner/e2e/signing/voluntary_exit_test.go
@@ -1,0 +1,89 @@
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/ssvlabs/ssv/ssvsigner/e2e"
+)
+
+// VoluntaryExitSigningTestSuite covers voluntary-exit signing, which (per EIP-7044)
+// must always use the Capella fork domain regardless of the current fork.
+type VoluntaryExitSigningTestSuite struct {
+	e2e.E2ETestSuite
+}
+
+// TestVoluntaryExitSigningConsistency verifies that LocalKeyManager, RemoteKeyManager
+// (via SSV-Signer + Web3Signer), and Web3Signer-direct all produce the same voluntary
+// exit signature, computed over the Capella domain — even though "now" is in the Fulu
+// era and the current fork differs from Capella.
+//
+// Note: this only exercises the EIP-7044-correct path. With --network=mainnet,
+// Web3Signer applies the EIP-7044 override itself and derives the Capella domain from
+// its own config, so the roots match regardless of the Capella pin in
+// RemoteKeyManager.prepareSignRequest. The Hoodi incident — a signer that falls back
+// to the fork_info we send — is not reproduced here; the Capella assertion in
+// remote_key_manager_test.go (SignVoluntaryExit) is what guards the pin.
+func (s *VoluntaryExitSigningTestSuite) TestVoluntaryExitSigningConsistency() {
+	// Place the chain clock in the Fulu era (mainnet Fulu @ epoch 411392) so the
+	// current fork (0x06000000) is well past Capella (0x03000000). Web3Signer is run
+	// with --network=mainnet, so at this epoch it applies the EIP-7044 override and
+	// signs exits with the Capella fork version.
+	testCurrentEpoch := phase0.Epoch(411392 + 256)
+	s.GetEnv().SetTestCurrentEpoch(testCurrentEpoch)
+
+	ctx, cancel := context.WithTimeout(s.GetContext(), 60*time.Second)
+	defer cancel()
+
+	validatorKeyPair := s.AddValidator(ctx)
+
+	exitEpoch := testCurrentEpoch
+	exitSlot := s.GetEnv().GetBeaconConfig().FirstSlotAtEpoch(exitEpoch)
+
+	voluntaryExit := &phase0.VoluntaryExit{
+		Epoch:          exitEpoch,
+		ValidatorIndex: 1,
+	}
+
+	// EIP-7044: exits are signed over the Capella domain, not the current fork's.
+	domain, err := s.CalculateVoluntaryExitDomain()
+	s.Require().NoError(err, "Failed to calculate voluntary exit domain")
+
+	s.T().Logf("Signing voluntary exit (epoch %d, current fork = Fulu) over the Capella domain", exitEpoch)
+
+	localSig, localRoot, err := s.GetEnv().GetLocalKeyManager().SignBeaconObject(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Local key manager failed to sign voluntary exit")
+	s.Require().NotEmpty(localSig)
+	s.Require().NotEmpty(localRoot)
+
+	remoteSig, remoteRoot, err := s.GetEnv().GetRemoteKeyManager().SignBeaconObject(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Remote key manager failed to sign voluntary exit")
+	s.Require().NotEmpty(remoteSig)
+	s.Require().NotEmpty(remoteRoot)
+
+	web3Sig, web3Root, err := s.SignWeb3Signer(
+		ctx, voluntaryExit, domain, validatorKeyPair.BLSPubKey, exitSlot, spectypes.DomainVoluntaryExit)
+	s.Require().NoError(err, "Web3Signer failed to sign voluntary exit")
+	s.Require().NotEmpty(web3Sig)
+	s.Require().NotEmpty(web3Root)
+
+	// All three paths must agree on both the (Capella) signing root and the signature.
+	s.Require().Equal(localRoot, remoteRoot, "local vs remote signing root should match")
+	s.Require().Equal(remoteRoot, web3Root, "remote vs web3signer signing root should match")
+	s.Require().Equal(localSig, remoteSig, "local vs remote signature should match")
+	s.Require().Equal(remoteSig, web3Sig, "remote vs web3signer signature should match")
+
+	s.T().Logf("All signers agree on the Capella-domain voluntary exit signature")
+}
+
+// TestVoluntaryExitSigning runs the voluntary exit signing test suite.
+func TestVoluntaryExitSigning(t *testing.T) {
+	suite.Run(t, new(VoluntaryExitSigningTestSuite))
+}

--- a/ssvsigner/e2e/suite.go
+++ b/ssvsigner/e2e/suite.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/sourcegraph/conc/pool"
@@ -77,6 +79,60 @@ func (s *E2ETestSuite) CalculateDomain(domainType phase0.DomainType, epoch phase
 	return domain, nil
 }
 
+// CalculateVoluntaryExitDomain computes the voluntary-exit signing domain, which per
+// EIP-7044 is permanently fixed to the Capella fork version (unlike CalculateDomain,
+// which uses the fork active at the given epoch). This mirrors what the SSV node's
+// beacon client computes for exits.
+func (s *E2ETestSuite) CalculateVoluntaryExitDomain() (phase0.Domain, error) {
+	capellaFork, ok := s.env.GetBeaconConfig().ForkAtVersion(spec.DataVersionCapella)
+	if !ok {
+		return phase0.Domain{}, errors.New("capella fork not configured")
+	}
+
+	forkData := &phase0.ForkData{
+		CurrentVersion:        capellaFork.CurrentVersion,
+		GenesisValidatorsRoot: s.env.GetBeaconConfig().GenesisValidatorsRoot,
+	}
+
+	forkDataRoot, err := forkData.HashTreeRoot()
+	if err != nil {
+		return phase0.Domain{}, err
+	}
+
+	domain := phase0.Domain{}
+	copy(domain[:4], spectypes.DomainVoluntaryExit[:])
+	copy(domain[4:], forkDataRoot[:28])
+
+	return domain, nil
+}
+
+// CalculateValidatorRegistrationDomain computes the validator-registration (application
+// builder) signing domain, which uses the genesis fork version and an empty genesis
+// validators root - independent of the current fork. Like the voluntary-exit domain it
+// is fixed, so it mirrors what the SSV node's beacon client computes for registrations.
+func (s *E2ETestSuite) CalculateValidatorRegistrationDomain() (phase0.Domain, error) {
+	genesisFork, ok := s.env.GetBeaconConfig().ForkAtVersion(spec.DataVersionPhase0)
+	if !ok {
+		return phase0.Domain{}, errors.New("genesis (phase0) fork not configured")
+	}
+
+	forkData := &phase0.ForkData{
+		CurrentVersion:        genesisFork.CurrentVersion,
+		GenesisValidatorsRoot: phase0.Root{},
+	}
+
+	forkDataRoot, err := forkData.HashTreeRoot()
+	if err != nil {
+		return phase0.Domain{}, err
+	}
+
+	domain := phase0.Domain{}
+	copy(domain[:4], spectypes.DomainApplicationBuilder[:])
+	copy(domain[4:], forkDataRoot[:28])
+
+	return domain, nil
+}
+
 // RequireSlashingError verifies that Web3Signer returns HTTP 412 for slashing protection violations
 func (s *E2ETestSuite) RequireSlashingError(err error, operation string) {
 	var httpErr web3signer.HTTPResponseError
@@ -118,6 +174,28 @@ func (s *E2ETestSuite) SignWeb3Signer(
 		}
 		req.Type = web3signer.TypeBlockV2
 		req.BeaconBlock = beaconBlockData
+
+	case spectypes.DomainVoluntaryExit:
+		data, ok := obj.(*phase0.VoluntaryExit)
+		if !ok {
+			return nil, phase0.Root{}, errors.New("could not cast obj to VoluntaryExit")
+		}
+		// Unlike the production RemoteKeyManager (which pins Capella, see
+		// voluntaryExitForkInfo), this helper intentionally forwards the current fork.
+		// The caller's signing_root is already over the Capella domain (EIP-7044), and
+		// the e2e Web3Signer (--network=mainnet) overrides the exit fork to Capella
+		// itself, so the roots still match — this exercises Web3Signer's own EIP-7044
+		// path. Do not "align" this with the production path without that context.
+		req.Type = web3signer.TypeVoluntaryExit
+		req.VoluntaryExit = data
+
+	case spectypes.DomainApplicationBuilder:
+		data, ok := obj.(*eth2apiv1.ValidatorRegistration)
+		if !ok {
+			return nil, phase0.Root{}, errors.New("could not cast obj to ValidatorRegistration")
+		}
+		req.Type = web3signer.TypeValidatorRegistration
+		req.ValidatorRegistration = data
 
 	default:
 		return nil, phase0.Root{}, errors.New("unsupported domain type for testing")

--- a/ssvsigner/ekm/contracts.go
+++ b/ssvsigner/ekm/contracts.go
@@ -48,4 +48,8 @@ type BeaconNetwork interface {
 	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
 	EstimatedSlotAtTime(time time.Time) phase0.Slot
 	BeaconForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase0.Fork)
+	// ForkAtVersion returns the configured fork for a data version, and whether it exists.
+	// Used to pin a fixed fork (Capella for exits per EIP-7044, genesis for registrations)
+	// independently of the current fork.
+	ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool)
 }

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -293,6 +294,15 @@ func (km *RemoteKeyManager) prepareSignRequest(
 			return web3signer.SignRequest{}, phase0.Root{}, errors.New("could not cast obj to VoluntaryExit")
 		}
 
+		// EIP-7044 pins voluntary exits to the Capella domain. Override the current fork
+		// (from GetForkInfo) with Capella to match the signing_root computed below; else a
+		// signer that doesn't apply EIP-7044 (e.g. a wrong Web3Signer --network) rejects it.
+		forkInfo, err := km.voluntaryExitForkInfo()
+		if err != nil {
+			return web3signer.SignRequest{}, phase0.Root{}, err
+		}
+		req.ForkInfo = forkInfo
+
 		req.Type = web3signer.TypeVoluntaryExit
 		req.VoluntaryExit = data
 
@@ -381,6 +391,15 @@ func (km *RemoteKeyManager) prepareSignRequest(
 			return web3signer.SignRequest{}, phase0.Root{}, errors.New("could not cast obj to ValidatorRegistration")
 		}
 
+		// The application-builder domain is fixed to the genesis fork, independent of the
+		// current fork. Pin it to match the signing_root computed below, mirroring the
+		// voluntary-exit case (a no-op for a correct signer, which derives the domain itself).
+		forkInfo, err := km.validatorRegistrationForkInfo()
+		if err != nil {
+			return web3signer.SignRequest{}, phase0.Root{}, err
+		}
+		req.ForkInfo = forkInfo
+
 		req.Type = web3signer.TypeValidatorRegistration
 		req.ValidatorRegistration = data
 	default:
@@ -459,6 +478,35 @@ func (km *RemoteKeyManager) GetForkInfo(epoch phase0.Epoch) web3signer.ForkInfo 
 		Fork:                  currentFork,
 		GenesisValidatorsRoot: km.genesisRoot,
 	}
+}
+
+// voluntaryExitForkInfo returns ForkInfo pinned to the Capella fork, as EIP-7044 requires for
+// voluntary exits. See the DomainVoluntaryExit case in prepareSignRequest.
+func (km *RemoteKeyManager) voluntaryExitForkInfo() (web3signer.ForkInfo, error) {
+	capellaFork, ok := km.beaconConfig.ForkAtVersion(spec.DataVersionCapella)
+	if !ok {
+		return web3signer.ForkInfo{}, errors.New("capella fork not configured")
+	}
+
+	return web3signer.ForkInfo{
+		Fork:                  &capellaFork,
+		GenesisValidatorsRoot: km.genesisRoot,
+	}, nil
+}
+
+// validatorRegistrationForkInfo returns ForkInfo pinned to the genesis fork and an empty
+// genesis validators root, matching the fixed application-builder domain. See the
+// DomainApplicationBuilder case in prepareSignRequest.
+func (km *RemoteKeyManager) validatorRegistrationForkInfo() (web3signer.ForkInfo, error) {
+	genesisFork, ok := km.beaconConfig.ForkAtVersion(spec.DataVersionPhase0)
+	if !ok {
+		return web3signer.ForkInfo{}, errors.New("genesis fork not configured")
+	}
+
+	return web3signer.ForkInfo{
+		Fork:                  &genesisFork,
+		GenesisValidatorsRoot: phase0.Root{},
+	}, nil
 }
 
 func (km *RemoteKeyManager) Sign(payload []byte) ([]byte, error) {

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -13,6 +13,7 @@ import (
 	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
 	apiv1electra "github.com/attestantio/go-eth2-client/api/v1/electra"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
@@ -1444,18 +1445,78 @@ func (s *RemoteKeyManagerTestSuite) TestSignBeaconObjectAdditionalDomains() {
 	slot := phase0.Slot(123)
 
 	s.Run("SignVoluntaryExit", func() {
+		// Use a post-Capella slot (epoch 6 = Fulu in the test config) so the current
+		// fork differs from Capella — that difference is what makes the EIP-7044
+		// pinning observable. Signing an exit must use the Capella fork regardless.
+		exitSlot := phase0.Slot(6 * testNetCfg.SlotsPerEpoch)
+		exitEpoch := testNetCfg.EstimatedEpochAtSlot(exitSlot)
+
 		voluntaryExit := &phase0.VoluntaryExit{
-			Epoch:          123,
+			Epoch:          exitEpoch,
 			ValidatorIndex: 456,
 		}
 
-		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).Return(expectedSignature, nil).Once()
+		var capturedReq web3signer.SignRequest
+		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).
+			Run(func(args mock.Arguments) {
+				capturedReq = args.Get(2).(web3signer.SignRequest)
+			}).
+			Return(expectedSignature, nil).Once()
 
-		signature, root, err := rm.SignBeaconObject(ctx, voluntaryExit, domain, pubKey, slot, spectypes.DomainVoluntaryExit)
+		signature, root, err := rm.SignBeaconObject(ctx, voluntaryExit, domain, pubKey, exitSlot, spectypes.DomainVoluntaryExit)
 
 		s.NoError(err)
 		s.EqualValues(expectedSignature[:], signature)
 		s.NotEqual([32]byte{}, root)
+
+		// EIP-7044: the exit must be signed with the Capella fork, not the current one.
+		s.Equal(web3signer.TypeVoluntaryExit, capturedReq.Type)
+		s.Require().NotNil(capturedReq.ForkInfo.Fork)
+		capellaFork, ok := testNetCfg.ForkAtVersion(spec.DataVersionCapella)
+		s.Require().True(ok)
+		s.Equal(capellaFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		_, currentFork := testNetCfg.BeaconForkAtEpoch(exitEpoch)
+		s.NotEqual(currentFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+
+		s.client.AssertExpectations(s.T())
+	})
+
+	s.Run("SignValidatorRegistration", func() {
+		// Validator registration uses the application-builder domain, fixed to the
+		// genesis fork version regardless of the current fork. Use a post-genesis slot
+		// (epoch 6 = Fulu in the test config) so the current fork differs from genesis;
+		// the request must carry the pinned genesis fork and an empty genesis root.
+		registrationSlot := phase0.Slot(6 * testNetCfg.SlotsPerEpoch)
+
+		registration := &eth2api.ValidatorRegistration{
+			FeeRecipient: bellatrix.ExecutionAddress{1, 2, 3},
+			GasLimit:     30000000,
+			Timestamp:    time.Unix(1700000000, 0),
+			Pubkey:       pubKey,
+		}
+
+		var capturedReq web3signer.SignRequest
+		s.client.On("Sign", mock.Anything, pubKey, mock.Anything).
+			Run(func(args mock.Arguments) {
+				capturedReq = args.Get(2).(web3signer.SignRequest)
+			}).
+			Return(expectedSignature, nil).Once()
+
+		signature, root, err := rm.SignBeaconObject(ctx, registration, domain, pubKey, registrationSlot, spectypes.DomainApplicationBuilder)
+
+		s.NoError(err)
+		s.EqualValues(expectedSignature[:], signature)
+		s.NotEqual([32]byte{}, root)
+
+		s.Equal(web3signer.TypeValidatorRegistration, capturedReq.Type)
+		s.Require().NotNil(capturedReq.ForkInfo.Fork)
+		genesisFork, ok := testNetCfg.ForkAtVersion(spec.DataVersionPhase0)
+		s.Require().True(ok)
+		s.Equal(genesisFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		_, currentFork := testNetCfg.BeaconForkAtEpoch(testNetCfg.EstimatedEpochAtSlot(registrationSlot))
+		s.NotEqual(currentFork.CurrentVersion, capturedReq.ForkInfo.Fork.CurrentVersion)
+		s.Equal(phase0.Root{}, capturedReq.ForkInfo.GenesisValidatorsRoot)
+
 		s.client.AssertExpectations(s.T())
 	})
 

--- a/ssvsigner/internal/beaconcfg/config.go
+++ b/ssvsigner/internal/beaconcfg/config.go
@@ -97,3 +97,8 @@ func (b *Config) BeaconForkAtEpoch(epoch phase0.Epoch) (spec.DataVersion, *phase
 
 	return previousVersion, &previousFork
 }
+
+func (b *Config) ForkAtVersion(version spec.DataVersion) (phase0.Fork, bool) {
+	fork, ok := b.Forks[version]
+	return fork, ok
+}


### PR DESCRIPTION
Bucket A of #2902 — **scoped** port of stage #2875 onto `boole-fork`: the remote-signing fix only.

**Bug ("Hoodi incident"):** voluntary exits are signed over the EIP-7044-pinned **Capella** domain, but the remote signer (ssv-signer → Web3Signer) sent the *current* fork in `fork_info`. A Web3Signer with a wrong/missing `--network` resolves the exit epoch pre-Deneb, recomputes a mismatched root, and rejects with **HTTP 400 → the exit never signs**. Liveness bug for remote-signing operators (you confirmed boole needs remote signing); local signing was already correct.

**Fix:** `prepareSignRequest` pins the fixed fork — Capella for `DomainVoluntaryExit`, genesis-builder for `DomainApplicationBuilder` — so the remote request is self-consistent with the locally-computed `signing_root` and matches the local signer. A missing-fork lookup **errors out** (never pins a zero-value `Fork`/wrong domain). New `ForkAtVersion` on the beacon config + interface does the fixed-fork lookup. Plus a signer-agnostic `--network` hint on exit-signing failure.

**Deliberately NOT ported (the bundled refactor):** #2875 also dedups `VerifyBeaconPartialSignature`/`ResolveDuplicateSignature` into shared code, touching `runner.go`, `runner_signatures.go`, `committee_observer.go`, `partial_sig_container.go`, `types/crypto.go` — boole's heavily-diverged consensus core. That cleanup is unrelated to remote signing and collides with boole; left out by design.

**Review:** deep-reviewed for signing-domain correctness — **APPROVE**. The reviewer verified by source that the pinned domain equals what the local node computes for both domains (`Forks[Capella]`+gvr for exits; `Forks[Phase0].CurrentVersion`+zeroed gvr for registration), and that the `ok=false` path errors rather than signing over a wrong domain. `MockBeaconNetwork` left as-is (didn't expand dead code). `go build/test/vet/gofmt` clean (except pre-existing `spectest fixRunnerForRun`); e2e signing tests added (Docker-gated).