### PR TITLE
fix(runner): fork-aware domain for pre-consensus partial-sig broadcasts (#2915)

### DIFF
--- a/protocol/v2/ssv/runner/preconsensus_domain_test.go
+++ b/protocol/v2/ssv/runner/preconsensus_domain_test.go
@@ -1,0 +1,105 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
+)
+
+// TestSignAndBroadcastPartialSigMsgsDomainIsForkAware asserts that the MsgID stamped on the
+// pre-consensus partial-signature broadcast uses the fork-aware domain (DomainTypeAtSlot), not the
+// static DomainType. This is the regression guard for #2915.
+//
+// The post-fork assertion is the discriminator: it fails on the old code (which always used the
+// static DomainType) and passes after the fix (which uses DomainTypeAtSlot).
+func TestSignAndBroadcastPartialSigMsgsDomainIsForkAware(t *testing.T) {
+	t.Parallel()
+
+	// Build a config where the Boole fork activates at epoch 5.
+	// SlotsPerEpoch = 32 for BeaconTestNetwork, so:
+	//   pre-fork slot  = 4*32 = 128  → epoch 4  → DomainType
+	//   post-fork slot = 5*32 = 160  → epoch 5  → NextDomainType
+	const booleEpoch = phase0.Epoch(5)
+	const preForkSlot = phase0.Slot(4 * 32)
+	const postForkSlot = phase0.Slot(5 * 32)
+
+	cfg := cloneTestNetworkConfig()
+	// cloneTestNetworkConfig deep-copies *SSV, so this mutation is local to this test
+	// and does not affect the package-level TestNetwork global or other parallel tests.
+	cfg.SSV.Forks.Boole = booleEpoch
+
+	preForkDomain := cfg.DomainTypeAtSlot(preForkSlot)
+	postForkDomain := cfg.DomainTypeAtSlot(postForkSlot)
+	require.Equal(t, cfg.DomainType, preForkDomain, "sanity: pre-fork domain must equal static DomainType")
+	require.Equal(t, cfg.NextDomainType, postForkDomain, "sanity: post-fork domain must equal NextDomainType")
+	require.NotEqual(t, preForkDomain, postForkDomain, "sanity: the two domains must differ")
+
+	validatorPubKey := spectestingValidatorPubKey()
+	signer := fixedOperatorSigner{id: 1}
+
+	runner := &BaseRunner{
+		NetworkConfig:  cfg,
+		RunnerRoleType: spectypes.RoleProposer,
+	}
+
+	// minimalPartialSigMsgs builds the smallest valid PartialSignatureMessages for a given slot.
+	// Encode (MarshalSSZ) requires the slice to be non-nil; Signer must be non-zero for
+	// PartialSignatureMessage.Validate, but signAndBroadcastPartialSigMsgs itself only calls Encode.
+	minimalMsgs := func(slot phase0.Slot) *spectypes.PartialSignatureMessages {
+		return &spectypes.PartialSignatureMessages{
+			Type: spectypes.RandaoPartialSig,
+			Slot: slot,
+			Messages: []*spectypes.PartialSignatureMessage{
+				{
+					PartialSignature: make([]byte, 96),
+					SigningRoot:      [32]byte{},
+					Signer:           1,
+					ValidatorIndex:   0,
+				},
+			},
+		}
+	}
+
+	t.Run("pre-fork slot stamps DomainType", func(t *testing.T) {
+		t.Parallel()
+
+		net := protocoltesting.NewTestingNetwork(1, nil)
+		err := runner.signAndBroadcastPartialSigMsgs(
+			context.Background(), net, signer, validatorPubKey, minimalMsgs(preForkSlot),
+		)
+		require.NoError(t, err)
+		require.Len(t, net.BroadcastedMsgs, 1)
+
+		gotDomain := spectypes.DomainType(net.BroadcastedMsgs[0].SSVMessage.MsgID.GetDomain())
+		require.Equal(t, preForkDomain, gotDomain, "pre-fork broadcast must use DomainType")
+	})
+
+	t.Run("post-fork slot stamps NextDomainType", func(t *testing.T) {
+		t.Parallel()
+
+		net := protocoltesting.NewTestingNetwork(1, nil)
+		err := runner.signAndBroadcastPartialSigMsgs(
+			context.Background(), net, signer, validatorPubKey, minimalMsgs(postForkSlot),
+		)
+		require.NoError(t, err)
+		require.Len(t, net.BroadcastedMsgs, 1)
+
+		gotDomain := spectypes.DomainType(net.BroadcastedMsgs[0].SSVMessage.MsgID.GetDomain())
+		// This assertion FAILS on the old code (which stamped the static DomainType).
+		// It passes after the fix (which stamps DomainTypeAtSlot(msgs.Slot)).
+		require.Equal(t, postForkDomain, gotDomain, "post-fork broadcast must use NextDomainType (fix for #2915)")
+	})
+}
+
+// spectestingValidatorPubKey returns a 48-byte public key for use in tests.
+// The content is arbitrary; only the domain portion of the MsgID is under test.
+func spectestingValidatorPubKey() []byte {
+	key := make([]byte, 48)
+	key[0] = 0xab
+	return key
+}

--- a/protocol/v2/ssv/runner/proposer_test.go
+++ b/protocol/v2/ssv/runner/proposer_test.go
@@ -520,5 +520,10 @@ func cloneTestNetworkConfig() *networkconfig.Network {
 		beaconCfg.Forks = maps.Clone(beaconCfg.Forks)
 	}
 	cfg.Beacon = &beaconCfg
+	// Clone SSV so tests can mutate Forks.Boole (or other SSV fields) without writing
+	// through to the package-level TestNetwork global. SSVForks is a value type, so a
+	// shallow *SSV copy fully isolates it.
+	ssvCfg := *networkconfig.TestNetwork.SSV
+	cfg.SSV = &ssvCfg
 	return &cfg
 }

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -348,7 +348,10 @@ func (b *BaseRunner) signAndBroadcastPartialSigMsgs(
 	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
 	span := trace.SpanFromContext(ctx)
 
-	msgID := spectypes.NewMsgID(b.NetworkConfig.DomainType, validatorPubKey, b.RunnerRoleType)
+	// Use the fork-aware domain so the pubsub message validator accepts the message after the
+	// Boole fork activates (post-fork it checks NextDomainType). Mirrors CommitteeRunner and
+	// QBFT domain selection. Fixes #2915.
+	msgID := spectypes.NewMsgID(b.NetworkConfig.DomainTypeAtSlot(msgs.Slot), validatorPubKey, b.RunnerRoleType)
 	encodedMsg, err := msgs.Encode()
 	if err != nil {
 		return fmt.Errorf("could not encode partial signature messages: %w", err)


### PR DESCRIPTION
Fixes #2915.

**Bug:** after the Boole fork activates, **PROPOSER and VALIDATOR_REGISTRATION duties stall**. `BaseRunner.signAndBroadcastPartialSigMsgs` stamps the pre-consensus partial-sig broadcast's `MsgID` with the static, fork-unaware `NetworkConfig.DomainType`, but the local pubsub validator checks `DomainTypeAtSlot(msg.Slot)` (= `NextDomainType` post-fork). The node **self-rejects its own message** ("wrong domain, got 00003114, want 00003115") before it leaves the node → pre-consensus never reaches quorum → duty times out. COMMITTEE (own fork-aware broadcast) and QBFT (already fork-aware) are unaffected. This was a gap in boole's *own* fork-awareness (not a stage port).

**Fix (one line):** stamp the `MsgID` with `DomainTypeAtSlot(msgs.Slot)`. Correctness guarantee (per deep review): the validator derives its expected domain from the **same** `PartialSignatureMessages.Slot` field, so sender and receiver compute the domain from identical input and can't disagree — on either side of the fork, and regardless of the #2879 wire-slot/execution-gate decoupling (both ends use the wire slot). Pre-fork behaviour is unchanged (`DomainTypeAtSlot(preForkSlot) == DomainType`).

**Regression test:** `TestSignAndBroadcastPartialSigMsgsDomainIsForkAware` calls the real method, captures the broadcast `MsgID`, and asserts the domain is fork-aware (pre-fork → `DomainType`, post-fork → `NextDomainType`). The post-fork sub-test is a true discriminator — it **fails on the old code** (`...0x3,0x2` vs `...0x3,0x3`). Also isolates `cloneTestNetworkConfig` (clone `*SSV`) so it can't mutate the global `TestNetwork` (clean under `-race`).

**Review:** deep-reviewed for domain correctness across all 5 `signAndBroadcastPartialSigMsgs` callers (proposer/validator_registration/aggregator/voluntary_exit/sync_committee_contribution — all pass `DutySlot()`, none unset); `go test -race` clean; `golangci-lint` 0 issues; build clean (except the pre-existing `spectest` quirk fixed by #2913).