### PR TITLE
observability(runner): classify AggregatorCommitteeRunner terminal failures as failed (#2902)

### DIFF
--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -588,7 +588,13 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 
 	// Else, if some aggregators or contributors were selected (even with an error for others), proceed to consensus
 	if err := consensusData.Validate(); err != nil {
-		r.markDutyFailed(err)
+		// Not markDutyFailed: this pre-consensus window is re-entrant until consensus starts
+		// (guarded by HasStartedConsensus). basePreConsensusMsgProcessing reports a new quorum
+		// per root, not once per duty, and a Validate error is non-retryable so the committee
+		// queue drops the message but keeps the runner alive. A transient GetAggregateAttestation
+		// failure can leave consensusData empty here, yet a later message whose root reaches quorum
+		// can still build valid data and start consensus — concluding "failed" now would mask a
+		// duty that still completes.
 		return fmt.Errorf("invalid aggregator committee consensus data: %w", err)
 	}
 
@@ -600,7 +606,11 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 		consensusData,
 		r.ValCheck,
 	); err != nil {
-		r.markDutyFailed(err)
+		// Not markDutyFailed: same re-entrant pre-consensus window as the Validate check above.
+		// decide sets RunningInstance only on success, so a failure here leaves HasStartedConsensus
+		// false and a later new-quorum message can start consensus and complete the duty. The
+		// message drop is non-terminal (runner survives), so concluding "failed" now would risk a
+		// false failure on a duty that still succeeds.
 		return fmt.Errorf("failed to start consensus: %w", err)
 	}
 

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -358,6 +358,8 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 
 	aggregatorMap, contributionMap, err := r.expectedPreConsensusRoots(ctx, logger)
 	if err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
 		return fmt.Errorf("could not get expected pre-consensus roots: %w", err)
 	}
 
@@ -507,8 +509,10 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 				}
 
 			default:
-				// This should never happen as we build rootToMetadata ourselves with valid roles
-				return fmt.Errorf("unexpected role type in pre-consensus metadata: %v", metadata.Role)
+				// deterministic terminal invariant violation → classify as failed, not stuck
+				err := fmt.Errorf("unexpected role type in pre-consensus metadata: %v", metadata.Role)
+				r.markDutyFailed(err)
+				return err
 			}
 		}
 	}
@@ -536,6 +540,8 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 	if len(aggregatorSelections) > 0 {
 		// Wait once per duty before fetching aggregate attestations (spec: 2/3 into slot).
 		if err := r.waitTwoThirdsIntoSlot(ctx, duty.DutySlot()); err != nil {
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
 			return err
 		}
 
@@ -582,6 +588,8 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 
 	// Else, if some aggregators or contributors were selected (even with an error for others), proceed to consensus
 	if err := consensusData.Validate(); err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
 		return fmt.Errorf("invalid aggregator committee consensus data: %w", err)
 	}
 
@@ -593,6 +601,8 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 		consensusData,
 		r.ValCheck,
 	); err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
 		return fmt.Errorf("failed to start consensus: %w", err)
 	}
 
@@ -788,6 +798,8 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 	// Get validator-root maps for attestations and sync committees, and the root-beacon object map
 	aggregatorMap, contributionMap, beaconObjects, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
 	if err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
 		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
 	}
 	if len(beaconObjects) == 0 {
@@ -925,7 +937,10 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		for {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				// terminal post-quorum failure → classify as failed, not stuck
+				err := ctx.Err()
+				r.markDutyFailed(err)
+				return err
 			case err := <-errCh:
 				executionErr = err
 			case signatureResult, ok := <-signatureCh:
@@ -972,7 +987,10 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 					contributionsToSubmit[signatureResult.validatorIndex][root] = signedContrib
 
 				default:
-					return fmt.Errorf("unexpected role type in post-consensus: %v", role)
+					// deterministic terminal invariant violation → classify as failed, not stuck
+					err := fmt.Errorf("unexpected role type in post-consensus: %v", role)
+					r.markDutyFailed(err)
+					return err
 				}
 			}
 		}
@@ -1043,6 +1061,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 	}
 
 	if executionErr != nil {
+		// Not markDutyFailed: a transient submit/reconstruct error can recover — a later post-consensus message re-enters the submit loops and retries the pending roots (already-submitted roots are skipped via HasSubmitted), so concluding "failed" here would prematurely mask a duty that still completes.
 		return executionErr
 	}
 

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -540,8 +540,8 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 	if len(aggregatorSelections) > 0 {
 		// Wait once per duty before fetching aggregate attestations (spec: 2/3 into slot).
 		if err := r.waitTwoThirdsIntoSlot(ctx, duty.DutySlot()); err != nil {
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
+			// Only reachable on shutdown (ctx canceled) within this short wait — markDutyFailed
+			// would drop a context.Canceled reason anyway, so there is nothing to record here.
 			return err
 		}
 
@@ -588,7 +588,6 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 
 	// Else, if some aggregators or contributors were selected (even with an error for others), proceed to consensus
 	if err := consensusData.Validate(); err != nil {
-		// terminal post-quorum failure → classify as failed, not stuck
 		r.markDutyFailed(err)
 		return fmt.Errorf("invalid aggregator committee consensus data: %w", err)
 	}
@@ -601,7 +600,6 @@ func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
 		consensusData,
 		r.ValCheck,
 	); err != nil {
-		// terminal post-quorum failure → classify as failed, not stuck
 		r.markDutyFailed(err)
 		return fmt.Errorf("failed to start consensus: %w", err)
 	}
@@ -803,6 +801,10 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
 	}
 	if len(beaconObjects) == 0 {
+		// Empty post-quorum (all beacon objects failed to build) is terminal and non-recoverable:
+		// committee_queue drops the message and terminates the runner on this error. Classify as
+		// failed (matching CommitteeRunner) rather than leaving the watcher to report a false stuck.
+		r.markDutyFailed(ErrNoValidDutiesToExecute)
 		return ErrNoValidDutiesToExecute
 	}
 
@@ -937,10 +939,9 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		for {
 			select {
 			case <-ctx.Done():
-				// terminal post-quorum failure → classify as failed, not stuck
-				err := ctx.Err()
-				r.markDutyFailed(err)
-				return err
+				// Only reachable on shutdown (ctx canceled) — the listener completes in ms and the
+				// duty deadline is ~1 epoch out — and markDutyFailed drops context.Canceled anyway.
+				return ctx.Err()
 			case err := <-errCh:
 				executionErr = err
 			case signatureResult, ok := <-signatureCh:
@@ -1061,7 +1062,10 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 	}
 
 	if executionErr != nil {
-		// Not markDutyFailed: a transient submit/reconstruct error can recover — a later post-consensus message re-enters the submit loops and retries the pending roots (already-submitted roots are skipped via HasSubmitted), so concluding "failed" here would prematurely mask a duty that still completes.
+		// Not markDutyFailed: a transient submit/reconstruct error can recover — a later
+		// post-consensus message re-enters the submit loops and retries the pending roots
+		// (already-submitted roots are skipped via HasSubmitted), so concluding "failed" here
+		// would prematurely mask a duty that still completes.
 		return executionErr
 	}
 

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -1072,10 +1072,17 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 	}
 
 	if executionErr != nil {
-		// Not markDutyFailed: a transient submit/reconstruct error can recover — a later
-		// post-consensus message re-enters the submit loops and retries the pending roots
-		// (already-submitted roots are skipped via HasSubmitted), so concluding "failed" here
-		// would prematurely mask a duty that still completes.
+		// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root
+		// below quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to
+		// retry pending roots (already-submitted roots are skipped via HasSubmitted). Not markDutyFailed.
+		var specErr *spectypes.Error
+		if errors.As(executionErr, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
+			return executionErr
+		}
+		// Submit/construct/missing-object failures: reconstruction already succeeded so the root keeps
+		// its quorum and is never re-reported (runner.go:534 reports only on first quorum crossing), so
+		// the submit loop never revisits it and the duty never concludes → mark failed, not a false stuck.
+		r.markDutyFailed(executionErr)
 		return executionErr
 	}
 

--- a/protocol/v2/ssv/runner/aggregator_committee_test.go
+++ b/protocol/v2/ssv/runner/aggregator_committee_test.go
@@ -1,0 +1,208 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv"
+	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
+	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+)
+
+// faultyAggregateSubmitBeacon wraps the testing beacon node and forces the aggregate-selection-proof
+// submission to fail, so we can exercise the terminal post-quorum "submit failed" path in
+// AggregatorCommitteeRunner.ProcessPostConsensus. All other beacon behavior is inherited unchanged
+// via the embedded *BeaconNodeWrapped (method promotion).
+type faultyAggregateSubmitBeacon struct {
+	*protocoltesting.BeaconNodeWrapped
+	submitErr error
+}
+
+func (b *faultyAggregateSubmitBeacon) SubmitSignedAggregateSelectionProof(_ context.Context, _ *spec.VersionedSignedAggregateAndProof) error {
+	return b.submitErr
+}
+
+type aggregatorCommitteeRunnerEnv struct {
+	logger    *zap.Logger
+	runner    *AggregatorCommitteeRunner
+	network   *protocoltesting.TestingNetwork
+	keySetMap map[phase0.ValidatorIndex]*spectestingutils.TestKeySet
+	sampleKey *spectestingutils.TestKeySet
+}
+
+// newAggregatorCommitteeRunnerEnv builds an AggregatorCommitteeRunner wired to the supplied beacon
+// node, mirroring newCommitteeRunnerEnv. The beacon is injected so a test can substitute a faulty one.
+func newAggregatorCommitteeRunnerEnv(
+	t *testing.T,
+	validatorIndices []int,
+	beaconNode beacon.BeaconNode,
+) *aggregatorCommitteeRunnerEnv {
+	t.Helper()
+
+	keySetMap := spectestingutils.KeySetMapForValidatorIndexList(validatorIndices)
+	sampleKey := keySetMap[phase0.ValidatorIndex(validatorIndices[0])]
+	shareMap := spectestingutils.ShareMapFromKeySetMap(keySetMap)
+
+	msgID := spectestingutils.AggregatorCommitteeMsgIDForKeySet(sampleKey)
+	network := protocoltesting.NewTestingNetwork(1, sampleKey.OperatorKeys[1])
+	logger := zaptest.NewLogger(t)
+	signer := ekm.NewTestingKeyManagerAdapter(spectestingutils.NewTestingKeyManager())
+
+	config := protocoltesting.TestingConfig(logger, sampleKey)
+	config.Network = network
+	ctrl := protocoltesting.NewTestingQBFTController(
+		sampleKey,
+		msgID[:],
+		spectestingutils.TestingCommitteeMember(sampleKey),
+		config,
+		false,
+	)
+
+	runnerI, err := NewAggregatorCommitteeRunner(AggregatorCommitteeRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig:  networkconfig.TestNetwork,
+			Share:          shareMap,
+			Beacon:         beaconNode,
+			Network:        network,
+			Signer:         signer,
+			OperatorSigner: spectestingutils.NewOperatorSigner(sampleKey, 1),
+		},
+		QBFTController: ctrl,
+	})
+	require.NoError(t, err)
+
+	arunner := runnerI.(*AggregatorCommitteeRunner)
+	arunner.SetQBFTRoundTimerF(func(_ context.Context, _ *zap.Logger, _ phase0.Slot) ssv.QBFTRoundTimer {
+		return roundtimer.NewTestingTimer()
+	})
+
+	return &aggregatorCommitteeRunnerEnv{
+		logger:    logger,
+		runner:    arunner,
+		network:   network,
+		keySetMap: keySetMap,
+		sampleKey: sampleKey,
+	}
+}
+
+// startAndFeedThroughConsensus starts the duty and feeds the pre-consensus and consensus messages from
+// the spec fixtures (everything except post-consensus), leaving the runner decided and ready to process
+// post-consensus. It swaps in a fresh conclusion channel so the caller can observe the duty outcome
+// deterministically instead of racing the deadline-watcher goroutine StartNewDuty spawned. It returns
+// that channel.
+func (e *aggregatorCommitteeRunnerEnv) startAndFeedThroughConsensus(t *testing.T, ctx context.Context, duty *spectypes.AggregatorCommitteeDuty, version spec.DataVersion) chan dutyConclusion {
+	t.Helper()
+
+	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.sampleKey.Threshold))
+
+	concluded := make(chan dutyConclusion, 1)
+	e.runner.BaseRunner.dutyConcluded = concluded
+
+	for _, msg := range spectestingutils.AggregatorCommitteeInputForDuty(duty, e.keySetMap, version) {
+		switch msg.SSVMessage.MsgType {
+		case spectypes.SSVConsensusMsgType:
+			require.NoError(t, e.runner.ProcessConsensus(ctx, e.logger, msg))
+		case spectypes.SSVPartialSignatureMsgType:
+			psig := &spectypes.PartialSignatureMessages{}
+			require.NoError(t, psig.Decode(msg.SSVMessage.Data))
+			if psig.Type != spectypes.PostConsensusPartialSig {
+				require.NoError(t, e.runner.ProcessPreConsensus(ctx, e.logger, psig))
+			}
+		}
+	}
+	return concluded
+}
+
+// postConsensusMsgsFromFixture returns the (valid) post-consensus PartialSignatureMessages from signers
+// 1..3 for the duty — the same messages AggregatorCommitteeInputForDuty carries.
+func postConsensusMsgsFromFixture(duty *spectypes.AggregatorCommitteeDuty, ksMap map[phase0.ValidatorIndex]*spectestingutils.TestKeySet, version spec.DataVersion) []*spectypes.PartialSignatureMessages {
+	msgs := make([]*spectypes.PartialSignatureMessages, 0, 3)
+	for id := spectypes.OperatorID(1); id <= 3; id++ {
+		msgs = append(msgs, spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, ksMap, id, version))
+	}
+	return msgs
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError asserts that a beacon
+// submit failure (a terminal post-quorum error) concludes the duty as failed — not left to surface
+// as a false "stuck".
+func TestAggregatorCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected aggregate")
+	faulty := &faultyAggregateSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, faulty)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.ErrorIs(t, postConsensusErr, submitErr, "submit failure should surface from ProcessPostConsensus")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome, "a terminal submit failure must be classified failed")
+		require.ErrorIs(t, c.reason, submitErr)
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs asserts that the
+// recoverable reconstruct-invalid-signatures case is NOT concluded failed: the root can later re-cross
+// quorum on a subsequent message, so concluding here would mask a duty that still completes.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, base)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	// Corrupt the beacon partial signatures. For the aggregator role, ValidatePostConsensusMsg only
+	// checks message structure (not the beacon sigs), so these still reach optimistic quorum, then
+	// ReconstructBeaconSig fails → the runner reports PostConsensusQuorumWithInvalidSignatures.
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		for _, m := range psig.Messages {
+			m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+		}
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.Error(t, postConsensusErr, "invalid signatures should surface an error")
+	var specErr *spectypes.Error
+	require.ErrorAs(t, postConsensusErr, &specErr)
+	require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code,
+		"invalid-sigs must carry the recoverable spec code")
+
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
+	require.False(t, env.runner.State.Succeeded)
+}

--- a/protocol/v2/ssv/runner/aggregator_committee_test.go
+++ b/protocol/v2/ssv/runner/aggregator_committee_test.go
@@ -109,7 +109,7 @@ func (e *aggregatorCommitteeRunnerEnv) startAndFeedThroughConsensus(t *testing.T
 	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.sampleKey.Threshold))
 
 	concluded := make(chan dutyConclusion, 1)
-	e.runner.BaseRunner.dutyConcluded = concluded
+	e.runner.dutyConcluded = concluded
 
 	for _, msg := range spectestingutils.AggregatorCommitteeInputForDuty(duty, e.keySetMap, version) {
 		switch msg.SSVMessage.MsgType {
@@ -121,6 +121,7 @@ func (e *aggregatorCommitteeRunnerEnv) startAndFeedThroughConsensus(t *testing.T
 			if psig.Type != spectypes.PostConsensusPartialSig {
 				require.NoError(t, e.runner.ProcessPreConsensus(ctx, e.logger, psig))
 			}
+		default:
 		}
 	}
 	return concluded


### PR DESCRIPTION
Bucket B of #2902 — the observability follow-up raised in the #2899 review.

**Gap:** boole's `AggregatorCommitteeRunner` never calls `markDutyFailed` on terminal post-quorum failures, so the duty-outcome watcher classifies genuine failures as **"stuck"** rather than **"failed"**.

**Fix:** `r.markDutyFailed(err)` at each terminal failure return — **6 sites**:

`ProcessPreConsensus`
- `expectedPreConsensusRoots` error
- defensive `default:` — unexpected role type in pre-consensus metadata (deterministic invariant violation)

`ProcessPostConsensus`
- `expectedPostConsensusRootsAndBeaconObjects` error
- empty beacon objects → `ErrNoValidDutiesToExecute` (terminal, non-recoverable: `committee_queue` drops the message and terminates the runner)
- defensive `default:` — unexpected role type in post-consensus (deterministic invariant violation)
- submit / construct / missing-object `executionErr` (reconstruction already succeeded, so the root keeps quorum and is never re-reported → the duty never concludes on its own)

**Deliberately NOT marked** (a blanket `defer` is unsafe — these are re-entrant or still-recoverable):
- the re-entrant pre-consensus window — `Validate()` / `decide()` and the keep-waiting `return anyErr` (duty still progressing; this window re-enters on every pre-consensus message until consensus starts)
- `waitTwoThirdsIntoSlot` + listener `ctx.Done()` returns — reachable only on shutdown within a short wait; `markDutyFailed` drops `context.Canceled`, and the duty deadline (~1 epoch out) is unreachable there, so there is nothing to record
- the recoverable post-consensus `PostConsensusQuorumWithInvalidSignatures` return — `FallBackAndVerifyEachSignature` can drop the root below quorum so a later partial-sig message re-crosses quorum and retries; discriminated from the terminal submit/construct case via `errors.As` + `.Code`
- the `markDutyNotRequired` / success paths

All exclusions are documented inline.

**Review:** deep-reviewed for duty-outcome correctness — **APPROVE**. Verified no marked site can fire while the duty is still recoverable (the pre-consensus re-entry marks were dropped for exactly this reason), and that the `executionErr` split correctly excludes only the recoverable invalid-sigs sub-case.

Regression coverage added in 64fa002: a new `AggregatorCommitteeRunner` post-consensus test env (mirroring `newCommitteeRunnerEnv`) plus a beacon wrapper that injects a submit error, covering both branches of the split — submit failure concludes `failed`, recoverable invalid-sigs does not.

`go build/test/vet/gofmt` clean (except the pre-existing `spectest fixRunnerForRun`).
