### PR TITLE
fix(dutytracer): join collector + slot-pruning before DB close on shutdown (#2884)

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -511,10 +511,13 @@ var StartNodeCmd = &cobra.Command{
 			})
 		}
 
+		// joinSlotPruning waits for all PruneContinuously goroutines to return.
+		// It is non-nil only in exporter-standard mode; must be called before db.Close().
+		var joinSlotPruning func()
 		if cfg.ExporterOptions.Enabled && cfg.ExporterOptions.Mode == exporter.ModeStandard {
 			retain := cfg.ExporterOptions.RetainSlots
 			threshold := cfg.SSVOptions.NetworkConfig.EstimatedCurrentSlot()
-			initSlotPruning(cmd.Context(), storageMap, slotTickerProvider, threshold, retain)
+			joinSlotPruning = initSlotPruning(cmd.Context(), storageMap, slotTickerProvider, threshold, retain)
 		}
 
 		cfg.SSVOptions.ValidatorOptions.StorageMap = storageMap
@@ -544,6 +547,9 @@ var StartNodeCmd = &cobra.Command{
 
 		// Exporter duty tracing
 		var collector *dutytracer.Collector
+		// collectorDone is closed when the collector goroutine returns; non-nil only
+		// in archive mode. Joined before db.Close() to prevent writes to a closed DB.
+		var collectorDone chan struct{}
 		if cfg.ExporterOptions.Enabled {
 			switch cfg.ExporterOptions.Mode {
 			case exporter.ModeArchive:
@@ -556,7 +562,11 @@ var StartNodeCmd = &cobra.Command{
 					dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 					dutyStore)
 
-				go collector.Start(cmd.Context(), slotTickerProvider)
+				collectorDone = make(chan struct{})
+				go func() {
+					defer close(collectorDone)
+					collector.Start(cmd.Context(), slotTickerProvider)
+				}()
 				cfg.SSVOptions.ValidatorOptions.DutyTraceCollector = collector
 				cfg.SSVOptions.ExporterRead = exporter2.NewExporter(
 					logger,
@@ -719,6 +729,16 @@ var StartNodeCmd = &cobra.Command{
 		}
 		if err := operatorNode.Start(cfg.SSVOptions.Context); err != nil {
 			logger.Fatal("failed to start SSV node", zap.Error(err))
+		}
+
+		// Join background goroutines before the deferred db.Close() runs.
+		// Both collector.Start and PruneContinuously return promptly on ctx.Done(),
+		// so these joins complete quickly after the shutdown signal is received.
+		if collectorDone != nil {
+			<-collectorDone
+		}
+		if joinSlotPruning != nil {
+			joinSlotPruning()
 		}
 	},
 }
@@ -1345,7 +1365,10 @@ func syncContractEvents(
 	return eventSyncer
 }
 
-func initSlotPruning(ctx context.Context, stores *ibftstorage.ParticipantStores, slotTickerProvider slotticker.Provider, slot phase0.Slot, retain uint64) {
+// initSlotPruning starts the slot-pruning goroutines and returns a join function
+// that waits for all PruneContinuously goroutines to return. The caller must invoke
+// the returned join before closing the DB to avoid writes against a closed DB.
+func initSlotPruning(ctx context.Context, stores *ibftstorage.ParticipantStores, slotTickerProvider slotticker.Provider, slot phase0.Slot, retain uint64) func() {
 	var wg sync.WaitGroup
 
 	threshold := slot - phase0.Slot(retain)
@@ -1362,9 +1385,17 @@ func initSlotPruning(ctx context.Context, stores *ibftstorage.ParticipantStores,
 
 	wg.Wait()
 
-	// start background job for removing old slots on every tick
+	// start background job for removing old slots on every tick; track each
+	// goroutine so the caller can join them before closing the DB.
+	var pruneWG sync.WaitGroup
 	_ = stores.Each(func(_ spectypes.BeaconRole, store ibftstorage.ParticipantStore) error {
-		go store.PruneContinuously(ctx, slotTickerProvider, phase0.Slot(retain))
+		pruneWG.Add(1)
+		go func() {
+			defer pruneWG.Done()
+			store.PruneContinuously(ctx, slotTickerProvider, phase0.Slot(retain))
+		}()
 		return nil
 	})
+
+	return pruneWG.Wait
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -734,6 +734,12 @@ var StartNodeCmd = &cobra.Command{
 		// Join background goroutines before the deferred db.Close() runs.
 		// Both collector.Start and PruneContinuously return promptly on ctx.Done(),
 		// so these joins complete quickly after the shutdown signal is received.
+		//
+		// Stop the message worker first: in archive mode handleWorkerMessages runs
+		// the duty-trace Collect synchronously (a late duty writes to the pebble DB),
+		// and that goroutine is otherwise unjoined. Quiescing it here also halts new
+		// late-retry spawns before the collector drains them below.
+		validatorCtrl.StopNetworkHandlers()
 		if collectorDone != nil {
 			<-collectorDone
 		}

--- a/operator/dutytracer/collector.go
+++ b/operator/dutytracer/collector.go
@@ -83,6 +83,15 @@ type Collector struct {
 	// scheduleJobs is a bounded queue for async schedule computation to avoid
 	// blocking the hot path and DB with synchronous writes.
 	scheduleJobs chan phase0.Slot
+
+	// lateWG tracks the detached goroutines Collect spawns to retry late messages
+	// (they persist to the DB). Start joins them on shutdown so a retry can't write
+	// to a closed DB; lateClosed (under lateMu) refuses new spawns once that join
+	// has begun, which keeps lateWG.Go's Add from racing lateWG.Wait. The close is
+	// one-way: Start runs once per Collector and never re-arms lateClosed.
+	lateWG     sync.WaitGroup
+	lateMu     sync.Mutex
+	lateClosed bool
 }
 
 type DomainDataProvider interface {
@@ -127,16 +136,37 @@ type scRootKey struct {
 	blockRoot phase0.Root
 }
 
+// Start runs the eviction loop until ctx is canceled, then waits for the goroutines
+// tied to the collector's lifetime — the schedule filler/worker and any in-flight
+// late-message retries — to return before returning itself. A caller that closes the
+// DB the collector writes to must wait for Start to return first: otherwise an
+// in-flight evict, schedule, or late-message write can run against a closed DB and panic.
 func (c *Collector) Start(ctx context.Context, tickerProvider slotticker.Provider) {
 	c.logger.Info("start duty tracer cache to disk evictor")
 	ticker := tickerProvider()
+
+	// The filler and worker share Start's lifetime; join them on the way out so no
+	// schedule write outlives Start (runScheduleWorker persists schedules to disk).
+	var helpers sync.WaitGroup
 	// Start schedule filler in a separate goroutine to avoid blocking eviction.
-	go c.startScheduleFiller(ctx, tickerProvider)
+	helpers.Go(func() {
+		c.startScheduleFiller(ctx, tickerProvider)
+	})
 	// Start a single worker to process schedule writes asynchronously.
-	go c.runScheduleWorker(ctx)
+	helpers.Go(func() {
+		c.runScheduleWorker(ctx)
+	})
+
 	for {
 		select {
 		case <-ctx.Done():
+			// Join the filler/worker first, then the late-message retries. This
+			// ordering is deadlock-free only because the late path (collect) never
+			// enqueues to scheduleJobs; if it did, a late goroutine could block on a
+			// full scheduleJobs after the worker has exited, hanging stopLateCollect
+			// (and thus shutdown).
+			helpers.Wait()
+			c.stopLateCollect()
 			return
 		case <-ticker.Next():
 			currentSlot := ticker.Slot()
@@ -654,10 +684,34 @@ func (c *Collector) computeRoleRoots(ctx context.Context, slot phase0.Slot, in [
 func (c *Collector) Collect(ctx context.Context, msg *queue.SSVMessage, verifySig func(*spectypes.PartialSignatureMessages) error) error {
 	err := c.collect(ctx, msg, verifySig)
 	if errors.Is(err, errInFlight) {
-		go c.collectLateMessage(ctx, msg, verifySig)
+		c.collectLateAsync(ctx, msg, verifySig)
 		return nil
 	}
 	return err
+}
+
+// collectLateAsync retries a late message in a tracked goroutine so Start can join
+// it on shutdown. Once shutdown has begun (Start is joining), it drops the retry
+// rather than spawn a goroutine that could outlive — and write to — a closed DB.
+func (c *Collector) collectLateAsync(ctx context.Context, msg *queue.SSVMessage, verifySig func(*spectypes.PartialSignatureMessages) error) {
+	c.lateMu.Lock()
+	defer c.lateMu.Unlock()
+	if c.lateClosed {
+		return
+	}
+	c.lateWG.Go(func() {
+		c.collectLateMessage(ctx, msg, verifySig)
+	})
+}
+
+// stopLateCollect refuses further late-message goroutines and waits for the
+// in-flight ones to return. Start calls it once ctx is canceled, before returning,
+// so the caller can close the DB without racing a late write.
+func (c *Collector) stopLateCollect() {
+	c.lateMu.Lock()
+	c.lateClosed = true
+	c.lateMu.Unlock()
+	c.lateWG.Wait()
 }
 
 const maxRetryCount = 3

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -1560,6 +1560,122 @@ func TestCollector_lateMessage(t *testing.T) {
 	})
 }
 
+// buildInFlightLateMsg returns a committee message whose trace is already marked
+// in-flight on c, so collect() returns errInFlight and collectLateMessage stays in
+// its retry loop until ctx is canceled (or the retries exhaust ~3s later) — giving
+// a late-collect goroutine that is reliably still running.
+func buildInFlightLateMsg(c *Collector) *queue.SSVMessage {
+	msgID := spectypes.NewMsgID(spectypes.DomainType{1}, []byte{1}, spectypes.RoleCommittee)
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], msgID.GetDutyExecutorID()[16:])
+	c.inFlightCommittee.Set(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}, struct{}{})
+	c.lastEvictedSlot.Store(uint64(1))
+	return &queue.SSVMessage{
+		SSVMessage: &spectypes.SSVMessage{
+			MsgType: spectypes.SSVConsensusMsgType,
+			MsgID:   spectypes.MessageID{1},
+		},
+		Body: &specqbft.Message{
+			Height:     1,
+			MsgType:    specqbft.RoundChangeMsgType,
+			Identifier: msgID[:],
+		},
+	}
+}
+
+// TestCollector_stopLateCollect covers the shutdown coordination between
+// collectLateAsync (which Collect uses to retry late messages off the hot path) and
+// stopLateCollect (which Start calls once ctx is canceled, before returning, so the
+// caller can close the DB without racing a late write).
+func TestCollector_stopLateCollect(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
+	dutyStore := new(mockDutyTraceStore)
+
+	newCollector := func() *Collector {
+		return New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
+	}
+
+	t.Run("waits for in-flight late goroutine", func(t *testing.T) {
+		c := newCollector()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		// collectLateAsync does lateWG.Add(1) synchronously, so the retry goroutine
+		// is tracked by the time this returns. It stays in-flight until we cancel.
+		c.collectLateAsync(ctx, buildInFlightLateMsg(c), nil)
+
+		stopped := make(chan struct{})
+		go func() {
+			c.stopLateCollect()
+			close(stopped)
+		}()
+
+		// stopLateCollect must block while the late goroutine is still running.
+		select {
+		case <-stopped:
+			t.Fatal("stopLateCollect returned before the in-flight late goroutine finished")
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		cancel() // release the late goroutine
+
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			t.Fatal("stopLateCollect did not return after the late goroutine exited")
+		}
+	})
+
+	t.Run("drops late collects after close", func(t *testing.T) {
+		c := newCollector()
+		c.stopLateCollect() // begin shutdown with no in-flight work
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		// A spawn after close must be dropped, not tracked — otherwise it could
+		// outlive (and write to) a closed DB. Were it spawned, this in-flight message
+		// would keep a goroutine busy ~3s and the join below would time out.
+		c.collectLateAsync(ctx, buildInFlightLateMsg(c), nil)
+
+		joined := make(chan struct{})
+		go func() {
+			c.stopLateCollect()
+			close(joined)
+		}()
+		select {
+		case <-joined:
+		case <-time.After(2 * time.Second):
+			t.Fatal("collectLateAsync spawned a tracked goroutine after close")
+		}
+	})
+
+	t.Run("concurrent spawns race shutdown", func(t *testing.T) {
+		c := newCollector()
+		ctx := t.Context()
+		// A bodyless consensus message returns from collect() immediately, keeping
+		// this focused on the lateWG.Add/Wait coordination that -race validates.
+		msg := &queue.SSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.SSVConsensusMsgType,
+				MsgID:   spectypes.MessageID{1},
+			},
+		}
+
+		var spawners sync.WaitGroup
+		for i := 0; i < 200; i++ {
+			spawners.Add(1)
+			go func() {
+				defer spawners.Done()
+				c.collectLateAsync(ctx, msg, nil)
+			}()
+		}
+		c.stopLateCollect() // races the spawners; -race validates Add against Wait
+		spawners.Wait()
+	})
+}
+
 func TestEvict(t *testing.T) {
 	t.Run("evict updates last evicted slot", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -551,7 +551,7 @@ func (c *Controller) StartNetworkHandlers() {
 // DB; callers must invoke this before closing the DB so an in-flight write
 // can't race db.Close() and panic with "pebble: closed".
 //
-// Call this only after the node context is cancelled: the router goroutines
+// Call this only after the node context is canceled: the router goroutines
 // stop on ctx cancellation (and only enqueue, never write to the DB), so they
 // need no separate join here. The wait can briefly block if a late duty misses
 // the domain cache and Collect's DomainData fetch is in flight against a slow

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -545,6 +545,21 @@ func (c *Controller) StartNetworkHandlers() {
 	c.messageWorker.UseHandler(c.handleWorkerMessages)
 }
 
+// StopNetworkHandlers quiesces the message worker, waiting for any in-flight
+// handleWorkerMessages to return. In exporter archive mode that handler runs
+// the duty-trace Collect synchronously, which writes late duties to the pebble
+// DB; callers must invoke this before closing the DB so an in-flight write
+// can't race db.Close() and panic with "pebble: closed".
+//
+// Call this only after the node context is cancelled: the router goroutines
+// stop on ctx cancellation (and only enqueue, never write to the DB), so they
+// need no separate join here. The wait can briefly block if a late duty misses
+// the domain cache and Collect's DomainData fetch is in flight against a slow
+// beacon node — bounded by the beacon client's request timeout.
+func (c *Controller) StopNetworkHandlers() {
+	c.messageWorker.Close()
+}
+
 // startEligibleValidators starts validators that transitioned to eligible to start due to a metadata update.
 func (c *Controller) startEligibleValidators(ctx context.Context, pubKeys []spectypes.ValidatorPK) (count int) {
 	// Build a map for quick lookup to ensure only explicitly listed validators start.

--- a/protocol/v2/queue/worker/message_worker.go
+++ b/protocol/v2/queue/worker/message_worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -39,6 +40,10 @@ type Worker struct {
 	handler       MsgHandler
 	errHandler    ErrorHandler
 	metricsPrefix string
+	// wg tracks the startWorker goroutines so Close can wait for any in-flight
+	// process() to finish. This lets callers quiesce the worker before closing
+	// resources (e.g. the DB) that a handler might still write to.
+	wg sync.WaitGroup
 }
 
 // NewWorker return new Worker
@@ -62,12 +67,14 @@ func NewWorker(logger *zap.Logger, cfg *Config) *Worker {
 // init the worker listening process
 func (w *Worker) init(logger *zap.Logger) {
 	for i := 1; i <= w.workersCount; i++ {
+		w.wg.Add(1)
 		go w.startWorker(logger, w.queue)
 	}
 }
 
 // startWorker process functionality
 func (w *Worker) startWorker(logger *zap.Logger, ch <-chan *queue.SSVMessage) {
+	defer w.wg.Done()
 	ctx, cancel := context.WithCancel(w.ctx)
 	defer cancel()
 	for {
@@ -102,10 +109,15 @@ func (w *Worker) TryEnqueue(msg *queue.SSVMessage) bool {
 	}
 }
 
-// Close queue and worker listener
+// Close stops the worker goroutines and waits for any in-flight message
+// processing to finish. Callers can rely on no handler being mid-execution
+// once Close returns — important when a handler writes to resources (e.g. the
+// DB) that are torn down right after. The queue is intentionally left open:
+// startWorker exits on ctx cancellation, and a closed queue would let it read
+// a nil message and feed it to the handler.
 func (w *Worker) Close() {
-	close(w.queue)
 	w.cancel()
+	w.wg.Wait()
 }
 
 // Size returns the queue size

--- a/protocol/v2/queue/worker/message_worker_test.go
+++ b/protocol/v2/queue/worker/message_worker_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -164,6 +165,67 @@ func TestBuffer(t *testing.T) {
 		t.Fatal("timed out waiting for buffered messages to be processed")
 	}
 	assertNoAsyncError(t, handlerErrCh)
+}
+
+// TestClose_WaitsForInflightProcess verifies Close blocks until an in-flight
+// handler returns, so callers can safely tear down resources the handler writes
+// to (e.g. the duty-trace DB) only after Close. It also asserts the handler is
+// never invoked with a nil message during shutdown — Close leaves the queue open
+// precisely to avoid that.
+func TestClose_WaitsForInflightProcess(t *testing.T) {
+	testCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	logger := log.TestLogger(t)
+	worker := NewWorker(logger, &Config{
+		Ctx:          testCtx,
+		WorkersCount: 1,
+		Buffer:       2,
+	})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var finished, sawNil atomic.Bool
+	worker.UseHandler(func(ctx context.Context, msg network.DecodedSSVMessage) error {
+		if msg == nil {
+			sawNil.Store(true)
+			return nil
+		}
+		close(started)
+		<-release
+		finished.Store(true)
+		return nil
+	})
+
+	require.True(t, worker.TryEnqueue(&queue.SSVMessage{}))
+	select {
+	case <-started:
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for handler to start")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		worker.Close()
+	}()
+
+	// Close must not return while the handler is still in-flight.
+	select {
+	case <-closed:
+		t.Fatal("Close returned before in-flight handler finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-closed:
+	case <-testCtx.Done():
+		t.Fatal("Close did not return after handler finished")
+	}
+	require.True(t, finished.Load(), "handler should have completed before Close returned")
+	require.False(t, sawNil.Load(), "handler must not receive a nil message during shutdown")
 }
 
 func TestMessageContextFields(t *testing.T) {


### PR DESCRIPTION
Bucket B of #2902 — ports stage #2884 onto `boole-fork` (defensive: harmless if boole doesn't run exporter/archive mode, a real crash-fix if it does).

**Bug:** the duty-trace collector and the slot-pruner spawn goroutines that write to the pebble DB. On shutdown the DB was closed **without waiting** for them, so an in-flight evict/schedule/late-retry write (collector, archive mode) or prune (slot-pruner, standard mode) could hit a closed DB → **panic (`pebble: closed`)**.

**Two-part fix** (the in-package drain is *inert* without the caller-side join — caught in deep review):
- **`operator/dutytracer/collector.go`** — track the detached late-retry goroutines (`lateWG`/`lateMu`/`lateClosed`); `Start` joins the schedule filler/worker then the late retries on `ctx.Done()` before returning; `collectLateAsync` refuses new spawns once shutdown began. Deadlock-free (the late path never enqueues to `scheduleJobs`); no `WaitGroup` Add-during-Wait race.
- **`cli/operator/node.go`** — actually **join** those lifetimes before `db.Close()`: the collector goroutine is made joinable (`collectorDone`) and `initSlotPruning` returns a join func; both are joined **inline** after `operatorNode.Start` returns, before the deferred `db.Close()` fires. This also closes the **standard-mode** `PruneContinuously` race (upstream #2884's first half).

**Review:** deep-reviewed for concurrency/shutdown correctness — **APPROVE**. Verified: joins run before `db.Close()` (inline, not deferred); no shutdown hang (the collector/pruner use `cmd.Context()`, provably Done by the join point in both modes); no `WaitGroup` Add-during-Wait race; `initSlotPruning` signature change has one caller + nil-guards. `go test -race ./operator/dutytracer/...` clean. The bundled p2p flaky-test fix was not ported (boole's test diverges).

Note: `go build ./...` has the pre-existing `spectest fixRunnerForRun` quirk on this branch's base — fixed by #2913.