### PR TITLE
observability(runner): classify CommitteeRunner terminal post-quorum failures as failed, not stuck

### DIFF
--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -511,9 +511,10 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	// Get validator-root maps for attestations and sync committees, and the root-beacon object map
 	attestationMap, committeeMap, beaconObjects, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
 	if err != nil {
+		err = fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
 		// terminal post-quorum failure → classify as failed, not stuck
 		r.markDutyFailed(err)
-		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
+		return err
 	}
 	if len(beaconObjects) == 0 {
 		// terminal post-quorum failure → classify as failed, not stuck
@@ -524,7 +525,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	attestationsToSubmit := make(map[phase0.ValidatorIndex]*spec.VersionedAttestation)
 	syncCommitteeMessagesToSubmit := make(map[phase0.ValidatorIndex]*altair.SyncCommitteeMessage)
 
-	var executionErr error
+	var recoverableErr, terminalErr error
 
 	span.SetAttributes(observability.BeaconBlockRootCountAttribute(len(roots)))
 	// For each root that got at least one quorum, find the duties associated to it and try to submit
@@ -646,7 +647,14 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 				r.markDutyFailed(err)
 				return err
 			case err := <-errCh:
-				executionErr = err
+				// errCh currently carries only the reconstruct-invalid-sigs error, which is recoverable;
+				// classify defensively by code so any other error arriving here is still treated as terminal.
+				var specErr *spectypes.Error
+				if errors.As(err, &specErr) && specErr.Code == spectypes.ReconstructSignatureErrorCode {
+					recoverableErr = err
+				} else {
+					terminalErr = err
+				}
 			case signatureResult, ok := <-signatureCh:
 				if !ok {
 					break listener
@@ -654,12 +662,12 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 
 				validatorObjects, exists := beaconObjects[signatureResult.validatorIndex]
 				if !exists {
-					executionErr = fmt.Errorf("could not find beacon object for validator index: %d", signatureResult.validatorIndex)
+					terminalErr = fmt.Errorf("could not find beacon object for validator index: %d", signatureResult.validatorIndex)
 					continue
 				}
 				sszObject, exists := validatorObjects[root]
 				if !exists {
-					executionErr = fmt.Errorf("could not find ssz object for root: %s", root)
+					terminalErr = fmt.Errorf("could not find ssz object for root: %s", root)
 					continue
 				}
 
@@ -678,7 +686,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					att := sszObject.(*spec.VersionedAttestation)
 					att, err = specssv.VersionedAttestationWithSignature(att, signatureResult.signature)
 					if err != nil {
-						executionErr = fmt.Errorf("could not insert signature in versioned attestation")
+						terminalErr = fmt.Errorf("could not insert signature in versioned attestation")
 						continue
 					}
 
@@ -825,19 +833,23 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		}
 	}
 
-	if executionErr != nil {
+	// A terminal error on any root wins over a recoverable one. executionErr used to be a single
+	// last-write-wins variable, so when a genuine failure and a recoverable reconstruct error happened
+	// in the same round, classification depended on goroutine/root ordering. Splitting the two keeps it
+	// deterministic — a real failure is always recorded as failed, never mislabeled as recoverable/stuck.
+	if terminalErr != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(terminalErr)
+		return terminalErr
+	}
+	if recoverableErr != nil {
 		// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root
 		// below quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to
 		// retry pending roots (already-submitted roots are skipped via HasSubmitted). ReconstructBeaconSig
-		// tags this with ReconstructSignatureErrorCode (spec expects code 32 for the committee role; the
-		// aggregator role uses PostConsensusQuorumWithInvalidSignatures instead). Not markDutyFailed.
-		var specErr *spectypes.Error
-		if errors.As(executionErr, &specErr) && specErr.Code == spectypes.ReconstructSignatureErrorCode {
-			return executionErr
-		}
-		// terminal post-quorum failure → classify as failed, not stuck
-		r.markDutyFailed(executionErr)
-		return executionErr
+		// tags this with ReconstructSignatureErrorCode (code 32 in the pinned ssv-spec). Not markDutyFailed.
+		// Note: the post-Boole AggregatorCommitteeRunner tags the analogous condition with
+		// PostConsensusQuorumWithInvalidSignatures (code 81) instead.
+		return recoverableErr
 	}
 
 	if r.HasSubmittedAllValidatorDuties(attestationMap, committeeMap) {

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -505,27 +505,19 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		return nil
 	}
 
-	// We have quorum and are committed to submitting. Pre-quorum waiting, full success
-	// (markDutySucceeded) and partial progress all return nil, so this only fires on a terminal
-	// post-quorum error — report it as failed instead of letting it fall through to a false "stuck".
-	// Unlike the consensus phase, a failure here is final: submission is the duty's last step.
-	// Shutdown (context cancellation) needs no special-casing — markDutyFailed drops a context.Canceled
-	// reason, so a submission aborted by shutdown isn't recorded as a failure.
-	defer func() {
-		if err != nil {
-			r.markDutyFailed(err)
-		}
-	}()
-
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleCommittee)
 
 	// Get validator-root maps for attestations and sync committees, and the root-beacon object map
 	attestationMap, committeeMap, beaconObjects, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
 	if err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
 		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
 	}
 	if len(beaconObjects) == 0 {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(ErrNoValidDutiesToExecute)
 		return ErrNoValidDutiesToExecute
 	}
 
@@ -648,7 +640,11 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		for {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				// terminal post-quorum failure → classify as failed, not stuck; markDutyFailed
+				// drops context.Canceled internally, so shutdown isn't recorded as a failure.
+				err := ctx.Err()
+				r.markDutyFailed(err)
+				return err
 			case err := <-errCh:
 				executionErr = err
 			case signatureResult, ok := <-signatureCh:
@@ -718,17 +714,26 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordFailedSubmission(ctx, spectypes.BNRoleAttester)
 			const errMsg = "could not submit attestations"
 			aLogger.Error(errMsg, zap.Error(err))
-			return fmt.Errorf("%s: %w", errMsg, err)
+			err = fmt.Errorf("%s: %w", errMsg, err)
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
+			return err
 		}
 
 		currentDutySlot, err := r.currentDutySlot()
 		if err != nil {
-			return fmt.Errorf("current duty slot: %w", err)
+			err = fmt.Errorf("current duty slot: %w", err)
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
+			return err
 		}
 		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.NetworkConfig.EstimatedEpochAtSlot(currentDutySlot), spectypes.BNRoleAttester)
 		attData, err := attestations[0].Data()
 		if err != nil {
-			return fmt.Errorf("could not get attestation data: %w", err)
+			err = fmt.Errorf("could not get attestation data: %w", err)
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
+			return err
 		}
 		const eventMsg = "✅ successfully submitted attestations"
 		span.AddEvent(eventMsg, trace.WithAttributes(
@@ -769,14 +774,20 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordFailedSubmission(ctx, spectypes.BNRoleSyncCommittee)
 			const errMsg = "could not submit sync committee messages"
 			scLogger.Error(errMsg, zap.Error(err))
-			return fmt.Errorf("%s: %w", errMsg, err)
+			err = fmt.Errorf("%s: %w", errMsg, err)
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
+			return err
 		}
 
 		syncMsgsCount := len(syncCommitteeMessages)
 		if syncMsgsCount <= math.MaxUint32 {
 			currentDutySlot, err := r.currentDutySlot()
 			if err != nil {
-				return fmt.Errorf("current duty slot: %w", err)
+				err = fmt.Errorf("current duty slot: %w", err)
+				// terminal post-quorum failure → classify as failed, not stuck
+				r.markDutyFailed(err)
+				return err
 			}
 			recordSuccessfulSubmission(
 				ctx,
@@ -788,7 +799,10 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 
 		currentDutySlot, err := r.currentDutySlot()
 		if err != nil {
-			return fmt.Errorf("current duty slot: %w", err)
+			err = fmt.Errorf("current duty slot: %w", err)
+			// terminal post-quorum failure → classify as failed, not stuck
+			r.markDutyFailed(err)
+			return err
 		}
 		const eventMsg = "✅ successfully submitted sync committee"
 		span.AddEvent(eventMsg, trace.WithAttributes(
@@ -812,6 +826,17 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	}
 
 	if executionErr != nil {
+		// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root
+		// below quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to
+		// retry pending roots (already-submitted roots are skipped via HasSubmitted). ReconstructBeaconSig
+		// tags this with ReconstructSignatureErrorCode (spec expects code 32 for the committee role; the
+		// aggregator role uses PostConsensusQuorumWithInvalidSignatures instead). Not markDutyFailed.
+		var specErr *spectypes.Error
+		if errors.As(executionErr, &specErr) && specErr.Code == spectypes.ReconstructSignatureErrorCode {
+			return executionErr
+		}
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(executionErr)
 		return executionErr
 	}
 

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -535,6 +535,10 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	attestationsToSubmit := make(map[phase0.ValidatorIndex]*spec.VersionedAttestation)
 	syncCommitteeMessagesToSubmit := make(map[phase0.ValidatorIndex]*altair.SyncCommitteeMessage)
 
+	// Recoverable reconstruct failures are discriminated by the recoverableReconstructError tag rather
+	// than by a spec error code — the tag also covers the uncoded BLS Deserialize/Recover failures.
+	// The sibling AggregatorCommitteeRunner instead classifies by the PostConsensusQuorumWithInvalidSignatures
+	// code; the divergence is deliberate (tagging with that code there breaks its spectest fixtures).
 	var recoverableErr, terminalErr error
 
 	span.SetAttributes(observability.BeaconBlockRootCountAttribute(len(roots)))

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -505,20 +505,30 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		return nil
 	}
 
+	// We have quorum and are committed to submitting. Pre-quorum waiting, full success
+	// (markDutySucceeded) and partial progress all return nil, so this only fires on a terminal
+	// post-quorum error — report it as failed instead of letting it fall through to a false "stuck".
+	// Unlike the consensus phase, a failure here is final: submission is the duty's last step.
+	// The one exception is a recoverable BLS-reconstruction failure: the offending partial sig has
+	// already been dropped by the fallback, so a later message can re-cross quorum and retry — those
+	// are tagged recoverableReconstructError and must not be recorded as failed.
+	// Shutdown (context cancellation) needs no special-casing — markDutyFailed drops a context.Canceled
+	// reason, so a submission aborted by shutdown isn't recorded as a failure.
+	defer func() {
+		if err != nil && !isRecoverableReconstructError(err) {
+			r.markDutyFailed(err)
+		}
+	}()
+
 	r.measurements.EndPostConsensus()
 	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleCommittee)
 
 	// Get validator-root maps for attestations and sync committees, and the root-beacon object map
 	attestationMap, committeeMap, beaconObjects, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
 	if err != nil {
-		err = fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
-		// terminal post-quorum failure → classify as failed, not stuck
-		r.markDutyFailed(err)
-		return err
+		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
 	}
 	if len(beaconObjects) == 0 {
-		// terminal post-quorum failure → classify as failed, not stuck
-		r.markDutyFailed(ErrNoValidDutiesToExecute)
 		return ErrNoValidDutiesToExecute
 	}
 
@@ -619,7 +629,12 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 					span.AddEvent(eventMsg)
 					vLogger.Error(eventMsg, zap.Error(err))
 
-					errCh <- fmt.Errorf("%s: %w", eventMsg, err)
+					// FallBackAndVerifyEachSignature ran above for any reconstruct error, so this is
+					// recoverable by construction: tag it at the push site rather than inferring
+					// recoverability from a spec error code at the receive site (the code is only
+					// attached by VerifyReconstructedSignature — the earlier Deserialize/Recover step
+					// returns an uncoded but equally recoverable error).
+					errCh <- recoverableReconstructError{fmt.Errorf("%s: %w", eventMsg, err)}
 					return
 				}
 
@@ -641,16 +656,14 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		for {
 			select {
 			case <-ctx.Done():
-				// terminal post-quorum failure → classify as failed, not stuck; markDutyFailed
-				// drops context.Canceled internally, so shutdown isn't recorded as a failure.
-				err := ctx.Err()
-				r.markDutyFailed(err)
-				return err
+				// markDutyFailed (via the defer) drops context.Canceled internally, so shutdown
+				// isn't recorded as a failure.
+				return ctx.Err()
 			case err := <-errCh:
-				// errCh currently carries only the reconstruct-invalid-sigs error, which is recoverable;
-				// classify defensively by code so any other error arriving here is still treated as terminal.
-				var specErr *spectypes.Error
-				if errors.As(err, &specErr) && specErr.Code == spectypes.ReconstructSignatureErrorCode {
+				// The reconstruct goroutine tags its (recoverable, post-fallback) error with
+				// recoverableReconstructError; classify defensively so any other error arriving
+				// here without the tag is still treated as terminal.
+				if isRecoverableReconstructError(err) {
 					recoverableErr = err
 				} else {
 					terminalErr = err
@@ -722,26 +735,17 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordFailedSubmission(ctx, spectypes.BNRoleAttester)
 			const errMsg = "could not submit attestations"
 			aLogger.Error(errMsg, zap.Error(err))
-			err = fmt.Errorf("%s: %w", errMsg, err)
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
-			return err
+			return fmt.Errorf("%s: %w", errMsg, err)
 		}
 
 		currentDutySlot, err := r.currentDutySlot()
 		if err != nil {
-			err = fmt.Errorf("current duty slot: %w", err)
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
-			return err
+			return fmt.Errorf("current duty slot: %w", err)
 		}
 		recordSuccessfulSubmission(ctx, int64(len(attestations)), r.NetworkConfig.EstimatedEpochAtSlot(currentDutySlot), spectypes.BNRoleAttester)
 		attData, err := attestations[0].Data()
 		if err != nil {
-			err = fmt.Errorf("could not get attestation data: %w", err)
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
-			return err
+			return fmt.Errorf("could not get attestation data: %w", err)
 		}
 		const eventMsg = "✅ successfully submitted attestations"
 		span.AddEvent(eventMsg, trace.WithAttributes(
@@ -782,20 +786,14 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			recordFailedSubmission(ctx, spectypes.BNRoleSyncCommittee)
 			const errMsg = "could not submit sync committee messages"
 			scLogger.Error(errMsg, zap.Error(err))
-			err = fmt.Errorf("%s: %w", errMsg, err)
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
-			return err
+			return fmt.Errorf("%s: %w", errMsg, err)
 		}
 
 		syncMsgsCount := len(syncCommitteeMessages)
 		if syncMsgsCount <= math.MaxUint32 {
 			currentDutySlot, err := r.currentDutySlot()
 			if err != nil {
-				err = fmt.Errorf("current duty slot: %w", err)
-				// terminal post-quorum failure → classify as failed, not stuck
-				r.markDutyFailed(err)
-				return err
+				return fmt.Errorf("current duty slot: %w", err)
 			}
 			recordSuccessfulSubmission(
 				ctx,
@@ -807,10 +805,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 
 		currentDutySlot, err := r.currentDutySlot()
 		if err != nil {
-			err = fmt.Errorf("current duty slot: %w", err)
-			// terminal post-quorum failure → classify as failed, not stuck
-			r.markDutyFailed(err)
-			return err
+			return fmt.Errorf("current duty slot: %w", err)
 		}
 		const eventMsg = "✅ successfully submitted sync committee"
 		span.AddEvent(eventMsg, trace.WithAttributes(
@@ -837,18 +832,15 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	// last-write-wins variable, so when a genuine failure and a recoverable reconstruct error happened
 	// in the same round, classification depended on goroutine/root ordering. Splitting the two keeps it
 	// deterministic — a real failure is always recorded as failed, never mislabeled as recoverable/stuck.
+	// The defer classifies both: terminalErr → markDutyFailed; recoverableErr carries its tag → excluded.
 	if terminalErr != nil {
-		// terminal post-quorum failure → classify as failed, not stuck
-		r.markDutyFailed(terminalErr)
 		return terminalErr
 	}
 	if recoverableErr != nil {
 		// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root
 		// below quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to
-		// retry pending roots (already-submitted roots are skipped via HasSubmitted). ReconstructBeaconSig
-		// tags this with ReconstructSignatureErrorCode (code 32 in the pinned ssv-spec). Not markDutyFailed.
-		// Note: the post-Boole AggregatorCommitteeRunner tags the analogous condition with
-		// PostConsensusQuorumWithInvalidSignatures (code 81) instead.
+		// retry pending roots (already-submitted roots are skipped via HasSubmitted). Returned with its
+		// recoverableReconstructError tag so the defer does not record the duty as failed.
 		return recoverableErr
 	}
 

--- a/protocol/v2/ssv/runner/committee_postconsensus_classification_test.go
+++ b/protocol/v2/ssv/runner/committee_postconsensus_classification_test.go
@@ -1,0 +1,124 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+
+	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
+)
+
+// faultyAttestationSubmitBeacon wraps the testing beacon node and forces attestation submission to
+// fail, so we can exercise the terminal post-quorum "submit failed" path in
+// CommitteeRunner.ProcessPostConsensus. All other beacon behavior is inherited unchanged via the
+// embedded *BeaconNodeWrapped (method promotion).
+type faultyAttestationSubmitBeacon struct {
+	*protocoltesting.BeaconNodeWrapped
+	submitErr error
+}
+
+func (b *faultyAttestationSubmitBeacon) SubmitAttestations(_ context.Context, _ []*spec.VersionedAttestation) error {
+	return b.submitErr
+}
+
+// observeConclusion swaps in a fresh, buffered conclusion channel so a test can read the duty's
+// terminal outcome deterministically instead of racing the deadline-watcher goroutine StartNewDuty
+// spawned. markDuty{Failed,Succeeded} send on the current dutyConcluded field, so the swap must
+// happen after StartNewDuty (which spawned the watcher on the original channel) and before the
+// ProcessPostConsensus call that concludes the duty.
+func observeConclusion(env *committeeRunnerEnv) chan dutyConclusion {
+	concluded := make(chan dutyConclusion, 1)
+	env.runner.BaseRunner.dutyConcluded = concluded
+	return concluded
+}
+
+// TestCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError asserts that a beacon submit
+// failure (a terminal post-quorum error) concludes the duty as failed — not left to surface as a
+// false "stuck". This is the terminal branch of the terminalErr/recoverableErr split.
+func TestCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError(t *testing.T) {
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected attestations")
+	faulty := &faultyAttestationSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newCommitteeRunnerEnvWithBeacon(t, []int{1}, faulty)
+	duty := spectestingutils.TestingCommitteeDuty([]int{1}, nil, spec.DataVersionElectra)
+
+	env.startAndDecideCommitteeDuty(t, duty)
+	concluded := observeConclusion(env)
+
+	var postConsensusErr error
+	for id := spectypes.OperatorID(1); id <= 3; id++ {
+		msg := spectestingutils.PostConsensusCommitteeMsgForDuty(duty, env.keySetMap, id)
+		if err := env.runner.ProcessPostConsensus(context.Background(), env.logger, msg); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.ErrorIs(t, postConsensusErr, submitErr, "submit failure should surface from ProcessPostConsensus")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome, "a terminal submit failure must be classified failed")
+		require.ErrorIs(t, c.reason, submitErr)
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds is the regression test
+// for the mis-classification fix: a quorum that contains one non-deserializable partial signature
+// must NOT conclude the duty failed (the offending sig is dropped by the fallback, so the root can
+// re-cross quorum), and a subsequent valid partial signature that re-crosses quorum must let the duty
+// conclude succeeded. This pins both the push-site recoverable tagging and the defer exclusion in a
+// single flow.
+func TestCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds(t *testing.T) {
+	env := newCommitteeRunnerEnv(t, []int{1}, &committeeDutyGuardStub{}, &doppelgangerStub{})
+	duty := spectestingutils.TestingCommitteeDuty([]int{1}, nil, spec.DataVersionElectra)
+
+	env.startAndDecideCommitteeDuty(t, duty)
+	concluded := observeConclusion(env)
+
+	// Signers 1 and 2 send valid post-consensus partial sigs; signer 3 sends a non-deserializable one.
+	// Post-consensus validation only checks message structure (not the beacon sig), so all three enter
+	// the container and cross quorum optimistically — then ReconstructBeaconSig fails on the garbage
+	// sig, FallBackAndVerifyEachSignature drops only signer 3, and the root falls back below quorum.
+	msg1 := spectestingutils.PostConsensusCommitteeMsgForDuty(duty, env.keySetMap, 1)
+	require.NoError(t, env.runner.ProcessPostConsensus(context.Background(), env.logger, msg1))
+
+	msg2 := spectestingutils.PostConsensusCommitteeMsgForDuty(duty, env.keySetMap, 2)
+	require.NoError(t, env.runner.ProcessPostConsensus(context.Background(), env.logger, msg2))
+
+	badMsg := spectestingutils.PostConsensusCommitteeMsgForDuty(duty, env.keySetMap, 3)
+	for _, m := range badMsg.Messages {
+		m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+	}
+	recoverableErr := env.runner.ProcessPostConsensus(context.Background(), env.logger, badMsg)
+	require.Error(t, recoverableErr, "a quorum with invalid signatures should surface an error")
+
+	// The recoverable case must NOT conclude the duty: nothing has been sent on the conclusion channel.
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty failed")
+	require.False(t, env.runner.State.Succeeded)
+	require.Empty(t, env.beacon.GetBroadcastedRoots(), "nothing should have been submitted yet")
+
+	// A subsequent valid partial signature from signer 4 re-crosses quorum with three good sigs
+	// (1, 2, 4) → reconstruction succeeds → the duty submits and concludes succeeded.
+	msg4 := spectestingutils.PostConsensusCommitteeMsgForDuty(duty, env.keySetMap, 4)
+	require.NoError(t, env.runner.ProcessPostConsensus(context.Background(), env.logger, msg4))
+
+	require.True(t, env.runner.State.Succeeded, "a valid quorum after recovery must conclude succeeded")
+	require.Len(t, env.beacon.GetBroadcastedRoots(), 1)
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeSucceeded, c.outcome, "recovery must conclude the duty succeeded, not failed")
+	default:
+		t.Fatal("expected a succeeded duty conclusion after recovery, got none")
+	}
+}

--- a/protocol/v2/ssv/runner/committee_postconsensus_classification_test.go
+++ b/protocol/v2/ssv/runner/committee_postconsensus_classification_test.go
@@ -34,7 +34,7 @@ func (b *faultyAttestationSubmitBeacon) SubmitAttestations(_ context.Context, _ 
 // ProcessPostConsensus call that concludes the duty.
 func observeConclusion(env *committeeRunnerEnv) chan dutyConclusion {
 	concluded := make(chan dutyConclusion, 1)
-	env.runner.BaseRunner.dutyConcluded = concluded
+	env.runner.dutyConcluded = concluded
 	return concluded
 }
 

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
@@ -93,6 +94,28 @@ func newCommitteeRunnerEnv(
 	doppelganger DoppelgangerProvider,
 ) *committeeRunnerEnv {
 	t.Helper()
+	return newCommitteeRunnerEnvInternal(t, validatorIndices, guard, doppelganger, nil)
+}
+
+// newCommitteeRunnerEnvWithBeacon mirrors newCommitteeRunnerEnv but wires the runner to the supplied
+// beacon node, so a test can substitute a faulty one to exercise submit-failure classification.
+func newCommitteeRunnerEnvWithBeacon(
+	t *testing.T,
+	validatorIndices []int,
+	beaconNode beacon.BeaconNode,
+) *committeeRunnerEnv {
+	t.Helper()
+	return newCommitteeRunnerEnvInternal(t, validatorIndices, &committeeDutyGuardStub{}, &doppelgangerStub{}, beaconNode)
+}
+
+func newCommitteeRunnerEnvInternal(
+	t *testing.T,
+	validatorIndices []int,
+	guard CommitteeDutyGuard,
+	doppelganger DoppelgangerProvider,
+	beaconNode beacon.BeaconNode,
+) *committeeRunnerEnv {
+	t.Helper()
 
 	keySetMap := spectestingutils.KeySetMapForValidatorIndexList(validatorIndices)
 	sorted := make([]int, 0, len(validatorIndices))
@@ -129,11 +152,19 @@ func newCommitteeRunnerEnv(
 		doppelganger = &doppelgangerStub{}
 	}
 
+	// The runner talks to the injected beacon when supplied (e.g. a faulty one), otherwise the plain
+	// testing wrapper. env.beacon keeps the base wrapper so broadcast assertions still work.
+	// (runnerBeacon takes beaconNode's interface type; the wrapped node satisfies it.)
+	runnerBeacon := beaconNode
+	if runnerBeacon == nil {
+		runnerBeacon = beacon
+	}
+
 	runnerI, err := NewCommitteeRunner(CommitteeRunnerOptions{
 		BaseRunnerOptions: BaseRunnerOptions{
 			NetworkConfig:  networkconfig.TestNetwork,
 			Share:          shareMap,
-			Beacon:         beacon,
+			Beacon:         runnerBeacon,
 			Network:        network,
 			Signer:         signer,
 			OperatorSigner: spectestingutils.NewOperatorSigner(sampleKey, 1),

--- a/protocol/v2/ssv/runner/committee_test.go
+++ b/protocol/v2/ssv/runner/committee_test.go
@@ -144,7 +144,7 @@ func newCommitteeRunnerEnvInternal(
 		false,
 	)
 
-	beacon := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	defaultBeacon := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
 	if guard == nil {
 		guard = &committeeDutyGuardStub{}
 	}
@@ -154,10 +154,9 @@ func newCommitteeRunnerEnvInternal(
 
 	// The runner talks to the injected beacon when supplied (e.g. a faulty one), otherwise the plain
 	// testing wrapper. env.beacon keeps the base wrapper so broadcast assertions still work.
-	// (runnerBeacon takes beaconNode's interface type; the wrapped node satisfies it.)
 	runnerBeacon := beaconNode
 	if runnerBeacon == nil {
-		runnerBeacon = beacon
+		runnerBeacon = defaultBeacon
 	}
 
 	runnerI, err := NewCommitteeRunner(CommitteeRunnerOptions{
@@ -184,7 +183,7 @@ func newCommitteeRunnerEnvInternal(
 	return &committeeRunnerEnv{
 		logger:     logger,
 		runner:     crunner,
-		beacon:     beacon,
+		beacon:     defaultBeacon,
 		network:    network,
 		keySetMap:  keySetMap,
 		sampleKey:  sampleKey,

--- a/protocol/v2/ssv/runner/error.go
+++ b/protocol/v2/ssv/runner/error.go
@@ -50,3 +50,26 @@ func IsRetryable(err error) bool {
 	var retryableErr *RetryableError
 	return errors.As(err, &retryableErr)
 }
+
+// recoverableReconstructError tags a post-consensus BLS-reconstruction failure as recoverable.
+// It is attached at the push site inside the reconstruct goroutine, which has by construction
+// already run FallBackAndVerifyEachSignature to drop the offending partial sig(s) — so a later
+// partial-sig message can re-cross quorum and retry the pending roots. Classifying by this tag
+// (rather than by the spec ReconstructSignatureErrorCode) covers the whole recoverable subclass:
+// VerifyReconstructedSignature attaches the code, but the earlier BLS Deserialize/Recover step
+// (e.g. 96 garbage bytes from a byzantine operator) returns an uncoded error that is equally
+// recoverable. Errors reaching the classifier without this tag stay terminal by default.
+// Unwrap keeps the wrapped chain (including any code-tagged *spectypes.Error) reachable via
+// errors.As so the committee role still observably emits the reconstruct error code.
+type recoverableReconstructError struct {
+	err error
+}
+
+func (e recoverableReconstructError) Error() string { return e.err.Error() }
+
+func (e recoverableReconstructError) Unwrap() error { return e.err }
+
+func isRecoverableReconstructError(err error) bool {
+	var rec recoverableReconstructError
+	return errors.As(err, &rec)
+}

--- a/protocol/v2/ssv/runner/error_test.go
+++ b/protocol/v2/ssv/runner/error_test.go
@@ -1,9 +1,11 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,4 +15,40 @@ func TestRetryableError(t *testing.T) {
 
 	wrappedErr := NewRetryableError(someErr)
 	require.True(t, IsRetryable(wrappedErr))
+}
+
+// TestIsRecoverableReconstructError pins the classifier the post-consensus defer relies on: only a
+// tagged error is recoverable, and the tag survives further wrapping. Crucially, it also verifies the
+// tag never hides the wrapped chain — a code-tagged *spectypes.Error stays reachable via errors.As, so
+// the committee role still observably emits the reconstruct error code even after tagging.
+func TestIsRecoverableReconstructError(t *testing.T) {
+	t.Run("plain error is not recoverable", func(t *testing.T) {
+		require.False(t, isRecoverableReconstructError(errors.New("boom")))
+	})
+
+	t.Run("nil is not recoverable", func(t *testing.T) {
+		require.False(t, isRecoverableReconstructError(nil))
+	})
+
+	t.Run("tagged error is recoverable", func(t *testing.T) {
+		tagged := recoverableReconstructError{errors.New("could not reconstruct")}
+		require.True(t, isRecoverableReconstructError(tagged))
+	})
+
+	t.Run("tag survives further wrapping", func(t *testing.T) {
+		tagged := recoverableReconstructError{errors.New("inner")}
+		wrapped := fmt.Errorf("submit stage: %w", tagged)
+		require.True(t, isRecoverableReconstructError(wrapped))
+	})
+
+	t.Run("wrapped coded spec error stays reachable via errors.As", func(t *testing.T) {
+		coded := spectypes.NewError(spectypes.ReconstructSignatureErrorCode, "could not reconstruct a valid signature")
+		tagged := recoverableReconstructError{fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", coded)}
+
+		require.True(t, isRecoverableReconstructError(tagged))
+
+		var specErr *spectypes.Error
+		require.ErrorAs(t, tagged, &specErr, "the tag must not hide the coded spec error underneath")
+		require.Equal(t, spectypes.ReconstructSignatureErrorCode, specErr.Code)
+	})
 }


### PR DESCRIPTION
## What

`CommitteeRunner.ProcessPostConsensus` used a blanket `defer { if err != nil { markDutyFailed(err) } }` on its named return, which concluded the duty **failed** on *any* non-nil return — including the genuinely recoverable reconstruct-invalid-signatures case.

`FallBackAndVerifyEachSignature` can drop a root below quorum, so a later partial-signature message re-crosses quorum and re-enters the loop and the duty completes. But the blanket defer had already consumed the single-shot `dutyConcluded` channel, so the eventual `markDutySucceeded` became a no-op — and a duty that **actually completed** was mis-reported as `failed`. This is the inverse of the false-`stuck` signal fixed for `AggregatorCommitteeRunner` in #2912.

## Fix

- Remove the blanket defer.
- Add explicit `r.markDutyFailed(...)` before **every** terminal post-quorum error return (expected-roots error, `ErrNoValidDutiesToExecute`, `ctx.Done()`, `SubmitAttestations`, the `currentDutySlot`/`Data` failures, `SubmitSyncMessages`).
- Exclude **only** the recoverable reconstruct-invalid-sigs case, discriminated via `errors.As` + `.Code` (the spec's `Error.Is` is code-blind, so `errors.Is` against a code would misroute).

### Note on the error code
The reconstruct error keeps its spec-mandated `ReconstructSignatureErrorCode` — the `errCh` push is left **untagged**. The spec fixtures expect the committee role to emit `ReconstructSignatureErrorCode` and only the *aggregator* role to emit `PostConsensusQuorumWithInvalidSignatures`, so the two runners discriminate on different codes by design. (An initial attempt to tag it like the aggregator broke 18 `TestSSVMapping` spectests — caught and reverted.)

## Testing
- `go build` / `go vet` / `gofmt` clean
- `go test ./protocol/v2/ssv/runner/...` ✅
- `go test ./protocol/v2/ssv/spectest/...` ✅ (all `TestSSVMapping` pass)

Companion to #2912 (same behavioral fix on `AggregatorCommitteeRunner`); both target `boole-fork`.
