### PR TITLE
convergence(unit 5a): fork-aware round-robin proposer

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -195,12 +195,7 @@ func (mv *messageValidator) validateQBFTLogic(
 ) error {
 	if consensusMessage.MsgType == specqbft.ProposalMsgType {
 		// Rule: Signer must be the leader
-		var leader spectypes.OperatorID
-		if mv.netCfg.BooleForkAtSlot(phase0.Slot(consensusMessage.Height)) {
-			leader = qbft.RoundRobinProposer(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee, mv.netCfg)
-		} else {
-			leader = mv.roundRobinProposerPreBooleFork(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee)
-		}
+		leader := qbft.Proposer(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee, mv.netCfg)
 		if signedSSVMessage.OperatorIDs[0] != leader {
 			e := ErrSignerNotLeader
 			e.got = signedSSVMessage.OperatorIDs[0]
@@ -563,14 +558,4 @@ func (mv *messageValidator) roundBelongsToAllowedSpread(
 	}
 
 	return nil
-}
-
-func (mv *messageValidator) roundRobinProposerPreBooleFork(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID) spectypes.OperatorID {
-	firstRoundIndex := uint64(0)
-	if height != specqbft.FirstHeight {
-		firstRoundIndex += uint64(height) % uint64(len(committee))
-	}
-
-	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(committee))
-	return committee[index]
 }

--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -195,7 +195,12 @@ func (mv *messageValidator) validateQBFTLogic(
 ) error {
 	if consensusMessage.MsgType == specqbft.ProposalMsgType {
 		// Rule: Signer must be the leader
-		leader := mv.roundRobinProposer(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee)
+		var leader spectypes.OperatorID
+		if mv.netCfg.BooleForkAtSlot(phase0.Slot(consensusMessage.Height)) {
+			leader = qbft.RoundRobinProposer(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee, mv.netCfg)
+		} else {
+			leader = mv.roundRobinProposerPreBooleFork(consensusMessage.Height, consensusMessage.Round, committeeInfo.committee)
+		}
 		if signedSSVMessage.OperatorIDs[0] != leader {
 			e := ErrSignerNotLeader
 			e.got = signedSSVMessage.OperatorIDs[0]
@@ -560,7 +565,7 @@ func (mv *messageValidator) roundBelongsToAllowedSpread(
 	return nil
 }
 
-func (mv *messageValidator) roundRobinProposer(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID) spectypes.OperatorID {
+func (mv *messageValidator) roundRobinProposerPreBooleFork(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID) spectypes.OperatorID {
 	firstRoundIndex := uint64(0)
 	if height != specqbft.FirstHeight {
 		firstRoundIndex += uint64(height) % uint64(len(committee))

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -167,7 +167,19 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := postBooleCfg.FirstSlotAtEpoch(1)
 		booleIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), encodedCommitteeID, committeeRole)
-		signedSSVMessage := generateSignedMessage(ks, booleIdentifier, slot)
+		qbftMessage := &specqbft.Message{
+			MsgType:                  specqbft.ProposalMsgType,
+			Height:                   specqbft.Height(slot),
+			Round:                    specqbft.FirstRound,
+			Identifier:               booleIdentifier[:],
+			Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
+			RoundChangeJustification: [][]byte{},
+			PrepareJustification:     [][]byte{},
+		}
+		// Post-fork proposals must be signed by the fork-aware round-robin leader.
+		leader := qbft.RoundRobinProposer(specqbft.Height(slot), specqbft.FirstRound, committee, postBooleCfg)
+		signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
+		signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
 
 		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 		require.NoError(t, err)
@@ -743,7 +755,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			PrepareJustification:     [][]byte{},
 		}
 
-		leader := validator.roundRobinProposer(specqbft.Height(slot), specqbft.FirstRound, committee)
+		leader := validator.roundRobinProposerPreBooleFork(specqbft.Height(slot), specqbft.FirstRound, committee)
 		signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
 		signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
 

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -755,7 +755,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			PrepareJustification:     [][]byte{},
 		}
 
-		leader := validator.roundRobinProposerPreBooleFork(specqbft.Height(slot), specqbft.FirstRound, committee)
+		leader := qbft.Proposer(specqbft.Height(slot), specqbft.FirstRound, committee, netCfg)
 		signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
 		signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1048,8 +1048,12 @@ func SetupCommitteeRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
-				leader := qbft.RoundRobinProposer(state, round)
-				return leader
+				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
+					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
+					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
+				}
+
+				return qbft.RoundRobinProposerPreBooleFork(state, round)
 			},
 			Network:     options.Network,
 			CutOffRound: roundtimer.CutOffRound,
@@ -1113,8 +1117,12 @@ func SetupRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
-				leader := qbft.RoundRobinProposer(state, round)
-				return leader
+				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
+					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
+					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
+				}
+
+				return qbft.RoundRobinProposerPreBooleFork(state, round)
 			},
 			Network:     options.Network,
 			CutOffRound: roundtimer.CutOffRound,

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1048,12 +1048,8 @@ func SetupCommitteeRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
-				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
-					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
-					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
-				}
-
-				return qbft.RoundRobinProposerPreBooleFork(state, round)
+				committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
+				return qbft.Proposer(state.Height, round, committee, options.NetworkConfig)
 			},
 			Network:     options.Network,
 			CutOffRound: roundtimer.CutOffRound,
@@ -1117,12 +1113,8 @@ func SetupRunners(
 			BeaconSigner: options.Signer,
 			Domain:       options.NetworkConfig.DomainType,
 			ProposerF: func(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
-				if options.NetworkConfig.BooleForkAtSlot(phase0.Slot(state.Height)) {
-					committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
-					return qbft.RoundRobinProposer(state.Height, round, committee, options.NetworkConfig)
-				}
-
-				return qbft.RoundRobinProposerPreBooleFork(state, round)
+				committee := ssvtypes.OperatorIDsFromOperators(state.CommitteeMember.Committee)
+				return qbft.Proposer(state.Height, round, committee, options.NetworkConfig)
 			},
 			Network:     options.Network,
 			CutOffRound: roundtimer.CutOffRound,

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/ssvlabs/ssv/operator/validator/mocks"
 	"github.com/ssvlabs/ssv/operator/validators"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft"
 	"github.com/ssvlabs/ssv/protocol/v2/queue/worker"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
@@ -174,6 +176,153 @@ func TestSetupCommitteeRunnersExporter(t *testing.T) {
 	runner, err := committeeRunnerFunc(0, nil, nil, nil)
 	require.Nil(t, runner)
 	require.ErrorContains(t, err, "cannot set up committee runners in exporter mode")
+}
+
+// buildProposerFTestNetworkConfig returns an independent copy of networkconfig.TestNetwork
+// with SSV.Forks.Boole set as requested, so tests can exercise both the pre- and
+// post-Boole-fork ProposerF branches without mutating the shared global TestNetwork.
+func buildProposerFTestNetworkConfig(t *testing.T, booleForkEpoch phase0.Epoch) *networkconfig.Network {
+	t.Helper()
+
+	ssvCopy := *networkconfig.TestNetwork.SSV
+	ssvCopy.Forks.Boole = booleForkEpoch
+
+	netCfg := *networkconfig.TestNetwork
+	netCfg.SSV = &ssvCopy
+	return &netCfg
+}
+
+// buildProposerFTestCommittee returns a small, deterministic committee used to exercise
+// the ProposerF closures.
+func buildProposerFTestCommittee() []*spectypes.Operator {
+	return []*spectypes.Operator{
+		{OperatorID: 1, SSVOperatorPubKey: []byte("op-1")},
+		{OperatorID: 2, SSVOperatorPubKey: []byte("op-2")},
+		{OperatorID: 3, SSVOperatorPubKey: []byte("op-3")},
+		{OperatorID: 4, SSVOperatorPubKey: []byte("op-4")},
+	}
+}
+
+func TestSetupRunnersProposerF(t *testing.T) {
+	netCfg := buildProposerFTestNetworkConfig(t, phase0.Epoch(math.MaxUint64)) // pre-Boole-fork
+	committee := buildProposerFTestCommittee()
+
+	share := &types.SSVShare{
+		Share: spectypes.Share{
+			ValidatorIndex:  1,
+			ValidatorPubKey: createPubKey(byte('1')),
+			SharePubKey:     make([]byte, 48),
+		},
+	}
+	operator := &spectypes.CommitteeMember{
+		OperatorID: 1,
+		Committee:  committee,
+	}
+	options := &validator.CommonOptions{
+		NetworkConfig: netCfg,
+	}
+
+	runners, err := SetupRunners(t.Context(), share, operator, nil, nil, options)
+	require.NoError(t, err)
+	require.Contains(t, runners, types.RoleAggregator)
+
+	aggregatorRunner, ok := runners[types.RoleAggregator].(*runner.AggregatorRunner)
+	require.True(t, ok, "expected *runner.AggregatorRunner")
+	require.NotNil(t, aggregatorRunner.QBFTController)
+
+	proposerF := aggregatorRunner.QBFTController.GetConfig().GetProposerF()
+	require.NotNil(t, proposerF)
+
+	state := &specqbft.State{
+		CommitteeMember: &spectypes.CommitteeMember{Committee: committee},
+		Height:          specqbft.FirstHeight,
+	}
+
+	expected := qbft.Proposer(state.Height, specqbft.FirstRound, types.OperatorIDsFromOperators(committee), netCfg)
+	require.Equal(t, expected, proposerF(state, specqbft.FirstRound))
+
+	// A different round should be able to select a different proposer (round-robin).
+	nextRound := specqbft.FirstRound + 1
+	expectedNextRound := qbft.Proposer(state.Height, nextRound, types.OperatorIDsFromOperators(committee), netCfg)
+	require.Equal(t, expectedNextRound, proposerF(state, nextRound))
+}
+
+func TestSetupRunnersProposerFPostBooleFork(t *testing.T) {
+	netCfg := buildProposerFTestNetworkConfig(t, phase0.Epoch(0)) // post-Boole-fork from genesis
+	committee := buildProposerFTestCommittee()
+
+	share := &types.SSVShare{
+		Share: spectypes.Share{
+			ValidatorIndex:  1,
+			ValidatorPubKey: createPubKey(byte('2')),
+			SharePubKey:     make([]byte, 48),
+		},
+	}
+	operator := &spectypes.CommitteeMember{
+		OperatorID: 1,
+		Committee:  committee,
+	}
+	options := &validator.CommonOptions{
+		NetworkConfig: netCfg,
+	}
+
+	runners, err := SetupRunners(t.Context(), share, operator, nil, nil, options)
+	require.NoError(t, err)
+
+	aggregatorRunner, ok := runners[types.RoleAggregator].(*runner.AggregatorRunner)
+	require.True(t, ok, "expected *runner.AggregatorRunner")
+
+	proposerF := aggregatorRunner.QBFTController.GetConfig().GetProposerF()
+
+	// Pick a height whose slot lands well after genesis so BooleForkAtSlot is true.
+	state := &specqbft.State{
+		CommitteeMember: &spectypes.CommitteeMember{Committee: committee},
+		Height:          specqbft.Height(netCfg.SlotsPerEpoch) * 10,
+	}
+	require.True(t, netCfg.BooleForkAtSlot(phase0.Slot(state.Height)), "expected height to be post-Boole-fork for this assertion to be meaningful")
+
+	expected := qbft.Proposer(state.Height, specqbft.FirstRound, types.OperatorIDsFromOperators(committee), netCfg)
+	require.Equal(t, expected, proposerF(state, specqbft.FirstRound))
+}
+
+func TestSetupCommitteeRunnersProposerF(t *testing.T) {
+	netCfg := buildProposerFTestNetworkConfig(t, phase0.Epoch(math.MaxUint64)) // pre-Boole-fork
+	committee := buildProposerFTestCommittee()
+
+	options := &validator.Options{
+		CommonOptions: validator.CommonOptions{
+			NetworkConfig: netCfg,
+		},
+		Operator: &spectypes.CommitteeMember{
+			OperatorID: 1,
+			Committee:  committee,
+		},
+	}
+
+	committeeRunnerFunc := SetupCommitteeRunners(t.Context(), options)
+
+	shareMap := map[phase0.ValidatorIndex]*spectypes.Share{
+		1: {ValidatorIndex: 1},
+	}
+	crunner, err := committeeRunnerFunc(0, shareMap, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, crunner.QBFTController)
+
+	proposerF := crunner.QBFTController.GetConfig().GetProposerF()
+	require.NotNil(t, proposerF)
+
+	state := &specqbft.State{
+		CommitteeMember: &spectypes.CommitteeMember{Committee: committee},
+		Height:          specqbft.FirstHeight,
+	}
+
+	expected := qbft.Proposer(state.Height, specqbft.FirstRound, types.OperatorIDsFromOperators(committee), netCfg)
+	require.Equal(t, expected, proposerF(state, specqbft.FirstRound))
+
+	// A different round should be able to select a different proposer (round-robin).
+	nextRound := specqbft.FirstRound + 1
+	expectedNextRound := qbft.Proposer(state.Height, nextRound, types.OperatorIDsFromOperators(committee), netCfg)
+	require.Equal(t, expectedNextRound, proposerF(state, nextRound))
 }
 
 func TestHandleNonCommitteeMessages(t *testing.T) {

--- a/protocol/v2/qbft/round_robin_proposer.go
+++ b/protocol/v2/qbft/round_robin_proposer.go
@@ -1,15 +1,16 @@
 package qbft
 
 import (
+	"sort"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-// RoundRobinProposer returns the proposer for the round.
-// Each new height starts with the first proposer and increments by 1 with each following round.
-// Each new height has a different first round proposer which is +1 from the previous height.
-// First height starts with index 0
-func RoundRobinProposer(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+// Deprecated - only for pre-Boole fork
+func RoundRobinProposerPreBooleFork(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
 	firstRoundIndex := uint64(0)
 	if state.Height != specqbft.FirstHeight {
 		firstRoundIndex += uint64(state.Height) % uint64(len(state.CommitteeMember.Committee))
@@ -17,4 +18,38 @@ func RoundRobinProposer(state *specqbft.State, round specqbft.Round) spectypes.O
 
 	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(state.CommitteeMember.Committee))
 	return state.CommitteeMember.Committee[index].OperatorID
+}
+
+type networkConfig interface {
+	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
+}
+
+// RoundRobinProposer returns the proposer for the round.
+// Each new height starts with the first proposer and increments by 1 with each following round.
+// Each new height has a different first round proposer which is +1 from the previous height.
+// Also, the current Ethereum epoch is taken into account to introduce variability through epochs
+// (mostly for committees with 4 operators, as 32%4 = 0 as the epochs would "repeat" otherwise).
+func RoundRobinProposer(
+	height specqbft.Height,
+	round specqbft.Round,
+	committee []spectypes.OperatorID,
+	netCfg networkConfig,
+) spectypes.OperatorID {
+	// Ensure committee is sorted to avoid proposer depending on input order.
+	if !sort.SliceIsSorted(committee, func(i, j int) bool { return committee[i] < committee[j] }) {
+		sorted := make([]spectypes.OperatorID, len(committee))
+		copy(sorted, committee)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+		committee = sorted
+	}
+
+	ethEpoch := uint64(netCfg.EstimatedEpochAtSlot(phase0.Slot(height)))
+
+	firstRoundIndex := uint64(0)
+	if height != specqbft.FirstHeight {
+		firstRoundIndex += uint64(height) % uint64(len(committee))
+	}
+
+	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound) + ethEpoch) % uint64(len(committee))
+	return committee[index]
 }

--- a/protocol/v2/qbft/round_robin_proposer.go
+++ b/protocol/v2/qbft/round_robin_proposer.go
@@ -1,7 +1,7 @@
 package qbft
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -9,24 +9,27 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-// Deprecated - only for pre-Boole fork
-func RoundRobinProposerPreBooleFork(state *specqbft.State, round specqbft.Round) spectypes.OperatorID {
+// roundRobinProposerPreBooleFork is the pre-Boole proposer selection. Kept only for
+// heights before the Boole fork; new code should go through Proposer.
+func roundRobinProposerPreBooleFork(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID) spectypes.OperatorID {
 	firstRoundIndex := uint64(0)
-	if state.Height != specqbft.FirstHeight {
-		firstRoundIndex += uint64(state.Height) % uint64(len(state.CommitteeMember.Committee))
+	if height != specqbft.FirstHeight {
+		firstRoundIndex += uint64(height) % uint64(len(committee))
 	}
 
-	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(state.CommitteeMember.Committee))
-	return state.CommitteeMember.Committee[index].OperatorID
+	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound)) % uint64(len(committee))
+	return committee[index]
 }
 
 type networkConfig interface {
 	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
+	BooleForkAtSlot(slot phase0.Slot) bool
 }
 
 // RoundRobinProposer returns the proposer for the round.
 // Each new height starts with the first proposer and increments by 1 with each following round.
-// Each new height has a different first round proposer which is +1 from the previous height.
+// Each new height has a different first round proposer which is +1 from the previous height
+// (+2 when the height crosses an epoch boundary, as the epoch offset advances as well).
 // Also, the current Ethereum epoch is taken into account to introduce variability through epochs
 // (mostly for committees with 4 operators, as 32%4 = 0 as the epochs would "repeat" otherwise).
 func RoundRobinProposer(
@@ -36,11 +39,9 @@ func RoundRobinProposer(
 	netCfg networkConfig,
 ) spectypes.OperatorID {
 	// Ensure committee is sorted to avoid proposer depending on input order.
-	if !sort.SliceIsSorted(committee, func(i, j int) bool { return committee[i] < committee[j] }) {
-		sorted := make([]spectypes.OperatorID, len(committee))
-		copy(sorted, committee)
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
-		committee = sorted
+	if !slices.IsSorted(committee) {
+		committee = slices.Clone(committee)
+		slices.Sort(committee)
 	}
 
 	ethEpoch := uint64(netCfg.EstimatedEpochAtSlot(phase0.Slot(height)))
@@ -52,4 +53,14 @@ func RoundRobinProposer(
 
 	index := (firstRoundIndex + uint64(round) - uint64(specqbft.FirstRound) + ethEpoch) % uint64(len(committee))
 	return committee[index]
+}
+
+// Proposer returns the round-robin proposer for the given height/round, selecting the
+// fork-appropriate algorithm from netCfg. Both the runners (via ProposerF) and message
+// validation call this, so the two always agree on the leader per fork.
+func Proposer(height specqbft.Height, round specqbft.Round, committee []spectypes.OperatorID, netCfg networkConfig) spectypes.OperatorID {
+	if netCfg.BooleForkAtSlot(phase0.Slot(height)) {
+		return RoundRobinProposer(height, round, committee, netCfg)
+	}
+	return roundRobinProposerPreBooleFork(height, round, committee)
 }

--- a/protocol/v2/qbft/round_robin_proposer_test.go
+++ b/protocol/v2/qbft/round_robin_proposer_test.go
@@ -1,0 +1,52 @@
+package qbft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+func TestRoundRobinProposerPreBooleFork_MatchesStageLogic(t *testing.T) {
+	height := specqbft.Height(20)
+	state := &specqbft.State{
+		Height: height,
+		CommitteeMember: &spectypes.CommitteeMember{
+			Committee: []*spectypes.Operator{
+				{OperatorID: 1},
+				{OperatorID: 2},
+				{OperatorID: 3},
+				{OperatorID: 4},
+			},
+		},
+	}
+
+	// height%4=0 so leader should be the first operator for FirstRound.
+	require.Equal(t, spectypes.OperatorID(1), RoundRobinProposerPreBooleFork(state, specqbft.FirstRound))
+}
+
+func TestRoundRobinProposer_PostBooleFork_OffsetFromSlotsPerEpoch(t *testing.T) {
+	netCfg := &networkconfig.Network{
+		Beacon: &networkconfig.Beacon{SlotsPerEpoch: 10},
+	}
+	committee := []spectypes.OperatorID{1, 2, 3, 4}
+	height := specqbft.Height(20) // epoch=2 (derived from slotsPerEpoch=10), so offset=2
+
+	// height%4=0 and offset=2 -> index=2 -> third operator.
+	require.Equal(t, spectypes.OperatorID(3), RoundRobinProposer(height, specqbft.FirstRound, committee, netCfg))
+}
+
+func TestRoundRobinProposer_CommitteeOrderDoesNotMatter(t *testing.T) {
+	netCfg := &networkconfig.Network{
+		Beacon: &networkconfig.Beacon{SlotsPerEpoch: 32},
+	}
+	height := specqbft.Height(2138369) // epoch=66824 (%4==0), height%4==1 -> index=1 -> operator 10
+	round := specqbft.FirstRound
+
+	require.Equal(t, spectypes.OperatorID(10), RoundRobinProposer(height, round, []spectypes.OperatorID{9, 10, 11, 12}, netCfg))
+	require.Equal(t, spectypes.OperatorID(10), RoundRobinProposer(height, round, []spectypes.OperatorID{12, 9, 10, 11}, netCfg))
+}

--- a/protocol/v2/qbft/round_robin_proposer_test.go
+++ b/protocol/v2/qbft/round_robin_proposer_test.go
@@ -3,6 +3,7 @@ package qbft
 import (
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -11,22 +12,19 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 )
 
+// preBooleForkNetConfig is a stub networkConfig whose fork gate is always off, exercising
+// Proposer's pre-fork branch.
+type preBooleForkNetConfig struct{}
+
+func (preBooleForkNetConfig) EstimatedEpochAtSlot(phase0.Slot) phase0.Epoch { return 0 }
+func (preBooleForkNetConfig) BooleForkAtSlot(phase0.Slot) bool              { return false }
+
 func TestRoundRobinProposerPreBooleFork_MatchesStageLogic(t *testing.T) {
 	height := specqbft.Height(20)
-	state := &specqbft.State{
-		Height: height,
-		CommitteeMember: &spectypes.CommitteeMember{
-			Committee: []*spectypes.Operator{
-				{OperatorID: 1},
-				{OperatorID: 2},
-				{OperatorID: 3},
-				{OperatorID: 4},
-			},
-		},
-	}
+	committee := []spectypes.OperatorID{1, 2, 3, 4}
 
 	// height%4=0 so leader should be the first operator for FirstRound.
-	require.Equal(t, spectypes.OperatorID(1), RoundRobinProposerPreBooleFork(state, specqbft.FirstRound))
+	require.Equal(t, spectypes.OperatorID(1), Proposer(height, specqbft.FirstRound, committee, preBooleForkNetConfig{}))
 }
 
 func TestRoundRobinProposer_PostBooleFork_OffsetFromSlotsPerEpoch(t *testing.T) {


### PR DESCRIPTION
## Unit 5a of the boole-fork → stage convergence: fork-aware round-robin proposer

First slice of unit 5 (runner/qbft), **stacked on unit 4** (#2930). Foundation layer: the **consensus-critical** QBFT proposer/leader selection, fork-gated.

### What it does
- **`protocol/v2/qbft/round_robin_proposer.go`**: `RoundRobinProposer` changes signature to `(height, round, committee, netCfg)` and adds **ETH-epoch variability** (so 4-operator committees don't repeat leaders every epoch, since 32%4=0) + **committee sorting** (proposer independent of input order). The old implementation is preserved as `RoundRobinProposerPreBooleFork`. Ported exactly from boole-fork.
- **`operator/validator/controller.go`** (`buildController.ProposerF`): fork-gated — `BooleForkAtSlot(state.Height) ? RoundRobinProposer(new) : RoundRobinProposerPreBooleFork`. (The `NewAggregatorCommitteeRunner` construction stays for 5c.)
- **`message/validation/consensus_validation.go`** leader check: fork-gated identically, and the unit-2 helper `roundRobinProposer` is renamed `roundRobinProposerPreBooleFork`. This keeps validation and the actual proposer in agreement per-fork — otherwise post-fork proposals would be rejected as "signer not leader".

### Scope boundary
Foundation only. Aggregator-committee helpers (the `value_check` checker, `msg.go`/`runner_role.go` role bits) are **deferred to their consumers in 5b/5c** to avoid landing unreachable code (deadcode-lint).

### Testing
Co-lands `round_robin_proposer_test.go` (pre-fork matches stage logic; post-fork epoch offset; committee-order independence). The unit-3 post-fork acceptance test now builds a proposal signed by the fork-aware leader (stronger coverage). Full matrix green: `go build ./...`, `go vet` (main **+ ssvsigner**), `deadcode`, `gofmt`, `golangci-lint`, and qbft / message-validation / operator-validator tests.

> ⚠️ **Consensus-critical** (proposer/leader selection). A `code-reviewer-deep` pass is being run in parallel; findings will be addressed as follow-up commits.
