### PR TITLE
Exporter refactoring #3: Move websocket query bridge into exporter v1 API

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -325,8 +325,9 @@ func newNode(
 
 	var newDecidedHandler qbftcontroller.NewDecidedHandler
 	var decidedStreamPublisherFn func(dutytracer.DecidedInfo)
+	var ws exporterapi.WebSocketServer
 	if cfg.WsAPIPort != 0 {
-		ws := exporterapi.NewWsServer(logger, nil, http.NewServeMux(), cfg.WithPing, fmt.Sprintf(":%d", cfg.WsAPIPort))
+		ws = exporterapi.NewWsServer(logger, nil, http.NewServeMux(), cfg.WithPing, fmt.Sprintf(":%d", cfg.WsAPIPort))
 		cfg.SSVOptions.WS = ws
 		newDecidedHandler = decided.NewStreamPublisher(logger, networkConfig.DomainType, ws)
 		decidedStreamPublisherFn = decided.NewDecidedListener(logger, networkConfig.DomainType, ws, nodeStorage.ValidatorStore())
@@ -432,11 +433,11 @@ func newNode(
 	cfg.SSVOptions.ValidatorController = validatorCtrl
 	cfg.SSVOptions.ValidatorStore = nodeStorage.ValidatorStore()
 
-	if cfg.WsAPIPort != 0 {
+	if ws != nil {
 		handler := exporterapi.NewHandler(logger)
-		cfg.SSVOptions.WSQueryHandler = func(nm *exporterapi.NetworkMessage) {
+		ws.UseQueryHandler(func(nm *exporterapi.NetworkMessage) {
 			handler.HandleQueryRequests(storageMap, exporterRead, nodeStorage.ValidatorStore(), networkConfig.DomainType, nm)
-		}
+		})
 	}
 
 	operatorNode := operator.New(logger, cfg.SSVOptions, cfg.ExporterOptions, slotTickerProvider)

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -377,6 +377,7 @@ func newNode(
 	// Exporter duty tracing. An invalid EXPORTER_MODE is rejected up front by resolveAndValidate,
 	// so res.mode here is always one of the known modes.
 	var collector *dutytracer.Collector
+	var exporterRead *exportercore.Exporter
 	switch res.mode {
 	case modeExporterArchive:
 		logger.Info("exporter mode: archive")
@@ -388,7 +389,7 @@ func newNode(
 			dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 			dutyStore)
 
-		cfg.SSVOptions.ExporterRead = exportercore.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
+		exporterRead = exportercore.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
 	case modeExporterStandard:
 		logger.Info("exporter mode: standard")
 	case modeOperator:
@@ -431,7 +432,14 @@ func newNode(
 	cfg.SSVOptions.ValidatorController = validatorCtrl
 	cfg.SSVOptions.ValidatorStore = nodeStorage.ValidatorStore()
 
-	operatorNode := operator.New(logger, cfg.SSVOptions, cfg.ExporterOptions, slotTickerProvider, storageMap)
+	if cfg.WsAPIPort != 0 {
+		handler := exporterapi.NewHandler(logger)
+		cfg.SSVOptions.WSQueryHandler = func(nm *exporterapi.NetworkMessage) {
+			handler.HandleQueryRequests(storageMap, exporterRead, nodeStorage.ValidatorStore(), networkConfig.DomainType, nm)
+		}
+	}
+
+	operatorNode := operator.New(logger, cfg.SSVOptions, cfg.ExporterOptions, slotTickerProvider)
 
 	return &node{
 		logger:              logger,

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ssvlabs/ssv/doppelganger"
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
-	exporterapi "github.com/ssvlabs/ssv/exporter/v1/api"
 	"github.com/ssvlabs/ssv/hprobe"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
@@ -176,48 +175,6 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 			require.NoError(t, a.close())
 		})
 	}
-}
-
-// Test_newNode_wiresWebsocketQueryHandler covers the WS composition point: when
-// the WS API is enabled, newNode must construct the server and provide the
-// query handler that operator.Node later installs when starting the server.
-func Test_newNode_wiresWebsocketQueryHandler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	logger := zap.NewNop()
-
-	netCfg := *networkconfig.TestNetwork
-	networkConfig := &netCfg
-
-	cfg := &config{}
-	cfg.DBOptions.Path = t.TempDir()
-	cfg.ExporterOptions.Enabled = true
-	cfg.ExporterOptions.Mode = exporterconfig.ModeArchive
-	cfg.MetricsAPIPort = 0
-	cfg.SSVAPIPort = 0
-	cfg.WsAPIPort = 1
-
-	res := resolved{mode: modeExporterArchive}
-
-	a, err := newNode(ctx, cfg, logger, res, networkConfig, stubBeaconClient{}, stubExecutionClient{})
-	require.NoError(t, err)
-	require.NotNil(t, a)
-	require.NotNil(t, cfg.SSVOptions.WS)
-	require.NotNil(t, cfg.SSVOptions.WSQueryHandler)
-
-	nm := &exporterapi.NetworkMessage{
-		Msg: exporterapi.Message{Type: exporterapi.MessageType("unsupported")},
-	}
-	cfg.SSVOptions.WSQueryHandler(nm)
-	require.Equal(t, exporterapi.TypeError, nm.Msg.Type)
-	errs, ok := nm.Msg.Data.([]string)
-	require.True(t, ok)
-	require.Equal(t, []string{"bad request - unknown message type 'unsupported'"}, errs)
-
-	// Mirror production teardown ordering: cancel the ctx, then close (newNode starts no goroutines).
-	cancel()
-	require.NoError(t, a.close())
 }
 
 // Test_newNode_closesDBOnAssemblyFailure locks in newNode()'s error-only cleanup contract: when

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ssvlabs/ssv/doppelganger"
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
+	exporterapi "github.com/ssvlabs/ssv/exporter/v1/api"
 	"github.com/ssvlabs/ssv/hprobe"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
@@ -175,6 +176,48 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 			require.NoError(t, a.close())
 		})
 	}
+}
+
+// Test_newNode_wiresWebsocketQueryHandler covers the WS composition point: when
+// the WS API is enabled, newNode must construct the server and provide the
+// query handler that operator.Node later installs when starting the server.
+func Test_newNode_wiresWebsocketQueryHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zap.NewNop()
+
+	netCfg := *networkconfig.TestNetwork
+	networkConfig := &netCfg
+
+	cfg := &config{}
+	cfg.DBOptions.Path = t.TempDir()
+	cfg.ExporterOptions.Enabled = true
+	cfg.ExporterOptions.Mode = exporterconfig.ModeArchive
+	cfg.MetricsAPIPort = 0
+	cfg.SSVAPIPort = 0
+	cfg.WsAPIPort = 1
+
+	res := resolved{mode: modeExporterArchive}
+
+	a, err := newNode(ctx, cfg, logger, res, networkConfig, stubBeaconClient{}, stubExecutionClient{})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.NotNil(t, cfg.SSVOptions.WS)
+	require.NotNil(t, cfg.SSVOptions.WSQueryHandler)
+
+	nm := &exporterapi.NetworkMessage{
+		Msg: exporterapi.Message{Type: exporterapi.MessageType("unsupported")},
+	}
+	cfg.SSVOptions.WSQueryHandler(nm)
+	require.Equal(t, exporterapi.TypeError, nm.Msg.Type)
+	errs, ok := nm.Msg.Data.([]string)
+	require.True(t, ok)
+	require.Equal(t, []string{"bad request - unknown message type 'unsupported'"}, errs)
+
+	// Mirror production teardown ordering: cancel the ctx, then close (newNode starts no goroutines).
+	cancel()
+	require.NoError(t, a.close())
 }
 
 // Test_newNode_closesDBOnAssemblyFailure locks in newNode()'s error-only cleanup contract: when

--- a/exporter/v1/api/query_bridge.go
+++ b/exporter/v1/api/query_bridge.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/hashicorp/go-multierror"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"go.uber.org/zap"
+
+	exportercore "github.com/ssvlabs/ssv/exporter"
+	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
+	exporterstore "github.com/ssvlabs/ssv/exporter/store"
+	"github.com/ssvlabs/ssv/ibft/storage"
+	"github.com/ssvlabs/ssv/observability/log/fields"
+	"github.com/ssvlabs/ssv/protocol/v2/message"
+)
+
+type traceDecidedsReader interface {
+	TraceDecidedsCore(*exportercore.DecidedsQuery) (*exportercore.TraceDecidedsResult, *multierror.Error)
+}
+
+type validatorIndexReader interface {
+	ValidatorIndex(spectypes.ValidatorPK) (phase0.ValidatorIndex, bool)
+}
+
+// HandleQueryRequests dispatches websocket query messages to either the legacy
+// participant-store path or the archive exporter-core compatibility path.
+func (h *Handler) HandleQueryRequests(store *storage.ParticipantStores, exporterRead traceDecidedsReader, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
+	if nm.Err != nil {
+		nm.Msg = Message{
+			Type: TypeError,
+			Data: []string{fmt.Sprintf("could not parse network message: %v", nm.Err)},
+		}
+	}
+	h.logger.Debug("got incoming export request",
+		zap.String("type", string(nm.Msg.Type)))
+
+	switch nm.Msg.Type {
+	case TypeDecided:
+		// In exporter archive mode we serve decided queries via exporter core.
+		// Fall back to legacy qbft storage when exporter isn't wired.
+		if exporterRead != nil {
+			h.handleDecidedViaExporter(exporterRead, validators, domain, nm)
+			break
+		}
+		h.HandleParticipantsQuery(store, nm, domain)
+	case TypeError:
+		h.HandleErrorQuery(nm)
+	default:
+		h.HandleUnknownQuery(nm)
+	}
+}
+
+func (h *Handler) handleDecidedViaExporter(exporterRead traceDecidedsReader, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
+	res := Message{Type: nm.Msg.Type, Filter: nm.Msg.Filter}
+
+	pkBytes, err := hex.DecodeString(nm.Msg.Filter.PublicKey)
+	if err != nil {
+		h.logger.Warn("failed to decode validator public key", zap.Error(err))
+		res.Type = TypeError
+		res.Data = []string{fmt.Sprintf("invalid publicKey %q: %v", nm.Msg.Filter.PublicKey, err)}
+		nm.Msg = res
+		return
+	}
+
+	var pk spectypes.ValidatorPK
+	copy(pk[:], pkBytes)
+
+	idx, ok := validators.ValidatorIndex(pk)
+	if !ok {
+		h.logger.Warn("validator not found for public key", zap.String("validator_pubkey", hex.EncodeToString(pk[:])))
+		res.Type = TypeError
+		res.Data = []string{fmt.Sprintf("validator not found for public key %s", nm.Msg.Filter.PublicKey)}
+		nm.Msg = res
+		return
+	}
+
+	role, err := message.BeaconRoleFromString(nm.Msg.Filter.Role)
+	if err != nil {
+		h.logger.Warn("failed to parse role", zap.Error(err))
+		res.Type = TypeError
+		res.Data = []string{fmt.Sprintf("role doesn't exist: %q", nm.Msg.Filter.Role)}
+		nm.Msg = res
+		return
+	}
+
+	coreQuery := &exportercore.DecidedsQuery{
+		From:    nm.Msg.Filter.From,
+		To:      nm.Msg.Filter.To,
+		Roles:   []spectypes.BeaconRole{role},
+		Indices: []phase0.ValidatorIndex{idx},
+	}
+
+	result, errs := exporterRead.TraceDecidedsCore(coreQuery)
+	participations := wsParticipationsFromCore(result)
+
+	var unexpectedErr error
+	filtered := filterOutDutyNotFoundErrors(errs)
+	if filtered.ErrorOrNil() != nil {
+		for _, e := range filtered.Errors {
+			// Preserve legacy WS leniency: treat validation errors as "no messages".
+			if isExporterValidationError(e) {
+				continue
+			}
+			unexpectedErr = e
+		}
+	}
+
+	if len(participations) == 0 {
+		if unexpectedErr != nil {
+			h.logger.Warn("failed to build participants api data due to exporter errors", zap.Error(unexpectedErr), fields.ValidatorIndex(idx))
+			res.Type = TypeError
+			res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", unexpectedErr)}
+		} else {
+			// Mirror legacy exporter behavior: empty range returns "no messages" as a decided response.
+			res.Data = []string{"no messages"}
+		}
+		nm.Msg = res
+		return
+	}
+
+	data, err := ParticipantsAPIData(domain, participations...)
+	if err != nil {
+		h.logger.Warn("failed to build participants api data", zap.Error(err))
+		res.Type = TypeError
+		res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", err)}
+		nm.Msg = res
+		return
+	}
+
+	res.Data = data
+	nm.Msg = res
+}
+
+func wsParticipationsFromCore(result *exportercore.TraceDecidedsResult) []storage.Participation {
+	out := make([]storage.Participation, 0)
+	if result == nil {
+		return out
+	}
+	for _, p := range result.Participants {
+		out = append(out, storage.Participation{
+			ParticipantsRangeEntry: storage.ParticipantsRangeEntry{
+				Slot:    p.Slot,
+				PubKey:  p.PubKey,
+				Signers: p.Signers,
+			},
+			Role:   p.Role,
+			PubKey: p.PubKey,
+		})
+	}
+	return out
+}
+
+func isExporterValidationError(err error) bool {
+	var ve *exportercore.ValidationError
+	return errors.As(err, &ve)
+}
+
+// isNotFoundError returns true if the error represents an expected "no duty"
+// condition, either from the duty tracer or the underlying exporter store.
+func isNotFoundError(err error) bool {
+	return errors.Is(err, dutytracer.ErrNotFound) || errors.Is(err, exporterstore.ErrNotFound)
+}
+
+func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
+	if e == nil || e.ErrorOrNil() == nil {
+		return nil
+	}
+	var filtered *multierror.Error
+	for _, err := range e.Errors {
+		if err != nil && !isNotFoundError(err) {
+			filtered = multierror.Append(filtered, err)
+		}
+	}
+	return filtered
+}

--- a/exporter/v1/api/query_bridge.go
+++ b/exporter/v1/api/query_bridge.go
@@ -18,17 +18,13 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/message"
 )
 
-type traceDecidedsReader interface {
-	TraceDecidedsCore(*exportercore.DecidedsQuery) (*exportercore.TraceDecidedsResult, *multierror.Error)
-}
-
 type validatorIndexReader interface {
 	ValidatorIndex(spectypes.ValidatorPK) (phase0.ValidatorIndex, bool)
 }
 
 // HandleQueryRequests dispatches websocket query messages to either the legacy
 // participant-store path or the archive exporter-core compatibility path.
-func (h *Handler) HandleQueryRequests(store *storage.ParticipantStores, exporterRead traceDecidedsReader, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
+func (h *Handler) HandleQueryRequests(store *storage.ParticipantStores, exporterRead *exportercore.Exporter, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
 	if nm.Err != nil {
 		nm.Msg = Message{
 			Type: TypeError,
@@ -54,7 +50,7 @@ func (h *Handler) HandleQueryRequests(store *storage.ParticipantStores, exporter
 	}
 }
 
-func (h *Handler) handleDecidedViaExporter(exporterRead traceDecidedsReader, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
+func (h *Handler) handleDecidedViaExporter(exporterRead *exportercore.Exporter, validators validatorIndexReader, domain spectypes.DomainType, nm *NetworkMessage) {
 	res := Message{Type: nm.Msg.Type, Filter: nm.Msg.Filter}
 
 	pkBytes, err := hex.DecodeString(nm.Msg.Filter.PublicKey)

--- a/exporter/v1/api/query_bridge.go
+++ b/exporter/v1/api/query_bridge.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/hashicorp/go-multierror"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
 	exportercore "github.com/ssvlabs/ssv/exporter"
-	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
-	exporterstore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/message"
@@ -94,9 +91,8 @@ func (h *Handler) handleDecidedViaExporter(exporterRead *exportercore.Exporter, 
 	participations := wsParticipationsFromCore(result)
 
 	var unexpectedErr error
-	filtered := filterOutDutyNotFoundErrors(errs)
-	if filtered.ErrorOrNil() != nil {
-		for _, e := range filtered.Errors {
+	if errs.ErrorOrNil() != nil {
+		for _, e := range errs.Errors {
 			// Preserve legacy WS leniency: treat validation errors as "no messages".
 			if isExporterValidationError(e) {
 				continue
@@ -153,23 +149,4 @@ func wsParticipationsFromCore(result *exportercore.TraceDecidedsResult) []storag
 func isExporterValidationError(err error) bool {
 	var ve *exportercore.ValidationError
 	return errors.As(err, &ve)
-}
-
-// isNotFoundError returns true if the error represents an expected "no duty"
-// condition, either from the duty tracer or the underlying exporter store.
-func isNotFoundError(err error) bool {
-	return errors.Is(err, dutytracer.ErrNotFound) || errors.Is(err, exporterstore.ErrNotFound)
-}
-
-func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
-	if e == nil || e.ErrorOrNil() == nil {
-		return nil
-	}
-	var filtered *multierror.Error
-	for _, err := range e.Errors {
-		if err != nil && !isNotFoundError(err) {
-			filtered = multierror.Append(filtered, err)
-		}
-	}
-	return filtered
 }

--- a/exporter/v1/api/query_bridge_test.go
+++ b/exporter/v1/api/query_bridge_test.go
@@ -1,4 +1,4 @@
-package operator
+package api
 
 import (
 	"encoding/hex"
@@ -17,10 +17,8 @@ import (
 	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
 	dutytracestore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/exporter/traces"
-	"github.com/ssvlabs/ssv/exporter/v1/api"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/networkconfig"
-	"github.com/ssvlabs/ssv/operator/validator"
 	registrystoragemocks "github.com/ssvlabs/ssv/registry/storage/mocks"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
@@ -61,7 +59,8 @@ func (s *faultingDutyTraceStore) GetValidatorDuty(slot phase0.Slot, role spectyp
 type wsQueryHarness struct {
 	t *testing.T
 
-	node *Node
+	handler      *Handler
+	exporterRead *exportercore.Exporter
 
 	ctrl          *gomock.Controller
 	validatorMock *registrystoragemocks.MockValidatorStore
@@ -87,18 +86,10 @@ func newWSQueryHarness(t *testing.T) *wsQueryHarness {
 	collector := dutytracer.New(zap.NewNop(), validatorMock, nil, store, networkconfig.TestNetwork.Beacon, nil, nil)
 	coreExporter := exportercore.NewExporter(zap.NewNop(), ibftstorage.NewStores(), collector, validatorMock)
 
-	node := &Node{
-		logger:       logger,
-		network:      networkconfig.TestNetwork,
-		exporterRead: coreExporter,
-		validatorOptions: validator.ControllerOptions{
-			ValidatorStore: validatorMock,
-		},
-	}
-
 	return &wsQueryHarness{
 		t:             t,
-		node:          node,
+		handler:       NewHandler(logger),
+		exporterRead:  coreExporter,
 		ctrl:          ctrl,
 		validatorMock: validatorMock,
 		db:            db,
@@ -155,17 +146,17 @@ func (h *wsQueryHarness) SaveCommitteeDutyAttester(slot phase0.Slot, validatorIn
 	require.NoError(h.t, h.store.SaveCommitteeDuty(duty))
 }
 
-func (h *wsQueryHarness) QueryDecided(from, to uint64, pkHex, role string) *api.NetworkMessage {
+func (h *wsQueryHarness) QueryDecided(from, to uint64, pkHex, role string) *NetworkMessage {
 	h.t.Helper()
 	nm := decidedMessage(from, to, pkHex, role)
-	h.node.handleQueryRequests(nm)
+	h.handler.HandleQueryRequests(nil, h.exporterRead, h.validatorMock, networkconfig.TestNetwork.DomainType, nm)
 	return nm
 }
 
-func decidedMessage(from, to uint64, pkHex, role string) *api.NetworkMessage {
-	return &api.NetworkMessage{Msg: api.Message{
-		Type: api.TypeDecided,
-		Filter: api.MessageFilter{
+func decidedMessage(from, to uint64, pkHex, role string) *NetworkMessage {
+	return &NetworkMessage{Msg: Message{
+		Type: TypeDecided,
+		Filter: MessageFilter{
 			From:      from,
 			To:        to,
 			PublicKey: pkHex,
@@ -189,9 +180,9 @@ func TestWSQuery_Decided_Proposer_SingleSlot(t *testing.T) {
 	h.SaveValidatorDuty(phase0.Slot(10), spectypes.BNRoleProposer, idx, []spectypes.OperatorID{11, 12})
 
 	nm := h.QueryDecided(uint64(10), uint64(10), hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
 	require.Equal(t, nm.Msg.Filter.PublicKey, hex.EncodeToString(pk[:]))
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	data, ok := nm.Msg.Data.([]*ParticipantsAPI)
 	require.True(t, ok, "response data should be participants slice")
 	require.Len(t, data, 1)
 	require.Equal(t, uint64(10), uint64(data[0].Slot))
@@ -211,8 +202,8 @@ func TestWSQuery_Decided_Attester_UsesCommitteeLookup(t *testing.T) {
 
 	nm := h.QueryDecided(3, 3, hex.EncodeToString(pk[:]), spectypes.BNRoleAttester.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*ParticipantsAPI)
 	require.True(t, ok, "response data should be participants slice")
 	require.Len(t, data, 1)
 	require.Equal(t, uint64(3), uint64(data[0].Slot))
@@ -232,8 +223,8 @@ func TestWSQuery_Decided_RangeMultipleSlots(t *testing.T) {
 
 	nm := h.QueryDecided(10, 12, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*ParticipantsAPI)
 	require.True(t, ok, "response data should be participants slice")
 	require.Len(t, data, 3)
 	require.Equal(t, uint64(10), uint64(data[0].Slot))
@@ -244,7 +235,7 @@ func TestWSQuery_Decided_RangeMultipleSlots(t *testing.T) {
 func TestWSQuery_InvalidPubKeyHex_ReturnsTypeError(t *testing.T) {
 	h := newWSQueryHarness(t)
 	nm := h.QueryDecided(1, 1, "zz-not-hex", spectypes.BNRoleProposer.String())
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.NotEmpty(t, errs)
@@ -260,7 +251,7 @@ func TestWSQuery_ValidatorNotFound_ReturnsTypeError(t *testing.T) {
 	h.ExpectValidator(pk, 0, false)
 
 	nm := h.QueryDecided(1, 1, "abcd", spectypes.BNRoleProposer.String())
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
@@ -276,7 +267,7 @@ func TestWSQuery_InvalidRole_ReturnsTypeError(t *testing.T) {
 
 	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), "NOT_A_ROLE")
 
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
@@ -292,7 +283,7 @@ func TestWSQuery_TraceStoreError_NoEntries_ReturnsInternalError(t *testing.T) {
 	h.store.SetGetValidatorDutyError(phase0.Slot(1), spectypes.BNRoleProposer, idx, errors.New("boom"))
 
 	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.NotEmpty(t, errs)
@@ -309,7 +300,7 @@ func TestWSQuery_NoMessagesOnNotFound(t *testing.T) {
 
 	nm := h.QueryDecided(1, 1, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
@@ -326,7 +317,7 @@ func TestWSQuery_Decided_Attester_NoMessagesWhenCommitteeNotFound(t *testing.T) 
 	// No committee duty link and no committee duty saved -> treated as "no messages".
 	nm := h.QueryDecided(3, 3, hex.EncodeToString(pk[:]), spectypes.BNRoleAttester.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
@@ -344,8 +335,8 @@ func TestWSQuery_ErrorOnOneSlotButEntriesOnAnother_StillReturnsEntries(t *testin
 
 	nm := h.QueryDecided(10, 11, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
-	data, ok := nm.Msg.Data.([]*api.ParticipantsAPI)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*ParticipantsAPI)
 	require.True(t, ok, "response data should be participants slice")
 	require.Len(t, data, 1)
 	require.Equal(t, uint64(10), uint64(data[0].Slot))
@@ -354,10 +345,10 @@ func TestWSQuery_ErrorOnOneSlotButEntriesOnAnother_StillReturnsEntries(t *testin
 func TestWSQuery_NetworkMessageParseError_GoesThroughErrorHandler(t *testing.T) {
 	h := newWSQueryHarness(t)
 
-	nm := &api.NetworkMessage{Err: errors.New("parsefail")}
-	h.node.handleQueryRequests(nm)
+	nm := &NetworkMessage{Err: errors.New("parsefail")}
+	h.handler.HandleQueryRequests(nil, h.exporterRead, h.validatorMock, networkconfig.TestNetwork.DomainType, nm)
 
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 2)
@@ -368,13 +359,13 @@ func TestWSQuery_NetworkMessageParseError_GoesThroughErrorHandler(t *testing.T) 
 func TestWSQuery_UnknownMessageType_ReturnsBadRequest(t *testing.T) {
 	h := newWSQueryHarness(t)
 
-	nm := &api.NetworkMessage{Msg: api.Message{
+	nm := &NetworkMessage{Msg: Message{
 		Type:   "banana",
-		Filter: api.MessageFilter{From: 1, To: 1},
+		Filter: MessageFilter{From: 1, To: 1},
 	}}
-	h.node.handleQueryRequests(nm)
+	h.handler.HandleQueryRequests(nil, h.exporterRead, h.validatorMock, networkconfig.TestNetwork.DomainType, nm)
 
-	require.Equal(t, api.TypeError, nm.Msg.Type)
+	require.Equal(t, TypeError, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)
@@ -390,7 +381,7 @@ func TestWSQuery_FromGreaterThanTo_ReturnsNoMessages(t *testing.T) {
 
 	nm := h.QueryDecided(11, 10, hex.EncodeToString(pk[:]), spectypes.BNRoleProposer.String())
 
-	require.Equal(t, api.TypeDecided, nm.Msg.Type)
+	require.Equal(t, TypeDecided, nm.Msg.Type)
 	errs, ok := nm.Msg.Data.([]string)
 	require.True(t, ok, "expected []string, got %#v", nm.Msg.Data)
 	require.Len(t, errs, 1)

--- a/exporter/v1/api/query_bridge_test.go
+++ b/exporter/v1/api/query_bridge_test.go
@@ -171,6 +171,34 @@ func makePK(bytes []byte) spectypes.ValidatorPK {
 	return pk
 }
 
+func TestWSQuery_Decided_NilExporterReadFallsBackToLegacyParticipants(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	db, err := kv.NewInMemory(zap.NewNop(), basedb.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	role := spectypes.BNRoleProposer
+	_, ibftStorage := newStorageForTest(db, logger, role)
+
+	pk := makePK([]byte{1, 2, 3, 4})
+	signers := []spectypes.OperatorID{11, 12}
+	_, err = ibftStorage.Get(role).SaveParticipants(pk, phase0.Slot(10), signers)
+	require.NoError(t, err)
+
+	nm := decidedMessage(uint64(10), uint64(10), hex.EncodeToString(pk[:]), role.String())
+	handler := NewHandler(logger)
+	handler.HandleQueryRequests(ibftStorage, nil, nil, networkconfig.TestNetwork.DomainType, nm)
+
+	require.Equal(t, TypeDecided, nm.Msg.Type)
+	data, ok := nm.Msg.Data.([]*ParticipantsAPI)
+	require.True(t, ok, "response data should be participants slice")
+	require.Len(t, data, 1)
+	require.Equal(t, uint64(10), uint64(data[0].Slot))
+	require.Equal(t, signers, data[0].Signers)
+	require.Equal(t, role.String(), data[0].Role)
+	require.Equal(t, hex.EncodeToString(pk[:]), data[0].ValidatorPK)
+}
+
 func TestWSQuery_Decided_Proposer_SingleSlot(t *testing.T) {
 	h := newWSQueryHarness(t)
 	pk := makePK([]byte{1, 2, 3, 4, 5})

--- a/operator/node.go
+++ b/operator/node.go
@@ -10,10 +10,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
-	exportercore "github.com/ssvlabs/ssv/exporter"
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	"github.com/ssvlabs/ssv/exporter/v1/api"
-	qbftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
@@ -44,8 +42,8 @@ type Options struct {
 	ValidatorStore      storage2.ValidatorStore
 	ValidatorOptions    validator.ControllerOptions `yaml:"ValidatorOptions"`
 	DutyStore           *dutystore.Store
-	ExporterRead        *exportercore.Exporter
 	WS                  api.WebSocketServer
+	WSQueryHandler      api.QueryMessageHandler
 }
 
 func (o *Options) ApplyDefaults() {
@@ -56,7 +54,6 @@ func (o *Options) ApplyDefaults() {
 type Node struct {
 	logger *zap.Logger
 
-	network          *networkconfig.Network
 	validatorsCtrl   *validator.Controller
 	validatorOptions validator.ControllerOptions
 	exporterOptions  exporterconfig.Options
@@ -64,13 +61,11 @@ type Node struct {
 	executionClient  executionclient.Provider
 	net              network.P2PNetwork
 	storage          storage.Storage
-	qbftStorage      *qbftstorage.ParticipantStores
 	dutyScheduler    *duties.Scheduler
 	feeRecipientCtrl fee_recipient.RecipientController
 
-	ws api.WebSocketServer
-
-	exporterRead *exportercore.Exporter
+	ws             api.WebSocketServer
+	wsQueryHandler api.QueryMessageHandler
 }
 
 func shouldRunDutyScheduler(exporterOpts exporterconfig.Options) bool {
@@ -78,7 +73,7 @@ func shouldRunDutyScheduler(exporterOpts exporterconfig.Options) bool {
 }
 
 // New is the constructor of Node
-func New(logger *zap.Logger, opts Options, exporterOpts exporterconfig.Options, slotTickerProvider slotticker.Provider, qbftStorage *qbftstorage.ParticipantStores) *Node {
+func New(logger *zap.Logger, opts Options, exporterOpts exporterconfig.Options, slotTickerProvider slotticker.Provider) *Node {
 	selfValidatorStore := opts.ValidatorStore.WithOperatorID(opts.ValidatorOptions.OperatorDataStore.GetOperatorID)
 
 	var (
@@ -135,17 +130,15 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporterconfig.Options, 
 		validatorsCtrl:   opts.ValidatorController,
 		validatorOptions: opts.ValidatorOptions,
 		exporterOptions:  exporterOpts,
-		network:          opts.NetworkConfig,
 		consensusClient:  opts.BeaconNode,
 		executionClient:  opts.ExecutionClient,
 		net:              opts.P2PNetwork,
 		storage:          opts.ValidatorOptions.RegistryStorage,
-		qbftStorage:      qbftStorage,
 		dutyScheduler:    dutyScheduler,
 		feeRecipientCtrl: feeRecipientCtrl,
 
-		ws:           opts.WS,
-		exporterRead: opts.ExporterRead,
+		ws:             opts.WS,
+		wsQueryHandler: opts.WSQueryHandler,
 	}
 
 	if feeRecipientCtrl != nil {
@@ -291,10 +284,7 @@ func (n *Node) HealthCheck() error {
 func (n *Node) startWSServer(ctx context.Context) (<-chan error, error) {
 	n.logger.Info("starting WS server")
 
-	h := api.NewHandler(n.logger)
-	n.ws.UseQueryHandler(func(nm *api.NetworkMessage) {
-		h.HandleQueryRequests(n.qbftStorage, n.exporterRead, n.validatorOptions.ValidatorStore, n.network.DomainType, nm)
-	})
+	n.ws.UseQueryHandler(n.wsQueryHandler)
 
 	_, serveErr, err := n.ws.Start(ctx)
 	if err != nil {

--- a/operator/node.go
+++ b/operator/node.go
@@ -2,24 +2,16 @@ package operator
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
-	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/attestantio/go-eth2-client/spec/phase0"
-
-	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	exportercore "github.com/ssvlabs/ssv/exporter"
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
-	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
-	exporterstore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/exporter/v1/api"
 	qbftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
@@ -33,7 +25,6 @@ import (
 	"github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/operator/validator"
 	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
-	"github.com/ssvlabs/ssv/protocol/v2/message"
 	storage2 "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
@@ -294,170 +285,16 @@ func (n *Node) HealthCheck() error {
 	return nil
 }
 
-// handleQueryRequests waits for incoming messages and
-func (n *Node) handleQueryRequests(nm *api.NetworkMessage) {
-	if nm.Err != nil {
-		nm.Msg = api.Message{
-			Type: api.TypeError,
-			Data: []string{fmt.Sprintf("could not parse network message: %v", nm.Err)},
-		}
-	}
-	n.logger.Debug("got incoming export request",
-		zap.String("type", string(nm.Msg.Type)))
-
-	h := api.NewHandler(n.logger)
-
-	switch nm.Msg.Type {
-	case api.TypeDecided:
-		// In exporter v2 (archive) mode we serve decided queries via exporter core.
-		// Fall back to legacy qbft storage when exporter isn't wired.
-		if n.exporterRead != nil {
-			n.handleDecidedViaExporter(nm)
-			break
-		}
-		h.HandleParticipantsQuery(n.qbftStorage, nm, n.network.DomainType)
-	case api.TypeError:
-		h.HandleErrorQuery(nm)
-	default:
-		h.HandleUnknownQuery(nm)
-	}
-}
-
-func (n *Node) handleDecidedViaExporter(nm *api.NetworkMessage) {
-	res := api.Message{Type: nm.Msg.Type, Filter: nm.Msg.Filter}
-
-	pkBytes, err := hex.DecodeString(nm.Msg.Filter.PublicKey)
-	if err != nil {
-		n.logger.Warn("failed to decode validator public key", zap.Error(err))
-		res.Type = api.TypeError
-		res.Data = []string{fmt.Sprintf("invalid publicKey %q: %v", nm.Msg.Filter.PublicKey, err)}
-		nm.Msg = res
-		return
-	}
-
-	var pk spectypes.ValidatorPK
-	copy(pk[:], pkBytes)
-
-	idx, ok := n.validatorOptions.ValidatorStore.ValidatorIndex(pk)
-	if !ok {
-		n.logger.Warn("validator not found for public key", zap.String("validator_pubkey", hex.EncodeToString(pk[:])))
-		res.Type = api.TypeError
-		res.Data = []string{fmt.Sprintf("validator not found for public key %s", nm.Msg.Filter.PublicKey)}
-		nm.Msg = res
-		return
-	}
-
-	role, err := message.BeaconRoleFromString(nm.Msg.Filter.Role)
-	if err != nil {
-		n.logger.Warn("failed to parse role", zap.Error(err))
-		res.Type = api.TypeError
-		res.Data = []string{fmt.Sprintf("role doesn't exist: %q", nm.Msg.Filter.Role)}
-		nm.Msg = res
-		return
-	}
-
-	coreQuery := &exportercore.DecidedsQuery{
-		From:    nm.Msg.Filter.From,
-		To:      nm.Msg.Filter.To,
-		Roles:   []spectypes.BeaconRole{role},
-		Indices: []phase0.ValidatorIndex{idx},
-	}
-
-	result, errs := n.exporterRead.TraceDecidedsCore(coreQuery)
-	participations := wsParticipationsFromCore(result)
-
-	var unexpectedErr error
-	filtered := filterOutDutyNotFoundErrors(errs)
-	if filtered.ErrorOrNil() != nil {
-		for _, e := range filtered.Errors {
-			// Preserve legacy WS leniency: treat validation errors as "no messages".
-			if isExporterValidationError(e) {
-				continue
-			}
-			unexpectedErr = e
-		}
-	}
-
-	if len(participations) == 0 {
-		if unexpectedErr != nil {
-			n.logger.Warn("failed to build participants api data due to exporter errors", zap.Error(unexpectedErr), fields.ValidatorIndex(idx))
-			res.Type = api.TypeError
-			res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", unexpectedErr)}
-		} else {
-			// Mirror legacy exporter behavior: empty range returns "no messages" as a decided response.
-			res.Data = []string{"no messages"}
-		}
-		nm.Msg = res
-		return
-	}
-
-	data, err := api.ParticipantsAPIData(n.network.DomainType, participations...)
-	if err != nil {
-		n.logger.Warn("failed to build participants api data", zap.Error(err))
-		res.Type = api.TypeError
-		res.Data = []string{fmt.Sprintf("internal error - could not build response: %v", err)}
-		nm.Msg = res
-		return
-	}
-
-	res.Data = data
-	nm.Msg = res
-}
-
-func wsParticipationsFromCore(result *exportercore.TraceDecidedsResult) []qbftstorage.Participation {
-	out := make([]qbftstorage.Participation, 0)
-	if result == nil {
-		return out
-	}
-	for _, p := range result.Participants {
-		out = append(out, qbftstorage.Participation{
-			ParticipantsRangeEntry: qbftstorage.ParticipantsRangeEntry{
-				Slot:    p.Slot,
-				PubKey:  p.PubKey,
-				Signers: p.Signers,
-			},
-			Role:   p.Role,
-			PubKey: p.PubKey,
-		})
-	}
-	return out
-}
-
-func isExporterValidationError(err error) bool {
-	var ve *exportercore.ValidationError
-	return errors.As(err, &ve)
-}
-
-// isNotFoundError returns true if the error represents an expected "no duty"
-// condition, either from the duty tracer or the underlying exporter store.
-// It mirrors the semantics in exporter helpers to ease future refactoring.
-func isNotFoundError(err error) bool {
-	return errors.Is(err, dutytracer.ErrNotFound) || errors.Is(err, exporterstore.ErrNotFound)
-}
-
-// filterOutDutyNotFoundErrors removes not-found duty errors from a multierror,
-// returning nil if nothing remains. It mirrors exportercore.filterOutDutyNotFoundErrors
-// to make future WS refactoring simpler.
-func filterOutDutyNotFoundErrors(e *multierror.Error) *multierror.Error {
-	if e == nil || e.ErrorOrNil() == nil {
-		return nil
-	}
-	var filtered *multierror.Error
-	for _, err := range e.Errors {
-		if err != nil && !isNotFoundError(err) {
-			filtered = multierror.Append(filtered, err)
-		}
-	}
-	return filtered
-}
-
 // startWSServer starts the WS API server and returns its serve-error channel. A serve failure
 // propagates via the channel — bringing the node down gracefully through Close — rather than
 // os.Exit-ing from a goroutine. Requires n.ws != nil.
 func (n *Node) startWSServer(ctx context.Context) (<-chan error, error) {
 	n.logger.Info("starting WS server")
 
-	n.ws.UseQueryHandler(n.handleQueryRequests)
+	h := api.NewHandler(n.logger)
+	n.ws.UseQueryHandler(func(nm *api.NetworkMessage) {
+		h.HandleQueryRequests(n.qbftStorage, n.exporterRead, n.validatorOptions.ValidatorStore, n.network.DomainType, nm)
+	})
 
 	_, serveErr, err := n.ws.Start(ctx)
 	if err != nil {

--- a/operator/node.go
+++ b/operator/node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
-	"github.com/ssvlabs/ssv/exporter/v1/api"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
@@ -26,6 +25,10 @@ import (
 	storage2 "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
+
+type webSocketServer interface {
+	Start(ctx context.Context) (string, <-chan error, error)
+}
 
 // Options contains options to create the node
 type Options struct {
@@ -42,8 +45,7 @@ type Options struct {
 	ValidatorStore      storage2.ValidatorStore
 	ValidatorOptions    validator.ControllerOptions `yaml:"ValidatorOptions"`
 	DutyStore           *dutystore.Store
-	WS                  api.WebSocketServer
-	WSQueryHandler      api.QueryMessageHandler
+	WS                  webSocketServer
 }
 
 func (o *Options) ApplyDefaults() {
@@ -64,8 +66,7 @@ type Node struct {
 	dutyScheduler    *duties.Scheduler
 	feeRecipientCtrl fee_recipient.RecipientController
 
-	ws             api.WebSocketServer
-	wsQueryHandler api.QueryMessageHandler
+	ws webSocketServer
 }
 
 func shouldRunDutyScheduler(exporterOpts exporterconfig.Options) bool {
@@ -137,8 +138,7 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporterconfig.Options, 
 		dutyScheduler:    dutyScheduler,
 		feeRecipientCtrl: feeRecipientCtrl,
 
-		ws:             opts.WS,
-		wsQueryHandler: opts.WSQueryHandler,
+		ws: opts.WS,
 	}
 
 	if feeRecipientCtrl != nil {
@@ -283,8 +283,6 @@ func (n *Node) HealthCheck() error {
 // os.Exit-ing from a goroutine. Requires n.ws != nil.
 func (n *Node) startWSServer(ctx context.Context) (<-chan error, error) {
 	n.logger.Info("starting WS server")
-
-	n.ws.UseQueryHandler(n.wsQueryHandler)
 
 	_, serveErr, err := n.ws.Start(ctx)
 	if err != nil {

--- a/operator/node_test.go
+++ b/operator/node_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/v4/async/event"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
-	"github.com/ssvlabs/ssv/exporter/v1/api"
 )
 
 func TestShouldRunDutyScheduler(t *testing.T) {
@@ -52,9 +50,7 @@ func TestShouldRunDutyScheduler(t *testing.T) {
 }
 
 type recordingWebSocketServer struct {
-	handler api.QueryMessageHandler
 	started bool
-	feed    *event.Feed
 }
 
 func (s *recordingWebSocketServer) Start(context.Context) (string, <-chan error, error) {
@@ -64,36 +60,16 @@ func (s *recordingWebSocketServer) Start(context.Context) (string, <-chan error,
 	return "", serveErr, nil
 }
 
-func (s *recordingWebSocketServer) BroadcastFeed() *event.Feed {
-	if s.feed == nil {
-		s.feed = new(event.Feed)
-	}
-	return s.feed
-}
-
-func (s *recordingWebSocketServer) UseQueryHandler(handler api.QueryMessageHandler) {
-	s.handler = handler
-}
-
-func TestStartWSServerUsesInjectedQueryHandler(t *testing.T) {
+func TestStartWSServerStartsConfiguredServer(t *testing.T) {
 	ws := &recordingWebSocketServer{}
-	called := false
-	queryHandler := func(*api.NetworkMessage) {
-		called = true
-	}
 
 	n := &Node{
-		logger:         zap.NewNop(),
-		ws:             ws,
-		wsQueryHandler: queryHandler,
+		logger: zap.NewNop(),
+		ws:     ws,
 	}
 
 	serveErr, err := n.startWSServer(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, serveErr)
 	require.True(t, ws.started)
-	require.NotNil(t, ws.handler)
-
-	ws.handler(&api.NetworkMessage{})
-	require.True(t, called)
 }

--- a/operator/node_test.go
+++ b/operator/node_test.go
@@ -1,11 +1,15 @@
 package operator
 
 import (
+	"context"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/v4/async/event"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
+	"github.com/ssvlabs/ssv/exporter/v1/api"
 )
 
 func TestShouldRunDutyScheduler(t *testing.T) {
@@ -45,4 +49,51 @@ func TestShouldRunDutyScheduler(t *testing.T) {
 			require.Equal(t, tc.expected, shouldRunDutyScheduler(tc.exporterOpts))
 		})
 	}
+}
+
+type recordingWebSocketServer struct {
+	handler api.QueryMessageHandler
+	started bool
+	feed    *event.Feed
+}
+
+func (s *recordingWebSocketServer) Start(context.Context) (string, <-chan error, error) {
+	s.started = true
+	serveErr := make(chan error)
+	close(serveErr)
+	return "", serveErr, nil
+}
+
+func (s *recordingWebSocketServer) BroadcastFeed() *event.Feed {
+	if s.feed == nil {
+		s.feed = new(event.Feed)
+	}
+	return s.feed
+}
+
+func (s *recordingWebSocketServer) UseQueryHandler(handler api.QueryMessageHandler) {
+	s.handler = handler
+}
+
+func TestStartWSServerUsesInjectedQueryHandler(t *testing.T) {
+	ws := &recordingWebSocketServer{}
+	called := false
+	queryHandler := func(*api.NetworkMessage) {
+		called = true
+	}
+
+	n := &Node{
+		logger:         zap.NewNop(),
+		ws:             ws,
+		wsQueryHandler: queryHandler,
+	}
+
+	serveErr, err := n.startWSServer(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, serveErr)
+	require.True(t, ws.started)
+	require.NotNil(t, ws.handler)
+
+	ws.handler(&api.NetworkMessage{})
+	require.True(t, called)
 }


### PR DESCRIPTION
 ## Summary

This PR continues the exporter refactor by moving the legacy websocket `/query` bridge out of `operator` and into `exporter/v1/api`, where the legacy exporter websocket API is owned.

There is no intended behavior change. The goal is clearer package ownership with a small, reviewable diff.

Actually diff is smaller than it looks because the code in `exporter/v1/api/query_bridge.go` was simply moved from `operator/node.go`.

## What Changed

  - Moved websocket `/query` dispatch and archive-read bridging into `exporter/v1/api`.
  - Moved the related websocket query tests with that code.
  - Changed `operator` to only start a preconfigured websocket server. This makes package boundaries clearer.
  - Kept `cli/operator` as the composition root that wires storage, exporter reads, and websocket handlers together.

  ## Why This Is Better

  Before this change, `operator` both started the websocket server and understood exporter websocket query semantics. That made runtime
  orchestration depend on exporter API details.

  After this change:

  - legacy websocket query behavior lives under `exporter/v1`
  - `operator` no longer imports exporter API code
  - root `exporter` remains independent from `operator`
  - future exporter cleanup can happen with less cross-package coupling

  ## Validation

  - `make lint`
  - `go test -tags "blst_enabled lfs" ./exporter/v1/... ./operator ./cli/operator`
  - `make docker-unit-test`