### PR TITLE
observability(runner): classify aggregator terminal post-quorum failures as failed (#2919)

### DIFF
--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -120,8 +120,13 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 		return nil
 	}
 
-	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
-	// so a terminal failure below won't be retried.
+	// We have quorum and are committed to completing this duty here, so this defer reports a terminal
+	// failure below as failed rather than letting it surface as a false "stuck".
+	// The one exception is a recoverable BLS-reconstruction failure: the fallback drops the offending
+	// partial sig(s) below quorum, so a later partial-sig message re-crosses quorum and re-enters here —
+	// those are tagged recoverableReconstructError and must not be recorded as failed (hence the guard).
+	// Shutdown (context cancellation) needs no special-casing — markDutyFailed drops a context.Canceled
+	// reason, so a duty aborted by shutdown isn't recorded as a failure.
 	defer func() {
 		if err != nil && !isRecoverableReconstructError(err) {
 			r.markDutyFailed(err)
@@ -309,8 +314,13 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 		return nil
 	}
 
-	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
-	// so a terminal failure below won't be retried.
+	// We have quorum and are committed to completing this duty here, so this defer reports a terminal
+	// failure below as failed rather than letting it surface as a false "stuck".
+	// The one exception is a recoverable BLS-reconstruction failure: the fallback drops the offending
+	// partial sig(s) below quorum, so a later partial-sig message re-crosses quorum and re-enters here —
+	// those are tagged recoverableReconstructError and must not be recorded as failed (hence the guard).
+	// Shutdown (context cancellation) needs no special-casing — markDutyFailed drops a context.Canceled
+	// reason, so a duty aborted by shutdown isn't recorded as a failure.
 	defer func() {
 		if err != nil && !isRecoverableReconstructError(err) {
 			r.markDutyFailed(err)

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -123,7 +123,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
 	// so a terminal failure below won't be retried.
 	defer func() {
-		if err != nil {
+		if err != nil && !isRecoverableReconstructError(err) {
 			r.markDutyFailed(err)
 		}
 	}()
@@ -140,7 +140,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.FallBackAndVerifyEachSignature(r.State.PreConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)
+		return recoverableReconstructError{fmt.Errorf("got pre-consensus quorum but it has invalid signatures: %w", err)}
 	}
 
 	duty, err := r.currentValidatorDuty()
@@ -312,7 +312,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	// We have quorum and are committed to completing this duty here. The quorum above fires only once,
 	// so a terminal failure below won't be retried.
 	defer func() {
-		if err != nil {
+		if err != nil && !isRecoverableReconstructError(err) {
 			r.markDutyFailed(err)
 		}
 	}()
@@ -328,7 +328,7 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	if err != nil {
 		// If the reconstructed signature verification failed, fall back to verifying each partial signature
 		r.FallBackAndVerifyEachSignature(r.State.PostConsensusContainer, root, r.GetShare().Committee, r.GetShare().ValidatorIndex)
-		return fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)
+		return recoverableReconstructError{fmt.Errorf("got post-consensus quorum but it has invalid signatures: %w", err)}
 	}
 	specSig := phase0.BLSSignature{}
 	copy(specSig[:], sig)

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -822,7 +822,14 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		return bytes.Compare(roots[i][:], roots[j][:]) < 0
 	})
 
-	var executionErr error
+	// Unlike the sibling CommitteeRunner (which tags recoverable reconstruct failures with the
+	// recoverableReconstructError sentinel), this runner classifies them by the
+	// PostConsensusQuorumWithInvalidSignatures spec code: every reconstruct error is force-wrapped
+	// with that code at the push site below, so there is no uncoded-BLS blind spot here, and tagging
+	// instead would break this runner's spectest fixtures. The divergence is deliberate — see the
+	// reciprocal note in committee.go. A single last-write-wins error made terminal-vs-recoverable
+	// classification depend on goroutine/root ordering; splitting keeps it deterministic (terminal wins).
+	var terminalErr, recoverableErr error
 	aggregatesToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*spec.VersionedSignedAggregateAndProof)
 	contributionsToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*altair.SignedContributionAndProof)
 
@@ -953,7 +960,14 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 				// duty deadline is ~1 epoch out — and markDutyFailed drops context.Canceled anyway.
 				return ctx.Err()
 			case err := <-errCh:
-				executionErr = err
+				// The reconstruct goroutine force-wraps its (recoverable, post-fallback) error with the
+				// PostConsensusQuorumWithInvalidSignatures code; anything arriving without that code is terminal.
+				var specErr *spectypes.Error
+				if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
+					recoverableErr = err
+				} else {
+					terminalErr = err
+				}
 			case signatureResult, ok := <-signatureCh:
 				if !ok {
 					break listener
@@ -961,13 +975,13 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 
 				validatorObjects, exists := beaconObjects[signatureResult.validatorIndex]
 				if !exists {
-					executionErr = fmt.Errorf("could not find beacon object for validator index: %d",
+					terminalErr = fmt.Errorf("could not find beacon object for validator index: %d",
 						signatureResult.validatorIndex)
 					continue
 				}
 				sszObject, exists := validatorObjects[root]
 				if !exists {
-					executionErr = fmt.Errorf("could not find ssz object for root: %s", root)
+					terminalErr = fmt.Errorf("could not find ssz object for root: %s", root)
 					continue
 				}
 
@@ -976,7 +990,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 					aggregateAndProof := sszObject.(*spec.VersionedAggregateAndProof)
 					signedAgg, err := r.constructSignedAggregateAndProof(aggregateAndProof, signatureResult.signature)
 					if err != nil {
-						executionErr = fmt.Errorf("failed to construct signed aggregate and proof: %w", err)
+						terminalErr = fmt.Errorf("failed to construct signed aggregate and proof: %w", err)
 						continue
 					}
 
@@ -1006,6 +1020,28 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 			}
 		}
 
+		// When signatureCh closes in the same iteration the select may take the close branch and skip an
+		// error still buffered on errCh. All workers have finished (signatureCh is closed only after
+		// wg.Wait), so no further sends occur and this non-blocking drain is complete. Today errCh carries
+		// only the recoverable reconstruct error (the sole producer above), and dropping one is benign —
+		// the root stays un-submitted and the duty stays open for a later retry rather than falsely
+		// succeeding. The drain is defensive: it classifies that error for completeness and future-proofs
+		// the path should a terminal error ever be pushed here.
+	drainErrCh:
+		for {
+			select {
+			case err := <-errCh:
+				var specErr *spectypes.Error
+				if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
+					recoverableErr = err
+				} else {
+					terminalErr = err
+				}
+			default:
+				break drainErrCh
+			}
+		}
+
 		logger.Debug("🧩 reconstructed partial signatures for root",
 			fields.BlockRoot(root),
 		)
@@ -1016,7 +1052,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 			start := time.Now()
 			if err := r.beacon.SubmitSignedAggregateSelectionProof(ctx, signedAgg); err != nil {
 				recordFailedSubmission(ctx, spectypes.BNRoleAggregator)
-				executionErr = fmt.Errorf("failed to submit signed aggregate and proof: %w", err)
+				terminalErr = fmt.Errorf("failed to submit signed aggregate and proof: %w", err)
 				continue
 			}
 
@@ -1046,7 +1082,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 			start := time.Now()
 			if err := r.beacon.SubmitSignedContributionAndProof(ctx, signedContrib); err != nil {
 				recordFailedSubmission(ctx, spectypes.BNRoleSyncCommitteeContribution)
-				executionErr = fmt.Errorf("failed to submit signed contribution and proof: %w", err)
+				terminalErr = fmt.Errorf("failed to submit signed contribution and proof: %w", err)
 				continue
 			}
 
@@ -1071,19 +1107,19 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		}
 	}
 
-	if executionErr != nil {
-		// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root
-		// below quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to
-		// retry pending roots (already-submitted roots are skipped via HasSubmitted). Not markDutyFailed.
-		var specErr *spectypes.Error
-		if errors.As(executionErr, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
-			return executionErr
-		}
-		// Submit/construct/missing-object failures: reconstruction already succeeded so the root keeps
-		// its quorum and is never re-reported (runner.go:534 reports only on first quorum crossing), so
-		// the submit loop never revisits it and the duty never concludes → mark failed, not a false stuck.
-		r.markDutyFailed(executionErr)
-		return executionErr
+	// Terminal wins deterministically over a concurrent recoverable error in the same round.
+	// Submit/construct/missing-object failures: reconstruction already succeeded so the root keeps its
+	// quorum and is never re-reported (runner.go reports only on first quorum crossing), so the submit
+	// loop never revisits it and the duty never concludes → mark failed, not a false stuck.
+	if terminalErr != nil {
+		r.markDutyFailed(terminalErr)
+		return terminalErr
+	}
+	// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root below
+	// quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to retry pending
+	// roots (already-submitted roots are skipped via HasSubmitted). Not markDutyFailed.
+	if recoverableErr != nil {
+		return recoverableErr
 	}
 
 	// Check if duty has terminated (runner has submitted for all duties)

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -830,6 +830,18 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 	// reciprocal note in committee.go. A single last-write-wins error made terminal-vs-recoverable
 	// classification depend on goroutine/root ordering; splitting keeps it deterministic (terminal wins).
 	var terminalErr, recoverableErr error
+	// classify is the single source of truth for the terminal/recoverable split, shared by the listener
+	// receive site and the post-listener drain so the two can never drift apart. The reconstruct
+	// goroutine force-wraps its (recoverable, post-fallback) error with the
+	// PostConsensusQuorumWithInvalidSignatures code; anything arriving without that code is terminal.
+	classify := func(err error) {
+		var specErr *spectypes.Error
+		if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
+			recoverableErr = err
+		} else {
+			terminalErr = err
+		}
+	}
 	aggregatesToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*spec.VersionedSignedAggregateAndProof)
 	contributionsToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*altair.SignedContributionAndProof)
 
@@ -960,14 +972,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 				// duty deadline is ~1 epoch out — and markDutyFailed drops context.Canceled anyway.
 				return ctx.Err()
 			case err := <-errCh:
-				// The reconstruct goroutine force-wraps its (recoverable, post-fallback) error with the
-				// PostConsensusQuorumWithInvalidSignatures code; anything arriving without that code is terminal.
-				var specErr *spectypes.Error
-				if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
-					recoverableErr = err
-				} else {
-					terminalErr = err
-				}
+				classify(err)
 			case signatureResult, ok := <-signatureCh:
 				if !ok {
 					break listener
@@ -1031,12 +1036,7 @@ func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
 		for {
 			select {
 			case err := <-errCh:
-				var specErr *spectypes.Error
-				if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
-					recoverableErr = err
-				} else {
-					terminalErr = err
-				}
+				classify(err)
 			default:
 				break drainErrCh
 			}

--- a/protocol/v2/ssv/runner/aggregator_committee_test.go
+++ b/protocol/v2/ssv/runner/aggregator_committee_test.go
@@ -208,6 +208,69 @@ func TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvali
 	require.False(t, env.runner.State.Succeeded)
 }
 
+// TestAggregatorCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds is the
+// regression test for the last coverage gap on #2919/#2918: a quorum that optimistically crosses
+// threshold but contains one non-deserializable partial signature must NOT conclude the duty (the
+// offending signer is dropped by FallBackAndVerifyEachSignature, so the root falls back below
+// quorum and the duty is left un-marked, recoverable), and a subsequent valid partial signature that
+// re-crosses quorum must let the duty conclude succeeded. This mirrors
+// TestCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds
+// (committee_postconsensus_classification_test.go) for the aggregator-committee runner, closing the
+// gap left by TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs above,
+// which only proves the "stays un-marked" half and never re-attempts a successful retry.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	// A healthy (non-faulty) beacon node: submission on the retry round must actually succeed.
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, base)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	// Round 1: signers 1 and 2 send valid post-consensus partial sigs; signer 3 sends a
+	// non-deserializable one. ValidatePostConsensusMsg only checks message structure (not the beacon
+	// signature), so all three enter the container and cross quorum (3-of-4) optimistically. Then
+	// ReconstructBeaconSig fails on the garbage signature, FallBackAndVerifyEachSignature drops only
+	// signer 3, and the root falls back below quorum (2-of-4) — recoverable, nothing submitted, and
+	// the duty must NOT be concluded.
+	msg1 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 1, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg1))
+
+	msg2 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 2, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg2))
+
+	badMsg3 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 3, version)
+	for _, m := range badMsg3.Messages {
+		m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+	}
+	recoverableErr := env.runner.ProcessPostConsensus(ctx, env.logger, badMsg3)
+	require.Error(t, recoverableErr, "a quorum with invalid signatures should surface an error")
+	var specErr *spectypes.Error
+	require.ErrorAs(t, recoverableErr, &specErr)
+	require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code,
+		"invalid-sigs must carry the recoverable spec code")
+
+	// The recoverable case must NOT conclude the duty: nothing has been sent on the conclusion channel.
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
+	require.False(t, env.runner.State.Succeeded)
+
+	// Round 2: a subsequent valid partial signature from signer 4 re-crosses quorum with three good
+	// sigs (1, 2, 4) → reconstruction succeeds → the duty submits and concludes succeeded.
+	msg4 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 4, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg4))
+
+	require.True(t, env.runner.State.Succeeded, "a valid quorum after recovery must conclude succeeded")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeSucceeded, c.outcome, "recovery must conclude the duty succeeded, not failed")
+	default:
+		t.Fatal("expected a succeeded duty conclusion after recovery, got none")
+	}
+}
+
 // TestAggregatorCommitteeRunnerProcessPostConsensus_TerminalWinsOverConcurrentRecoverable is the
 // regression test for the terminalErr/recoverableErr split: within a single ProcessPostConsensus
 // call, one validator's post-consensus signatures reconstruct fine but then fail to submit (terminal,

--- a/protocol/v2/ssv/runner/aggregator_committee_test.go
+++ b/protocol/v2/ssv/runner/aggregator_committee_test.go
@@ -207,3 +207,99 @@ func TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvali
 	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
 	require.False(t, env.runner.State.Succeeded)
 }
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_TerminalWinsOverConcurrentRecoverable is the
+// regression test for the terminalErr/recoverableErr split: within a single ProcessPostConsensus
+// call, one validator's post-consensus signatures reconstruct fine but then fail to submit (terminal,
+// set from the submit loop after the roots loop), while a second validator's signatures are corrupted
+// and reconstruct-fails with the recoverable PostConsensusQuorumWithInvalidSignatures code (set from
+// the errCh receive site during the roots loop). Both land in the same call, so which one is observed
+// first by the listener select is not controlled by the test. Before the split, a single
+// last-write-wins `executionErr` made the final classification depend on that arrival order; the
+// fixed code always classifies the duty failed here because terminalErr is checked first,
+// independent of goroutine/channel scheduling. We assert on the conclusion outcome, not on which
+// error message ends up attached (that part is still last-write-wins by design for same-class
+// errors).
+func TestAggregatorCommitteeRunnerProcessPostConsensus_TerminalWinsOverConcurrentRecoverable(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected aggregate")
+	faulty := &faultyAggregateSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1, 2}, faulty)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1, 2}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		// Corrupt only validator 2's signature in this signer's batch: validator 1 keeps a valid
+		// signature (reconstructs fine, submits, and fails there — terminal), validator 2's
+		// reconstruct fails outright (recoverable).
+		for _, m := range psig.Messages {
+			if m.ValidatorIndex == phase0.ValidatorIndex(2) {
+				m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+			}
+		}
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.Error(t, postConsensusErr, "a terminal error concurrent with a recoverable one must still surface")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome,
+			"terminal must win deterministically over a concurrent recoverable error in the same round")
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_DrainsBufferedErrCh is a best-effort regression
+// test for Ovi finding 1 (the drainErrCh block): when the reconstruct goroutines' errCh sends race
+// against signatureCh's close, a buffered recoverable error could previously be skipped by the
+// listener select (which may take the "signatureCh closed" branch over a simultaneously-ready errCh
+// receive), silently discarding the error and letting ProcessPostConsensus return nil despite a
+// validator's post-consensus signature never having been submitted (a false "stuck", never
+// concluded). The fix drains any leftover errCh value right after the listener loop, so the error is
+// classified and returned regardless of which branch the race took.
+//
+// This exercises many validators corrupted in the same call and repeats the scenario to raise the
+// odds of hitting the race window on any single run; the assertion (a non-nil, correctly-coded error
+// on every iteration) is unconditionally guaranteed by the fix regardless of which branch fires, so
+// the test is not flaky when the drain is present — it only has a chance (not a guarantee) of
+// reproducing the pre-fix bug on a revert.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_DrainsBufferedErrCh(t *testing.T) {
+	const version = spec.DataVersionElectra
+	aggValidators := []int{1, 2, 3, 4, 5, 6, 7, 8}
+
+	for iter := 0; iter < 20; iter++ {
+		ctx := t.Context()
+		base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+		env := newAggregatorCommitteeRunnerEnv(t, aggValidators, base)
+		duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators(aggValidators, []int{}, version)
+
+		env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+		var postConsensusErr error
+		for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+			for _, m := range psig.Messages {
+				m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+			}
+			if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+				postConsensusErr = err
+			}
+		}
+
+		require.Error(t, postConsensusErr, "iteration %d: a fully-corrupted quorum must surface an error, not vanish", iter)
+		var specErr *spectypes.Error
+		require.ErrorAs(t, postConsensusErr, &specErr, "iteration %d", iter)
+		require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code, "iteration %d", iter)
+		require.False(t, env.runner.State.Succeeded, "iteration %d", iter)
+	}
+}

--- a/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
+++ b/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
@@ -103,7 +102,7 @@ func (e *aggregatorRunnerEnv) startAndDecideAggregatorDuty(
 	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.keySet.Threshold))
 
 	aggData := spectestingutils.TestingAggregateAndProofV(version, duty.ValidatorIndex)
-	dataSSZ, err := aggData.(ssz.Marshaler).MarshalSSZ()
+	dataSSZ, err := aggData.MarshalSSZ()
 	require.NoError(t, err)
 
 	consensusData := &spectypes.ProposerConsensusData{
@@ -123,8 +122,7 @@ func (e *aggregatorRunnerEnv) startAndDecideAggregatorDuty(
 func aggregatorPostConsensusMsgs(keySet *spectestingutils.TestKeySet, version spec.DataVersion) []*spectypes.PartialSignatureMessages {
 	msgs := make([]*spectypes.PartialSignatureMessages, 0, keySet.Threshold)
 	for i := uint64(1); i <= keySet.Threshold; i++ {
-		id := spectypes.OperatorID(i)
-		msgs = append(msgs, spectestingutils.PostConsensusAggregatorMsg(keySet.Shares[id], id, version))
+		msgs = append(msgs, spectestingutils.PostConsensusAggregatorMsg(keySet.Shares[i], i, version))
 	}
 	return msgs
 }

--- a/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
+++ b/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
@@ -1,0 +1,216 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv"
+	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+)
+
+// aggregatorRunnerEnv wires a legacy (non-committee) AggregatorRunner exactly like
+// newAggregatorCommitteeRunnerEnv wires its committee counterpart, so the post-consensus
+// terminal/recoverable classification added for #2919 can be exercised the same way #2912 did for
+// AggregatorCommitteeRunner. The beacon node is injected so a test can substitute a faulty one.
+type aggregatorRunnerEnv struct {
+	logger  *zap.Logger
+	runner  *AggregatorRunner
+	network *protocoltesting.TestingNetwork
+	keySet  *spectestingutils.TestKeySet
+}
+
+func newAggregatorRunnerEnv(t *testing.T, beaconNode beacon.BeaconNode) *aggregatorRunnerEnv {
+	t.Helper()
+
+	keySet := spectestingutils.Testing4SharesSet()
+	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
+
+	network := protocoltesting.NewTestingNetwork(1, keySet.OperatorKeys[1])
+	logger := zaptest.NewLogger(t)
+	signer := ekm.NewTestingKeyManagerAdapter(spectestingutils.NewTestingKeyManager())
+
+	config := protocoltesting.TestingConfig(logger, keySet)
+	config.Network = network
+
+	identifier := spectypes.NewMsgID(spectypes.JatoTestnet, spectestingutils.TestingValidatorPubKey[:], ssvtypes.RoleAggregator)
+	ctrl := protocoltesting.NewTestingQBFTController(
+		keySet,
+		identifier[:],
+		spectestingutils.TestingCommitteeMember(keySet),
+		config,
+		false,
+	)
+
+	runnerI, err := NewAggregatorRunner(AggregatorRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig:  networkconfig.TestNetwork,
+			Share:          map[phase0.ValidatorIndex]*spectypes.Share{share.ValidatorIndex: share},
+			Beacon:         beaconNode,
+			Network:        network,
+			Signer:         signer,
+			OperatorSigner: spectestingutils.NewOperatorSigner(keySet, 1),
+		},
+		QBFTController:     ctrl,
+		ValCheck:           dummyValueChecker{},
+		HighestDecidedSlot: 0,
+	})
+	require.NoError(t, err)
+
+	arunner := runnerI.(*AggregatorRunner)
+	arunner.SetQBFTRoundTimerF(func(_ context.Context, _ *zap.Logger, _ phase0.Slot) ssv.QBFTRoundTimer {
+		return roundtimer.NewTestingTimer()
+	})
+
+	return &aggregatorRunnerEnv{
+		logger:  logger,
+		runner:  arunner,
+		network: network,
+		keySet:  keySet,
+	}
+}
+
+// startAndDecideAggregatorDuty starts the duty and drives the QBFT round to decided, bypassing
+// pre-consensus entirely (it is orthogonal to the post-consensus classification under test): the
+// runner's own decide() is invoked directly with a hand-built ProposerConsensusData wrapping the
+// same AggregateAndProof the postConsensusAggregatorMsg fixtures sign, then that value/round is
+// carried to a decision using the generic SSVDecidingMsgsV consensus-message builder (role !=
+// RoleProposer, so it emits no pre-consensus messages, only proposal/prepare/commit). Feeding those
+// messages through the real ProcessConsensus exercises the same code path production traffic would.
+func (e *aggregatorRunnerEnv) startAndDecideAggregatorDuty(
+	t *testing.T,
+	ctx context.Context,
+	duty *spectypes.ValidatorDuty,
+	version spec.DataVersion,
+) {
+	t.Helper()
+
+	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.keySet.Threshold))
+
+	aggData := spectestingutils.TestingAggregateAndProofV(version, duty.ValidatorIndex)
+	dataSSZ, err := aggData.(ssz.Marshaler).MarshalSSZ()
+	require.NoError(t, err)
+
+	consensusData := &spectypes.ProposerConsensusData{
+		Duty:    *duty,
+		Version: version,
+		DataSSZ: dataSSZ,
+	}
+	require.NoError(t, e.runner.decide(ctx, e.logger, duty.Slot, consensusData, dummyValueChecker{}))
+
+	for _, msg := range spectestingutils.SSVDecidingMsgsV(consensusData, e.keySet, ssvtypes.RoleAggregator) {
+		require.NoError(t, e.runner.ProcessConsensus(ctx, e.logger, msg))
+	}
+}
+
+// aggregatorPostConsensusMsgs returns the (valid) post-consensus PartialSignatureMessages from
+// enough signers to cross quorum for the given duty/version.
+func aggregatorPostConsensusMsgs(keySet *spectestingutils.TestKeySet, version spec.DataVersion) []*spectypes.PartialSignatureMessages {
+	msgs := make([]*spectypes.PartialSignatureMessages, 0, keySet.Threshold)
+	for i := uint64(1); i <= keySet.Threshold; i++ {
+		id := spectypes.OperatorID(i)
+		msgs = append(msgs, spectestingutils.PostConsensusAggregatorMsg(keySet.Shares[id], id, version))
+	}
+	return msgs
+}
+
+// TestAggregatorRunnerProcessPostConsensus_MarksFailedOnSubmitError asserts that a beacon submit
+// failure (a terminal post-quorum error) concludes the duty as failed for the legacy AggregatorRunner
+// — the counterpart of the AggregatorCommitteeRunner and CommitteeRunner regressions already covered.
+func TestAggregatorRunnerProcessPostConsensus_MarksFailedOnSubmitError(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionPhase0
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected aggregate")
+	faulty := &faultyAggregateSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newAggregatorRunnerEnv(t, faulty)
+	duty := &spectypes.ValidatorDuty{
+		Type:           spectypes.BNRoleAggregator,
+		PubKey:         spectestingutils.TestingValidatorPubKey,
+		Slot:           spectestingutils.TestingDutySlotV(version),
+		ValidatorIndex: spectestingutils.TestingValidatorIndex,
+	}
+
+	env.startAndDecideAggregatorDuty(t, ctx, duty, version)
+
+	concluded := make(chan dutyConclusion, 1)
+	env.runner.dutyConcluded = concluded
+
+	var postConsensusErr error
+	for _, psig := range aggregatorPostConsensusMsgs(env.keySet, version) {
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.ErrorIs(t, postConsensusErr, submitErr, "submit failure should surface from ProcessPostConsensus")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome, "a terminal submit failure must be classified failed")
+		require.ErrorIs(t, c.reason, submitErr)
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestAggregatorRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs is the regression test for
+// the legacy AggregatorRunner side of #2919: a recoverable reconstruct-invalid-signatures failure
+// (wrapped in recoverableReconstructError at the push site in aggregator.go) must NOT conclude the
+// duty failed, mirroring the CommitteeRunner fix from #2918/#2912.
+func TestAggregatorRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionPhase0
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	env := newAggregatorRunnerEnv(t, base)
+	duty := &spectypes.ValidatorDuty{
+		Type:           spectypes.BNRoleAggregator,
+		PubKey:         spectestingutils.TestingValidatorPubKey,
+		Slot:           spectestingutils.TestingDutySlotV(version),
+		ValidatorIndex: spectestingutils.TestingValidatorIndex,
+	}
+
+	env.startAndDecideAggregatorDuty(t, ctx, duty, version)
+
+	concluded := make(chan dutyConclusion, 1)
+	env.runner.dutyConcluded = concluded
+
+	// Corrupt the beacon partial signatures. ValidatePostConsensusMsg only checks message structure
+	// (not the beacon sig), so these still reach optimistic quorum, then ReconstructBeaconSig fails
+	// and the defer must see the recoverableReconstructError tag and skip markDutyFailed.
+	var postConsensusErr error
+	for _, psig := range aggregatorPostConsensusMsgs(env.keySet, version) {
+		for _, m := range psig.Messages {
+			m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+		}
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.Error(t, postConsensusErr, "invalid signatures should surface an error")
+	require.True(t, isRecoverableReconstructError(postConsensusErr),
+		"invalid-sigs must carry the recoverableReconstructError tag")
+
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
+	require.False(t, env.runner.State.Succeeded)
+}

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -712,6 +712,26 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 			}
 		}
 
+		// Drain any error still buffered on errCh: when signatureCh closes in the same iteration the select
+		// may take the close branch and skip it. All workers have finished (signatureCh closes only after
+		// wg.Wait), so this non-blocking drain is complete. Today errCh carries only the recoverable
+		// reconstruct error (the sole producer above), and dropping one is benign (the duty stays open for
+		// retry). The drain is defensive: it classifies that error for completeness and future-proofs the
+		// path should a terminal error ever be pushed here.
+	drainErrCh:
+		for {
+			select {
+			case err := <-errCh:
+				if isRecoverableReconstructError(err) {
+					recoverableErr = err
+				} else {
+					terminalErr = err
+				}
+			default:
+				break drainErrCh
+			}
+		}
+
 		logger.Debug("🧩 reconstructed partial signatures for root", fields.BlockRoot(root))
 	}
 

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -540,6 +540,16 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 	// The sibling AggregatorCommitteeRunner instead classifies by the PostConsensusQuorumWithInvalidSignatures
 	// code; the divergence is deliberate (tagging with that code there breaks its spectest fixtures).
 	var recoverableErr, terminalErr error
+	// classify is the single source of truth for the terminal/recoverable split, shared by the listener
+	// receive site and the post-listener drain so the two can never drift apart. Recoverable failures
+	// carry the recoverableReconstructError tag; anything arriving without it is treated as terminal.
+	classify := func(err error) {
+		if isRecoverableReconstructError(err) {
+			recoverableErr = err
+		} else {
+			terminalErr = err
+		}
+	}
 
 	span.SetAttributes(observability.BeaconBlockRootCountAttribute(len(roots)))
 	// For each root that got at least one quorum, find the duties associated to it and try to submit
@@ -664,14 +674,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 				// isn't recorded as a failure.
 				return ctx.Err()
 			case err := <-errCh:
-				// The reconstruct goroutine tags its (recoverable, post-fallback) error with
-				// recoverableReconstructError; classify defensively so any other error arriving
-				// here without the tag is still treated as terminal.
-				if isRecoverableReconstructError(err) {
-					recoverableErr = err
-				} else {
-					terminalErr = err
-				}
+				classify(err)
 			case signatureResult, ok := <-signatureCh:
 				if !ok {
 					break listener
@@ -722,11 +725,7 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 		for {
 			select {
 			case err := <-errCh:
-				if isRecoverableReconstructError(err) {
-					recoverableErr = err
-				} else {
-					terminalErr = err
-				}
+				classify(err)
 			default:
 				break drainErrCh
 			}

--- a/protocol/v2/ssv/runner/error_test.go
+++ b/protocol/v2/ssv/runner/error_test.go
@@ -51,4 +51,20 @@ func TestIsRecoverableReconstructError(t *testing.T) {
 		require.ErrorAs(t, tagged, &specErr, "the tag must not hide the coded spec error underneath")
 		require.Equal(t, spectypes.ReconstructSignatureErrorCode, specErr.Code)
 	})
+
+	// Defends the tag-based design (as opposed to classifying by spec error code): an untagged error
+	// is terminal by default even when it happens to carry a spec code, including the recoverable
+	// PostConsensusQuorumWithInvalidSignatures code the AggregatorCommitteeRunner push-site uses.
+	// Only the recoverableReconstructError wrapper — attached at the push site after
+	// FallBackAndVerifyEachSignature has already run — makes an error recoverable.
+	t.Run("untagged error with an unrelated spec code stays terminal", func(t *testing.T) {
+		coded := spectypes.NewError(spectypes.UnknownValidatorIndexErrorCode, "unknown validator index")
+		require.False(t, isRecoverableReconstructError(coded))
+	})
+
+	t.Run("untagged error carrying the post-consensus-invalid-sigs code stays terminal without the tag", func(t *testing.T) {
+		coded := spectypes.WrapError(spectypes.PostConsensusQuorumWithInvalidSignatures, errors.New("got post-consensus quorum but it has invalid signatures"))
+		require.False(t, isRecoverableReconstructError(coded),
+			"classification must key off the recoverableReconstructError tag, not the spec code")
+	})
 }


### PR DESCRIPTION
Follow-up to #2918. Brings the aggregator runners in line with the committee fix so terminal post-quorum failures are concluded as `failed` (instead of surfacing later as a false "stuck"), while recoverable reconstruct-invalid-sigs stay un-marked so a later partial-sig can retry.

Closes #2919.

## Changes

- **`aggregator.go` (legacy `AggregatorRunner`, pre-Boole)** — wrap the pre- and post-consensus reconstruct-invalid-sigs returns in `recoverableReconstructError` and guard both defers with `!isRecoverableReconstructError`, mirroring #2918. This runner previously reproduced the exact blanket-`markDutyFailed` bug committee had.

- **`aggregator_committee.go`** — replace the single last-write-wins `executionErr` with a deterministic `terminalErr`/`recoverableErr` split (terminal wins regardless of goroutine/root ordering); classify the recoverable path by the `PostConsensusQuorumWithInvalidSignatures` (code 81) at the errCh receive site; drain `errCh` after the listener closes so a buffered error can't be skipped by the `signatureCh`-close race.
  - The aggregator deliberately keeps classifying by **code 81** (not the sentinel tag): it force-wraps every reconstruct error with that code at the sole push site, so it has no uncoded-BLS blind spot, and tagging here would break its spectest fixtures. The divergence from committee's tag approach is documented from both sides.

- **`committee.go`** — add the same defensive `errCh` drain (the close-race is pre-existing here too).

## Review input folded in (from #2918)

- **@ovidiu-ssv-labs** — the pre-existing `errCh` drain race (buffered error skippable when `signatureCh` closes) and the reciprocal cross-reference comment documenting the code-vs-tag divergence.
- **@iurii-ssv** — confirmed the deterministic terminal-vs-recoverable classification direction and the deadline-as-terminal semantics.

## Testing

- `go test ./protocol/v2/ssv/runner/... -race` — green
- `go test ./protocol/v2/ssv/spectest/...` incl. `TestSSVMapping` — green (per-runner emitted codes 32/81 preserved)

New/extended runner tests cover: legacy-aggregator terminal vs recoverable classification; deterministic terminal-wins-over-concurrent-recoverable; the `errCh` drain postcondition; tag-not-code classification; and the recoverable-invalid-sigs → retry → **succeeds** flow for `AggregatorCommitteeRunner`.

> Note: the legacy `AggregatorRunner`'s recoverable→retry-succeeds path is covered structurally by the equivalent `CommitteeRunner` test (shared BaseRunner conclusion machinery) rather than re-tested explicitly, since it's pre-Boole-only and its spec harness is awkward. Happy to add it if reviewers prefer full symmetry.
