### PR TITLE
convergence(unit 5c): AggregatorCommitteeRunner + consensus wiring

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -2,6 +2,8 @@ package goclient
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"time"
@@ -13,12 +15,45 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 )
 
+// IsAggregator returns true if the validator is selected as an aggregator for the given
+// slot/committee, per the selection-proof modulo check.
+func (gc *GoClient) IsAggregator(
+	_ context.Context,
+	_ phase0.Slot,
+	_ phase0.CommitteeIndex,
+	committeeLength uint64,
+	slotSig []byte,
+) bool {
+	modulo := committeeLength / gc.beaconConfig.TargetAggregatorsPerCommittee
+	if modulo == 0 {
+		modulo = 1
+	}
+
+	h := sha256.Sum256(slotSig)
+	x := binary.LittleEndian.Uint64(h[:8])
+
+	return x%modulo == 0
+}
+
+// GetAggregateAttestation returns the aggregate attestation for the given slot and committee.
+func (gc *GoClient) GetAggregateAttestation(
+	ctx context.Context,
+	slot phase0.Slot,
+	committeeIndex phase0.CommitteeIndex,
+) (ssz.Marshaler, spec.DataVersion, error) {
+	va, _, err := gc.fetchVersionedAggregate(ctx, slot, committeeIndex)
+	if err != nil {
+		return nil, DataVersionNil, err
+	}
+	return versionedAggregateToSSZ(va)
+}
+
 // SubmitAggregateSelectionProof returns an AggregateAndProof object
 func (gc *GoClient) SubmitAggregateSelectionProof(
 	ctx context.Context,
 	slot phase0.Slot,
 	committeeIndex phase0.CommitteeIndex,
-	committeeLength uint64,
+	_ uint64,
 	index phase0.ValidatorIndex,
 	slotSig []byte,
 ) (ssz.Marshaler, spec.DataVersion, error) {
@@ -29,31 +64,81 @@ func (gc *GoClient) SubmitAggregateSelectionProof(
 		return nil, 0, fmt.Errorf("wait for 2/3 of slot: %w", err)
 	}
 
-	// Aggregate for the root of the attestation data this node actually submitted for this
-	// duty (the cluster-decided value): the beacon node then holds at least our own
-	// attestation matching it. Re-deriving the data locally can yield a root nobody
-	// attested with, which the node answers with a 404 (no matching aggregate).
+	va, _, err := gc.fetchVersionedAggregate(ctx, slot, committeeIndex)
+	if err != nil {
+		return nil, DataVersionNil, err
+	}
+
+	var selectionProof phase0.BLSSignature
+	copy(selectionProof[:], slotSig)
+
+	return versionedToAggregateAndProof(va, index, selectionProof)
+}
+
+// SubmitSignedAggregateSelectionProof broadcasts a signed aggregator msg
+func (gc *GoClient) SubmitSignedAggregateSelectionProof(
+	ctx context.Context,
+	msg *spec.VersionedSignedAggregateAndProof,
+) error {
+	start := time.Now()
+	err := gc.multiClient.SubmitAggregateAttestations(ctx, &api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*spec.VersionedSignedAggregateAndProof{msg}})
+	recordRequest(ctx, gc.log, "SubmitAggregateAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
+	if err != nil {
+		return errMultiClient(fmt.Errorf("submit aggregate attestations: %w", err), "SubmitAggregateAttestations")
+	}
+
+	return nil
+}
+
+// computeAttestationDataRoot re-derives the attestation data root for the given slot/committee
+// from this node's own view, used as a fallback when the cluster-attested root is unknown.
+func (gc *GoClient) computeAttestationDataRoot(
+	ctx context.Context,
+	slot phase0.Slot,
+	committeeIndex phase0.CommitteeIndex,
+) (root [32]byte, err error) {
+	attData, _, err := gc.GetAttestationData(ctx, slot)
+	if err != nil {
+		return root, fmt.Errorf("fetch attestation data: %w", err)
+	}
+
+	// Explicitly set Index field as beacon nodes may return inconsistent values.
+	// EIP-7549: For Electra and later, index must always be 0, pre-Electra uses committee index.
+	config := gc.getBeaconConfig()
+	dataVersion, _ := config.ForkAtEpoch(config.EstimatedEpochAtSlot(slot))
+	attData.Index = 0
+	if dataVersion < spec.DataVersionElectra {
+		attData.Index = committeeIndex
+	}
+
+	root, err = attData.HashTreeRoot()
+	if err != nil {
+		return root, fmt.Errorf("fetch attestation data root: %w", err)
+	}
+	return root, nil
+}
+
+// fetchVersionedAggregate fetches the aggregate attestation for the given slot/committee,
+// shared by SubmitAggregateSelectionProof (AggregatorRunner) and GetAggregateAttestation
+// (AggregatorCommitteeRunner).
+//
+// Prefers the root of the attestation data this node actually submitted for this duty (the
+// cluster-decided value): the beacon node then holds at least our own attestation matching it.
+// Re-deriving the data locally can yield a root nobody attested with, which the node answers
+// with a 404 (no matching aggregate).
+func (gc *GoClient) fetchVersionedAggregate(
+	ctx context.Context,
+	slot phase0.Slot,
+	committeeIndex phase0.CommitteeIndex,
+) (*spec.VersionedAttestation, spec.DataVersion, error) {
 	root, found := gc.attestedDataRoot(slot, committeeIndex)
 	if !found {
 		// No record of our own attestation (it failed or hasn't landed yet) — fall back
 		// to re-deriving the root from this node's view of the slot.
-		attData, _, err := gc.GetAttestationData(ctx, slot)
+		var err error
+		root, err = gc.computeAttestationDataRoot(ctx, slot, committeeIndex)
 		if err != nil {
-			return nil, DataVersionNil, fmt.Errorf("fetch attestation data: %w", err)
-		}
-
-		// Explicitly set Index field as beacon nodes may return inconsistent values.
-		// EIP-7549: For Electra and later, index must always be 0, pre-Electra uses committee index.
-		config := gc.getBeaconConfig()
-		dataVersion, _ := config.ForkAtEpoch(config.EstimatedEpochAtSlot(slot))
-		attData.Index = 0
-		if dataVersion < spec.DataVersionElectra {
-			attData.Index = committeeIndex
-		}
-
-		root, err = attData.HashTreeRoot()
-		if err != nil {
-			return nil, DataVersionNil, fmt.Errorf("fetch attestation data root: %w", err)
+			return nil, DataVersionNil, err
 		}
 	}
 
@@ -71,92 +156,123 @@ func (gc *GoClient) SubmitAggregateSelectionProof(
 		return nil, DataVersionNil, errMultiClient(err, "AggregateAttestation")
 	}
 
-	var selectionProof phase0.BLSSignature
-	copy(selectionProof[:], slotSig)
+	return aggDataResp.Data, aggDataResp.Data.Version, nil
+}
 
-	vAtt := aggDataResp.Data
-	switch vAtt.Version {
+func versionedAggregateToSSZ(va *spec.VersionedAttestation) (ssz.Marshaler, spec.DataVersion, error) {
+	switch va.Version {
 	case spec.DataVersionPhase0:
-		if vAtt.Phase0 == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Phase0 == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &phase0.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Phase0,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Phase0, va.Version, nil
 	case spec.DataVersionAltair:
-		if vAtt.Altair == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Altair == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &phase0.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Altair,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Altair, va.Version, nil
 	case spec.DataVersionBellatrix:
-		if vAtt.Bellatrix == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Bellatrix == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &phase0.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Bellatrix,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Bellatrix, va.Version, nil
 	case spec.DataVersionCapella:
-		if vAtt.Capella == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Capella == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &phase0.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Capella,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Capella, va.Version, nil
 	case spec.DataVersionDeneb:
-		if vAtt.Deneb == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Deneb == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &phase0.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Deneb,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Deneb, va.Version, nil
 	case spec.DataVersionElectra:
-		if vAtt.Electra == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Electra == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &electra.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Electra,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Electra, va.Version, nil
 	case spec.DataVersionFulu:
-		if vAtt.Fulu == nil {
-			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", vAtt.Version.String()), "AggregateAttestation")
+		if va.Fulu == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
 		}
-		return &electra.AggregateAndProof{
-			AggregatorIndex: index,
-			Aggregate:       vAtt.Fulu,
-			SelectionProof:  selectionProof,
-		}, vAtt.Version, nil
+		return va.Fulu, va.Version, nil
 	default:
-		return nil, DataVersionNil, fmt.Errorf("unknown data version: %d", vAtt.Version)
+		return nil, DataVersionNil, errMultiClient(fmt.Errorf("unknown data version: %d", va.Version), "AggregateAttestation")
 	}
 }
 
-// SubmitSignedAggregateSelectionProof broadcasts a signed aggregator msg
-func (gc *GoClient) SubmitSignedAggregateSelectionProof(
-	ctx context.Context,
-	msg *spec.VersionedSignedAggregateAndProof,
-) error {
-	start := time.Now()
-	err := gc.multiClient.SubmitAggregateAttestations(ctx, &api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*spec.VersionedSignedAggregateAndProof{msg}})
-	recordRequest(ctx, gc.log, "SubmitAggregateAttestations", gc.multiClient, http.MethodPost, true, time.Since(start), err)
-	if err != nil {
-		return errMultiClient(fmt.Errorf("submit aggregate attestations: %w", err), "SubmitAggregateAttestations")
+func versionedToAggregateAndProof(
+	va *spec.VersionedAttestation,
+	index phase0.ValidatorIndex,
+	selectionProof phase0.BLSSignature,
+) (ssz.Marshaler, spec.DataVersion, error) {
+	switch va.Version {
+	case spec.DataVersionPhase0:
+		if va.Phase0 == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &phase0.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Phase0,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionAltair:
+		if va.Altair == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &phase0.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Altair,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionBellatrix:
+		if va.Bellatrix == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &phase0.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Bellatrix,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionCapella:
+		if va.Capella == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &phase0.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Capella,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionDeneb:
+		if va.Deneb == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &phase0.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Deneb,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionElectra:
+		if va.Electra == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &electra.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Electra,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	case spec.DataVersionFulu:
+		if va.Fulu == nil {
+			return nil, DataVersionNil, errMultiClient(fmt.Errorf("aggregate attestation %s data is nil", va.Version.String()), "AggregateAttestation")
+		}
+		return &electra.AggregateAndProof{
+			AggregatorIndex: index,
+			Aggregate:       va.Fulu,
+			SelectionProof:  selectionProof,
+		}, va.Version, nil
+	default:
+		return nil, DataVersionNil, fmt.Errorf("unknown data version: %d", va.Version)
 	}
-
-	return nil
 }
 
 // waitTwoThirdsIntoSlot waits until two-third of the slot has transpired (SECONDS_PER_SLOT * 2 / 3 seconds after the start of slot)

--- a/beacon/goclient/aggregator_test.go
+++ b/beacon/goclient/aggregator_test.go
@@ -1,7 +1,10 @@
 package goclient
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -26,7 +29,8 @@ import (
 type aggregatorClientMock struct {
 	mock.Service
 
-	submitAttestationsFn func(context.Context, *api.SubmitAttestationsOpts) error
+	submitAttestationsFn          func(context.Context, *api.SubmitAttestationsOpts) error
+	submitAggregateAttestationsFn func(context.Context, *api.SubmitAggregateAttestationsOpts) error
 }
 
 var _ Client = (*aggregatorClientMock)(nil)
@@ -38,6 +42,13 @@ func (*aggregatorClientMock) SubmitProposal(context.Context, *api.SubmitProposal
 func (m *aggregatorClientMock) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
 	if m.submitAttestationsFn != nil {
 		return m.submitAttestationsFn(ctx, opts)
+	}
+	return nil
+}
+
+func (m *aggregatorClientMock) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
+	if m.submitAggregateAttestationsFn != nil {
+		return m.submitAggregateAttestationsFn(ctx, opts)
 	}
 	return nil
 }
@@ -367,6 +378,300 @@ func TestAttestationCommitteeIndex(t *testing.T) {
 		att := &spec.VersionedAttestation{Version: spec.DataVersionElectra}
 		_, err := attestationCommitteeIndex(att, data)
 		require.Error(t, err)
+	})
+}
+
+func TestIsAggregator(t *testing.T) {
+	t.Parallel()
+
+	slotSigA := bytes.Repeat([]byte{0xAA}, 96)
+	slotSigB := bytes.Repeat([]byte{0xBB}, 96)
+
+	// Mirrors the documented selection-proof modulo check so we can assert the production
+	// code wires committeeLength/TargetAggregatorsPerCommittee/slotSig into it correctly,
+	// rather than e.g. accidentally using TargetAggregatorsPerSyncSubcommittee.
+	computeExpected := func(committeeLength, target uint64, slotSig []byte) bool {
+		modulo := committeeLength / target
+		if modulo == 0 {
+			modulo = 1
+		}
+		h := sha256.Sum256(slotSig)
+		x := binary.LittleEndian.Uint64(h[:8])
+		return x%modulo == 0
+	}
+
+	testCases := []struct {
+		name            string
+		committeeLength uint64
+		target          uint64
+		slotSig         []byte
+	}{
+		{name: "small committee forces modulo to one", committeeLength: 2, target: 16, slotSig: slotSigA},
+		{name: "zero committee length forces modulo to one", committeeLength: 0, target: 16, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig A)", committeeLength: 128, target: 16, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig B)", committeeLength: 128, target: 16, slotSig: slotSigB},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := aggregatorTestBeaconConfig(time.Now())
+			cfg.TargetAggregatorsPerCommittee = tc.target
+			// Sentinel: distinct from TargetAggregatorsPerCommittee so a bug reading the wrong
+			// field would flip the expected/actual comparison below.
+			cfg.TargetAggregatorsPerSyncSubcommittee = tc.target + 12345
+
+			client := &GoClient{beaconConfig: &cfg}
+
+			got := client.IsAggregator(t.Context(), 0, 0, tc.committeeLength, tc.slotSig)
+			want := computeExpected(tc.committeeLength, tc.target, tc.slotSig)
+			require.Equal(t, want, got)
+		})
+	}
+
+	t.Run("modulo forced to one always selects aggregator regardless of signature", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := aggregatorTestBeaconConfig(time.Now())
+		cfg.TargetAggregatorsPerCommittee = 16
+
+		client := &GoClient{beaconConfig: &cfg}
+
+		require.True(t, client.IsAggregator(t.Context(), 0, 0, 2, slotSigA))
+		require.True(t, client.IsAggregator(t.Context(), 0, 0, 0, slotSigB))
+	})
+
+	t.Run("deterministic for identical inputs", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := aggregatorTestBeaconConfig(time.Now())
+		cfg.TargetAggregatorsPerCommittee = 16
+
+		client := &GoClient{beaconConfig: &cfg}
+
+		first := client.IsAggregator(t.Context(), 5, 3, 128, slotSigA)
+		second := client.IsAggregator(t.Context(), 5, 3, 128, slotSigA)
+		require.Equal(t, first, second)
+	})
+}
+
+func TestGetAggregateAttestation(t *testing.T) {
+	t.Parallel()
+
+	committeeIndex := phase0.CommitteeIndex(7)
+
+	testCases := []struct {
+		name    string
+		version spec.DataVersion
+	}{
+		{name: "phase0", version: spec.DataVersionPhase0},
+		{name: "altair", version: spec.DataVersionAltair},
+		{name: "bellatrix", version: spec.DataVersionBellatrix},
+		{name: "capella", version: spec.DataVersionCapella},
+		{name: "deneb", version: spec.DataVersionDeneb},
+		{name: "electra", version: spec.DataVersionElectra},
+		{name: "fulu", version: spec.DataVersionFulu},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+			slot := cfg.FirstSlotAtEpoch(0)
+
+			attestedData := &phase0.AttestationData{
+				Slot:            slot,
+				Index:           committeeIndex,
+				BeaconBlockRoot: phase0.Root{4, 5, 6},
+				Source:          &phase0.Checkpoint{Epoch: 1},
+				Target:          &phase0.Checkpoint{Epoch: 2},
+			}
+			if tc.version >= spec.DataVersionElectra {
+				attestedData.Index = 0
+			}
+			expectedRoot, err := attestedData.HashTreeRoot()
+			require.NoError(t, err)
+
+			service := &aggregatorClientMock{}
+			service.AggregateAttestationFunc = func(_ context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+				require.Equal(t, slot, opts.Slot)
+				require.Equal(t, committeeIndex, opts.CommitteeIndex)
+				require.EqualValues(t, expectedRoot, opts.AttestationDataRoot)
+
+				return &api.Response[*spec.VersionedAttestation]{
+					Data: aggregatorVersionedAttestation(tc.version, attestedData),
+				}, nil
+			}
+
+			client := newAggregatorTestClient(&cfg, service)
+
+			require.NoError(t, client.SubmitAttestations(t.Context(), []*spec.VersionedAttestation{
+				attestedVersionedAttestation(tc.version, attestedData, committeeIndex),
+			}))
+
+			got, gotVersion, err := client.GetAggregateAttestation(t.Context(), slot, committeeIndex)
+			require.NoError(t, err)
+			require.Equal(t, tc.version, gotVersion)
+			require.NotNil(t, got)
+		})
+	}
+
+	t.Run("surfaces fetch error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+		slot := cfg.FirstSlotAtEpoch(0)
+
+		service := &aggregatorClientMock{}
+		service.AttestationDataFunc = func(context.Context, *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+			return nil, errors.New("attestation data unavailable")
+		}
+
+		client := newAggregatorTestClient(&cfg, service)
+
+		// No prior SubmitAttestations call, so the attested root is unknown and the fallback
+		// re-derivation path's error must surface.
+		_, _, err := client.GetAggregateAttestation(t.Context(), slot, 7)
+		require.ErrorContains(t, err, "fetch attestation data")
+	})
+
+	t.Run("surfaces nil inner attestation error from unmarshal", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := aggregatorTestBeaconConfig(time.Now().Add(-1000 * networkconfig.TestNetwork.SlotDuration))
+		slot := cfg.FirstSlotAtEpoch(0)
+		committeeIndex := phase0.CommitteeIndex(3)
+
+		data := &phase0.AttestationData{
+			Slot:   slot,
+			Index:  committeeIndex,
+			Source: &phase0.Checkpoint{Epoch: 1},
+			Target: &phase0.Checkpoint{Epoch: 2},
+		}
+		root, err := data.HashTreeRoot()
+		require.NoError(t, err)
+
+		service := &aggregatorClientMock{}
+		service.AggregateAttestationFunc = func(context.Context, *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+			// Version is set but the inner attestation payload is nil.
+			return &api.Response[*spec.VersionedAttestation]{
+				Data: &spec.VersionedAttestation{Version: spec.DataVersionPhase0},
+			}, nil
+		}
+
+		client := newAggregatorTestClient(&cfg, service)
+		client.rememberAttestedDataRoots([]*spec.VersionedAttestation{
+			aggregatorVersionedAttestation(spec.DataVersionPhase0, data),
+		})
+		require.NotZero(t, root)
+
+		_, _, err = client.GetAggregateAttestation(t.Context(), slot, committeeIndex)
+		require.ErrorContains(t, err, "data is nil")
+	})
+}
+
+func TestSubmitSignedAggregateSelectionProof(t *testing.T) {
+	t.Parallel()
+
+	t.Run("broadcasts the signed aggregate and proof", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &spec.VersionedSignedAggregateAndProof{Version: spec.DataVersionPhase0}
+
+		var gotOpts *api.SubmitAggregateAttestationsOpts
+		service := &aggregatorClientMock{
+			submitAggregateAttestationsFn: func(_ context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
+				gotOpts = opts
+				return nil
+			},
+		}
+
+		client := &GoClient{log: zap.NewNop(), multiClient: service}
+
+		require.NoError(t, client.SubmitSignedAggregateSelectionProof(t.Context(), msg))
+		require.NotNil(t, gotOpts)
+		require.Len(t, gotOpts.SignedAggregateAndProofs, 1)
+		require.Same(t, msg, gotOpts.SignedAggregateAndProofs[0])
+	})
+
+	t.Run("wraps submission error", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &spec.VersionedSignedAggregateAndProof{Version: spec.DataVersionPhase0}
+
+		service := &aggregatorClientMock{
+			submitAggregateAttestationsFn: func(context.Context, *api.SubmitAggregateAttestationsOpts) error {
+				return errors.New("node rejected the aggregate")
+			},
+		}
+
+		client := &GoClient{log: zap.NewNop(), multiClient: service}
+
+		err := client.SubmitSignedAggregateSelectionProof(t.Context(), msg)
+		require.ErrorContains(t, err, "submit aggregate attestations")
+		require.ErrorContains(t, err, "node rejected the aggregate")
+	})
+}
+
+func TestVersionedAggregateToSSZ(t *testing.T) {
+	t.Parallel()
+
+	versions := []spec.DataVersion{
+		spec.DataVersionPhase0,
+		spec.DataVersionAltair,
+		spec.DataVersionBellatrix,
+		spec.DataVersionCapella,
+		spec.DataVersionDeneb,
+		spec.DataVersionElectra,
+		spec.DataVersionFulu,
+	}
+
+	for _, version := range versions {
+		t.Run(version.String()+" nil inner attestation errors", func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := versionedAggregateToSSZ(&spec.VersionedAttestation{Version: version})
+			require.ErrorContains(t, err, "data is nil")
+		})
+	}
+
+	t.Run("unknown version errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := versionedAggregateToSSZ(&spec.VersionedAttestation{Version: spec.DataVersion(99)})
+		require.ErrorContains(t, err, "unknown data version")
+	})
+}
+
+func TestVersionedToAggregateAndProofNilAndUnknownVersion(t *testing.T) {
+	t.Parallel()
+
+	versions := []spec.DataVersion{
+		spec.DataVersionPhase0,
+		spec.DataVersionAltair,
+		spec.DataVersionBellatrix,
+		spec.DataVersionCapella,
+		spec.DataVersionDeneb,
+		spec.DataVersionElectra,
+		spec.DataVersionFulu,
+	}
+
+	for _, version := range versions {
+		t.Run(version.String()+" nil inner attestation errors", func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := versionedToAggregateAndProof(&spec.VersionedAttestation{Version: version}, 1, phase0.BLSSignature{})
+			require.ErrorContains(t, err, "data is nil")
+		})
+	}
+
+	t.Run("unknown version errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := versionedToAggregateAndProof(&spec.VersionedAttestation{Version: spec.DataVersion(99)}, 1, phase0.BLSSignature{})
+		require.ErrorContains(t, err, "unknown data version")
 	})
 }
 

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -101,7 +101,7 @@ func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
 	if lf.Role == spectypes.RoleCommittee || lf.Role == spectypes.RoleAggregatorCommittee {
 		c, ok := mv.validatorStore.Committee(spectypes.CommitteeID(lf.DutyExecutorID[16:]))
 		if ok {
-			lf.DutyID = fields.BuildCommitteeDutyID(c.Operators, mv.netCfg.EstimatedEpochAtSlot(lf.Slot), lf.Slot)
+			lf.DutyID = fields.BuildCommitteeDutyID(c.Operators, mv.netCfg.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role)
 		}
 	} else {
 		// get the validator index from the msgid

--- a/message/validation/logger_fields_test.go
+++ b/message/validation/logger_fields_test.go
@@ -10,9 +10,28 @@ import (
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
+
+// fakeValidatorStore is a minimal validatorStore double for exercising addDutyIDField, which
+// only needs Committee/Validator lookups (no full registry/storage machinery).
+type fakeValidatorStore struct {
+	validator      *ssvtypes.SSVShare
+	validatorFound bool
+	committee      *registrystorage.Committee
+	committeeFound bool
+}
+
+func (f *fakeValidatorStore) Validator([]byte) (*ssvtypes.SSVShare, bool) {
+	return f.validator, f.validatorFound
+}
+
+func (f *fakeValidatorStore) Committee(spectypes.CommitteeID) (*registrystorage.Committee, bool) {
+	return f.committee, f.committeeFound
+}
 
 func TestBuildLoggerFields(t *testing.T) {
 	mv := &messageValidator{
@@ -378,5 +397,130 @@ func TestAsZapFields(t *testing.T) {
 
 		// Should have minimum required fields
 		require.Len(t, fields, 5) // DutyExecutorID, Role, SSVMessageType, Slot, Signers (all with zero values)
+	})
+}
+
+// TestBuildLoggerFields_DutyID covers addDutyIDField, which buildLoggerFields only invokes at
+// debug log level. It must build a duty ID for both the committee and aggregator-committee
+// roles (using the committee lookup), and for per-validator roles (using the validator lookup).
+func TestBuildLoggerFields_DutyID(t *testing.T) {
+	debugLogger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	require.Equal(t, zap.DebugLevel, debugLogger.Level())
+
+	committeeID := spectypes.CommitteeID{1, 2, 3}
+	operators := []spectypes.OperatorID{4, 5, 6}
+
+	newConsensusMsg := func(role spectypes.RunnerRole, dutyExecutorID []byte, slot phase0.Slot) *queue.SSVMessage {
+		consensusMsg := &specqbft.Message{
+			MsgType: specqbft.CommitMsgType,
+			Height:  specqbft.Height(slot),
+		}
+		ssvMsg := &spectypes.SSVMessage{
+			MsgType: spectypes.SSVConsensusMsgType,
+			MsgID:   spectypes.NewMsgID(spectypes.DomainType{}, dutyExecutorID, role),
+		}
+		return &queue.SSVMessage{
+			SignedSSVMessage: &spectypes.SignedSSVMessage{SSVMessage: ssvMsg},
+			SSVMessage:       ssvMsg,
+			Body:             consensusMsg,
+		}
+	}
+
+	t.Run("committee role builds duty ID from committee lookup", func(t *testing.T) {
+		mv := &messageValidator{
+			logger: debugLogger,
+			netCfg: networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{
+				committee:      &registrystorage.Committee{Operators: operators},
+				committeeFound: true,
+			},
+		}
+
+		msg := newConsensusMsg(spectypes.RoleCommittee, committeeID[:], phase0.Slot(100))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Equal(t, "COMMITTEE-4_5_6-e3-s100", fields.DutyID)
+	})
+
+	t.Run("aggregator-committee role builds a distinct duty ID from the same committee lookup", func(t *testing.T) {
+		mv := &messageValidator{
+			logger: debugLogger,
+			netCfg: networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{
+				committee:      &registrystorage.Committee{Operators: operators},
+				committeeFound: true,
+			},
+		}
+
+		msg := newConsensusMsg(spectypes.RoleAggregatorCommittee, committeeID[:], phase0.Slot(100))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Equal(t, "AGGREGATOR_COMMITTEE-4_5_6-e3-s100", fields.DutyID)
+		require.NotEqual(t, "COMMITTEE-4_5_6-e3-s100", fields.DutyID)
+	})
+
+	t.Run("committee role with unknown committee leaves duty ID empty", func(t *testing.T) {
+		mv := &messageValidator{
+			logger:         debugLogger,
+			netCfg:         networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{committeeFound: false},
+		}
+
+		msg := newConsensusMsg(spectypes.RoleCommittee, committeeID[:], phase0.Slot(100))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Empty(t, fields.DutyID)
+	})
+
+	t.Run("per-validator role builds duty ID from validator lookup", func(t *testing.T) {
+		pubKey := make([]byte, 48)
+		pubKey[0] = 0xAB
+
+		mv := &messageValidator{
+			logger: debugLogger,
+			netCfg: networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{
+				validator:      &ssvtypes.SSVShare{Share: spectypes.Share{ValidatorIndex: phase0.ValidatorIndex(77)}},
+				validatorFound: true,
+			},
+		}
+
+		msg := newConsensusMsg(ssvtypes.RoleAggregator, pubKey, phase0.Slot(200))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Equal(t, "AGGREGATOR-e6-s200-v77", fields.DutyID)
+	})
+
+	t.Run("per-validator role with unknown validator leaves duty ID empty", func(t *testing.T) {
+		pubKey := make([]byte, 48)
+		pubKey[0] = 0xCD
+
+		mv := &messageValidator{
+			logger:         debugLogger,
+			netCfg:         networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{validatorFound: false},
+		}
+
+		msg := newConsensusMsg(ssvtypes.RoleAggregator, pubKey, phase0.Slot(200))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Empty(t, fields.DutyID)
+	})
+
+	t.Run("not invoked below debug level", func(t *testing.T) {
+		mv := &messageValidator{
+			logger: zap.NewNop(),
+			netCfg: networkconfig.TestNetwork,
+			validatorStore: &fakeValidatorStore{
+				committee:      &registrystorage.Committee{Operators: operators},
+				committeeFound: true,
+			},
+		}
+
+		msg := newConsensusMsg(spectypes.RoleCommittee, committeeID[:], phase0.Slot(100))
+		fields := mv.buildLoggerFields(msg)
+
+		require.Empty(t, fields.DutyID, "addDutyIDField must be skipped when the logger isn't at debug level")
 	})
 }

--- a/observability/log/fields/duty_id.go
+++ b/observability/log/fields/duty_id.go
@@ -13,6 +13,11 @@ func BuildDutyID(epoch phase0.Epoch, slot phase0.Slot, runnerRole spectypes.Runn
 	return fmt.Sprintf("%v-e%v-s%v-v%v", utils.FormatRunnerRole(runnerRole), epoch, slot, index)
 }
 
-func BuildCommitteeDutyID(operators []spectypes.OperatorID, epoch phase0.Epoch, slot phase0.Slot) string {
-	return fmt.Sprintf("COMMITTEE-%s-e%d-s%d", utils.FormatCommittee(operators), epoch, slot)
+func BuildCommitteeDutyID(
+	operators []spectypes.OperatorID,
+	epoch phase0.Epoch,
+	slot phase0.Slot,
+	role spectypes.RunnerRole,
+) string {
+	return fmt.Sprintf("%s-%s-e%d-s%d", utils.FormatRunnerRole(role), utils.FormatCommittee(operators), epoch, slot)
 }

--- a/observability/log/fields/duty_id_test.go
+++ b/observability/log/fields/duty_id_test.go
@@ -1,0 +1,74 @@
+package fields
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDutyID(t *testing.T) {
+	t.Parallel()
+
+	got := BuildDutyID(phase0.Epoch(3), phase0.Slot(100), spectypes.RoleCommittee, phase0.ValidatorIndex(42))
+	require.Equal(t, "COMMITTEE-e3-s100-v42", got)
+}
+
+func TestBuildCommitteeDutyID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		operators []spectypes.OperatorID
+		epoch     phase0.Epoch
+		slot      phase0.Slot
+		role      spectypes.RunnerRole
+		want      string
+	}{
+		{
+			name:      "committee role",
+			operators: []spectypes.OperatorID{1, 2, 3},
+			epoch:     phase0.Epoch(5),
+			slot:      phase0.Slot(160),
+			role:      spectypes.RoleCommittee,
+			want:      "COMMITTEE-1_2_3-e5-s160",
+		},
+		{
+			name:      "aggregator-committee role produces a distinct duty ID for the same slot/operators",
+			operators: []spectypes.OperatorID{1, 2, 3},
+			epoch:     phase0.Epoch(5),
+			slot:      phase0.Slot(160),
+			role:      spectypes.RoleAggregatorCommittee,
+			want:      "AGGREGATOR_COMMITTEE-1_2_3-e5-s160",
+		},
+		{
+			name:      "empty operator list",
+			operators: nil,
+			epoch:     phase0.Epoch(0),
+			slot:      phase0.Slot(0),
+			role:      spectypes.RoleCommittee,
+			want:      "COMMITTEE--e0-s0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BuildCommitteeDutyID(tc.operators, tc.epoch, tc.slot, tc.role)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	// The role must be reflected in the ID so committee and aggregator-committee duties for the
+	// same committee/slot never collide.
+	t.Run("committee and aggregator-committee IDs never collide", func(t *testing.T) {
+		t.Parallel()
+
+		operators := []spectypes.OperatorID{7, 8}
+		committeeID := BuildCommitteeDutyID(operators, 1, 1, spectypes.RoleCommittee)
+		aggregatorID := BuildCommitteeDutyID(operators, 1, 1, spectypes.RoleAggregatorCommittee)
+		require.NotEqual(t, committeeID, aggregatorID)
+	})
+}

--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
+	"github.com/ssvlabs/ssv/observability/utils"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -24,25 +25,76 @@ type CommitteeHandler struct {
 
 	attDuties  *dutystore.Duties[eth2apiv1.AttesterDuty]
 	syncDuties *dutystore.SyncCommitteeDuties
+
+	isAggregator bool
 }
 
 type committeeDuty struct {
-	duty        *spectypes.CommitteeDuty
+	duty        spectypes.Duty
 	id          spectypes.CommitteeID
 	operatorIDs []spectypes.OperatorID
 }
 
-func NewCommitteeHandler(attDuties *dutystore.Duties[eth2apiv1.AttesterDuty], syncDuties *dutystore.SyncCommitteeDuties) *CommitteeHandler {
-	h := &CommitteeHandler{
-		attDuties:  attDuties,
-		syncDuties: syncDuties,
+func (cd *committeeDuty) validatorDuties() []*spectypes.ValidatorDuty {
+	switch duty := cd.duty.(type) {
+	case *spectypes.CommitteeDuty:
+		return duty.ValidatorDuties
+	case *spectypes.AggregatorCommitteeDuty:
+		return duty.ValidatorDuties
+	default:
+		return nil
 	}
+}
 
-	return h
+func (cd *committeeDuty) appendValidatorDuty(duty *spectypes.ValidatorDuty) {
+	switch target := cd.duty.(type) {
+	case *spectypes.CommitteeDuty:
+		target.ValidatorDuties = append(target.ValidatorDuties, duty)
+	case *spectypes.AggregatorCommitteeDuty:
+		target.ValidatorDuties = append(target.ValidatorDuties, duty)
+	}
+}
+
+func (h *CommitteeHandler) newCommitteeDuty(slot phase0.Slot) spectypes.Duty {
+	if h.isAggregator {
+		return &spectypes.AggregatorCommitteeDuty{
+			Slot:            slot,
+			ValidatorDuties: []*spectypes.ValidatorDuty{},
+		}
+	}
+	return &spectypes.CommitteeDuty{
+		Slot:            slot,
+		ValidatorDuties: []*spectypes.ValidatorDuty{},
+	}
+}
+
+func NewCommitteeHandler(
+	attDuties *dutystore.Duties[eth2apiv1.AttesterDuty],
+	syncDuties *dutystore.SyncCommitteeDuties,
+) *CommitteeHandler {
+	return &CommitteeHandler{
+		isAggregator: false,
+		attDuties:    attDuties,
+		syncDuties:   syncDuties,
+	}
+}
+
+func NewAggregatorCommitteeHandler(
+	attDuties *dutystore.Duties[eth2apiv1.AttesterDuty],
+	syncDuties *dutystore.SyncCommitteeDuties,
+) *CommitteeHandler {
+	return &CommitteeHandler{
+		isAggregator: true,
+		attDuties:    attDuties,
+		syncDuties:   syncDuties,
+	}
 }
 
 func (h *CommitteeHandler) Name() string {
-	return "CLUSTER"
+	if h.isAggregator {
+		return utils.FormatRunnerRole(spectypes.RoleAggregatorCommittee)
+	}
+	return utils.FormatRunnerRole(spectypes.RoleCommittee)
 }
 
 func (h *CommitteeHandler) WaitShutdown() {}
@@ -60,6 +112,11 @@ func (h *CommitteeHandler) HandleDuties(ctx context.Context) {
 		case <-next:
 			currentSlot := h.ticker.Slot()
 			next = h.ticker.Next()
+
+			if h.isAggregator && !h.netCfg.BooleForkAtSlot(currentSlot) {
+				continue
+			}
+
 			currentEpoch := h.netCfg.EstimatedEpochAtSlot(currentSlot)
 			currentPeriod := h.netCfg.EstimatedSyncCommitteePeriodAtEpoch(currentEpoch)
 
@@ -87,8 +144,12 @@ func (h *CommitteeHandler) HandleDuties(ctx context.Context) {
 }
 
 func (h *CommitteeHandler) processExecution(ctx context.Context, period uint64, epoch phase0.Epoch, slot phase0.Slot) {
+	spanName := "committee.execute"
+	if h.isAggregator {
+		spanName = "aggregator_committee.execute"
+	}
 	ctx, span := tracer.Start(ctx,
-		observability.InstrumentName(observabilityNamespace, "committee.execute"),
+		observability.InstrumentName(observabilityNamespace, spanName),
 		trace.WithAttributes(
 			observability.BeaconSlotAttribute(slot),
 			observability.BeaconEpochAttribute(epoch),
@@ -129,6 +190,13 @@ func (h *CommitteeHandler) buildCommitteeDuties(
 	epoch phase0.Epoch,
 	slot phase0.Slot,
 ) committeeDutiesMap {
+	attRole := spectypes.BNRoleAttester
+	syncRole := spectypes.BNRoleSyncCommittee
+	if h.isAggregator {
+		attRole = spectypes.BNRoleAggregator
+		syncRole = spectypes.BNRoleSyncCommitteeContribution
+	}
+
 	// NOTE: Instead of getting validators using duties one by one, we are getting all validators for the slot at once.
 	// This approach reduces contention and improves performance, as multiple individual calls would be slower.
 	selfValidators := h.validatorProvider.SelfParticipatingValidators(epoch)
@@ -145,12 +213,12 @@ func (h *CommitteeHandler) buildCommitteeDuties(
 	resultCommitteeMap := make(committeeDutiesMap)
 	for _, duty := range attDuties {
 		if h.shouldExecuteAtt(duty, epoch) {
-			h.addToCommitteeMap(resultCommitteeMap, validatorCommittees, h.toSpecAttDuty(duty, spectypes.BNRoleAttester))
+			h.addToCommitteeMap(resultCommitteeMap, validatorCommittees, h.toSpecAttDuty(duty, attRole))
 		}
 	}
 	for _, duty := range syncDuties {
 		if h.shouldExecuteSync(duty, slot, epoch) {
-			h.addToCommitteeMap(resultCommitteeMap, validatorCommittees, h.toSpecSyncDuty(duty, slot, spectypes.BNRoleSyncCommittee))
+			h.addToCommitteeMap(resultCommitteeMap, validatorCommittees, h.toSpecSyncDuty(duty, slot, syncRole))
 		}
 	}
 
@@ -173,16 +241,13 @@ func (h *CommitteeHandler) addToCommitteeMap(
 		cd = &committeeDuty{
 			id:          committee.id,
 			operatorIDs: committee.operatorIDs,
-			duty: &spectypes.CommitteeDuty{
-				Slot:            specDuty.Slot,
-				ValidatorDuties: []*spectypes.ValidatorDuty{},
-			},
+			duty:        h.newCommitteeDuty(specDuty.Slot),
 		}
 
 		committeeDutyMap[committee.id] = cd
 	}
 
-	cd.duty.ValidatorDuties = append(cd.duty.ValidatorDuties, specDuty)
+	cd.appendValidatorDuty(specDuty)
 }
 
 func (h *CommitteeHandler) toSpecAttDuty(duty *eth2apiv1.AttesterDuty, role spectypes.BeaconRole) *spectypes.ValidatorDuty {

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
+	mockslotticker "github.com/ssvlabs/ssv/operator/slotticker/mocks"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
@@ -1040,6 +1041,186 @@ func TestCommitteeHandlerBuildCommitteeDutiesIncludesSyncButNotAttesterDuringPar
 	require.Len(t, validatorDuties, 1)
 	require.Equal(t, spectypes.BNRoleSyncCommittee, validatorDuties[0].Type)
 	require.Equal(t, share.ValidatorIndex, validatorDuties[0].ValidatorIndex)
+}
+
+func TestCommitteeHandlerName(t *testing.T) {
+	dutyStore := dutystore.New()
+
+	committeeHandler := NewCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+	require.Equal(t, "COMMITTEE", committeeHandler.Name())
+
+	aggregatorCommitteeHandler := NewAggregatorCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+	require.Equal(t, "AGGREGATOR_COMMITTEE", aggregatorCommitteeHandler.Name())
+}
+
+func TestAggregatorCommitteeHandlerBuildCommitteeDutiesUsesAggregatorRolesAndDutyType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	share := activeShare(1)
+	share.ValidatorPubKey = spectypes.ValidatorPK{1, 2, 3}
+
+	validatorProvider := NewMockValidatorProvider(ctrl)
+	validatorProvider.EXPECT().SelfParticipatingValidators(phase0.Epoch(0)).Return([]*ssvtypes.SSVShare{share})
+	validatorProvider.EXPECT().Validator(share.ValidatorPubKey[:]).Return(share, true).Times(2)
+
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	beaconCfg.GenesisTime = time.Now()
+	beaconCfg.SlotDuration = time.Hour
+	beaconCfg.SlotsPerEpoch = testSlotsPerEpoch
+	netCfg := *networkconfig.TestNetwork
+	netCfg.Beacon = &beaconCfg
+
+	dutyStore := dutystore.New()
+	handler := NewAggregatorCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+	handler.logger = zap.NewNop()
+	handler.netCfg = &netCfg
+	handler.validatorProvider = validatorProvider
+
+	committeeMap := handler.buildCommitteeDuties(
+		[]*eth2apiv1.AttesterDuty{{
+			PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+			Slot:           0,
+			ValidatorIndex: share.ValidatorIndex,
+		}},
+		[]*eth2apiv1.SyncCommitteeDuty{{
+			PubKey:         phase0.BLSPubKey(share.ValidatorPubKey),
+			ValidatorIndex: share.ValidatorIndex,
+		}},
+		0,
+		0,
+	)
+
+	require.Len(t, committeeMap, 1)
+	cd := committeeMap[share.CommitteeID()]
+	require.NotNil(t, cd)
+
+	// The aggregator-committee handler must build an AggregatorCommitteeDuty (not a
+	// CommitteeDuty), and tag the validator duties with the aggregator-flavored beacon roles.
+	aggDuty, ok := cd.duty.(*spectypes.AggregatorCommitteeDuty)
+	require.True(t, ok, "expected *spectypes.AggregatorCommitteeDuty, got %T", cd.duty)
+	require.Equal(t, phase0.Slot(0), aggDuty.Slot)
+
+	validatorDuties := cd.validatorDuties()
+	require.Len(t, validatorDuties, 2)
+
+	gotRoles := make(map[spectypes.BeaconRole]struct{})
+	for _, vd := range validatorDuties {
+		gotRoles[vd.Type] = struct{}{}
+	}
+	require.Contains(t, gotRoles, spectypes.BNRoleAggregator)
+	require.Contains(t, gotRoles, spectypes.BNRoleSyncCommitteeContribution)
+	require.NotContains(t, gotRoles, spectypes.BNRoleAttester)
+	require.NotContains(t, gotRoles, spectypes.BNRoleSyncCommittee)
+}
+
+func TestCommitteeHandlerHandleDuties_AggregatorSkipsTicksPreBooleFork(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		// A validatorProvider/dutiesExecutor with no EXPECT() calls set: if the pre-fork skip
+		// branch didn't short-circuit HandleDuties, processExecution would call into these and
+		// gomock would fail the test on the unexpected call.
+		validatorProvider := NewMockValidatorProvider(ctrl)
+		dutiesExecutor := NewMockDutiesExecutor(ctrl)
+		mockTicker := mockslotticker.NewMockSlotTicker(ctrl)
+
+		tickCh := make(chan time.Time, 1)
+		mockTicker.EXPECT().Next().Return((<-chan time.Time)(tickCh)).AnyTimes()
+		mockTicker.EXPECT().Slot().Return(phase0.Slot(1)).AnyTimes()
+
+		// Pre-fork: BooleForkAtSlot must be false for any slot.
+		netCfg := *networkconfig.TestNetwork
+
+		dutyStore := dutystore.New()
+		handler := NewAggregatorCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+		handler.logger = zap.NewNop()
+		handler.netCfg = &netCfg
+		handler.validatorProvider = validatorProvider
+		handler.dutiesExecutor = dutiesExecutor
+		handler.ticker = mockTicker
+		handler.reorgEventsCh = make(chan ReorgEvent)
+		handler.indicesChangeCh = make(chan struct{})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			handler.HandleDuties(ctx)
+			close(done)
+		}()
+
+		tickCh <- time.Now()
+		synctest.Wait()
+
+		cancel()
+		<-done
+	})
+}
+
+func TestCommitteeHandlerHandleDuties_AggregatorExecutesTicksPostBooleFork(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		pubKey := phase0.BLSPubKey{9, 9, 9}
+
+		validatorProvider := NewMockValidatorProvider(ctrl)
+		validatorProvider.EXPECT().SelfParticipatingValidators(phase0.Epoch(0)).Return(nil).Times(1)
+		// The seeded duty's validator isn't self-participating, so buildCommitteeDuties ends up
+		// with an empty result — but reaching this call at all proves the tick was processed
+		// rather than skipped by the pre-fork guard.
+		validatorProvider.EXPECT().Validator(pubKey[:]).Return(nil, false).Times(1)
+
+		dutiesExecutor := NewMockDutiesExecutor(ctrl)
+		dutiesExecutor.EXPECT().ExecuteCommitteeDuties(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+
+		mockTicker := mockslotticker.NewMockSlotTicker(ctrl)
+		tickCh := make(chan time.Time, 1)
+		mockTicker.EXPECT().Next().Return((<-chan time.Time)(tickCh)).AnyTimes()
+		mockTicker.EXPECT().Slot().Return(phase0.Slot(1)).AnyTimes()
+
+		// Post-fork: BooleForkAtSlot must be true from genesis.
+		netCfg := *networkconfig.TestNetwork
+		ssvCfg := *networkconfig.TestNetwork.SSV
+		ssvCfg.Forks.Boole = phase0.Epoch(0)
+		netCfg.SSV = &ssvCfg
+
+		dutyStore := dutystore.New()
+		dutyStore.Attester.Set(phase0.Epoch(0), []dutystore.StoreDuty[eth2apiv1.AttesterDuty]{
+			{
+				Slot:           phase0.Slot(1),
+				ValidatorIndex: phase0.ValidatorIndex(1),
+				InCommittee:    true,
+				Duty: &eth2apiv1.AttesterDuty{
+					PubKey:         pubKey,
+					Slot:           phase0.Slot(1),
+					ValidatorIndex: phase0.ValidatorIndex(1),
+				},
+			},
+		})
+
+		handler := NewAggregatorCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee)
+		handler.logger = zap.NewNop()
+		handler.netCfg = &netCfg
+		handler.validatorProvider = validatorProvider
+		handler.dutiesExecutor = dutiesExecutor
+		handler.ticker = mockTicker
+		handler.reorgEventsCh = make(chan ReorgEvent)
+		handler.indicesChangeCh = make(chan struct{})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			handler.HandleDuties(ctx)
+			close(done)
+		}()
+
+		tickCh <- time.Now()
+		synctest.Wait()
+
+		cancel()
+		<-done
+
+		ctrl.Finish()
+	})
 }
 
 // The purpose of the test is to ensure that the scheduler can handle the case where the indices change

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -1036,7 +1036,7 @@ func TestCommitteeHandlerBuildCommitteeDutiesIncludesSyncButNotAttesterDuringPar
 	require.Len(t, committeeMap, 1)
 	committeeDuty := committeeMap[share.CommitteeID()]
 	require.NotNil(t, committeeDuty)
-	validatorDuties := committeeDuty.duty.ValidatorDuties
+	validatorDuties := committeeDuty.validatorDuties()
 	require.Len(t, validatorDuties, 1)
 	require.Equal(t, spectypes.BNRoleSyncCommittee, validatorDuties[0].Type)
 	require.Equal(t, share.ValidatorIndex, validatorDuties[0].ValidatorIndex)

--- a/operator/duties/executor_noop.go
+++ b/operator/duties/executor_noop.go
@@ -15,7 +15,7 @@ func NewNoopExecutor() *noopExecutor { return &noopExecutor{} }
 func (n *noopExecutor) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty) {
 }
 
-func (n *noopExecutor) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, _ spectypes.CommitteeID, _ *spectypes.CommitteeDuty) {
+func (n *noopExecutor) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, _ spectypes.CommitteeID, _ spectypes.Duty) {
 }
 
 // Ensure interface conformance.

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -48,7 +48,7 @@ type DutiesExecutor interface {
 // DutyExecutor is an interface for executing duty.
 type DutyExecutor interface {
 	ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty)
-	ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, committeeID spectypes.CommitteeID, duty *spectypes.CommitteeDuty)
+	ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, committeeID spectypes.CommitteeID, duty spectypes.Duty)
 }
 
 type BeaconNode interface {
@@ -176,6 +176,7 @@ func NewScheduler(logger *zap.Logger, opts *SchedulerOptions) *Scheduler {
 	if !opts.ExporterMode {
 		s.dutyHandlers = append(s.dutyHandlers,
 			NewCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee),
+			NewAggregatorCommitteeHandler(dutyStore.Attester, dutyStore.SyncCommittee),
 			NewValidatorRegistrationHandler(opts.ValidatorRegistrationCh),
 			NewVoluntaryExitHandler(dutyStore.VoluntaryExit, opts.ValidatorExitCh),
 		)
@@ -522,20 +523,23 @@ func (s *Scheduler) ExecuteCommitteeDuties(ctx context.Context, duties committee
 
 	for _, committee := range duties {
 		duty := committee.duty
+		slot := duty.DutySlot()
+		role := types.RunnerRoleForDuty(duty, s.netCfg.BooleForkAtSlot(slot))
 
 		logger := s.loggerWithCommitteeDutyContext(committee)
 
 		const eventMsg = "🔧 executing committee duty"
-		dutyEpoch := s.netCfg.EstimatedEpochAtSlot(duty.Slot)
-		logger.Debug(eventMsg, fields.Duties(dutyEpoch, duty.ValidatorDuties, -1, func(duty *spectypes.ValidatorDuty) spectypes.RunnerRole {
+		dutyEpoch := s.netCfg.EstimatedEpochAtSlot(slot)
+		logger.Debug(eventMsg, fields.Duties(dutyEpoch, committee.validatorDuties(), -1, func(duty *spectypes.ValidatorDuty) spectypes.RunnerRole {
 			return types.RunnerRoleForValidatorDuty(duty, s.netCfg.BooleForkAtSlot(duty.Slot))
 		}))
 		span.AddEvent(eventMsg, trace.WithAttributes(
+			observability.RunnerRoleAttribute(role),
 			observability.CommitteeIDAttribute(committee.id),
-			observability.DutyCountAttribute(len(duty.ValidatorDuties)),
+			observability.DutyCountAttribute(len(committee.validatorDuties())),
 		))
 
-		slotDelay := time.Since(s.netCfg.SlotStartTime(duty.Slot))
+		slotDelay := time.Since(s.netCfg.SlotStartTime(slot))
 		if slotDelay >= 100*time.Millisecond {
 			const eventMsg = "⚠️ late duty execution"
 			logger.Warn(eventMsg, zap.Duration("slot_delay", slotDelay))
@@ -544,7 +548,7 @@ func (s *Scheduler) ExecuteCommitteeDuties(ctx context.Context, duties committee
 				attribute.Int64("ssv.beacon.slot_delay_ms", slotDelay.Milliseconds())))
 		}
 
-		recordDutyScheduled(ctx, duty.RunnerRole(), slotDelay)
+		recordDutyScheduled(ctx, role, slotDelay)
 
 		s.backgroundTasks.Add(1)
 		go func() {
@@ -555,7 +559,9 @@ func (s *Scheduler) ExecuteCommitteeDuties(ctx context.Context, duties committee
 			dutyCtx, cancel := context.WithDeadline(s.ctx, dutyDeadline)
 			defer cancel()
 
-			s.waitOneThirdIntoSlotOrValidBlock(duty.Slot)
+			if role == spectypes.RoleCommittee {
+				s.waitOneThirdIntoSlotOrValidBlock(slot)
+			}
 			s.dutyExecutor.ExecuteCommitteeDuty(dutyCtx, logger, committee.id, duty)
 		}()
 	}
@@ -565,8 +571,8 @@ func (s *Scheduler) ExecuteCommitteeDuties(ctx context.Context, duties committee
 
 // loggerWithDutyContext returns an instance of logger with the given duty's information
 func (s *Scheduler) loggerWithDutyContext(duty *spectypes.ValidatorDuty) *zap.Logger {
-	role := types.RunnerRoleForValidatorDuty(duty, s.netCfg.BooleForkAtSlot(duty.Slot))
 	dutyEpoch := s.netCfg.EstimatedEpochAtSlot(duty.Slot)
+	role := types.RunnerRoleForValidatorDuty(duty, s.netCfg.BooleForkAtSlot(duty.Slot))
 	dutyID := fields.BuildDutyID(dutyEpoch, duty.Slot, role, duty.ValidatorIndex)
 
 	return s.logger.
@@ -581,14 +587,15 @@ func (s *Scheduler) loggerWithDutyContext(duty *spectypes.ValidatorDuty) *zap.Lo
 
 // loggerWithCommitteeDutyContext returns an instance of logger with the given committee duty's information
 func (s *Scheduler) loggerWithCommitteeDutyContext(committeeDuty *committeeDuty) *zap.Logger {
-	duty := committeeDuty.duty
+	slot := committeeDuty.duty.DutySlot()
 
-	dutyEpoch := s.netCfg.EstimatedEpochAtSlot(duty.Slot)
-	committeeDutyID := fields.BuildCommitteeDutyID(committeeDuty.operatorIDs, dutyEpoch, duty.Slot)
+	dutyEpoch := s.netCfg.EstimatedEpochAtSlot(slot)
+	role := types.RunnerRoleForDuty(committeeDuty.duty, s.netCfg.BooleForkAtSlot(slot))
+	committeeDutyID := fields.BuildCommitteeDutyID(committeeDuty.operatorIDs, dutyEpoch, slot, role)
 
 	return s.logger.
-		With(fields.RunnerRole(duty.RunnerRole())).
-		With(fields.Slot(duty.Slot)).
+		With(fields.RunnerRole(role)).
+		With(fields.Slot(slot)).
 		With(fields.DutyID(committeeDutyID)).
 		With(fields.CommitteeID(committeeDuty.id)).
 		With(fields.EstimatedCurrentEpoch(s.netCfg.EstimatedCurrentEpoch())).

--- a/operator/duties/scheduler_mock.go
+++ b/operator/duties/scheduler_mock.go
@@ -97,7 +97,7 @@ func (m *MockDutyExecutor) EXPECT() *MockDutyExecutorMockRecorder {
 }
 
 // ExecuteCommitteeDuty mocks base method.
-func (m *MockDutyExecutor) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, committeeID types0.CommitteeID, duty *types0.CommitteeDuty) {
+func (m *MockDutyExecutor) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, committeeID types0.CommitteeID, duty types0.Duty) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ExecuteCommitteeDuty", ctx, logger, committeeID, duty)
 }

--- a/operator/duties/scheduler_test.go
+++ b/operator/duties/scheduler_test.go
@@ -383,11 +383,11 @@ func waitForDutiesExecutionCommittee(
 			if !ok {
 				require.FailNow(t, "missing cluster id")
 			}
-			require.Len(t, aCommDuty.duty.ValidatorDuties, len(eCommDuty.duty.ValidatorDuties))
+			require.Len(t, aCommDuty.validatorDuties(), len(eCommDuty.validatorDuties()))
 
-			for _, e := range eCommDuty.duty.ValidatorDuties {
+			for _, e := range eCommDuty.validatorDuties() {
 				found := false
-				for _, d := range aCommDuty.duty.ValidatorDuties {
+				for _, d := range aCommDuty.validatorDuties() {
 					if e.Type == d.Type && e.PubKey == d.PubKey && e.ValidatorIndex == d.ValidatorIndex && e.Slot == d.Slot {
 						found = true
 						break

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -159,9 +159,12 @@ type Controller struct {
 	committeesObservers      *ttlcache.Cache[spectypes.MessageID, *validator.CommitteeObserver]
 	committeesObserversMutex sync.Mutex
 
-	attesterRoots   *ttlcache.Cache[phase0.Root, struct{}]
-	syncCommRoots   *ttlcache.Cache[phase0.Root, struct{}]
-	beaconVoteRoots *ttlcache.Cache[validator.BeaconVoteCacheKey, struct{}]
+	attesterRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	aggregatorRoots      *ttlcache.Cache[phase0.Root, struct{}]
+	syncCommRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	syncCommContribRoots *ttlcache.Cache[phase0.Root, struct{}]
+	beaconVoteRoots      *ttlcache.Cache[validator.BeaconVoteCacheKey, struct{}]
+	aggregatorCommRoots  *ttlcache.Cache[validator.AggregatorCommitteeCacheKey, struct{}]
 
 	domainCache *validator.DomainCache
 
@@ -239,12 +242,21 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 		attesterRoots: ttlcache.New(
 			ttlcache.WithTTL[phase0.Root, struct{}](cacheTTL),
 		),
+		aggregatorRoots: ttlcache.New(
+			ttlcache.WithTTL[phase0.Root, struct{}](cacheTTL),
+		),
 		syncCommRoots: ttlcache.New(
+			ttlcache.WithTTL[phase0.Root, struct{}](cacheTTL),
+		),
+		syncCommContribRoots: ttlcache.New(
 			ttlcache.WithTTL[phase0.Root, struct{}](cacheTTL),
 		),
 		domainCache: validator.NewDomainCache(options.Beacon, cacheTTL),
 		beaconVoteRoots: ttlcache.New(
 			ttlcache.WithTTL[validator.BeaconVoteCacheKey, struct{}](cacheTTL),
+		),
+		aggregatorCommRoots: ttlcache.New(
+			ttlcache.WithTTL[validator.AggregatorCommitteeCacheKey, struct{}](cacheTTL),
 		),
 		indicesChangeCh:         make(chan struct{}),
 		validatorRegistrationCh: make(chan duties.RegistrationDescriptor),
@@ -265,9 +277,12 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 	go ctrl.committeesObservers.Start()
 	// Delete old root and domain entries.
 	go ctrl.attesterRoots.Start()
+	go ctrl.aggregatorRoots.Start()
 	go ctrl.syncCommRoots.Start()
+	go ctrl.syncCommContribRoots.Start()
 	go ctrl.domainCache.Start()
 	go ctrl.beaconVoteRoots.Start()
+	go ctrl.aggregatorCommRoots.Start()
 
 	return ctrl
 }
@@ -278,9 +293,12 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 func (c *Controller) Stop() {
 	c.committeesObservers.Stop()
 	c.attesterRoots.Stop()
+	c.aggregatorRoots.Stop()
 	c.syncCommRoots.Stop()
+	c.syncCommContribRoots.Stop()
 	c.domainCache.Stop()
 	c.beaconVoteRoots.Stop()
+	c.aggregatorCommRoots.Stop()
 }
 
 func (c *Controller) IndicesChangeChan() chan struct{} {
@@ -359,9 +377,10 @@ func (c *Controller) handleRouterMessages() {
 }
 
 var nonCommitteeValidatorTTLs = map[spectypes.RunnerRole]int{
-	spectypes.RoleCommittee: 64,
-	spectypes.RoleProposer:  4,
-	ssvtypes.RoleAggregator: 4,
+	spectypes.RoleCommittee:           64,
+	spectypes.RoleAggregatorCommittee: 4,
+	spectypes.RoleProposer:            4,
+	ssvtypes.RoleAggregator:           4,
 	//spectypes.BNRoleSyncCommittee:             4,
 	ssvtypes.RoleSyncCommitteeContribution: 4,
 }
@@ -374,18 +393,21 @@ func (c *Controller) handleWorkerMessages(ctx context.Context, msg network.Decod
 	item := c.committeesObservers.Get(ssvMsg.GetID())
 	if item == nil || item.Value() == nil {
 		committeeObserverOptions := validator.CommitteeObserverOptions{
-			Logger:            c.logger,
-			BeaconConfig:      c.networkConfig.Beacon,
-			ValidatorStore:    c.validatorStore,
-			Network:           c.validatorCommonOpts.Network,
-			Storage:           c.validatorCommonOpts.Storage,
-			FullNode:          c.validatorCommonOpts.FullNode,
-			OperatorSigner:    c.validatorCommonOpts.OperatorSigner,
-			NewDecidedHandler: c.validatorCommonOpts.NewDecidedHandler,
-			AttesterRoots:     c.attesterRoots,
-			SyncCommRoots:     c.syncCommRoots,
-			DomainCache:       c.domainCache,
-			BeaconVoteRoots:   c.beaconVoteRoots,
+			Logger:               c.logger,
+			BeaconConfig:         c.networkConfig.Beacon,
+			ValidatorStore:       c.validatorStore,
+			Network:              c.validatorCommonOpts.Network,
+			Storage:              c.validatorCommonOpts.Storage,
+			FullNode:             c.validatorCommonOpts.FullNode,
+			OperatorSigner:       c.validatorCommonOpts.OperatorSigner,
+			NewDecidedHandler:    c.validatorCommonOpts.NewDecidedHandler,
+			AttesterRoots:        c.attesterRoots,
+			AggregatorRoots:      c.aggregatorRoots,
+			SyncCommRoots:        c.syncCommRoots,
+			SyncCommContribRoots: c.syncCommContribRoots,
+			DomainCache:          c.domainCache,
+			BeaconVoteRoots:      c.beaconVoteRoots,
+			AggregatorCommRoots:  c.aggregatorCommRoots,
 		}
 
 		ncv = validator.NewCommitteeObserver(ssvMsg.GetID(), committeeObserverOptions)
@@ -416,8 +438,10 @@ func (c *Controller) handleNonCommitteeMessages(
 	defer c.committeesObserversMutex.Unlock()
 
 	if msg.MsgType == spectypes.SSVConsensusMsgType {
-		// Process proposal messages for committee consensus only to get the roots
-		if msg.MsgID.GetRoleType() != spectypes.RoleCommittee {
+		// Process proposal messages for committee (and aggregator-committee) consensus only to
+		// get the roots
+		role := msg.MsgID.GetRoleType()
+		if role != spectypes.RoleCommittee && role != spectypes.RoleAggregatorCommittee {
 			return nil
 		}
 
@@ -1095,9 +1119,23 @@ func SetupCommitteeRunners(
 				return nil, err
 			}
 			return crunner, nil
+		case *spectypes.AggregatorCommitteeDuty:
+			acrunner, err := runner.NewAggregatorCommitteeRunner(runner.AggregatorCommitteeRunnerOptions{
+				BaseRunnerOptions: runner.BaseRunnerOptions{
+					NetworkConfig:  options.NetworkConfig,
+					Share:          shares,
+					Beacon:         options.Beacon,
+					Network:        options.Network,
+					Signer:         options.Signer,
+					OperatorSigner: options.OperatorSigner,
+				},
+				QBFTController: buildController(spectypes.RoleAggregatorCommittee),
+			})
+			if err != nil {
+				return nil, err
+			}
+			return acrunner, nil
 		default:
-			// TODO(convergence unit 5c, group 3): construct AggregatorCommitteeRunner for
-			// *spectypes.AggregatorCommitteeDuty here.
 			return nil, fmt.Errorf("unsupported committee duty type: %T", duty)
 		}
 	}
@@ -1173,21 +1211,29 @@ func SetupRunners(
 				ProposerDelay:       options.ProposerDelay,
 			})
 		case ssvtypes.RoleAggregator:
-			aggregatorValueChecker := ssv.NewAggregatorChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
-			runners[role], err = runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
-				BaseRunnerOptions:  baseOpts,
-				QBFTController:     buildController(ssvtypes.RoleAggregator),
-				ValCheck:           aggregatorValueChecker,
-				HighestDecidedSlot: 0,
-			})
+			// Post-Boole, aggregator duties route through the merged AggregatorCommitteeRunner
+			// (committee-scoped) instead of this legacy per-validator runner.
+			if !options.NetworkConfig.BooleFork() {
+				aggregatorValueChecker := ssv.NewAggregatorChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
+				runners[role], err = runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
+					BaseRunnerOptions:  baseOpts,
+					QBFTController:     buildController(ssvtypes.RoleAggregator),
+					ValCheck:           aggregatorValueChecker,
+					HighestDecidedSlot: 0,
+				})
+			}
 		case ssvtypes.RoleSyncCommitteeContribution:
-			syncCommitteeContributionValueChecker := ssv.NewSyncCommitteeContributionChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
-			runners[role], err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{
-				BaseRunnerOptions:  baseOpts,
-				QBFTController:     buildController(ssvtypes.RoleSyncCommitteeContribution),
-				ValCheck:           syncCommitteeContributionValueChecker,
-				HighestDecidedSlot: 0,
-			})
+			// Post-Boole, sync committee contribution duties route through the merged
+			// AggregatorCommitteeRunner (committee-scoped) instead of this legacy per-validator runner.
+			if !options.NetworkConfig.BooleFork() {
+				syncCommitteeContributionValueChecker := ssv.NewSyncCommitteeContributionChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
+				runners[role], err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{
+					BaseRunnerOptions:  baseOpts,
+					QBFTController:     buildController(ssvtypes.RoleSyncCommitteeContribution),
+					ValCheck:           syncCommitteeContributionValueChecker,
+					HighestDecidedSlot: 0,
+				})
+			}
 		case spectypes.RoleValidatorRegistration:
 			runners[role], err = runner.NewValidatorRegistrationRunner(runner.ValidatorRegistrationRunnerOptions{
 				BaseRunnerOptions:              baseOpts,

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -620,14 +620,13 @@ func (c *Controller) GetValidator(pubKey spectypes.ValidatorPK) (*validator.Vali
 }
 
 func (c *Controller) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty) {
-	// TODO(convergence unit 5): thread real fork bit instead of a literal false.
-	runnerRole := ssvtypes.RunnerRoleForValidatorDuty(duty, false)
 	dutyEpoch := c.networkConfig.EstimatedEpochAtSlot(duty.Slot)
-	dutyID := fields.BuildDutyID(c.networkConfig.EstimatedEpochAtSlot(duty.Slot), duty.Slot, runnerRole, duty.ValidatorIndex)
+	role := ssvtypes.RunnerRoleForValidatorDuty(duty, c.networkConfig.BooleForkAtSlot(duty.Slot))
+	dutyID := fields.BuildDutyID(dutyEpoch, duty.Slot, role, duty.ValidatorIndex)
 	ctx, span := tracer.Start(traces.Context(ctx, dutyID),
 		observability.InstrumentName(observabilityNamespace, "execute_duty"),
 		trace.WithAttributes(
-			observability.RunnerRoleAttribute(runnerRole),
+			observability.RunnerRoleAttribute(role),
 			observability.BeaconRoleAttribute(duty.Type),
 			observability.CommitteeIndexAttribute(duty.CommitteeIndex),
 			observability.BeaconEpochAttribute(dutyEpoch),
@@ -658,7 +657,12 @@ func (c *Controller) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *
 	span.SetStatus(codes.Ok, "")
 }
 
-func (c *Controller) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logger, committeeID spectypes.CommitteeID, duty *spectypes.CommitteeDuty) {
+func (c *Controller) ExecuteCommitteeDuty(
+	ctx context.Context,
+	logger *zap.Logger,
+	committeeID spectypes.CommitteeID,
+	duty spectypes.Duty,
+) {
 	cm, ok := c.validatorsMap.GetCommittee(committeeID)
 	if !ok {
 		const eventMsg = "could not find committee"
@@ -671,14 +675,15 @@ func (c *Controller) ExecuteCommitteeDuty(ctx context.Context, logger *zap.Logge
 		committee = append(committee, operator.OperatorID)
 	}
 
-	dutyEpoch := c.networkConfig.EstimatedEpochAtSlot(duty.Slot)
-	dutyID := fields.BuildCommitteeDutyID(committee, dutyEpoch, duty.Slot)
+	dutyEpoch := c.networkConfig.EstimatedEpochAtSlot(duty.DutySlot())
+	role := ssvtypes.RunnerRoleForDuty(duty, c.networkConfig.BooleForkAtSlot(duty.DutySlot()))
+	dutyID := fields.BuildCommitteeDutyID(committee, dutyEpoch, duty.DutySlot(), role)
 	ctx, span := tracer.Start(traces.Context(ctx, dutyID),
 		observability.InstrumentName(observabilityNamespace, "execute_committee_duty"),
 		trace.WithAttributes(
-			observability.RunnerRoleAttribute(duty.RunnerRole()),
+			observability.RunnerRoleAttribute(role),
 			observability.BeaconEpochAttribute(dutyEpoch),
-			observability.BeaconSlotAttribute(duty.Slot),
+			observability.BeaconSlotAttribute(duty.DutySlot()),
 			observability.CommitteeIDAttribute(committeeID),
 			observability.DutyIDAttribute(dutyID),
 		),
@@ -1034,11 +1039,11 @@ func SetupCommitteeRunners(
 ) validator.CommitteeRunnerFunc {
 	if options.ExporterOptions.Enabled {
 		return func(
-			phase0.Slot,
+			spectypes.Duty,
 			map[phase0.ValidatorIndex]*spectypes.Share,
 			[]phase0.BLSPubKey,
 			runner.CommitteeDutyGuard,
-		) (*runner.CommitteeRunner, error) {
+		) (runner.Runner, error) {
 			return nil, fmt.Errorf("cannot set up committee runners in exporter mode")
 		}
 	}
@@ -1065,29 +1070,36 @@ func SetupCommitteeRunners(
 	}
 
 	return func(
-		slot phase0.Slot,
+		duty spectypes.Duty,
 		shares map[phase0.ValidatorIndex]*spectypes.Share,
 		attestingValidators []phase0.BLSPubKey,
 		dutyGuard runner.CommitteeDutyGuard,
-	) (*runner.CommitteeRunner, error) {
-		crunner, err := runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
-			BaseRunnerOptions: runner.BaseRunnerOptions{
-				NetworkConfig:  options.NetworkConfig,
-				Share:          shares,
-				Beacon:         options.Beacon,
-				Network:        options.Network,
-				Signer:         options.Signer,
-				OperatorSigner: options.OperatorSigner,
-			},
-			AttestingValidators: attestingValidators,
-			QBFTController:      buildController(spectypes.RoleCommittee),
-			DutyGuard:           dutyGuard,
-			DoppelgangerHandler: options.DoppelgangerHandler,
-		})
-		if err != nil {
-			return nil, err
+	) (runner.Runner, error) {
+		switch duty.(type) {
+		case *spectypes.CommitteeDuty:
+			crunner, err := runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
+				BaseRunnerOptions: runner.BaseRunnerOptions{
+					NetworkConfig:  options.NetworkConfig,
+					Share:          shares,
+					Beacon:         options.Beacon,
+					Network:        options.Network,
+					Signer:         options.Signer,
+					OperatorSigner: options.OperatorSigner,
+				},
+				AttestingValidators: attestingValidators,
+				QBFTController:      buildController(spectypes.RoleCommittee),
+				DutyGuard:           dutyGuard,
+				DoppelgangerHandler: options.DoppelgangerHandler,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return crunner, nil
+		default:
+			// TODO(convergence unit 5c, group 3): construct AggregatorCommitteeRunner for
+			// *spectypes.AggregatorCommitteeDuty here.
+			return nil, fmt.Errorf("unsupported committee duty type: %T", duty)
 		}
-		return crunner.(*runner.CommitteeRunner), nil
 	}
 }
 

--- a/operator/validator/controller_bench_test.go
+++ b/operator/validator/controller_bench_test.go
@@ -183,7 +183,7 @@ func benchmarkCommitteeFixture(
 
 	warmupMsg := benchmarkRouterMessage(committeeID, slot)
 	committee.EnqueueMessage(ctx, warmupMsg)
-	committeeQueue := committee.Queues[slot]
+	committeeQueue := committee.Queues[slot].Q
 	committeeQueue.TryPop(queue.NewCommitteeQueuePrioritizer(&queue.State{
 		Slot:   slot,
 		Quorum: 3,

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -171,7 +171,7 @@ func TestSetupCommitteeRunnersExporter(t *testing.T) {
 		},
 	})
 
-	runner, err := committeeRunnerFunc(0, nil, nil, nil)
+	runner, err := committeeRunnerFunc(&spectypes.CommitteeDuty{}, nil, nil, nil)
 	require.Nil(t, runner)
 	require.ErrorContains(t, err, "cannot set up committee runners in exporter mode")
 }

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -176,6 +176,195 @@ func TestSetupCommitteeRunnersExporter(t *testing.T) {
 	require.ErrorContains(t, err, "cannot set up committee runners in exporter mode")
 }
 
+func TestSetupCommitteeRunners(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBeaconNode := beacon.NewMockBeaconNode(ctrl)
+
+	options := &validator.Options{
+		CommonOptions: validator.CommonOptions{
+			NetworkConfig: networkconfig.TestNetwork,
+			Beacon:        mockBeaconNode,
+		},
+		Operator: &spectypes.CommitteeMember{},
+	}
+
+	committeeRunnerFunc := SetupCommitteeRunners(t.Context(), options)
+
+	shares := map[phase0.ValidatorIndex]*spectypes.Share{
+		0: {},
+	}
+
+	t.Run("CommitteeDuty builds a CommitteeRunner", func(t *testing.T) {
+		r, err := committeeRunnerFunc(&spectypes.CommitteeDuty{}, shares, nil, nil)
+		require.NoError(t, err)
+		require.IsType(t, &runner.CommitteeRunner{}, r)
+	})
+
+	t.Run("AggregatorCommitteeDuty builds an AggregatorCommitteeRunner", func(t *testing.T) {
+		r, err := committeeRunnerFunc(&spectypes.AggregatorCommitteeDuty{}, shares, nil, nil)
+		require.NoError(t, err)
+		require.IsType(t, &runner.AggregatorCommitteeRunner{}, r)
+	})
+
+	t.Run("unsupported duty type errors", func(t *testing.T) {
+		r, err := committeeRunnerFunc(&spectypes.ValidatorDuty{}, shares, nil, nil)
+		require.Nil(t, r)
+		require.ErrorContains(t, err, "unsupported committee duty type")
+	})
+
+	t.Run("no shares errors regardless of duty type", func(t *testing.T) {
+		r, err := committeeRunnerFunc(&spectypes.CommitteeDuty{}, nil, nil, nil)
+		require.Nil(t, r)
+		require.ErrorContains(t, err, "no shares")
+
+		r, err = committeeRunnerFunc(&spectypes.AggregatorCommitteeDuty{}, nil, nil, nil)
+		require.Nil(t, r)
+		require.ErrorContains(t, err, "no shares")
+	})
+}
+
+func TestHandleNonCommitteeMessages_RoleGuard(t *testing.T) {
+	logger := log.TestLogger(t)
+	controllerOptions := MockControllerOptions{
+		validatorCommonOpts: &validator.CommonOptions{},
+	}
+	ctr := setupController(t, logger, controllerOptions)
+
+	newConsensusMsg := func(role spectypes.RunnerRole, body any) *queue.SSVMessage {
+		return &queue.SSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.SSVConsensusMsgType,
+				MsgID:   spectypes.NewMsgID(spectypes.DomainType{}, make([]byte, 48), role),
+			},
+			Body: body,
+		}
+	}
+
+	t.Run("non-committee, non-aggregator-committee roles are ignored", func(t *testing.T) {
+		msg := newConsensusMsg(types.RoleAggregator, &specqbft.Message{MsgType: specqbft.ProposalMsgType})
+
+		// ncv is nil: if the role guard didn't short-circuit before touching ncv, this would panic.
+		err := ctr.handleNonCommitteeMessages(t.Context(), msg, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("aggregator-committee role with non-proposal consensus message is ignored", func(t *testing.T) {
+		msg := newConsensusMsg(spectypes.RoleAggregatorCommittee, &specqbft.Message{MsgType: specqbft.CommitMsgType})
+
+		err := ctr.handleNonCommitteeMessages(t.Context(), msg, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("committee role with non-proposal consensus message is ignored", func(t *testing.T) {
+		msg := newConsensusMsg(spectypes.RoleCommittee, &specqbft.Message{MsgType: specqbft.CommitMsgType})
+
+		err := ctr.handleNonCommitteeMessages(t.Context(), msg, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("unrelated message types are ignored", func(t *testing.T) {
+		msg := &queue.SSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.DKGMsgType,
+				MsgID:   spectypes.NewMsgID(spectypes.DomainType{}, make([]byte, 48), spectypes.RoleCommittee),
+			},
+		}
+
+		err := ctr.handleNonCommitteeMessages(t.Context(), msg, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestExecuteDuty(t *testing.T) {
+	t.Run("validator not found logs and returns without panicking", func(t *testing.T) {
+		logger := log.TestLogger(t)
+		controllerOptions := MockControllerOptions{
+			validatorsMap:       validators.New(t.Context()),
+			validatorCommonOpts: &validator.CommonOptions{},
+		}
+		ctr := setupController(t, logger, controllerOptions)
+
+		// No validator registered for this pubkey. This also exercises the real
+		// c.networkConfig.BooleForkAtSlot(duty.Slot) role computation (replacing the previous
+		// hard-coded `false`) on the way to the early-return.
+		duty := &spectypes.ValidatorDuty{
+			Type:           spectypes.BNRoleAttester,
+			PubKey:         phase0.BLSPubKey{1, 2, 3},
+			Slot:           1,
+			ValidatorIndex: 7,
+		}
+		ctr.ExecuteDuty(t.Context(), logger, duty)
+	})
+}
+
+func TestExecuteCommitteeDuty(t *testing.T) {
+	t.Run("committee not found logs and returns without panicking", func(t *testing.T) {
+		logger := log.TestLogger(t)
+		controllerOptions := MockControllerOptions{
+			validatorsMap:       validators.New(t.Context()),
+			validatorCommonOpts: &validator.CommonOptions{},
+		}
+		ctr := setupController(t, logger, controllerOptions)
+
+		// No committee registered for this ID — must not panic despite the duty carrying no
+		// runner-role information the caller can rely on ahead of time.
+		ctr.ExecuteCommitteeDuty(t.Context(), logger, spectypes.CommitteeID{1, 2, 3}, &spectypes.CommitteeDuty{Slot: 1})
+	})
+
+	t.Run("committee found but duty preparation fails is handled without panicking", func(t *testing.T) {
+		logger := log.TestLogger(t)
+		vmap := validators.New(t.Context())
+		controllerOptions := MockControllerOptions{
+			validatorsMap:       vmap,
+			validatorCommonOpts: &validator.CommonOptions{NetworkConfig: networkconfig.TestNetwork},
+		}
+		ctr := setupController(t, logger, controllerOptions)
+
+		committeeID := spectypes.CommitteeID{9, 9, 9}
+		cm := validator.NewCommittee(
+			logger,
+			networkconfig.TestNetwork,
+			&spectypes.CommitteeMember{CommitteeID: committeeID, Committee: []*spectypes.Operator{{OperatorID: 1}}},
+			nil, // CreateRunnerFn is never invoked: prepareDuty fails before createRunner runs.
+			nil,
+			nil,
+		)
+		vmap.PutCommittee(committeeID, cm)
+
+		// An empty ValidatorDuties list makes the committee's StartDuty fail fast with
+		// "no beacon duties" — this exercises ExecuteCommitteeDuty's new
+		// duty.DutySlot()/RunnerRoleForDuty(duty, ...) plumbing (replacing the old
+		// *spectypes.CommitteeDuty-only signature) down the error-handling path, without
+		// needing a fully wired runner stack.
+		ctr.ExecuteCommitteeDuty(t.Context(), logger, committeeID, &spectypes.CommitteeDuty{Slot: 1, ValidatorDuties: nil})
+	})
+
+	t.Run("aggregator-committee duty found but duty preparation fails is handled without panicking", func(t *testing.T) {
+		logger := log.TestLogger(t)
+		vmap := validators.New(t.Context())
+		controllerOptions := MockControllerOptions{
+			validatorsMap:       vmap,
+			validatorCommonOpts: &validator.CommonOptions{NetworkConfig: networkconfig.TestNetwork},
+		}
+		ctr := setupController(t, logger, controllerOptions)
+
+		committeeID := spectypes.CommitteeID{4, 5, 6}
+		cm := validator.NewCommittee(
+			logger,
+			networkconfig.TestNetwork,
+			&spectypes.CommitteeMember{CommitteeID: committeeID, Committee: []*spectypes.Operator{{OperatorID: 1}}},
+			nil,
+			nil,
+			nil,
+		)
+		vmap.PutCommittee(committeeID, cm)
+
+		// Same as above but for the new AggregatorCommitteeDuty type, so RunnerRoleForDuty
+		// resolves to RoleAggregatorCommittee instead of RoleCommittee.
+		ctr.ExecuteCommitteeDuty(t.Context(), logger, committeeID, &spectypes.AggregatorCommitteeDuty{Slot: 1, ValidatorDuties: nil})
+	})
+}
+
 func TestHandleNonCommitteeMessages(t *testing.T) {
 	logger := log.TestLogger(t)
 	mockValidatorsMap := validators.New(t.Context())

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -35,7 +35,12 @@ type ProposerCalls interface {
 
 // AggregatorCalls interface has all attestation aggregator duty specific calls
 type AggregatorCalls interface {
+	// IsAggregator returns true if the validator is selected as an aggregator
+	IsAggregator(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, slotSig []byte) bool
+	// GetAggregateAttestation returns the aggregate attestation for the given slot and committee
+	GetAggregateAttestation(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (ssz.Marshaler, spec.DataVersion, error)
 	// SubmitAggregateSelectionProof returns an AggregateAndProof object
+	// Deprecated: Use IsAggregator and GetAggregateAttestation instead. Kept for backward compatibility.
 	SubmitAggregateSelectionProof(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, index phase0.ValidatorIndex, slotSig []byte) (ssz.Marshaler, spec.DataVersion, error)
 	// SubmitSignedAggregateSelectionProof broadcasts a signed aggregator msg
 	SubmitSignedAggregateSelectionProof(ctx context.Context, msg *spec.VersionedSignedAggregateAndProof) error

--- a/protocol/v2/blockchain/beacon/mock_client.go
+++ b/protocol/v2/blockchain/beacon/mock_client.go
@@ -154,6 +154,36 @@ func (m *MockAggregatorCalls) EXPECT() *MockAggregatorCallsMockRecorder {
 	return m.recorder
 }
 
+// GetAggregateAttestation mocks base method.
+func (m *MockAggregatorCalls) GetAggregateAttestation(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (ssz.Marshaler, spec.DataVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAggregateAttestation", ctx, slot, committeeIndex)
+	ret0, _ := ret[0].(ssz.Marshaler)
+	ret1, _ := ret[1].(spec.DataVersion)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAggregateAttestation indicates an expected call of GetAggregateAttestation.
+func (mr *MockAggregatorCallsMockRecorder) GetAggregateAttestation(ctx, slot, committeeIndex any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAggregateAttestation", reflect.TypeOf((*MockAggregatorCalls)(nil).GetAggregateAttestation), ctx, slot, committeeIndex)
+}
+
+// IsAggregator mocks base method.
+func (m *MockAggregatorCalls) IsAggregator(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, slotSig []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAggregator", ctx, slot, committeeIndex, committeeLength, slotSig)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAggregator indicates an expected call of IsAggregator.
+func (mr *MockAggregatorCallsMockRecorder) IsAggregator(ctx, slot, committeeIndex, committeeLength, slotSig any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAggregator", reflect.TypeOf((*MockAggregatorCalls)(nil).IsAggregator), ctx, slot, committeeIndex, committeeLength, slotSig)
+}
+
 // SubmitAggregateSelectionProof mocks base method.
 func (m *MockAggregatorCalls) SubmitAggregateSelectionProof(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, index phase0.ValidatorIndex, slotSig []byte) (ssz.Marshaler, spec.DataVersion, error) {
 	m.ctrl.T.Helper()
@@ -751,6 +781,22 @@ func (mr *MockBeaconNodeMockRecorder) DomainData(ctx, epoch, domain any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DomainData", reflect.TypeOf((*MockBeaconNode)(nil).DomainData), ctx, epoch, domain)
 }
 
+// GetAggregateAttestation mocks base method.
+func (m *MockBeaconNode) GetAggregateAttestation(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (ssz.Marshaler, spec.DataVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAggregateAttestation", ctx, slot, committeeIndex)
+	ret0, _ := ret[0].(ssz.Marshaler)
+	ret1, _ := ret[1].(spec.DataVersion)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAggregateAttestation indicates an expected call of GetAggregateAttestation.
+func (mr *MockBeaconNodeMockRecorder) GetAggregateAttestation(ctx, slot, committeeIndex any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAggregateAttestation", reflect.TypeOf((*MockBeaconNode)(nil).GetAggregateAttestation), ctx, slot, committeeIndex)
+}
+
 // GetAttestationData mocks base method.
 func (m *MockBeaconNode) GetAttestationData(ctx context.Context, slot phase0.Slot) (*phase0.AttestationData, spec.DataVersion, error) {
 	m.ctrl.T.Helper()
@@ -812,6 +858,20 @@ func (m *MockBeaconNode) GetValidatorData(ctx context.Context, validatorPubKeys 
 func (mr *MockBeaconNodeMockRecorder) GetValidatorData(ctx, validatorPubKeys any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorData", reflect.TypeOf((*MockBeaconNode)(nil).GetValidatorData), ctx, validatorPubKeys)
+}
+
+// IsAggregator mocks base method.
+func (m *MockBeaconNode) IsAggregator(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, slotSig []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAggregator", ctx, slot, committeeIndex, committeeLength, slotSig)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAggregator indicates an expected call of IsAggregator.
+func (mr *MockBeaconNodeMockRecorder) IsAggregator(ctx, slot, committeeIndex, committeeLength, slotSig any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAggregator", reflect.TypeOf((*MockBeaconNode)(nil).IsAggregator), ctx, slot, committeeIndex, committeeLength, slotSig)
 }
 
 // IsSyncCommitteeAggregator mocks base method.

--- a/protocol/v2/ssv/queue/observability.go
+++ b/protocol/v2/ssv/queue/observability.go
@@ -42,8 +42,9 @@ var (
 )
 
 const (
-	ValidatorQueueMetricType = "validator"
-	CommitteeQueueMetricType = "committee"
+	ValidatorQueueMetricType           = "validator"
+	CommitteeQueueMetricType           = "committee"
+	AggregatorCommitteeQueueMetricType = "aggregator_committee"
 
 	DropReasonBufferFull = "buffer_full"
 )

--- a/protocol/v2/ssv/runner/aggregator_committee.go
+++ b/protocol/v2/ssv/runner/aggregator_committee.go
@@ -1,0 +1,1817 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+
+	"github.com/ssvlabs/ssv/observability"
+	"github.com/ssvlabs/ssv/observability/log/fields"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	protocolp2p "github.com/ssvlabs/ssv/protocol/v2/p2p"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+// AggregatorCommitteeRunner has no DutyGuard because AggregatorCommitteeRunner's duties aren't slashable.
+type AggregatorCommitteeRunner struct {
+	*BaseRunner
+	network        protocolp2p.Network
+	beacon         beacon.BeaconNode
+	signer         ekm.BeaconSigner
+	operatorSigner ssvtypes.OperatorSigner
+
+	// ValCheck is used to validate the qbft-value(s) proposed by other Operators.
+	ValCheck ssv.ValueChecker
+
+	measurements *dutyMeasurements
+
+	// For aggregator role: tracks by validator index only (one submission per validator)
+	// For sync committee contribution role: tracks by validator index and root (multiple submissions per validator)
+	submittedDuties map[spectypes.BeaconRole]map[phase0.ValidatorIndex]map[[32]byte]struct{}
+	// rootToSyncCommitteeIdx is the root->sync committee index mapping for the current duty.
+	rootToSyncCommitteeIdx map[phase0.Root]phase0.CommitteeIndex
+
+	// Pre-consensus markers:
+	// - seen signers.
+	preConsensusSeenSigners map[spectypes.OperatorID]struct{}
+	// - (validator index, beacon root) tuples checked for aggregation/scc selection with the beacon node.
+	preConsensusDutiesCheckedForSelection map[phase0.ValidatorIndex]map[[32]byte]struct{}
+
+	// IsAggregator is an exported struct field, so it can be mocked out for easy testing.
+	IsAggregator func(
+		ctx context.Context,
+		slot phase0.Slot,
+		committeeIndex phase0.CommitteeIndex,
+		committeeLength uint64,
+		slotSig []byte,
+	) bool `json:"-"`
+}
+
+// AggregatorCommitteeRunnerOptions bundles all dependencies required by NewAggregatorCommitteeRunner.
+type AggregatorCommitteeRunnerOptions struct {
+	BaseRunnerOptions
+
+	QBFTController *controller.Controller
+}
+
+func NewAggregatorCommitteeRunner(
+	opts AggregatorCommitteeRunnerOptions,
+) (Runner, error) {
+	if len(opts.Share) == 0 {
+		return nil, errors.New("no shares")
+	}
+
+	return &AggregatorCommitteeRunner{
+		BaseRunner: &BaseRunner{
+			RunnerRoleType: spectypes.RoleAggregatorCommittee,
+			NetworkConfig:  opts.NetworkConfig,
+			Share:          opts.Share,
+			QBFTController: opts.QBFTController,
+		},
+		ValCheck:                              ssv.NewAggregatorCommitteeChecker(),
+		beacon:                                opts.Beacon,
+		network:                               opts.Network,
+		signer:                                opts.Signer,
+		operatorSigner:                        opts.OperatorSigner,
+		submittedDuties:                       make(map[spectypes.BeaconRole]map[phase0.ValidatorIndex]map[[32]byte]struct{}),
+		measurements:                          newMeasurementsStore(),
+		preConsensusSeenSigners:               make(map[spectypes.OperatorID]struct{}),
+		preConsensusDutiesCheckedForSelection: make(map[phase0.ValidatorIndex]map[[32]byte]struct{}),
+
+		IsAggregator: opts.Beacon.IsAggregator,
+	}, nil
+}
+
+func (r *AggregatorCommitteeRunner) StartNewDuty(
+	ctx context.Context,
+	logger *zap.Logger,
+	duty spectypes.Duty,
+	quorum uint64,
+) error {
+	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
+	span := trace.SpanFromContext(ctx)
+
+	d, ok := duty.(*spectypes.AggregatorCommitteeDuty)
+	if !ok {
+		return fmt.Errorf("duty is not an AggregatorCommitteeDuty: %T", duty)
+	}
+
+	span.SetAttributes(observability.DutyCountAttribute(len(d.ValidatorDuties)))
+	err := r.baseStartNewDuty(ctx, logger, r, duty, quorum)
+	if err != nil {
+		return err
+	}
+
+	r.submittedDuties[spectypes.BNRoleAggregator] = make(map[phase0.ValidatorIndex]map[[32]byte]struct{})
+	r.submittedDuties[spectypes.BNRoleSyncCommitteeContribution] = make(map[phase0.ValidatorIndex]map[[32]byte]struct{})
+
+	r.preConsensusSeenSigners = make(map[spectypes.OperatorID]struct{})
+	r.preConsensusDutiesCheckedForSelection = make(map[phase0.ValidatorIndex]map[[32]byte]struct{})
+
+	return nil
+}
+
+func (r *AggregatorCommitteeRunner) Encode() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+func (r *AggregatorCommitteeRunner) Decode(data []byte) error {
+	return json.Unmarshal(data, r)
+}
+
+func (r *AggregatorCommitteeRunner) GetRoot() ([32]byte, error) {
+	marshaledRoot, err := r.Encode()
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("could not encode AggregatorCommitteeRunner: %w", err)
+	}
+	ret := sha256.Sum256(marshaledRoot)
+	return ret, nil
+}
+
+func (r *AggregatorCommitteeRunner) MarshalJSON() ([]byte, error) {
+	type AggregatorCommitteeRunnerAlias struct {
+		BaseRunner     *BaseRunner
+		beacon         beacon.BeaconNode
+		network        protocolp2p.Network
+		signer         ekm.BeaconSigner
+		operatorSigner ssvtypes.OperatorSigner
+		valCheck       ssv.ValueChecker
+	}
+
+	// Create object and marshal
+	alias := &AggregatorCommitteeRunnerAlias{
+		BaseRunner:     r.BaseRunner,
+		beacon:         r.beacon,
+		network:        r.network,
+		signer:         r.signer,
+		operatorSigner: r.operatorSigner,
+		valCheck:       r.ValCheck,
+	}
+
+	byts, err := json.Marshal(alias)
+
+	return byts, err
+}
+
+func (r *AggregatorCommitteeRunner) UnmarshalJSON(data []byte) error {
+	type AggregatorCommitteeRunnerAlias struct {
+		BaseRunner     *BaseRunner
+		beacon         beacon.BeaconNode
+		network        protocolp2p.Network
+		signer         ekm.BeaconSigner
+		operatorSigner ssvtypes.OperatorSigner
+		valCheck       ssv.ValueChecker
+	}
+
+	// Unmarshal the JSON data into the auxiliary struct
+	aux := &AggregatorCommitteeRunnerAlias{}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.BaseRunner == nil {
+		return fmt.Errorf("missing BaseRunner")
+	}
+
+	// Assign fields
+	r.BaseRunner = aux.BaseRunner
+	r.beacon = aux.beacon
+	r.network = aux.network
+	r.signer = aux.signer
+	r.operatorSigner = aux.operatorSigner
+	r.ValCheck = aux.valCheck
+	return nil
+}
+
+func (r *AggregatorCommitteeRunner) GetBeaconNode() beacon.BeaconNode {
+	return r.beacon
+}
+
+func (r *AggregatorCommitteeRunner) GetNetwork() protocolp2p.Network {
+	return r.network
+}
+
+func (r *AggregatorCommitteeRunner) GetBeaconSigner() ekm.BeaconSigner {
+	return r.signer
+}
+
+// findValidatorDuty finds the validator duty for a specific role
+func (r *AggregatorCommitteeRunner) findValidatorDuty(
+	validatorIndex phase0.ValidatorIndex,
+	role spectypes.BeaconRole,
+) *spectypes.ValidatorDuty {
+	duty := r.State.CurrentDuty.(*spectypes.AggregatorCommitteeDuty)
+
+	for _, d := range duty.ValidatorDuties {
+		if d.ValidatorIndex == validatorIndex && d.Type == role {
+			return d
+		}
+	}
+
+	return nil
+}
+
+// waitTwoThirdsIntoSlot waits until two-thirds of the slot has passed.
+func (r *AggregatorCommitteeRunner) waitTwoThirdsIntoSlot(ctx context.Context, slot phase0.Slot) error {
+	finalTime := r.NetworkConfig.SlotStartTime(slot).Add(2 * r.NetworkConfig.IntervalDuration())
+	wait := time.Until(finalTime)
+	if wait <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(wait):
+		return nil
+	}
+}
+
+// processSyncCommitteeSelectionProof handles sync committee selection proofs with known index
+func (r *AggregatorCommitteeRunner) processSyncCommitteeSelectionProof(
+	ctx context.Context,
+	selectionProof phase0.BLSSignature,
+	validatorSyncCommitteeIndex phase0.CommitteeIndex,
+	vDuty *spectypes.ValidatorDuty,
+	aggregatorData *spectypes.AggregatorCommitteeConsensusData,
+) (bool, error) {
+	if !r.beacon.IsSyncCommitteeAggregator(selectionProof[:]) {
+		return false, nil // Not selected as sync committee aggregator
+	}
+
+	subnetID := r.beacon.SyncCommitteeSubnetID(validatorSyncCommitteeIndex)
+
+	// Check if we already have a contribution for this sync committee subnet ID
+	for _, contrib := range aggregatorData.SyncCommitteeContributions {
+		if contrib.SubcommitteeIndex == subnetID {
+			// If so, just add to contributors and return
+			aggregatorData.Contributors = append(aggregatorData.Contributors, spectypes.AssignedAggregator{
+				ValidatorIndex: vDuty.ValidatorIndex,
+				SelectionProof: selectionProof,
+				CommitteeIndex: subnetID,
+			})
+			return true, nil
+		}
+	}
+
+	// Else, fetch contribution and include everything (if successful)
+	contributions, _, err := r.GetBeaconNode().GetSyncCommitteeContribution(
+		ctx,
+		vDuty.Slot,
+		[]phase0.BLSSignature{selectionProof},
+		[]uint64{subnetID},
+	)
+	if err != nil {
+		return true, fmt.Errorf("get sync committee contribution: %w", err)
+	}
+
+	// Type assertion to get the actual Contributions object
+	contribs, ok := contributions.(*spectypes.Contributions)
+	if !ok {
+		return true, fmt.Errorf("unexpected contributions type: %T", contributions)
+	}
+
+	if len(*contribs) == 0 {
+		return true, errors.New("no contributions found")
+	}
+
+	// Append the contribution(s)
+	for _, contrib := range *contribs {
+		if contrib.Contribution.SubcommitteeIndex != subnetID {
+			continue
+		}
+
+		aggregatorData.Contributors = append(aggregatorData.Contributors, spectypes.AssignedAggregator{
+			ValidatorIndex: vDuty.ValidatorIndex,
+			SelectionProof: selectionProof,
+			CommitteeIndex: subnetID,
+		})
+
+		aggregatorData.SyncCommitteeContributions = append(aggregatorData.SyncCommitteeContributions, contrib.Contribution)
+	}
+
+	return true, nil
+}
+
+func (r *AggregatorCommitteeRunner) ProcessPreConsensus(
+	ctx context.Context,
+	logger *zap.Logger,
+	signedMsg *spectypes.PartialSignatureMessages,
+) error {
+	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
+	span := trace.SpanFromContext(ctx)
+
+	// If already started consensus, ignore pre-consensus messages.
+	// This is important because it avoids redundant processing and prevents the pre-consensus termination checks.
+	if r.HasStartedConsensus() {
+		return nil
+	}
+
+	// Mark signer as seen.
+	r.MarkPreConsensusSignerAsSeen(signedMsg)
+
+	hasNewQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	if err != nil {
+		return fmt.Errorf("failed processing selection proof message: %w", err)
+	}
+	// quorum returns true only once (first time quorum achieved)
+	if !hasNewQuorum {
+		// If didn't get any new quorum, didn't yet start QBFT (checked above), and has received the last message, then terminate.
+		if r.HasSeenAllPreConsensusSigners() {
+			r.markDutyNotRequired()
+			r.measurements.EndPreConsensus()
+			recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleAggregatorCommittee)
+			r.measurements.EndDutyFlow()
+			recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregatorCommittee, 0)
+			const dutyFinishedNoMessages = "✔️successfully finished duty processing (got no quorums in pre-consensus)"
+			logger.Info(dutyFinishedNoMessages,
+				fields.PreConsensusTime(r.measurements.PreConsensusTime()),
+				fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+			)
+			span.AddEvent(dutyFinishedNoMessages)
+		}
+		return nil
+	}
+
+	r.measurements.EndPreConsensus()
+	recordPreConsensusDuration(ctx, r.measurements.PreConsensusTime(), spectypes.RoleAggregatorCommittee)
+
+	aggregatorMap, contributionMap, err := r.expectedPreConsensusRoots(ctx, logger)
+	if err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
+		return fmt.Errorf("could not get expected pre-consensus roots: %w", err)
+	}
+
+	duty := r.State.CurrentDuty.(*spectypes.AggregatorCommitteeDuty)
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(duty.DutySlot())
+	dataVersion, _ := r.NetworkConfig.ForkAtEpoch(epoch)
+	consensusData := &spectypes.AggregatorCommitteeConsensusData{
+		Version: dataVersion,
+	}
+	hasAnyAggregatorForNewQuorum := false
+
+	sort.Slice(roots, func(i, j int) bool {
+		return bytes.Compare(roots[i][:], roots[j][:]) < 0
+	})
+
+	span.SetAttributes(observability.BeaconBlockRootCountAttribute(len(roots)))
+
+	type aggregatorSelection struct {
+		duty           *spectypes.ValidatorDuty
+		selectionProof phase0.BLSSignature
+	}
+
+	var aggregatorSelections []aggregatorSelection
+	var anyErr error
+	for i, root := range roots {
+		metadataList, found := r.findValidatorsForPreConsensusRoot(root, aggregatorMap, contributionMap)
+		if !found {
+			// Edge case: since operators may have divergent sets of validators,
+			// it's possible that an operator doesn't have the validator associated to a root.
+			// In this case, we simply continue.
+			continue
+		}
+
+		sort.Slice(metadataList, func(i, j int) bool {
+			return metadataList[i].ValidatorIndex < metadataList[j].ValidatorIndex
+		})
+
+		for _, metadata := range metadataList {
+			validatorIndex := metadata.ValidatorIndex
+			share := r.Share[validatorIndex]
+			// Operators might have diverging views on which validators they have in a committee
+			// (e.g., an operator might have not yet seen an ValidatorAdded event,
+			// or failed to process it and moved on). Hence, we need to check for this explicitly every time.
+			if share == nil {
+				continue
+			}
+			pubKey := share.ValidatorPubKey
+
+			// As per the comments below, the quorums (for root+validator pairs) we got from basePostConsensusMsgProcessing
+			// call above are optimistic - some of these quorums might have been invalidated now, hence, to avoid an
+			// unnecessary unsuccessful BLS signature reconstruction attempt we need to check if root+validator pair
+			// still has quorum.
+			gotQuorum, quorumSigners := r.State.PreConsensusContainer.HasQuorum(validatorIndex, root)
+			// Explanation on why we need this check: https://github.com/ssvlabs/ssv/pull/2503#discussion_r2658112575
+			if !gotQuorum {
+				continue
+			}
+
+			vLogger := logger.With(
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.String("pubkey", hex.EncodeToString(pubKey[:])),
+				fields.BlockRoot(root),
+				zap.Uint64s("quorum_signers", quorumSigners),
+			)
+
+			// Reconstruct signature
+			fullSig, err := r.State.ReconstructBeaconSig(
+				r.State.PreConsensusContainer,
+				root,
+				share.ValidatorPubKey[:],
+				validatorIndex,
+			)
+			if err != nil {
+				// If the reconstructed signature verification failed, fall back to verifying each individual
+				// partial signature + discarding the invalid ones. This should not happen often in practice,
+				// but it's a very desirable optimization to have because when it does happen - we wouldn't
+				// want to reconstruct lots of BLS signatures only to discover most of them being invalid.
+				// Notes:
+				// 1) FallBackAndVerifyEachSignature call may also lead to a certain root+validator pairs
+				//    in PostConsensusContainer not having quorum anymore since it previously was computed
+				//    optimistically.
+				// 2) we need to verify partial signatures only for the roots we haven't tried reconstructing
+				//    signatures for (hence roots[i:])
+				// 3) since this code is running a bunch of concurrent go-routines, we need to be careful to
+				//    not call FallBackAndVerifyEachSignature for the same root+validator pair multiple times -
+				//    this is why we are parallelizing by validators only (and not by root+validator), processing
+				//    each root sequentially
+				for _, root := range roots[i:] {
+					r.FallBackAndVerifyEachSignature(
+						r.State.PreConsensusContainer,
+						root,
+						share.Committee,
+						validatorIndex,
+					)
+				}
+
+				const eventMsg = "got pre-consensus quorum but it has invalid signatures"
+				span.AddEvent(eventMsg)
+				vLogger.Error(eventMsg, zap.Error(err))
+
+				anyErr = err
+				continue
+			}
+
+			var blsSig phase0.BLSSignature
+			copy(blsSig[:], fullSig)
+
+			switch metadata.Role {
+			case spectypes.BNRoleAggregator:
+				vDuty := r.findValidatorDuty(validatorIndex, spectypes.BNRoleAggregator)
+				if vDuty != nil {
+					r.MarkDutyAsCheckedForSelection(validatorIndex, root)
+					if r.IsAggregator(ctx, vDuty.Slot, vDuty.CommitteeIndex, vDuty.CommitteeLength, blsSig[:]) {
+						hasAnyAggregatorForNewQuorum = true
+						aggregatorSelections = append(aggregatorSelections, aggregatorSelection{
+							duty:           vDuty,
+							selectionProof: blsSig,
+						})
+					}
+				}
+
+			case spectypes.BNRoleSyncCommitteeContribution:
+				vDuty := r.findValidatorDuty(validatorIndex, spectypes.BNRoleSyncCommitteeContribution)
+				if vDuty != nil {
+					scIndex, ok := r.rootToSyncCommitteeIdx[root]
+					if !ok {
+						logger.Warn("root got a quorum, but is unknown to us", fields.Root(root))
+						continue
+					}
+
+					isAggregator, err := r.processSyncCommitteeSelectionProof(
+						ctx,
+						blsSig,
+						scIndex,
+						vDuty,
+						consensusData,
+					)
+					if err == nil {
+						r.MarkDutyAsCheckedForSelection(validatorIndex, root)
+						if isAggregator {
+							hasAnyAggregatorForNewQuorum = true
+						}
+					} else {
+						vLogger.Warn("failed to process sync committee selection proof", zap.Error(err))
+						anyErr = fmt.Errorf("failed to process sync committee selection proof: %w", err)
+					}
+				}
+
+			default:
+				// deterministic terminal invariant violation → classify as failed, not stuck
+				err := fmt.Errorf("unexpected role type in pre-consensus metadata: %v", metadata.Role)
+				r.markDutyFailed(err)
+				return err
+			}
+		}
+	}
+
+	// No aggregators selected: decide whether to finish or wait for more messages.
+	if !hasAnyAggregatorForNewQuorum {
+		// If all duties have been tested for selection or all messages (from all operators) have been seen, terminate.
+		if r.HaveCheckedAllDutiesForSelection(aggregatorMap, contributionMap) || r.HasSeenAllPreConsensusSigners() {
+			r.markDutyNotRequired()
+			r.measurements.EndDutyFlow()
+			recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregatorCommittee, 0)
+			const dutyFinishedNoAggregators = "✔️successfully finished duty processing (no validator is aggregator or sync committee contributor)"
+			logger.Info(dutyFinishedNoAggregators,
+				fields.PreConsensusTime(r.measurements.PreConsensusTime()),
+				fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+			)
+			span.AddEvent(dutyFinishedNoAggregators)
+			return anyErr
+		}
+
+		// If no validator was selected, but there are more possible messages, keep waiting for more messages.
+		return anyErr
+	}
+
+	if len(aggregatorSelections) > 0 {
+		// Wait once per duty before fetching aggregate attestations (spec: 2/3 into slot).
+		if err := r.waitTwoThirdsIntoSlot(ctx, duty.DutySlot()); err != nil {
+			// Only reachable on shutdown (ctx canceled) within this short wait — markDutyFailed
+			// would drop a context.Canceled reason anyway, so there is nothing to record here.
+			return err
+		}
+
+	selectionLoop:
+		for _, selection := range aggregatorSelections {
+			// Check if attestation for committee index was already included
+			for _, idx := range consensusData.AggregatorsCommitteeIndexes {
+				if idx == uint64(selection.duty.CommitteeIndex) {
+					// If so, just add to aggregators and return
+					consensusData.Aggregators = append(consensusData.Aggregators, spectypes.AssignedAggregator{
+						ValidatorIndex: selection.duty.ValidatorIndex,
+						SelectionProof: selection.selectionProof,
+						CommitteeIndex: uint64(selection.duty.CommitteeIndex),
+					})
+					continue selectionLoop
+				}
+			}
+
+			// Else, fetch attestation and include everything (if successful)
+			attestation, _, err := r.beacon.GetAggregateAttestation(ctx, selection.duty.Slot, selection.duty.CommitteeIndex)
+			if err != nil {
+				anyErr = fmt.Errorf("failed to get aggregate attestation: %w", err)
+				continue
+			}
+
+			attestationBytes, err := attestation.MarshalSSZ()
+			if err != nil {
+				anyErr = fmt.Errorf("failed to marshal attestation: %w", err)
+				continue
+			}
+
+			consensusData.Aggregators = append(consensusData.Aggregators, spectypes.AssignedAggregator{
+				ValidatorIndex: selection.duty.ValidatorIndex,
+				SelectionProof: selection.selectionProof,
+				CommitteeIndex: uint64(selection.duty.CommitteeIndex),
+			})
+			consensusData.AggregatorsCommitteeIndexes = append(
+				consensusData.AggregatorsCommitteeIndexes,
+				uint64(selection.duty.CommitteeIndex),
+			)
+			consensusData.AggregatedAttestations = append(consensusData.AggregatedAttestations, attestationBytes)
+		}
+	}
+
+	// Else, if some aggregators or contributors were selected (even with an error for others), proceed to consensus
+	if err := consensusData.Validate(); err != nil {
+		// Not markDutyFailed: this pre-consensus window is re-entrant until consensus starts
+		// (guarded by HasStartedConsensus). basePreConsensusMsgProcessing reports a new quorum
+		// per root, not once per duty, and a Validate error is non-retryable so the committee
+		// queue drops the message but keeps the runner alive. A transient GetAggregateAttestation
+		// failure can leave consensusData empty here, yet a later message whose root reaches quorum
+		// can still build valid data and start consensus — concluding "failed" now would mask a
+		// duty that still completes.
+		return fmt.Errorf("invalid aggregator committee consensus data: %w", err)
+	}
+
+	r.measurements.StartConsensus()
+	if err := r.decide(
+		ctx,
+		logger,
+		r.State.CurrentDuty.DutySlot(),
+		consensusData,
+		r.ValCheck,
+	); err != nil {
+		// Not markDutyFailed: same re-entrant pre-consensus window as the Validate check above.
+		// decide sets RunningInstance only on success, so a failure here leaves HasStartedConsensus
+		// false and a later new-quorum message can start consensus and complete the duty. The
+		// message drop is non-terminal (runner survives), so concluding "failed" now would risk a
+		// false failure on a duty that still succeeds.
+		return fmt.Errorf("failed to start consensus: %w", err)
+	}
+
+	return anyErr // raise error so it is visible(logged), if any
+}
+
+func (r *AggregatorCommitteeRunner) ProcessConsensus(
+	ctx context.Context,
+	logger *zap.Logger,
+	msg *spectypes.SignedSSVMessage,
+) error {
+	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
+	span := trace.SpanFromContext(ctx)
+
+	span.AddEvent("checking if instance is decided")
+	decided, decidedValue, err := r.baseConsensusMsgProcessing(
+		ctx,
+		logger,
+		r.ValCheck.CheckValue,
+		msg,
+		&spectypes.AggregatorCommitteeConsensusData{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed processing consensus message: %w", err)
+	}
+
+	// Decided returns true only once so if it is true it must be for the current running instance
+	if !decided {
+		span.AddEvent("instance is not decided")
+		return nil
+	}
+
+	r.measurements.EndConsensus()
+	recordConsensusDuration(ctx, r.measurements.ConsensusTime(), spectypes.RoleAggregatorCommittee)
+
+	duty := r.State.CurrentDuty
+	aggCommDuty, ok := duty.(*spectypes.AggregatorCommitteeDuty)
+	if !ok {
+		return fmt.Errorf("duty is not an AggregatorCommitteeDuty: %T", duty)
+	}
+
+	consensusData := decidedValue.(*spectypes.AggregatorCommitteeConsensusData)
+
+	aggProofs, err := consensusData.GetAggregateAndProofs()
+	if err != nil {
+		return fmt.Errorf("failed to get aggregate and proofs: %w", err)
+	}
+
+	messages := make([]*spectypes.PartialSignatureMessage, 0)
+	for i, aggProof := range aggProofs {
+		validatorIndex := consensusData.Aggregators[i].ValidatorIndex
+
+		_, exists := r.Share[validatorIndex]
+		// Operators might have diverging views on which validators they have in a committee
+		// (e.g., an operator might have not yet seen an ValidatorAdded event,
+		// or failed to process it and moved on). Hence, we need to check for this explicitly every time.
+		if !exists {
+			continue
+		}
+
+		vDuty := r.findValidatorDuty(validatorIndex, spectypes.BNRoleAggregator)
+		if vDuty == nil {
+			continue
+		}
+
+		// Sign the aggregate and proof
+		hashRoot, err := spectypes.GetAggregateAndProofHashRoot(aggProof)
+		if err != nil {
+			return fmt.Errorf("failed to get aggregate and proof hash root: %w", err)
+		}
+
+		msg, err := signBeaconObject(
+			ctx,
+			r, r.NetworkConfig, vDuty, hashRoot,
+			aggCommDuty.DutySlot(),
+			spectypes.DomainAggregateAndProof,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to sign aggregate and proof: %w", err)
+		}
+
+		messages = append(messages, msg)
+	}
+
+	contributions, err := consensusData.GetSyncCommitteeContributions()
+	if err != nil {
+		return fmt.Errorf("failed to get sync committee contributions: %w", err)
+	}
+
+	for i, contribution := range contributions {
+		validatorIndex := consensusData.Contributors[i].ValidatorIndex
+
+		_, exists := r.Share[validatorIndex]
+		// Operators might have diverging views on which validators they have in a committee
+		// (e.g., an operator might have not yet seen an ValidatorAdded event,
+		// or failed to process it and moved on). Hence, we need to check for this explicitly every time.
+		if !exists {
+			continue
+		}
+
+		vDuty := r.findValidatorDuty(validatorIndex, spectypes.BNRoleSyncCommitteeContribution)
+		if vDuty == nil {
+			continue
+		}
+
+		contribAndProof := &altair.ContributionAndProof{
+			AggregatorIndex: validatorIndex,
+			Contribution:    &contribution.Contribution,
+			SelectionProof:  consensusData.Contributors[i].SelectionProof,
+		}
+
+		// Sign the contribution and proof
+		msg, err := signBeaconObject(
+			ctx,
+			r, r.NetworkConfig, vDuty, contribAndProof,
+			aggCommDuty.DutySlot(),
+			spectypes.DomainContributionAndProof,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to sign contribution and proof: %w", err)
+		}
+
+		messages = append(messages, msg)
+	}
+
+	if len(messages) == 0 {
+		// Nothing to broadcast for this operator
+		return nil
+	}
+
+	postConsensusMsg := &spectypes.PartialSignatureMessages{
+		Type:     spectypes.PostConsensusPartialSig,
+		Slot:     duty.DutySlot(),
+		Messages: messages,
+	}
+
+	ssvMsg := &spectypes.SSVMessage{
+		MsgType: spectypes.SSVPartialSignatureMsgType,
+		MsgID: spectypes.NewMsgID(
+			r.NetworkConfig.DomainTypeAtSlot(duty.DutySlot()),
+			r.QBFTController.CommitteeMember.CommitteeID[:],
+			r.RunnerRoleType,
+		),
+	}
+	ssvMsg.Data, err = postConsensusMsg.Encode()
+	if err != nil {
+		return fmt.Errorf("failed to encode post consensus signature msg: %w", err)
+	}
+
+	span.AddEvent("signing post consensus partial signature message")
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return fmt.Errorf("could not sign SSVMessage: %w", err)
+	}
+
+	msgToBroadcast := &spectypes.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []spectypes.OperatorID{r.QBFTController.CommitteeMember.OperatorID},
+		SSVMessage:  ssvMsg,
+	}
+
+	r.measurements.StartPostConsensus()
+	span.AddEvent("broadcasting post consensus partial signature message")
+	if err := r.GetNetwork().Broadcast(ssvMsg.MsgID, msgToBroadcast); err != nil {
+		return fmt.Errorf("can't broadcast partial post consensus sig: %w", err)
+	}
+
+	return nil
+}
+
+func (r *AggregatorCommitteeRunner) ProcessPostConsensus(
+	ctx context.Context,
+	logger *zap.Logger,
+	signedMsg *spectypes.PartialSignatureMessages,
+) error {
+	// Reuse the existing span instead of generating new one to keep tracing-data lightweight.
+	span := trace.SpanFromContext(ctx)
+
+	span.AddEvent("base post consensus message processing")
+	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
+	if err != nil {
+		return fmt.Errorf("failed processing post consensus message: %w", err)
+	}
+
+	if !hasQuorum {
+		return nil
+	}
+
+	r.measurements.EndPostConsensus()
+	recordPostConsensusDuration(ctx, r.measurements.PostConsensusTime(), spectypes.RoleAggregatorCommittee)
+
+	span.AddEvent("getting aggregations, sync committee contributions and root beacon objects")
+	// Get validator-root maps for attestations and sync committees, and the root-beacon object map
+	aggregatorMap, contributionMap, beaconObjects, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
+	if err != nil {
+		// terminal post-quorum failure → classify as failed, not stuck
+		r.markDutyFailed(err)
+		return fmt.Errorf("could not get expected post consensus roots and beacon objects: %w", err)
+	}
+	if len(beaconObjects) == 0 {
+		// Empty post-quorum (all beacon objects failed to build) is terminal and non-recoverable:
+		// committee_queue drops the message and terminates the runner on this error. Classify as
+		// failed (matching CommitteeRunner) rather than leaving the watcher to report a false stuck.
+		r.markDutyFailed(ErrNoValidDutiesToExecute)
+		return ErrNoValidDutiesToExecute
+	}
+
+	sort.Slice(roots, func(i, j int) bool {
+		return bytes.Compare(roots[i][:], roots[j][:]) < 0
+	})
+
+	// Unlike the sibling CommitteeRunner (which tags recoverable reconstruct failures with the
+	// recoverableReconstructError sentinel), this runner classifies them by the
+	// PostConsensusQuorumWithInvalidSignatures spec code: every reconstruct error is force-wrapped
+	// with that code at the push site below, so there is no uncoded-BLS blind spot here, and tagging
+	// instead would break this runner's spectest fixtures. The divergence is deliberate — see the
+	// reciprocal note in committee.go. A single last-write-wins error made terminal-vs-recoverable
+	// classification depend on goroutine/root ordering; splitting keeps it deterministic (terminal wins).
+	var terminalErr, recoverableErr error
+	// classify is the single source of truth for the terminal/recoverable split, shared by the listener
+	// receive site and the post-listener drain so the two can never drift apart. The reconstruct
+	// goroutine force-wraps its (recoverable, post-fallback) error with the
+	// PostConsensusQuorumWithInvalidSignatures code; anything arriving without that code is terminal.
+	classify := func(err error) {
+		var specErr *spectypes.Error
+		if errors.As(err, &specErr) && specErr.Code == spectypes.PostConsensusQuorumWithInvalidSignatures {
+			recoverableErr = err
+		} else {
+			terminalErr = err
+		}
+	}
+	aggregatesToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*spec.VersionedSignedAggregateAndProof)
+	contributionsToSubmit := make(map[phase0.ValidatorIndex]map[[32]byte]*altair.SignedContributionAndProof)
+
+	span.SetAttributes(observability.BeaconBlockRootCountAttribute(len(roots)))
+	// For each root that got at least one quorum, find the duties associated to it and try to submit
+	for i, root := range roots {
+		// Get validators related to the given root
+		role, validators, found := r.findValidatorsForPostConsensusRoot(root, aggregatorMap, contributionMap)
+		if !found {
+			// Edge case: operator doesn't have the validator associated to a root. This probably might mean a bug.
+			logger.Error("BUG: could not find validators for root",
+				zap.String("root", hex.EncodeToString(root[:])),
+			)
+			continue
+		}
+
+		const eventMsg = "found validators for root"
+		span.AddEvent(eventMsg, trace.WithAttributes(
+			observability.BeaconRoleAttribute(role),
+			observability.BeaconBlockRootAttribute(root),
+			observability.ValidatorCountAttribute(len(validators)),
+		))
+		logger.Debug(eventMsg,
+			zap.String("root", hex.EncodeToString(root[:])),
+			zap.Any("validators", validators),
+		)
+
+		type signatureResult struct {
+			signature      phase0.BLSSignature
+			validatorIndex phase0.ValidatorIndex
+		}
+		var (
+			wg          sync.WaitGroup
+			errCh       = make(chan error, len(validators))
+			signatureCh = make(chan signatureResult, len(validators))
+		)
+
+		span.AddEvent("constructing sync committee contribution and aggregations signature messages",
+			trace.WithAttributes(observability.BeaconBlockRootAttribute(root)))
+		for _, validator := range validators {
+			// As per the comments below, the quorums (for root+validator pairs) we got from basePostConsensusMsgProcessing
+			// call above are optimistic - some of these quorums might have been invalidated now, hence, to avoid an
+			// unnecessary unsuccessful BLS signature reconstruction attempt we need to check if root+validator pair
+			// still has quorum.
+			gotQuorum, quorumSigners := r.State.PostConsensusContainer.HasQuorum(validator, root)
+			if !gotQuorum {
+				continue
+			}
+			// Skip if already submitted
+			if r.HasSubmitted(role, validator, root) {
+				continue
+			}
+
+			wg.Add(1)
+			go func(validatorIndex phase0.ValidatorIndex, root [32]byte) {
+				defer wg.Done()
+
+				share := r.Share[validatorIndex]
+				// Operators might have diverging views on which validators they have in a committee
+				// (e.g., an operator might have not yet seen an ValidatorAdded event,
+				// or failed to process it and moved on). Hence, we need to check for this explicitly every time.
+				if share == nil {
+					return
+				}
+				pubKey := share.ValidatorPubKey
+
+				vlogger := logger.With(
+					zap.Uint64("validator_index", uint64(validatorIndex)),
+					zap.String("pubkey", hex.EncodeToString(pubKey[:])),
+					fields.BlockRoot(root),
+					zap.Uint64s("quorum_signers", quorumSigners),
+				)
+
+				sig, err := r.State.ReconstructBeaconSig(r.State.PostConsensusContainer, root, pubKey[:], validatorIndex)
+				if err != nil {
+					// If the reconstructed signature verification failed, fall back to verifying each individual
+					// partial signature + discarding the invalid ones. This should not happen often in practice,
+					// but it's a very desirable optimization to have because when it does happen - we wouldn't
+					// want to reconstruct lots of BLS signatures only to discover most of them being invalid.
+					// Notes:
+					// 1) FallBackAndVerifyEachSignature call may also lead to a certain root+validator pairs
+					//    in PostConsensusContainer not having quorum anymore since it previously was computed
+					//    optimistically.
+					// 2) we need to verify partial signatures only for the roots we haven't tried reconstructing
+					//    signatures for (hence roots[i:])
+					// 3) since this code is running a bunch of concurrent go-routines, we need to be careful to
+					//    not call FallBackAndVerifyEachSignature for the same root+validator pair multiple times -
+					//    this is why we are parallelizing by validators only (and not by root+validator), processing
+					//    each root sequentially
+					for _, root := range roots[i:] {
+						r.FallBackAndVerifyEachSignature(
+							r.State.PostConsensusContainer,
+							root,
+							share.Committee,
+							validatorIndex,
+						)
+					}
+					const eventMsg = "got post-consensus quorum but it has invalid signatures"
+					span.AddEvent(eventMsg)
+					vlogger.Error(eventMsg, zap.Error(err))
+
+					errCh <- spectypes.WrapError(
+						spectypes.PostConsensusQuorumWithInvalidSignatures,
+						fmt.Errorf("%s: %w", eventMsg, err),
+					)
+					return
+				}
+
+				vlogger.Debug("🧩 reconstructed partial signature")
+
+				signatureCh <- signatureResult{
+					validatorIndex: validatorIndex,
+					signature:      (phase0.BLSSignature)(sig),
+				}
+			}(validator, root)
+		}
+
+		go func() {
+			wg.Wait()
+			close(signatureCh)
+		}()
+
+	listener:
+		for {
+			select {
+			case <-ctx.Done():
+				// Only reachable on shutdown (ctx canceled) — the listener completes in ms and the
+				// duty deadline is ~1 epoch out — and markDutyFailed drops context.Canceled anyway.
+				return ctx.Err()
+			case err := <-errCh:
+				classify(err)
+			case signatureResult, ok := <-signatureCh:
+				if !ok {
+					break listener
+				}
+
+				validatorObjects, exists := beaconObjects[signatureResult.validatorIndex]
+				if !exists {
+					terminalErr = fmt.Errorf("could not find beacon object for validator index: %d",
+						signatureResult.validatorIndex)
+					continue
+				}
+				sszObject, exists := validatorObjects[root]
+				if !exists {
+					terminalErr = fmt.Errorf("could not find ssz object for root: %s", root)
+					continue
+				}
+
+				switch role {
+				case spectypes.BNRoleAggregator:
+					aggregateAndProof := sszObject.(*spec.VersionedAggregateAndProof)
+					signedAgg, err := r.constructSignedAggregateAndProof(aggregateAndProof, signatureResult.signature)
+					if err != nil {
+						terminalErr = fmt.Errorf("failed to construct signed aggregate and proof: %w", err)
+						continue
+					}
+
+					if aggregatesToSubmit[signatureResult.validatorIndex] == nil {
+						aggregatesToSubmit[signatureResult.validatorIndex] = make(map[[32]byte]*spec.VersionedSignedAggregateAndProof)
+					}
+					aggregatesToSubmit[signatureResult.validatorIndex][root] = signedAgg
+
+				case spectypes.BNRoleSyncCommitteeContribution:
+					contribAndProof := sszObject.(*altair.ContributionAndProof)
+					signedContrib := &altair.SignedContributionAndProof{
+						Message:   contribAndProof,
+						Signature: signatureResult.signature,
+					}
+
+					if contributionsToSubmit[signatureResult.validatorIndex] == nil {
+						contributionsToSubmit[signatureResult.validatorIndex] = make(map[[32]byte]*altair.SignedContributionAndProof)
+					}
+					contributionsToSubmit[signatureResult.validatorIndex][root] = signedContrib
+
+				default:
+					// deterministic terminal invariant violation → classify as failed, not stuck
+					err := fmt.Errorf("unexpected role type in post-consensus: %v", role)
+					r.markDutyFailed(err)
+					return err
+				}
+			}
+		}
+
+		// When signatureCh closes in the same iteration the select may take the close branch and skip an
+		// error still buffered on errCh. All workers have finished (signatureCh is closed only after
+		// wg.Wait), so no further sends occur and this non-blocking drain is complete. Today errCh carries
+		// only the recoverable reconstruct error (the sole producer above), and dropping one is benign —
+		// the root stays un-submitted and the duty stays open for a later retry rather than falsely
+		// succeeding. The drain is defensive: it classifies that error for completeness and future-proofs
+		// the path should a terminal error ever be pushed here.
+	drainErrCh:
+		for {
+			select {
+			case err := <-errCh:
+				classify(err)
+			default:
+				break drainErrCh
+			}
+		}
+
+		logger.Debug("🧩 reconstructed partial signatures for root",
+			fields.BlockRoot(root),
+		)
+	}
+
+	for validatorIndex, signedByRoot := range aggregatesToSubmit {
+		for root, signedAgg := range signedByRoot {
+			start := time.Now()
+			if err := r.beacon.SubmitSignedAggregateSelectionProof(ctx, signedAgg); err != nil {
+				recordFailedSubmission(ctx, spectypes.BNRoleAggregator)
+				terminalErr = fmt.Errorf("failed to submit signed aggregate and proof: %w", err)
+				continue
+			}
+
+			const eventMsg = "✅ successfully submitted signed aggregate and proof"
+			span.AddEvent(eventMsg)
+			logger.Debug(
+				eventMsg,
+				fields.BlockRoot(root),
+				fields.Took(time.Since(start)),
+				fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
+				fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+			)
+
+			recordSuccessfulSubmission(
+				ctx,
+				1,
+				r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()),
+				spectypes.BNRoleAggregator,
+			)
+
+			r.RecordSubmission(spectypes.BNRoleAggregator, validatorIndex, root)
+		}
+	}
+
+	for validatorIndex, signedByRoot := range contributionsToSubmit {
+		for root, signedContrib := range signedByRoot {
+			start := time.Now()
+			if err := r.beacon.SubmitSignedContributionAndProof(ctx, signedContrib); err != nil {
+				recordFailedSubmission(ctx, spectypes.BNRoleSyncCommitteeContribution)
+				terminalErr = fmt.Errorf("failed to submit signed contribution and proof: %w", err)
+				continue
+			}
+
+			const eventMsg = "✅ successfully submitted sync committee contributions"
+			span.AddEvent(eventMsg)
+			logger.Debug(
+				eventMsg,
+				fields.BlockRoot(root),
+				fields.Took(time.Since(start)),
+				fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
+				fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+			)
+
+			recordSuccessfulSubmission(
+				ctx,
+				1,
+				r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot()),
+				spectypes.BNRoleSyncCommitteeContribution,
+			)
+
+			r.RecordSubmission(spectypes.BNRoleSyncCommitteeContribution, validatorIndex, root)
+		}
+	}
+
+	// Terminal wins deterministically over a concurrent recoverable error in the same round.
+	// Submit/construct/missing-object failures: reconstruction already succeeded so the root keeps its
+	// quorum and is never re-reported (runner.go reports only on first quorum crossing), so the submit
+	// loop never revisits it and the duty never concludes → mark failed, not a false stuck.
+	if terminalErr != nil {
+		r.markDutyFailed(terminalErr)
+		return terminalErr
+	}
+	// Reconstruct-invalid-sigs is recoverable: FallBackAndVerifyEachSignature can drop the root below
+	// quorum, so a later partial-sig message re-crosses quorum and re-enters this loop to retry pending
+	// roots (already-submitted roots are skipped via HasSubmitted). Not markDutyFailed.
+	if recoverableErr != nil {
+		return recoverableErr
+	}
+
+	// Check if duty has terminated (runner has submitted for all duties)
+	if r.HasSubmittedAllDuties(ctx, logger) {
+		r.markDutySucceeded()
+		r.measurements.EndDutyFlow()
+		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregatorCommittee, r.State.RunningInstance.State.Round)
+		const dutyFinishedEvent = "✔️finished duty processing (100% success)"
+		logger.Info(dutyFinishedEvent,
+			fields.PreConsensusTime(r.measurements.PreConsensusTime()),
+			fields.ConsensusTime(r.measurements.ConsensusTime()),
+			fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
+			fields.PostConsensusTime(r.measurements.PostConsensusTime()),
+			fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
+			fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+		)
+		span.AddEvent(dutyFinishedEvent)
+		return nil
+	}
+	const dutyFinishedEvent = "✔️finished duty processing (partial success)"
+	logger.Info(dutyFinishedEvent,
+		fields.PreConsensusTime(r.measurements.PreConsensusTime()),
+		fields.ConsensusTime(r.measurements.ConsensusTime()),
+		fields.ConsensusRounds(uint64(r.State.RunningInstance.State.Round)),
+		fields.PostConsensusTime(r.measurements.PostConsensusTime()),
+		fields.TotalConsensusTime(r.measurements.TotalConsensusTime()),
+		fields.TotalDutyTime(r.measurements.TotalDutyTime()),
+	)
+	span.AddEvent(dutyFinishedEvent)
+
+	return nil
+}
+
+// HasSubmittedAllDuties checks if all expected duties have been submitted.
+// For aggregator role we expect exactly one submission per validator.
+// For sync committee contribution role we expect one submission per expected root
+// (i.e., per subcommittee index assigned to that validator for this slot).
+func (r *AggregatorCommitteeRunner) HasSubmittedAllDuties(ctx context.Context, logger *zap.Logger) bool {
+	// Build the expected post-consensus roots per validator/role from the decided data.
+	aggregatorMap, contributionMap, _, err := r.expectedPostConsensusRootsAndBeaconObjects(ctx, logger)
+	if err != nil {
+		// If we can't resolve the expected set, do not finish yet.
+		return false
+	}
+
+	// Use decided data as the source of truth; non-selected validators won't appear here.
+	for validatorIndex, expectedRoot := range aggregatorMap {
+		// Only consider validators this operator actually runs.
+		if _, hasShare := r.Share[validatorIndex]; !hasShare {
+			continue
+		}
+		if !r.HasSubmitted(spectypes.BNRoleAggregator, validatorIndex, expectedRoot) {
+			return false
+		}
+	}
+
+	for validatorIndex, expectedRoots := range contributionMap {
+		// Only consider validators this operator actually runs.
+		if _, hasShare := r.Share[validatorIndex]; !hasShare {
+			continue
+		}
+		for _, root := range expectedRoots {
+			if !r.HasSubmitted(spectypes.BNRoleSyncCommitteeContribution, validatorIndex, root) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// RecordSubmission -- Records a submission for the (role, validator index, slot) tuple
+func (r *AggregatorCommitteeRunner) RecordSubmission(
+	role spectypes.BeaconRole,
+	validatorIndex phase0.ValidatorIndex,
+	root [32]byte,
+) {
+	if _, ok := r.submittedDuties[role]; !ok {
+		r.submittedDuties[role] = make(map[phase0.ValidatorIndex]map[[32]byte]struct{})
+	}
+	if _, ok := r.submittedDuties[role][validatorIndex]; !ok {
+		r.submittedDuties[role][validatorIndex] = make(map[[32]byte]struct{})
+	}
+	r.submittedDuties[role][validatorIndex][root] = struct{}{}
+}
+
+// HasSubmitted -- Returns true if there is a record of submission for the (role, validator index, slot) tuple
+func (r *AggregatorCommitteeRunner) HasSubmitted(
+	role spectypes.BeaconRole,
+	validatorIndex phase0.ValidatorIndex,
+	root [32]byte,
+) bool {
+	if _, ok := r.submittedDuties[role]; !ok {
+		return false
+	}
+	if _, ok := r.submittedDuties[role][validatorIndex]; !ok {
+		return false
+	}
+	_, submitted := r.submittedDuties[role][validatorIndex][root]
+	return submitted
+}
+
+// This function signature returns only one domain type... but we can have mixed domains
+// instead we rely on expectedPreConsensusRoots that is called later
+func (r *AggregatorCommitteeRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+	return nil, spectypes.DomainError,
+		fmt.Errorf("unexpected expectedPreConsensusRootsAndDomain func call, runner role %v", r.GetRole())
+}
+
+// This function signature returns only one domain type... but we can have mixed domains
+// instead we rely on expectedPostConsensusRootsAndBeaconObjects that is called later
+func (r *AggregatorCommitteeRunner) expectedPostConsensusRootsAndDomain(context.Context) (
+	[]ssz.HashRoot,
+	phase0.DomainType,
+	error,
+) {
+	return nil, spectypes.DomainError, errors.New("unexpected expectedPostConsensusRootsAndDomain func call")
+}
+
+// expectedPreConsensusRoots returns the expected roots for the pre-consensus phase.
+// It returns the aggregator and sync committee validator to root maps.
+func (r *AggregatorCommitteeRunner) expectedPreConsensusRoots(
+	ctx context.Context,
+	logger *zap.Logger,
+) (
+	aggregatorMap map[phase0.ValidatorIndex][32]byte,
+	contributionMap map[phase0.ValidatorIndex]map[ValidatorSyncCommitteeIndex][32]byte,
+	err error,
+) {
+	aggregatorMap = make(map[phase0.ValidatorIndex][32]byte)
+	contributionMap = make(map[phase0.ValidatorIndex]map[ValidatorSyncCommitteeIndex][32]byte)
+
+	duty := r.State.CurrentDuty.(*spectypes.AggregatorCommitteeDuty)
+
+	for _, vDuty := range duty.ValidatorDuties {
+		if vDuty == nil {
+			continue
+		}
+
+		switch vDuty.Type {
+		case spectypes.BNRoleAggregator:
+			root, err := r.expectedAggregatorSelectionRoot(ctx, duty.Slot)
+			if err != nil {
+				logger.Debug("failed to compute aggregator selection root",
+					zap.Uint64("validator_index", uint64(vDuty.ValidatorIndex)),
+					zap.Error(err),
+				)
+				continue
+			}
+			aggregatorMap[vDuty.ValidatorIndex] = root
+
+		case spectypes.BNRoleSyncCommitteeContribution:
+			if _, ok := contributionMap[vDuty.ValidatorIndex]; !ok {
+				contributionMap[vDuty.ValidatorIndex] = make(map[uint64][32]byte)
+			}
+
+			for _, index := range vDuty.ValidatorSyncCommitteeIndices {
+				root, err := r.expectedSyncCommitteeSelectionRoot(ctx, duty.Slot, index)
+				if err != nil {
+					logger.Debug("failed to compute sync committee selection root",
+						zap.Uint64("validator_index", uint64(vDuty.ValidatorIndex)),
+						zap.Uint64("subcommittee_index", index),
+						zap.Error(err),
+					)
+					continue
+				}
+				contributionMap[vDuty.ValidatorIndex][index] = root
+			}
+
+		default:
+			return nil, nil,
+				fmt.Errorf("invalid duty type in aggregator committee duty: %v", vDuty.Type)
+		}
+	}
+
+	return aggregatorMap, contributionMap, nil
+}
+
+// expectedAggregatorSelectionRoot calculates the expected signing root for aggregator selection
+func (r *AggregatorCommitteeRunner) expectedAggregatorSelectionRoot(
+	ctx context.Context,
+	slot phase0.Slot,
+) ([32]byte, error) {
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(slot)
+	domain, err := r.beacon.DomainData(ctx, epoch, spectypes.DomainSelectionProof)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	return spectypes.ComputeETHSigningRoot(spectypes.SSZUint64(slot), domain)
+}
+
+// expectedSyncCommitteeSelectionRoot calculates the expected signing root for sync committee selection
+func (r *AggregatorCommitteeRunner) expectedSyncCommitteeSelectionRoot(
+	ctx context.Context,
+	slot phase0.Slot,
+	validatorSyncCommitteeIndex uint64,
+) ([32]byte, error) {
+	subnet := r.beacon.SyncCommitteeSubnetID(phase0.CommitteeIndex(validatorSyncCommitteeIndex))
+
+	data := &altair.SyncAggregatorSelectionData{
+		Slot:              slot,
+		SubcommitteeIndex: subnet,
+	}
+
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(slot)
+	domain, err := r.beacon.DomainData(ctx, epoch, spectypes.DomainSyncCommitteeSelectionProof)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	return spectypes.ComputeETHSigningRoot(data, domain)
+}
+
+func (r *AggregatorCommitteeRunner) expectedPostConsensusRootsAndBeaconObjects(
+	ctx context.Context,
+	logger *zap.Logger,
+) (
+	aggregatorMap map[phase0.ValidatorIndex][32]byte,
+	contributionMap map[phase0.ValidatorIndex][][32]byte,
+	beaconObjects map[phase0.ValidatorIndex]map[[32]byte]interface{}, err error,
+) {
+	aggregatorMap = make(map[phase0.ValidatorIndex][32]byte)
+	contributionMap = make(map[phase0.ValidatorIndex][][32]byte)
+	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]interface{})
+
+	consensusData := &spectypes.AggregatorCommitteeConsensusData{}
+	if err := consensusData.Decode(r.State.DecidedValue); err != nil {
+		return nil, nil, nil,
+			fmt.Errorf("could not decode consensus data: %w", err)
+	}
+
+	epoch := r.NetworkConfig.EstimatedEpochAtSlot(r.State.CurrentDuty.DutySlot())
+
+	aggregateAndProofs, err := consensusData.GetAggregateAndProofs()
+	if err != nil {
+		return nil, nil, nil,
+			fmt.Errorf("could not get aggregate and proofs: %w", err)
+	}
+
+	for i, aggregateAndProof := range aggregateAndProofs {
+		validatorIndex := consensusData.Aggregators[i].ValidatorIndex
+		hashRoot, err := spectypes.GetAggregateAndProofHashRoot(aggregateAndProof)
+		if err != nil {
+			logger.Debug("failed to compute aggregate and proof hash root",
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Calculate signing root for aggregate and proof
+		domain, err := r.beacon.DomainData(ctx, epoch, spectypes.DomainAggregateAndProof)
+		if err != nil {
+			logger.Debug("failed to get aggregate and proof domain",
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		root, err := spectypes.ComputeETHSigningRoot(hashRoot, domain)
+		if err != nil {
+			logger.Debug("failed to compute aggregate and proof signing root",
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		aggregatorMap[validatorIndex] = root
+
+		// Store beacon object
+		if _, ok := beaconObjects[validatorIndex]; !ok {
+			beaconObjects[validatorIndex] = make(map[[32]byte]interface{})
+		}
+		beaconObjects[validatorIndex][root] = aggregateAndProof
+	}
+
+	contributions, err := consensusData.GetSyncCommitteeContributions()
+	if err != nil {
+		return nil, nil, nil,
+			fmt.Errorf("could not get sync committee contributions: %w", err)
+	}
+	for i, contribution := range contributions {
+		validatorIndex := consensusData.Contributors[i].ValidatorIndex
+
+		// Create contribution and proof
+		contribAndProof := &altair.ContributionAndProof{
+			AggregatorIndex: validatorIndex,
+			Contribution:    &contribution.Contribution,
+			SelectionProof:  consensusData.Contributors[i].SelectionProof,
+		}
+
+		// Calculate signing root
+		domain, err := r.beacon.DomainData(ctx, epoch, spectypes.DomainContributionAndProof)
+		if err != nil {
+			logger.Debug("failed to get contribution and proof domain",
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.Uint64("subcommittee_index", contribution.Contribution.SubcommitteeIndex),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		root, err := spectypes.ComputeETHSigningRoot(contribAndProof, domain)
+		if err != nil {
+			logger.Debug("failed to compute contribution and proof signing root",
+				zap.Uint64("validator_index", uint64(validatorIndex)),
+				zap.Uint64("subcommittee_index", contribution.Contribution.SubcommitteeIndex),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		contributionMap[validatorIndex] = append(contributionMap[validatorIndex], root)
+
+		// Store beacon object
+		if _, ok := beaconObjects[validatorIndex]; !ok {
+			beaconObjects[validatorIndex] = make(map[[32]byte]interface{})
+		}
+		beaconObjects[validatorIndex][root] = contribAndProof
+	}
+
+	return aggregatorMap, contributionMap, beaconObjects, nil
+}
+
+// ValidatorSyncCommitteeIndex is the index of the validator in the list of sync committee participants.
+// The SubnetID (or SubcommitteeIndex) can be computed as ValidatorSyncCommitteeIndex // (SYNC_COMMITTEE_SIZE/ SYNC_COMMITTEE_SUBNET_COUNT)
+type ValidatorSyncCommitteeIndex = uint64
+
+type preConsensusMetadata struct {
+	ValidatorIndex              phase0.ValidatorIndex
+	Role                        spectypes.BeaconRole
+	ValidatorSyncCommitteeIndex ValidatorSyncCommitteeIndex // only for sync committee role
+}
+
+// findValidatorsForPreConsensusRoot finds all validators that have the given root in pre-consensus
+func (r *AggregatorCommitteeRunner) findValidatorsForPreConsensusRoot(
+	expectedRoot [32]byte,
+	aggregatorMap map[phase0.ValidatorIndex][32]byte,
+	contributionMap map[phase0.ValidatorIndex]map[ValidatorSyncCommitteeIndex][32]byte,
+) ([]preConsensusMetadata, bool) {
+	var metadata []preConsensusMetadata
+
+	// Check aggregator map
+	for validator, root := range aggregatorMap {
+		if root == expectedRoot {
+			metadata = append(metadata, preConsensusMetadata{
+				ValidatorIndex: validator,
+				Role:           spectypes.BNRoleAggregator,
+			})
+		}
+	}
+
+	// Check sync committee contribution map
+	for validator, indexMap := range contributionMap {
+		for index, root := range indexMap {
+			if root == expectedRoot {
+				metadata = append(metadata, preConsensusMetadata{
+					ValidatorIndex:              validator,
+					Role:                        spectypes.BNRoleSyncCommitteeContribution,
+					ValidatorSyncCommitteeIndex: index,
+				})
+			}
+		}
+	}
+
+	return metadata, len(metadata) > 0
+}
+
+func (r *AggregatorCommitteeRunner) findValidatorsForPostConsensusRoot(
+	expectedRoot [32]byte,
+	aggregatorMap map[phase0.ValidatorIndex][32]byte,
+	contributionMap map[phase0.ValidatorIndex][][32]byte,
+) (spectypes.BeaconRole, []phase0.ValidatorIndex, bool) {
+	var validators []phase0.ValidatorIndex
+
+	// Check aggregator map
+	for validator, root := range aggregatorMap {
+		if root == expectedRoot {
+			validators = append(validators, validator)
+		}
+	}
+	if len(validators) > 0 {
+		return spectypes.BNRoleAggregator, validators, true
+	}
+
+	// Check contribution map
+	for validator, roots := range contributionMap {
+		for _, root := range roots {
+			if root == expectedRoot {
+				validators = append(validators, validator)
+				break
+			}
+		}
+	}
+	if len(validators) > 0 {
+		return spectypes.BNRoleSyncCommitteeContribution, validators, true
+	}
+
+	return spectypes.BNRoleUnknown, nil, false
+}
+
+// constructSignedAggregateAndProof constructs a signed aggregate and proof from versioned data
+func (r *AggregatorCommitteeRunner) constructSignedAggregateAndProof(
+	aggregateAndProof *spec.VersionedAggregateAndProof,
+	signature phase0.BLSSignature,
+) (*spec.VersionedSignedAggregateAndProof, error) {
+	ret := &spec.VersionedSignedAggregateAndProof{
+		Version: aggregateAndProof.Version,
+	}
+
+	switch ret.Version {
+	case spec.DataVersionPhase0:
+		ret.Phase0 = &phase0.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Phase0,
+			Signature: signature,
+		}
+	case spec.DataVersionAltair:
+		ret.Altair = &phase0.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Altair,
+			Signature: signature,
+		}
+	case spec.DataVersionBellatrix:
+		ret.Bellatrix = &phase0.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Bellatrix,
+			Signature: signature,
+		}
+	case spec.DataVersionCapella:
+		ret.Capella = &phase0.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Capella,
+			Signature: signature,
+		}
+	case spec.DataVersionDeneb:
+		ret.Deneb = &phase0.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Deneb,
+			Signature: signature,
+		}
+	case spec.DataVersionElectra:
+		if aggregateAndProof.Electra == nil {
+			return nil, errors.New("nil Electra aggregate and proof")
+		}
+		ret.Electra = &electra.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Electra,
+			Signature: signature,
+		}
+	case spec.DataVersionFulu:
+		if aggregateAndProof.Fulu == nil {
+			return nil, errors.New("nil Fulu aggregate and proof")
+		}
+		ret.Fulu = &electra.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Fulu,
+			Signature: signature,
+		}
+	default:
+		return nil, fmt.Errorf("unknown version %s", ret.Version.String())
+	}
+
+	return ret, nil
+}
+
+// ValidateAggregatorCommitteeDuty checks that:
+// - all slots values are equal
+// - BeaconRole is either BNRoleAggregator or BNRoleSyncCommitteeContribution
+// - Validator indexes exist in the provided map
+// TODO: use (*AggregatorCommitteeDuty).Validate from spec after fork
+func ValidateAggregatorCommitteeDuty(
+	acd *spectypes.AggregatorCommitteeDuty,
+	validatorIndex map[phase0.ValidatorIndex]struct{},
+) error {
+	const InvalidAggregatorCommitteeDutyErrorCode = 82
+
+	slot := acd.Slot
+	for _, vd := range acd.ValidatorDuties {
+		if vd.Slot != slot {
+			return spectypes.NewError(InvalidAggregatorCommitteeDutyErrorCode, "mismatched slot in validator duty")
+		}
+		if vd.Type != spectypes.BNRoleAggregator && vd.Type != spectypes.BNRoleSyncCommitteeContribution {
+			return spectypes.NewError(InvalidAggregatorCommitteeDutyErrorCode, "invalid beacon role in validator duty")
+		}
+		if _, ok := validatorIndex[vd.ValidatorIndex]; !ok {
+			return spectypes.NewError(InvalidAggregatorCommitteeDutyErrorCode, "validator index not found in duty")
+		}
+	}
+
+	return nil
+}
+
+func (r *AggregatorCommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) error {
+	span := trace.SpanFromContext(ctx)
+
+	r.measurements.StartDutyFlow()
+
+	aggCommitteeDuty, ok := duty.(*spectypes.AggregatorCommitteeDuty)
+	if !ok {
+		return errors.New("invalid duty type for aggregator committee runner")
+	}
+
+	// Validate duty
+	valIdxs := make(map[phase0.ValidatorIndex]struct{})
+	for idx := range r.Share {
+		valIdxs[idx] = struct{}{}
+	}
+	if err := ValidateAggregatorCommitteeDuty(aggCommitteeDuty, valIdxs); err != nil {
+		return err
+	}
+
+	msg := &spectypes.PartialSignatureMessages{
+		Type:     spectypes.AggregatorCommitteePartialSig,
+		Slot:     duty.DutySlot(),
+		Messages: []*spectypes.PartialSignatureMessage{},
+	}
+
+	r.rootToSyncCommitteeIdx = make(map[phase0.Root]phase0.CommitteeIndex)
+
+	// Generate selection proofs for all validators and duties
+	for _, vDuty := range aggCommitteeDuty.ValidatorDuties {
+		switch vDuty.Type {
+		case spectypes.BNRoleAggregator:
+			span.AddEvent("signing beacon object")
+			// Sign slot for aggregator selection proof
+			partialSig, err := signBeaconObject(
+				ctx,
+				r,
+				r.NetworkConfig,
+				vDuty,
+				spectypes.SSZUint64(duty.DutySlot()),
+				duty.DutySlot(),
+				spectypes.DomainSelectionProof,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to sign aggregator selection proof: %w", err)
+			}
+
+			msg.Messages = append(msg.Messages, partialSig)
+
+		case spectypes.BNRoleSyncCommitteeContribution:
+			// Sign sync committee selection proofs for each subcommittee
+			// Selection proof depends only on slot+subcommittee index, so emit at most one per subnet.
+			seenSubnets := make(map[uint64]struct{})
+			for _, index := range vDuty.ValidatorSyncCommitteeIndices {
+				subnet := r.GetBeaconNode().SyncCommitteeSubnetID(phase0.CommitteeIndex(index))
+				if _, seen := seenSubnets[subnet]; seen {
+					continue
+				}
+				seenSubnets[subnet] = struct{}{}
+
+				data := &altair.SyncAggregatorSelectionData{
+					Slot:              duty.DutySlot(),
+					SubcommitteeIndex: subnet,
+				}
+
+				span.AddEvent("signing beacon object")
+				partialSig, err := signBeaconObject(
+					ctx,
+					r,
+					r.NetworkConfig,
+					vDuty,
+					data,
+					duty.DutySlot(),
+					spectypes.DomainSyncCommitteeSelectionProof,
+				)
+				if err != nil {
+					return fmt.Errorf("failed to sign sync committee selection proof: %w", err)
+				}
+
+				msg.Messages = append(msg.Messages, partialSig)
+				r.rootToSyncCommitteeIdx[partialSig.SigningRoot] = phase0.CommitteeIndex(index)
+			}
+
+		default:
+			return fmt.Errorf("invalid validator duty type for aggregator committee: %v", vDuty.Type)
+		}
+	}
+
+	// Early exit if no selection proofs needed
+	if len(msg.Messages) == 0 {
+		r.markDutyNotRequired()
+		r.measurements.EndDutyFlow()
+		recordTotalDutyDuration(ctx, r.measurements.TotalDutyTime(), spectypes.RoleAggregatorCommittee, 0)
+		const dutyFinishedNoMessages = "✔️successfully finished duty processing (no selection proofs needed)"
+		logger.Info(dutyFinishedNoMessages, fields.TotalDutyTime(r.measurements.TotalDutyTime()))
+		span.AddEvent(dutyFinishedNoMessages)
+		return nil
+	}
+
+	msgID := spectypes.NewMsgID(
+		r.NetworkConfig.DomainTypeAtSlot(duty.DutySlot()),
+		r.QBFTController.CommitteeMember.CommitteeID[:],
+		r.RunnerRoleType,
+	)
+	encodedMsg, err := msg.Encode()
+	if err != nil {
+		return fmt.Errorf("could not encode aggregator committee partial signature message: %w", err)
+	}
+
+	ssvMsg := &spectypes.SSVMessage{
+		MsgType: spectypes.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	span.AddEvent("signing SSV message")
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return fmt.Errorf("could not sign SSVMessage: %w", err)
+	}
+
+	msgToBroadcast := &spectypes.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []spectypes.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
+	}
+
+	r.measurements.StartPreConsensus()
+	span.AddEvent("broadcasting signed SSV message")
+	if err := r.GetNetwork().Broadcast(msgID, msgToBroadcast); err != nil {
+		return fmt.Errorf("can't broadcast partial aggregator committee sig: %w", err)
+	}
+
+	return nil
+}
+
+func (r *AggregatorCommitteeRunner) GetSigner() ekm.BeaconSigner {
+	return r.signer
+}
+
+func (r *AggregatorCommitteeRunner) GetOperatorSigner() ssvtypes.OperatorSigner {
+	return r.operatorSigner
+}
+
+// HasStartedConsensus checks if consensus has already started for the duty slot.
+func (r *AggregatorCommitteeRunner) HasStartedConsensus() bool {
+	if r.State == nil {
+		return false
+	}
+	return r.State.RunningInstance != nil || r.State.DecidedValue != nil
+}
+
+// MarkPreConsensusSignerAsSeen marks the signer of the given pre-consensus message as seen.
+func (r *AggregatorCommitteeRunner) MarkPreConsensusSignerAsSeen(signedMsg *spectypes.PartialSignatureMessages) {
+	for _, msg := range signedMsg.Messages {
+		r.preConsensusSeenSigners[msg.Signer] = struct{}{}
+		break // all messages have the same signer, no need to inspect more messages
+	}
+}
+
+// HasSeenAllPreConsensusSigners checks if we've seen messages from all committee operators.
+func (r *AggregatorCommitteeRunner) HasSeenAllPreConsensusSigners() bool {
+	committeeSize := len(r.QBFTController.CommitteeMember.Committee)
+	return len(r.preConsensusSeenSigners) >= committeeSize
+}
+
+// MarkDutyAsCheckedForSelection marks a given (validator index, root) selection as checked in pre-consensus.
+func (r *AggregatorCommitteeRunner) MarkDutyAsCheckedForSelection(validatorIndex phase0.ValidatorIndex, root [32]byte) {
+	if _, ok := r.preConsensusDutiesCheckedForSelection[validatorIndex]; !ok {
+		r.preConsensusDutiesCheckedForSelection[validatorIndex] = make(map[[32]byte]struct{})
+	}
+	r.preConsensusDutiesCheckedForSelection[validatorIndex][root] = struct{}{}
+}
+
+// HaveCheckedAllDutiesForSelection checks if all possible (validator index, root) selections were checked.
+func (r *AggregatorCommitteeRunner) HaveCheckedAllDutiesForSelection(
+	aggregatorMap map[phase0.ValidatorIndex][32]byte,
+	contributionMap map[phase0.ValidatorIndex]map[ValidatorSyncCommitteeIndex][32]byte,
+) bool {
+	for validatorIndex, root := range aggregatorMap {
+		if _, hasShare := r.Share[validatorIndex]; !hasShare {
+			continue
+		}
+		if _, ok := r.preConsensusDutiesCheckedForSelection[validatorIndex]; !ok {
+			return false
+		}
+		if _, ok := r.preConsensusDutiesCheckedForSelection[validatorIndex][root]; !ok {
+			return false
+		}
+	}
+
+	for validatorIndex, syncCommitteeRoots := range contributionMap {
+		if _, hasShare := r.Share[validatorIndex]; !hasShare {
+			continue
+		}
+		if _, ok := r.preConsensusDutiesCheckedForSelection[validatorIndex]; !ok {
+			return false
+		}
+		for _, root := range syncCommitteeRoots {
+			if _, ok := r.preConsensusDutiesCheckedForSelection[validatorIndex][root]; !ok {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/protocol/v2/ssv/runner/aggregator_committee_test.go
+++ b/protocol/v2/ssv/runner/aggregator_committee_test.go
@@ -1,0 +1,368 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv"
+	protocoltesting "github.com/ssvlabs/ssv/protocol/v2/testing"
+	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+)
+
+// faultyAggregateSubmitBeacon wraps the testing beacon node and forces the aggregate-selection-proof
+// submission to fail, so we can exercise the terminal post-quorum "submit failed" path in
+// AggregatorCommitteeRunner.ProcessPostConsensus. All other beacon behavior is inherited unchanged
+// via the embedded *BeaconNodeWrapped (method promotion).
+type faultyAggregateSubmitBeacon struct {
+	*protocoltesting.BeaconNodeWrapped
+	submitErr error
+}
+
+func (b *faultyAggregateSubmitBeacon) SubmitSignedAggregateSelectionProof(_ context.Context, _ *spec.VersionedSignedAggregateAndProof) error {
+	return b.submitErr
+}
+
+type aggregatorCommitteeRunnerEnv struct {
+	logger    *zap.Logger
+	runner    *AggregatorCommitteeRunner
+	network   *protocoltesting.TestingNetwork
+	keySetMap map[phase0.ValidatorIndex]*spectestingutils.TestKeySet
+	sampleKey *spectestingutils.TestKeySet
+}
+
+// newAggregatorCommitteeRunnerEnv builds an AggregatorCommitteeRunner wired to the supplied beacon
+// node, mirroring newCommitteeRunnerEnv. The beacon is injected so a test can substitute a faulty one.
+func newAggregatorCommitteeRunnerEnv(
+	t *testing.T,
+	validatorIndices []int,
+	beaconNode beacon.BeaconNode,
+) *aggregatorCommitteeRunnerEnv {
+	t.Helper()
+
+	keySetMap := spectestingutils.KeySetMapForValidatorIndexList(validatorIndices)
+	sampleKey := keySetMap[phase0.ValidatorIndex(validatorIndices[0])]
+	shareMap := spectestingutils.ShareMapFromKeySetMap(keySetMap)
+
+	msgID := spectestingutils.AggregatorCommitteeMsgIDForKeySet(sampleKey)
+	network := protocoltesting.NewTestingNetwork(1, sampleKey.OperatorKeys[1])
+	logger := zaptest.NewLogger(t)
+	signer := ekm.NewTestingKeyManagerAdapter(spectestingutils.NewTestingKeyManager())
+
+	config := protocoltesting.TestingConfig(logger, sampleKey)
+	config.Network = network
+	ctrl := protocoltesting.NewTestingQBFTController(
+		sampleKey,
+		msgID[:],
+		spectestingutils.TestingCommitteeMember(sampleKey),
+		config,
+		false,
+	)
+
+	runnerI, err := NewAggregatorCommitteeRunner(AggregatorCommitteeRunnerOptions{
+		BaseRunnerOptions: BaseRunnerOptions{
+			NetworkConfig:  networkconfig.TestNetwork,
+			Share:          shareMap,
+			Beacon:         beaconNode,
+			Network:        network,
+			Signer:         signer,
+			OperatorSigner: spectestingutils.NewOperatorSigner(sampleKey, 1),
+		},
+		QBFTController: ctrl,
+	})
+	require.NoError(t, err)
+
+	arunner := runnerI.(*AggregatorCommitteeRunner)
+	arunner.SetQBFTRoundTimerF(func(_ context.Context, _ *zap.Logger, _ phase0.Slot) ssv.QBFTRoundTimer {
+		return roundtimer.NewTestingTimer()
+	})
+
+	return &aggregatorCommitteeRunnerEnv{
+		logger:    logger,
+		runner:    arunner,
+		network:   network,
+		keySetMap: keySetMap,
+		sampleKey: sampleKey,
+	}
+}
+
+// startAndFeedThroughConsensus starts the duty and feeds the pre-consensus and consensus messages from
+// the spec fixtures (everything except post-consensus), leaving the runner decided and ready to process
+// post-consensus. It swaps in a fresh conclusion channel so the caller can observe the duty outcome
+// deterministically instead of racing the deadline-watcher goroutine StartNewDuty spawned. It returns
+// that channel.
+func (e *aggregatorCommitteeRunnerEnv) startAndFeedThroughConsensus(t *testing.T, ctx context.Context, duty *spectypes.AggregatorCommitteeDuty, version spec.DataVersion) chan dutyConclusion {
+	t.Helper()
+
+	require.NoError(t, e.runner.StartNewDuty(ctx, e.logger, duty, e.sampleKey.Threshold))
+
+	concluded := make(chan dutyConclusion, 1)
+	e.runner.dutyConcluded = concluded
+
+	for _, msg := range spectestingutils.AggregatorCommitteeInputForDuty(duty, e.keySetMap, version) {
+		switch msg.SSVMessage.MsgType {
+		case spectypes.SSVConsensusMsgType:
+			require.NoError(t, e.runner.ProcessConsensus(ctx, e.logger, msg))
+		case spectypes.SSVPartialSignatureMsgType:
+			psig := &spectypes.PartialSignatureMessages{}
+			require.NoError(t, psig.Decode(msg.SSVMessage.Data))
+			if psig.Type != spectypes.PostConsensusPartialSig {
+				require.NoError(t, e.runner.ProcessPreConsensus(ctx, e.logger, psig))
+			}
+		default:
+		}
+	}
+	return concluded
+}
+
+// postConsensusMsgsFromFixture returns the (valid) post-consensus PartialSignatureMessages from signers
+// 1..3 for the duty — the same messages AggregatorCommitteeInputForDuty carries.
+func postConsensusMsgsFromFixture(duty *spectypes.AggregatorCommitteeDuty, ksMap map[phase0.ValidatorIndex]*spectestingutils.TestKeySet, version spec.DataVersion) []*spectypes.PartialSignatureMessages {
+	msgs := make([]*spectypes.PartialSignatureMessages, 0, 3)
+	for id := spectypes.OperatorID(1); id <= 3; id++ {
+		msgs = append(msgs, spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, ksMap, id, version))
+	}
+	return msgs
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError asserts that a beacon
+// submit failure (a terminal post-quorum error) concludes the duty as failed — not left to surface
+// as a false "stuck".
+func TestAggregatorCommitteeRunnerProcessPostConsensus_MarksFailedOnSubmitError(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected aggregate")
+	faulty := &faultyAggregateSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, faulty)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.ErrorIs(t, postConsensusErr, submitErr, "submit failure should surface from ProcessPostConsensus")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome, "a terminal submit failure must be classified failed")
+		require.ErrorIs(t, c.reason, submitErr)
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs asserts that the
+// recoverable reconstruct-invalid-signatures case is NOT concluded failed: the root can later re-cross
+// quorum on a subsequent message, so concluding here would mask a duty that still completes.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, base)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	// Corrupt the beacon partial signatures. For the aggregator role, ValidatePostConsensusMsg only
+	// checks message structure (not the beacon sigs), so these still reach optimistic quorum, then
+	// ReconstructBeaconSig fails → the runner reports PostConsensusQuorumWithInvalidSignatures.
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		for _, m := range psig.Messages {
+			m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+		}
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.Error(t, postConsensusErr, "invalid signatures should surface an error")
+	var specErr *spectypes.Error
+	require.ErrorAs(t, postConsensusErr, &specErr)
+	require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code,
+		"invalid-sigs must carry the recoverable spec code")
+
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
+	require.False(t, env.runner.State.Succeeded)
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds is the
+// regression test for the last coverage gap on #2919/#2918: a quorum that optimistically crosses
+// threshold but contains one non-deserializable partial signature must NOT conclude the duty (the
+// offending signer is dropped by FallBackAndVerifyEachSignature, so the root falls back below
+// quorum and the duty is left un-marked, recoverable), and a subsequent valid partial signature that
+// re-crosses quorum must let the duty conclude succeeded. This mirrors
+// TestCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds
+// (committee_postconsensus_classification_test.go) for the aggregator-committee runner, closing the
+// gap left by TestAggregatorCommitteeRunnerProcessPostConsensus_DoesNotMarkFailedOnInvalidSigs above,
+// which only proves the "stays un-marked" half and never re-attempts a successful retry.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_RecoverableInvalidSigsThenSucceeds(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	// A healthy (non-faulty) beacon node: submission on the retry round must actually succeed.
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1}, base)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	// Round 1: signers 1 and 2 send valid post-consensus partial sigs; signer 3 sends a
+	// non-deserializable one. ValidatePostConsensusMsg only checks message structure (not the beacon
+	// signature), so all three enter the container and cross quorum (3-of-4) optimistically. Then
+	// ReconstructBeaconSig fails on the garbage signature, FallBackAndVerifyEachSignature drops only
+	// signer 3, and the root falls back below quorum (2-of-4) — recoverable, nothing submitted, and
+	// the duty must NOT be concluded.
+	msg1 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 1, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg1))
+
+	msg2 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 2, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg2))
+
+	badMsg3 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 3, version)
+	for _, m := range badMsg3.Messages {
+		m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+	}
+	recoverableErr := env.runner.ProcessPostConsensus(ctx, env.logger, badMsg3)
+	require.Error(t, recoverableErr, "a quorum with invalid signatures should surface an error")
+	var specErr *spectypes.Error
+	require.ErrorAs(t, recoverableErr, &specErr)
+	require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code,
+		"invalid-sigs must carry the recoverable spec code")
+
+	// The recoverable case must NOT conclude the duty: nothing has been sent on the conclusion channel.
+	require.Empty(t, concluded, "a recoverable invalid-sigs error must NOT conclude the duty")
+	require.False(t, env.runner.State.Succeeded)
+
+	// Round 2: a subsequent valid partial signature from signer 4 re-crosses quorum with three good
+	// sigs (1, 2, 4) → reconstruction succeeds → the duty submits and concludes succeeded.
+	msg4 := spectestingutils.PostConsensusAggregatorCommitteeMsgForDuty(duty, env.keySetMap, 4, version)
+	require.NoError(t, env.runner.ProcessPostConsensus(ctx, env.logger, msg4))
+
+	require.True(t, env.runner.State.Succeeded, "a valid quorum after recovery must conclude succeeded")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeSucceeded, c.outcome, "recovery must conclude the duty succeeded, not failed")
+	default:
+		t.Fatal("expected a succeeded duty conclusion after recovery, got none")
+	}
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_TerminalWinsOverConcurrentRecoverable is the
+// regression test for the terminalErr/recoverableErr split: within a single ProcessPostConsensus
+// call, one validator's post-consensus signatures reconstruct fine but then fail to submit (terminal,
+// set from the submit loop after the roots loop), while a second validator's signatures are corrupted
+// and reconstruct-fails with the recoverable PostConsensusQuorumWithInvalidSignatures code (set from
+// the errCh receive site during the roots loop). Both land in the same call, so which one is observed
+// first by the listener select is not controlled by the test. Before the split, a single
+// last-write-wins `executionErr` made the final classification depend on that arrival order; the
+// fixed code always classifies the duty failed here because terminalErr is checked first,
+// independent of goroutine/channel scheduling. We assert on the conclusion outcome, not on which
+// error message ends up attached (that part is still last-write-wins by design for same-class
+// errors).
+func TestAggregatorCommitteeRunnerProcessPostConsensus_TerminalWinsOverConcurrentRecoverable(t *testing.T) {
+	ctx := t.Context()
+	const version = spec.DataVersionElectra
+
+	base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+	submitErr := errors.New("beacon rejected aggregate")
+	faulty := &faultyAggregateSubmitBeacon{BeaconNodeWrapped: base, submitErr: submitErr}
+
+	env := newAggregatorCommitteeRunnerEnv(t, []int{1, 2}, faulty)
+	duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators([]int{1, 2}, []int{}, version)
+
+	concluded := env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+	var postConsensusErr error
+	for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+		// Corrupt only validator 2's signature in this signer's batch: validator 1 keeps a valid
+		// signature (reconstructs fine, submits, and fails there — terminal), validator 2's
+		// reconstruct fails outright (recoverable).
+		for _, m := range psig.Messages {
+			if m.ValidatorIndex == phase0.ValidatorIndex(2) {
+				m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+			}
+		}
+		if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+			postConsensusErr = err
+		}
+	}
+
+	require.Error(t, postConsensusErr, "a terminal error concurrent with a recoverable one must still surface")
+
+	select {
+	case c := <-concluded:
+		require.Equal(t, dutyOutcomeFailed, c.outcome,
+			"terminal must win deterministically over a concurrent recoverable error in the same round")
+	default:
+		t.Fatal("expected a failed duty conclusion, got none")
+	}
+	require.False(t, env.runner.State.Succeeded, "a failed duty must not be marked succeeded")
+}
+
+// TestAggregatorCommitteeRunnerProcessPostConsensus_DrainsBufferedErrCh is a best-effort regression
+// test for Ovi finding 1 (the drainErrCh block): when the reconstruct goroutines' errCh sends race
+// against signatureCh's close, a buffered recoverable error could previously be skipped by the
+// listener select (which may take the "signatureCh closed" branch over a simultaneously-ready errCh
+// receive), silently discarding the error and letting ProcessPostConsensus return nil despite a
+// validator's post-consensus signature never having been submitted (a false "stuck", never
+// concluded). The fix drains any leftover errCh value right after the listener loop, so the error is
+// classified and returned regardless of which branch the race took.
+//
+// This exercises many validators corrupted in the same call and repeats the scenario to raise the
+// odds of hitting the race window on any single run; the assertion (a non-nil, correctly-coded error
+// on every iteration) is unconditionally guaranteed by the fix regardless of which branch fires, so
+// the test is not flaky when the drain is present — it only has a chance (not a guarantee) of
+// reproducing the pre-fix bug on a revert.
+func TestAggregatorCommitteeRunnerProcessPostConsensus_DrainsBufferedErrCh(t *testing.T) {
+	const version = spec.DataVersionElectra
+	aggValidators := []int{1, 2, 3, 4, 5, 6, 7, 8}
+
+	for iter := 0; iter < 20; iter++ {
+		ctx := t.Context()
+		base := protocoltesting.NewTestingBeaconNodeWrapped().(*protocoltesting.BeaconNodeWrapped)
+		env := newAggregatorCommitteeRunnerEnv(t, aggValidators, base)
+		duty := spectestingutils.TestingAggregatorCommitteeDutyForValidators(aggValidators, []int{}, version)
+
+		env.startAndFeedThroughConsensus(t, ctx, duty, version)
+
+		var postConsensusErr error
+		for _, psig := range postConsensusMsgsFromFixture(duty, env.keySetMap, version) {
+			for _, m := range psig.Messages {
+				m.PartialSignature = bytes.Repeat([]byte{0xEE}, len(m.PartialSignature))
+			}
+			if err := env.runner.ProcessPostConsensus(ctx, env.logger, psig); err != nil {
+				postConsensusErr = err
+			}
+		}
+
+		require.Error(t, postConsensusErr, "iteration %d: a fully-corrupted quorum must surface an error, not vanish", iter)
+		var specErr *spectypes.Error
+		require.ErrorAs(t, postConsensusErr, &specErr, "iteration %d", iter)
+		require.Equal(t, spectypes.PostConsensusQuorumWithInvalidSignatures, specErr.Code, "iteration %d", iter)
+		require.False(t, env.runner.State.Succeeded, "iteration %d", iter)
+	}
+}

--- a/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
+++ b/protocol/v2/ssv/runner/aggregator_postconsensus_classification_test.go
@@ -23,22 +23,8 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 )
 
-// faultyAggregateSubmitBeacon wraps the testing beacon node and forces the aggregate-selection-proof
-// submission to fail, so we can exercise the terminal post-quorum "submit failed" path in
-// AggregatorRunner.ProcessPostConsensus. All other beacon behavior is inherited unchanged via the
-// embedded *BeaconNodeWrapped (method promotion).
-//
-// NOTE: AggregatorCommitteeRunner's test suite (deferred to a later unit) defines an identical
-// helper in aggregator_committee_test.go. When that file lands, dedup by keeping a single
-// definition rather than declaring it twice in this package.
-type faultyAggregateSubmitBeacon struct {
-	*protocoltesting.BeaconNodeWrapped
-	submitErr error
-}
-
-func (b *faultyAggregateSubmitBeacon) SubmitSignedAggregateSelectionProof(_ context.Context, _ *spec.VersionedSignedAggregateAndProof) error {
-	return b.submitErr
-}
+// faultyAggregateSubmitBeacon is declared in aggregator_committee_test.go and shared by both
+// AggregatorRunner (this file) and AggregatorCommitteeRunner test suites.
 
 // aggregatorRunnerEnv wires a legacy (non-committee) AggregatorRunner. The beacon node is injected
 // so a test can substitute a faulty one.

--- a/protocol/v2/ssv/spectest/committee_msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/committee_msg_processing_type.go
@@ -205,8 +205,13 @@ func overrideStateComparisonCommitteeSpecTest(t *testing.T, test *CommitteeSpecT
 	// AggregatorCommitteeRunners map for the merged runner), so struct-tag-based json.Unmarshal
 	// above no longer finds our (unrenamed) Committee.Runners field. Read the raw comparison-state
 	// JSON directly instead, falling back to the legacy "Runners" key for older fixtures.
-	// TODO(convergence unit 5): also read AggregatorCommitteeRunners.
+	// This test type (CommitteeSpecTest) only ever exercises RoleCommittee duties (there is no
+	// AggregatorCommitteeDuty input path here), so there is no AggregatorCommitteeRunners fixture
+	// data to read; initialize an empty map so it matches test.Committee's own zero state (an
+	// unset nil map here would otherwise diverge in JSON encoding from the non-nil empty map the
+	// Committee constructor always produces, and desync the compared post-duty roots).
 	committee.Runners = readCommitteeRunnersFromStateComparison(t, specDir, name, testType)
+	committee.AggregatorRunners = make(map[phase0.Slot]*runner.AggregatorCommitteeRunner)
 
 	for slot := range committee.Runners {
 		committee.Runners[slot].NetworkConfig = networkconfig.TestNetwork

--- a/protocol/v2/ssv/spectest/msg_processing_type.go
+++ b/protocol/v2/ssv/spectest/msg_processing_type.go
@@ -282,11 +282,11 @@ var baseCommitteeWithRunnerSample = func(
 	}
 
 	createRunnerF := func(
-		_ phase0.Slot,
+		_ spectypes.Duty,
 		shareMap map[phase0.ValidatorIndex]*spectypes.Share,
 		attestingValidators []phase0.BLSPubKey,
 		_ runner.CommitteeDutyGuard,
-	) (*runner.CommitteeRunner, error) {
+	) (runner.Runner, error) {
 		r, err := runner.NewCommitteeRunner(runner.CommitteeRunnerOptions{
 			BaseRunnerOptions: runner.BaseRunnerOptions{
 				NetworkConfig:  networkconfig.TestNetwork,
@@ -307,7 +307,7 @@ var baseCommitteeWithRunnerSample = func(
 			DutyGuard:           committeeDutyGuard,
 			DoppelgangerHandler: runnerSample.GetDoppelgangerHandler(),
 		})
-		return r.(*runner.CommitteeRunner), err
+		return r, err
 	}
 
 	c := validator.NewCommittee(

--- a/protocol/v2/ssv/spectest/runner_construction_type.go
+++ b/protocol/v2/ssv/spectest/runner_construction_type.go
@@ -29,11 +29,6 @@ func (test *RunnerConstructionSpecTest) Run(t *testing.T) {
 	}
 
 	for role, expectedError := range test.RoleError {
-		// TODO(convergence unit 5): enable AggregatorCommittee runner construction vectors.
-		if role == types.RoleAggregatorCommittee {
-			continue
-		}
-
 		// Construct runner and get construction error
 		_, err := runnertesting.ConstructBaseRunnerWithShareMap(logger, role, test.Shares)
 

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -687,9 +687,9 @@ func fixCommitteeForRun(t *testing.T, logger *zap.Logger, committeeMap map[strin
 		logger,
 		networkconfig.TestNetwork,
 		&specCommittee.CommitteeMember,
-		func(slot phase0.Slot, shareMap map[phase0.ValidatorIndex]*spectypes.Share, _ []phase0.BLSPubKey, _ runner.CommitteeDutyGuard) (*runner.CommitteeRunner, error) {
+		func(_ spectypes.Duty, shareMap map[phase0.ValidatorIndex]*spectypes.Share, _ []phase0.BLSPubKey, _ runner.CommitteeDutyGuard) (runner.Runner, error) {
 			r := ssvtesting.CommitteeRunnerWithShareMap(logger, shareMap)
-			return r.(*runner.CommitteeRunner), nil
+			return r, nil
 		},
 		specCommittee.Share,
 		validator.NewCommitteeDutyGuard(),

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -34,6 +34,14 @@ var CommitteeRunnerWithShareMap = func(logger *zap.Logger, shareMap map[phase0.V
 	return baseRunnerWithShareMap(logger, spectypes.RoleCommittee, shareMap)
 }
 
+var AggregatorCommitteeRunner = func(logger *zap.Logger, keySet *spectestingutils.TestKeySet) runner.Runner {
+	return baseRunner(logger, spectypes.RoleAggregatorCommittee, keySet)
+}
+
+var AggregatorCommitteeRunnerWithShareMap = func(logger *zap.Logger, shareMap map[phase0.ValidatorIndex]*spectypes.Share) runner.Runner {
+	return baseRunnerWithShareMap(logger, spectypes.RoleAggregatorCommittee, shareMap)
+}
+
 var ProposerRunner = func(logger *zap.Logger, keySet *spectestingutils.TestKeySet) runner.Runner {
 	return baseRunner(logger, spectypes.RoleProposer, keySet)
 }
@@ -91,6 +99,8 @@ var ConstructBaseRunner = func(
 	case spectypes.RoleCommittee:
 		valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
 			[]phase0.BLSPubKey{phase0.BLSPubKey(share.SharePubKey)}, vote)
+	case spectypes.RoleAggregatorCommittee:
+		valCheck = ssv.NewAggregatorCommitteeChecker()
 	case spectypes.RoleProposer:
 		valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 			(spectypes.ValidatorPK)(spectestingutils.TestingValidatorPubKey), spectestingutils.TestingValidatorIndex,
@@ -145,6 +155,15 @@ var ConstructBaseRunner = func(
 			DutyGuard:           dutyGuard,
 			DoppelgangerHandler: dgHandler,
 		})
+	case spectypes.RoleAggregatorCommittee:
+		rnr, err := runner.NewAggregatorCommitteeRunner(runner.AggregatorCommitteeRunnerOptions{
+			BaseRunnerOptions: baseOpts,
+			QBFTController:    contr,
+		})
+		if err != nil {
+			return nil, err
+		}
+		r = rnr
 	case ssvtypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
 			BaseRunnerOptions:  baseOpts,
@@ -242,7 +261,9 @@ var ConstructBaseRunnerWithShareMap = func(
 
 		// Identifier
 		var ownerID []byte
-		if role == spectypes.RoleCommittee {
+		switch role {
+		case spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee:
+			// Committee-scoped identifiers: use CommitteeID for both committee and aggregator-committee runners
 			ops := keySetInstance.Committee()
 			committee := make([]uint64, 0, len(ops))
 			for _, op := range ops {
@@ -250,7 +271,8 @@ var ConstructBaseRunnerWithShareMap = func(
 			}
 			committeeID := spectypes.GetCommitteeID(committee)
 			ownerID = bytes.Clone(committeeID[:])
-		} else {
+		default:
+			// Validator-scoped identifiers
 			ownerID = spectestingutils.TestingValidatorPubKey[:]
 		}
 		identifier = spectypes.NewMsgID(spectestingutils.TestingSSVDomainType, ownerID, role)
@@ -265,6 +287,8 @@ var ConstructBaseRunnerWithShareMap = func(
 		case spectypes.RoleCommittee:
 			valCheck = ssv.NewVoteChecker(km, spectestingutils.TestingDutySlot,
 				sharePubKeys, vote)
+		case spectypes.RoleAggregatorCommittee:
+			valCheck = ssv.NewAggregatorCommitteeChecker()
 		case spectypes.RoleProposer:
 			valCheck = ssv.NewProposerChecker(km, networkconfig.TestNetwork.Beacon,
 				shareInstance.ValidatorPubKey, shareInstance.ValidatorIndex, phase0.BLSPubKey(shareInstance.SharePubKey))
@@ -314,6 +338,15 @@ var ConstructBaseRunnerWithShareMap = func(
 			DutyGuard:           dutyGuard,
 			DoppelgangerHandler: dgHandler,
 		})
+	case spectypes.RoleAggregatorCommittee:
+		rnr, err := runner.NewAggregatorCommitteeRunner(runner.AggregatorCommitteeRunnerOptions{
+			BaseRunnerOptions: baseOpts,
+			QBFTController:    contr,
+		})
+		if err != nil {
+			return nil, err
+		}
+		r = rnr
 	case ssvtypes.RoleAggregator:
 		rnr, err := runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
 			BaseRunnerOptions:  baseOpts,

--- a/protocol/v2/ssv/testing/validator.go
+++ b/protocol/v2/ssv/testing/validator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/validator"
 	"github.com/ssvlabs/ssv/protocol/v2/testing"
-	"github.com/ssvlabs/ssv/protocol/v2/types"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 var BaseValidator = func(logger *zap.Logger, keySet *spectestingutils.TestKeySet) *validator.Validator {
@@ -32,17 +32,18 @@ var BaseValidator = func(logger *zap.Logger, keySet *spectestingutils.TestKeySet
 		cancel,
 		logger,
 		commonOpts.NewOptions(
-			&types.SSVShare{
+			&ssvtypes.SSVShare{
 				Share: *spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex),
 			},
 			spectestingutils.TestingCommitteeMember(keySet),
 			map[spectypes.RunnerRole]runner.Runner{
-				spectypes.RoleCommittee:             CommitteeRunner(logger, keySet),
-				spectypes.RoleProposer:              ProposerRunner(logger, keySet),
-				types.RoleAggregator:                AggregatorRunner(logger, keySet),
-				types.RoleSyncCommitteeContribution: SyncCommitteeContributionRunner(logger, keySet),
-				spectypes.RoleValidatorRegistration: ValidatorRegistrationRunner(logger, keySet),
-				spectypes.RoleVoluntaryExit:         VoluntaryExitRunner(logger, keySet),
+				spectypes.RoleCommittee:                CommitteeRunner(logger, keySet),
+				spectypes.RoleProposer:                 ProposerRunner(logger, keySet),
+				ssvtypes.RoleAggregator:                AggregatorRunner(logger, keySet),
+				ssvtypes.RoleSyncCommitteeContribution: SyncCommitteeContributionRunner(logger, keySet),
+				spectypes.RoleAggregatorCommittee:      AggregatorCommitteeRunner(logger, keySet),
+				spectypes.RoleValidatorRegistration:    ValidatorRegistrationRunner(logger, keySet),
+				spectypes.RoleVoluntaryExit:            VoluntaryExitRunner(logger, keySet),
 			}),
 	)
 }

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -26,18 +26,27 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
-type CommitteeRunnerFunc func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share, attestingValidators []phase0.BLSPubKey, dutyGuard runner.CommitteeDutyGuard) (*runner.CommitteeRunner, error)
+type CommitteeRunnerFunc func(
+	duty spectypes.Duty,
+	shares map[phase0.ValidatorIndex]*spectypes.Share,
+	attestingValidators []phase0.BLSPubKey,
+	dutyGuard runner.CommitteeDutyGuard,
+) (runner.Runner, error)
 
 type Committee struct {
 	logger *zap.Logger
 
 	networkConfig *networkconfig.Network
 
-	// mtx syncs access to Queues, Runners, Shares.
-	mtx     sync.RWMutex
-	Queues  map[phase0.Slot]queue.Queue
-	Runners map[phase0.Slot]*runner.CommitteeRunner
-	Shares  map[phase0.ValidatorIndex]*spectypes.Share
+	// mtx syncs access to Queues, AggregatorQueues, Runners, AggregatorRunners, Shares.
+	mtx sync.RWMutex
+	// Queues is used for Committee duties (attestations and sync committees).
+	Queues map[phase0.Slot]queueContainer
+	// AggregatorQueues is used for AggregatorCommittee duties (aggregations and sync committee contributions).
+	AggregatorQueues  map[phase0.Slot]queueContainer
+	Runners           map[phase0.Slot]*runner.CommitteeRunner
+	AggregatorRunners map[phase0.Slot]*runner.AggregatorCommitteeRunner
+	Shares            map[phase0.ValidatorIndex]*spectypes.Share
 
 	CommitteeMember *spectypes.CommitteeMember
 
@@ -63,14 +72,16 @@ func NewCommittee(
 		With(fields.CommitteeID(operator.CommitteeID))
 
 	return &Committee{
-		logger:          logger,
-		networkConfig:   networkConfig,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		Shares:          shares,
-		CommitteeMember: operator,
-		CreateRunnerFn:  createRunnerFn,
-		dutyGuard:       dutyGuard,
+		logger:            logger,
+		networkConfig:     networkConfig,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		AggregatorQueues:  make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		Shares:            shares,
+		CommitteeMember:   operator,
+		CreateRunnerFn:    createRunnerFn,
+		dutyGuard:         dutyGuard,
 	}
 }
 
@@ -90,118 +101,143 @@ func (c *Committee) RemoveShare(validatorIndex phase0.ValidatorIndex) {
 }
 
 // StartDuty starts a new duty for the given slot.
-func (c *Committee) StartDuty(ctx context.Context, logger *zap.Logger, duty *spectypes.CommitteeDuty) (
-	*runner.CommitteeRunner,
-	queue.Queue,
+func (c *Committee) StartDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) (
+	runner.Runner,
+	queueContainer,
 	error,
 ) {
+	role := types.RunnerRoleForDuty(duty, c.networkConfig.BooleForkAtSlot(duty.DutySlot()))
 	ctx, span := tracer.Start(ctx,
 		observability.InstrumentName(observabilityNamespace, "start_committee_duty"),
 		trace.WithAttributes(
-			observability.RunnerRoleAttribute(duty.RunnerRole()),
-			observability.DutyCountAttribute(len(duty.ValidatorDuties)),
-			observability.BeaconSlotAttribute(duty.Slot)))
+			observability.RunnerRoleAttribute(role),
+			observability.DutyCountAttribute(len(c.extractValidatorDuties(duty))),
+			observability.BeaconSlotAttribute(duty.DutySlot())))
 	defer span.End()
 
 	span.AddEvent("prepare duty and runner")
-	r, q, runnableDuty, err := c.prepareDutyAndRunner(ctx, logger, duty)
+	commRunner, q, runnableDuty, err := c.prepareDutyAndRunner(ctx, logger, duty)
 	if err != nil {
-		return nil, nil, traces.Errorf(span, "prepare duty and runner: %w", err)
+		return nil, queueContainer{}, traces.Errorf(span, "prepare duty and runner: %w", err)
 	}
 
 	logger.Info("ℹ️ starting duty processing")
-	err = r.StartNewDuty(ctx, logger, runnableDuty, c.CommitteeMember.GetQuorum())
+	err = commRunner.StartNewDuty(ctx, logger, runnableDuty, c.CommitteeMember.GetQuorum())
 	if err != nil {
-		return nil, nil, traces.Errorf(span, "runner failed to start duty: %w", err)
+		return nil, queueContainer{}, traces.Errorf(span, "runner failed to start duty: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
-	return r, q, nil
+	return commRunner, q, nil
 }
 
-func (c *Committee) prepareDutyAndRunner(ctx context.Context, logger *zap.Logger, duty *spectypes.CommitteeDuty) (
-	r *runner.CommitteeRunner,
-	q queue.Queue,
-	runnableDuty *spectypes.CommitteeDuty,
+func (c *Committee) prepareDutyAndRunner(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) (
+	commRunner runner.Runner,
+	q queueContainer,
+	runnableDuty spectypes.Duty,
 	err error,
 ) {
+	validatorDuties := c.extractValidatorDuties(duty)
+	role := types.RunnerRoleForDuty(duty, c.networkConfig.BooleForkAtSlot(duty.DutySlot()))
+
 	_, span := tracer.Start(ctx,
 		observability.InstrumentName(observabilityNamespace, "prepare_duty_runner"),
 		trace.WithAttributes(
-			observability.RunnerRoleAttribute(duty.RunnerRole()),
-			observability.DutyCountAttribute(len(duty.ValidatorDuties)),
-			observability.BeaconSlotAttribute(duty.Slot)))
+			observability.RunnerRoleAttribute(role),
+			observability.DutyCountAttribute(len(validatorDuties)),
+			observability.BeaconSlotAttribute(duty.DutySlot())))
 	defer span.End()
 
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if _, exists := c.Runners[duty.Slot]; exists {
-		return nil, nil, nil, traces.Errorf(span, "CommitteeRunner for slot %d already exists", duty.Slot)
+	if _, ok := c.runnerForDuty(duty); ok {
+		return nil, queueContainer{}, nil, traces.Errorf(span, "committee runner for slot %d already exists", duty.DutySlot())
 	}
 
 	shares, attesters, runnableDuty, err := c.prepareDuty(logger, duty)
 	if err != nil {
-		return nil, nil, nil, traces.Error(span, err)
+		return nil, queueContainer{}, nil, traces.Error(span, err)
 	}
 
-	// Create the corresponding runner.
-	r, err = c.CreateRunnerFn(duty.Slot, shares, attesters, c.dutyGuard)
+	commRunner, err = c.createRunner(duty, shares, attesters)
 	if err != nil {
-		return nil, nil, nil, traces.Errorf(span, "could not create CommitteeRunner: %w", err)
+		return nil, queueContainer{}, nil, traces.Error(span, err)
 	}
-	runnerIdentifier := spectypes.NewMsgID(c.networkConfig.DomainType, c.CommitteeMember.CommitteeID[:], spectypes.RoleCommittee)
-	r.SetQBFTRoundTimerF(c.newQBFTRoundTimerF(runnerIdentifier))
-	c.Runners[duty.Slot] = r
 
 	// Initialize the corresponding queue preemptively (so we can skip this during duty execution).
-	q = c.getQueue(logger, duty.Slot)
+	q = c.getQueueForRole(logger, duty.DutySlot(), role)
 
 	// Prunes all expired committee runners opportunistically (when a new runner is created).
-	c.unsafePruneExpiredRunners(logger, duty.Slot)
+	c.unsafePruneExpiredRunners(logger, duty.DutySlot())
 
 	span.SetStatus(codes.Ok, "")
-	return r, q, runnableDuty, nil
+	return commRunner, q, runnableDuty, nil
 }
 
 // getQueue returns queue for the provided slot, lazily initializing it if it didn't exist previously.
 // MUST be called with c.mtx locked!
-func (c *Committee) getQueue(logger *zap.Logger, slot phase0.Slot) queue.Queue {
-	q, exists := c.Queues[slot]
-	if !exists {
-		q = queue.New(
-			logger,
-			defaultValidatorQueueSize,
-			queue.WithQueueMetrics(
-				queue.InboxSizeMetric,
-				queue.CommitteeQueueMetricType,
-				queue.CommitteeMetricID(slot),
-			),
-		)
-		c.Queues[slot] = q
+func (c *Committee) getQueueForRole(logger *zap.Logger, slot phase0.Slot, role spectypes.RunnerRole) queueContainer {
+	// Select backing map by role.
+	var m map[phase0.Slot]queueContainer
+	var assign func(slot phase0.Slot, qc queueContainer)
+
+	switch role {
+	case spectypes.RoleAggregatorCommittee:
+		m = c.AggregatorQueues
+		assign = func(slot phase0.Slot, qc queueContainer) { c.AggregatorQueues[slot] = qc }
+	case spectypes.RoleCommittee:
+		m = c.Queues
+		assign = func(slot phase0.Slot, qc queueContainer) { c.Queues[slot] = qc }
+	default:
+		c.logger.Panic("BUG: unexpected committee queue role", fields.RunnerRole(role))
 	}
 
+	q, exists := m[slot]
+	if !exists {
+		qType := queue.CommitteeQueueMetricType
+		if role == spectypes.RoleAggregatorCommittee {
+			qType = queue.AggregatorCommitteeQueueMetricType
+		}
+		q = queueContainer{
+			Q: queue.New(
+				logger,
+				defaultValidatorQueueSize,
+				queue.WithQueueMetrics(
+					queue.InboxSizeMetric,
+					qType,
+					queue.CommitteeMetricID(slot),
+				),
+			),
+			queueState: &queue.State{
+				HasRunningInstance: false,
+				Slot:               slot,
+				Quorum:             c.CommitteeMember.GetQuorum(),
+			},
+		}
+		assign(slot, q)
+	}
 	return q
 }
 
 // prepareDuty filters out unrunnable validator duties and returns the shares and attesters.
-func (c *Committee) prepareDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty) (
+func (c *Committee) prepareDuty(logger *zap.Logger, duty spectypes.Duty) (
 	shares map[phase0.ValidatorIndex]*spectypes.Share,
 	attesters []phase0.BLSPubKey,
-	runnableDuty *spectypes.CommitteeDuty,
+	runnableDuty spectypes.Duty,
 	err error,
 ) {
-	if len(duty.ValidatorDuties) == 0 {
-		return nil, nil, nil, spectypes.NewError(spectypes.NoBeaconDutiesErrorCode, "no beacon duties")
+	validatorDuties := c.extractValidatorDuties(duty)
+	if len(validatorDuties) == 0 {
+		return nil, nil, nil,
+			spectypes.NewError(spectypes.NoBeaconDutiesErrorCode, "no beacon duties")
 	}
 
-	runnableDuty = &spectypes.CommitteeDuty{
-		Slot:            duty.Slot,
-		ValidatorDuties: make([]*spectypes.ValidatorDuty, 0, len(duty.ValidatorDuties)),
-	}
-	shares = make(map[phase0.ValidatorIndex]*spectypes.Share, len(duty.ValidatorDuties))
-	attesters = make([]phase0.BLSPubKey, 0, len(duty.ValidatorDuties))
-	for _, beaconDuty := range duty.ValidatorDuties {
+	runnableValidatorDuties := make([]*spectypes.ValidatorDuty, 0, len(validatorDuties))
+
+	shares = make(map[phase0.ValidatorIndex]*spectypes.Share, len(validatorDuties))
+	attesters = make([]phase0.BLSPubKey, 0, len(validatorDuties))
+	for _, beaconDuty := range validatorDuties {
 		share, exists := c.Shares[beaconDuty.ValidatorIndex]
 		if !exists {
 			// Filter out Beacon duties for which we don't have a share.
@@ -211,7 +247,7 @@ func (c *Committee) prepareDuty(logger *zap.Logger, duty *spectypes.CommitteeDut
 			continue
 		}
 		shares[beaconDuty.ValidatorIndex] = share
-		runnableDuty.ValidatorDuties = append(runnableDuty.ValidatorDuties, beaconDuty)
+		runnableValidatorDuties = append(runnableValidatorDuties, beaconDuty)
 
 		if beaconDuty.Type == spectypes.BNRoleAttester {
 			attesters = append(attesters, phase0.BLSPubKey(share.SharePubKey))
@@ -219,7 +255,23 @@ func (c *Committee) prepareDuty(logger *zap.Logger, duty *spectypes.CommitteeDut
 	}
 
 	if len(shares) == 0 {
-		return nil, nil, nil, spectypes.NewError(spectypes.NoValidatorSharesErrorCode, "no shares for duty's validators")
+		return nil, nil, nil,
+			spectypes.NewError(spectypes.NoValidatorSharesErrorCode, "no shares for duty's validators")
+	}
+
+	switch duty := duty.(type) {
+	case *spectypes.CommitteeDuty:
+		runnableDuty = &spectypes.CommitteeDuty{
+			Slot:            duty.Slot,
+			ValidatorDuties: runnableValidatorDuties,
+		}
+	case *spectypes.AggregatorCommitteeDuty:
+		runnableDuty = &spectypes.AggregatorCommitteeDuty{
+			Slot:            duty.Slot,
+			ValidatorDuties: runnableValidatorDuties,
+		}
+	default:
+		c.logger.Panic("BUG: unexpected duty type", zap.String("type", fmt.Sprintf("%T", duty)))
 	}
 
 	return shares, attesters, runnableDuty, nil
@@ -252,6 +304,7 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 		return fmt.Errorf("couldn't get message slot: %w", err)
 	}
 
+	role := msg.GetID().GetRoleType()
 	switch msgType {
 	case spectypes.SSVConsensusMsgType:
 		span.AddEvent("process committee message = consensus message")
@@ -265,9 +318,9 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 		}
 
 		c.mtx.RLock()
-		r, exists := c.Runners[slot]
+		r, ok := c.runnerForRole(role, slot)
 		c.mtx.RUnlock()
-		if !exists {
+		if !ok {
 			return spectypes.WrapError(spectypes.NoRunnerForSlotErrorCode, fmt.Errorf("no runner found for message's slot %d", slot))
 		}
 
@@ -287,20 +340,32 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 			return fmt.Errorf("PartialSignatureMessages signer is invalid: %w", err)
 		}
 
+		// Locate the runner for this slot once and route by message subtype.
+		c.mtx.RLock()
+		r, ok := c.runnerForRole(role, slot)
+		c.mtx.RUnlock()
+		if !ok {
+			return spectypes.WrapError(spectypes.NoRunnerForSlotErrorCode, fmt.Errorf("no runner found for message's slot %d", slot))
+		}
+
 		if pSigMessages.Type == spectypes.PostConsensusPartialSig {
 			span.AddEvent("process committee message = post-consensus message")
-
-			c.mtx.RLock()
-			r, exists := c.Runners[pSigMessages.Slot]
-			c.mtx.RUnlock()
-			if !exists {
-				return spectypes.WrapError(spectypes.NoRunnerForSlotErrorCode, fmt.Errorf("no runner found for message's slot"))
-			}
 			if err := r.ProcessPostConsensus(ctx, logger, pSigMessages); err != nil {
 				return fmt.Errorf("process post-consensus message: %w", err)
 			}
+			return nil
 		}
 
+		if role != spectypes.RoleAggregatorCommittee {
+			return fmt.Errorf("invalid aggregator partial sig msg for committee role")
+		}
+
+		// Handle all non-post consensus partial signatures via pre-consensus path
+		// (e.g., aggregator selection proofs and sync committee selection proofs).
+		span.AddEvent("process committee message = pre-consensus message")
+		if err := r.ProcessPreConsensus(ctx, logger, pSigMessages); err != nil {
+			return fmt.Errorf("process pre-consensus message: %w", err)
+		}
 		return nil
 	case message.SSVEventMsgType:
 		eventMsg, ok := msg.Body.(*types.EventMsg)
@@ -315,7 +380,7 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 			span.AddEvent("process committee message = event(timeout)")
 
 			c.mtx.RLock()
-			dutyRunner, found := c.Runners[slot]
+			r, found := c.runnerForRole(role, slot)
 			c.mtx.RUnlock()
 			if !found {
 				// Old runners are pruned, timeout-event issuer is unaware of that - that's why we can end up here
@@ -328,7 +393,7 @@ func (c *Committee) ProcessMessage(ctx context.Context, logger *zap.Logger, msg 
 				return fmt.Errorf("event message: get timeout data: %w", err)
 			}
 
-			if err := dutyRunner.OnQBFTRoundTimeout(ctx, logger, timeoutData); err != nil {
+			if err := r.OnQBFTRoundTimeout(ctx, logger, timeoutData); err != nil {
 				return fmt.Errorf("event message: process timeout event: %w", err)
 			}
 
@@ -355,11 +420,23 @@ func (c *Committee) unsafePruneExpiredRunners(logger *zap.Logger, currentSlot ph
 		if slot < minValidSlot {
 			opIds := types.OperatorIDsFromOperators(c.CommitteeMember.Committee)
 			epoch := c.networkConfig.EstimatedEpochAtSlot(slot)
-			committeeDutyID := fields.BuildCommitteeDutyID(opIds, epoch, slot)
+			committeeDutyID := fields.BuildCommitteeDutyID(opIds, epoch, slot, spectypes.RoleCommittee)
 			logger = logger.With(fields.DutyID(committeeDutyID))
 			logger.Debug("pruning expired committee runner", zap.Uint64("prune_slot", uint64(slot)))
 			delete(c.Runners, slot)
 			delete(c.Queues, slot)
+		}
+	}
+
+	for slot := range c.AggregatorRunners {
+		if slot < minValidSlot {
+			opIds := types.OperatorIDsFromOperators(c.CommitteeMember.Committee)
+			epoch := c.networkConfig.EstimatedEpochAtSlot(slot)
+			committeeDutyID := fields.BuildCommitteeDutyID(opIds, epoch, slot, spectypes.RoleAggregatorCommittee)
+			logger = logger.With(fields.DutyID(committeeDutyID))
+			logger.Debug("pruning expired aggregator committee runner", zap.Uint64("slot", uint64(slot)))
+			delete(c.AggregatorRunners, slot)
+			delete(c.AggregatorQueues, slot)
 		}
 	}
 }
@@ -384,16 +461,18 @@ func (c *Committee) GetRoot() ([32]byte, error) {
 
 func (c *Committee) MarshalJSON() ([]byte, error) {
 	type CommitteeAlias struct {
-		Runners         map[phase0.Slot]*runner.CommitteeRunner
-		CommitteeMember *spectypes.CommitteeMember
-		Share           map[phase0.ValidatorIndex]*spectypes.Share
+		Runners           map[phase0.Slot]*runner.CommitteeRunner
+		AggregatorRunners map[phase0.Slot]*runner.AggregatorCommitteeRunner
+		CommitteeMember   *spectypes.CommitteeMember
+		Share             map[phase0.ValidatorIndex]*spectypes.Share
 	}
 
 	// Create object and marshal
 	alias := &CommitteeAlias{
-		Runners:         c.Runners,
-		CommitteeMember: c.CommitteeMember,
-		Share:           c.Shares,
+		Runners:           c.Runners,
+		AggregatorRunners: c.AggregatorRunners,
+		CommitteeMember:   c.CommitteeMember,
+		Share:             c.Shares,
 	}
 
 	byts, err := json.Marshal(alias)
@@ -403,9 +482,10 @@ func (c *Committee) MarshalJSON() ([]byte, error) {
 
 func (c *Committee) UnmarshalJSON(data []byte) error {
 	type CommitteeAlias struct {
-		Runners         map[phase0.Slot]*runner.CommitteeRunner
-		CommitteeMember *spectypes.CommitteeMember
-		Shares          map[phase0.ValidatorIndex]*spectypes.Share
+		Runners           map[phase0.Slot]*runner.CommitteeRunner
+		AggregatorRunners map[phase0.Slot]*runner.AggregatorCommitteeRunner
+		CommitteeMember   *spectypes.CommitteeMember
+		Shares            map[phase0.ValidatorIndex]*spectypes.Share
 	}
 
 	// Unmarshal the JSON data into the auxiliary struct
@@ -416,6 +496,7 @@ func (c *Committee) UnmarshalJSON(data []byte) error {
 
 	// Assign fields
 	c.Runners = aux.Runners
+	c.AggregatorRunners = aux.AggregatorRunners
 	c.CommitteeMember = aux.CommitteeMember
 	c.Shares = aux.Shares
 
@@ -427,8 +508,6 @@ func (c *Committee) validateMessage(msg *spectypes.SSVMessage) error {
 		return spectypes.NewError(spectypes.MessageIDCommitteeIDMismatchErrorCode, "msg ID doesn't match committee ID")
 	}
 
-	// TODO(convergence unit 5): RoleAggregatorCommittee is accepted here for parity with boole, but
-	// no such messages exist before the AggregatorCommittee runner lands.
 	role := msg.GetID().GetRoleType()
 	if role != spectypes.RoleCommittee && role != spectypes.RoleAggregatorCommittee {
 		return spectypes.NewError(spectypes.CommitteeWrongRoleErrorCode, "msg role is invalid")
@@ -439,4 +518,72 @@ func (c *Committee) validateMessage(msg *spectypes.SSVMessage) error {
 	}
 
 	return nil
+}
+
+func (c *Committee) runnerForDuty(duty spectypes.Duty) (runner.Runner, bool) {
+	switch duty.(type) {
+	case *spectypes.CommitteeDuty:
+		r, ok := c.Runners[duty.DutySlot()]
+		return r, ok
+	case *spectypes.AggregatorCommitteeDuty:
+		r, ok := c.AggregatorRunners[duty.DutySlot()]
+		return r, ok
+	default:
+		return nil, false
+	}
+}
+
+func (c *Committee) runnerForRole(role spectypes.RunnerRole, slot phase0.Slot) (runner.Runner, bool) {
+	switch role {
+	case spectypes.RoleCommittee:
+		r, ok := c.Runners[slot]
+		return r, ok
+	case spectypes.RoleAggregatorCommittee:
+		r, ok := c.AggregatorRunners[slot]
+		return r, ok
+	default:
+		return nil, false
+	}
+}
+
+func (c *Committee) createRunner(
+	duty spectypes.Duty,
+	shares map[phase0.ValidatorIndex]*spectypes.Share,
+	attesters []phase0.BLSPubKey,
+) (runner.Runner, error) {
+	r, err := c.CreateRunnerFn(duty, shares, attesters, c.dutyGuard)
+	if err != nil {
+		return nil, fmt.Errorf("create committee runner: %w", err)
+	}
+
+	// Wire the QBFT round-timer factory, bound to a msg ID carrying this duty's role so timeout
+	// events are routed to the matching (committee vs aggregator-committee) slot queue.
+	role := types.RunnerRoleForDuty(duty, c.networkConfig.BooleForkAtSlot(duty.DutySlot()))
+	runnerIdentifier := spectypes.NewMsgID(c.networkConfig.CurrentDomainType(), c.CommitteeMember.CommitteeID[:], role)
+	r.SetQBFTRoundTimerF(c.newQBFTRoundTimerF(runnerIdentifier))
+
+	switch duty := duty.(type) {
+	case *spectypes.CommitteeDuty:
+		c.Runners[duty.DutySlot()] = r.(*runner.CommitteeRunner)
+	case *spectypes.AggregatorCommitteeDuty:
+		c.AggregatorRunners[duty.DutySlot()] = r.(*runner.AggregatorCommitteeRunner)
+	default:
+		c.logger.Panic("BUG: attempt to create committee runner with non-committee duty type",
+			zap.String("type", fmt.Sprintf("%T", duty)))
+	}
+
+	return r, err
+}
+
+func (c *Committee) extractValidatorDuties(duty spectypes.Duty) []*spectypes.ValidatorDuty {
+	switch duty := duty.(type) {
+	case *spectypes.CommitteeDuty:
+		return duty.ValidatorDuties
+	case *spectypes.AggregatorCommitteeDuty:
+		return duty.ValidatorDuties
+	default:
+		c.logger.Panic("BUG: attempt to extract validator duties from non-committee duty type",
+			zap.String("type", fmt.Sprintf("%T", duty)))
+		panic("BUG: unreachable")
+	}
 }

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -209,11 +209,6 @@ func (c *Committee) getQueueForRole(logger *zap.Logger, slot phase0.Slot, role s
 					queue.CommitteeMetricID(slot),
 				),
 			),
-			queueState: &queue.State{
-				HasRunningInstance: false,
-				Slot:               slot,
-				Quorum:             c.CommitteeMember.GetQuorum(),
-			},
 		}
 		assign(slot, q)
 	}

--- a/protocol/v2/ssv/validator/committee_observer.go
+++ b/protocol/v2/ssv/validator/committee_observer.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/jellydator/ttlcache/v3"
 	"go.uber.org/zap"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log/fields"
+	protocolp2p "github.com/ssvlabs/ssv/protocol/v2/p2p"
 	qbftcontroller "github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
@@ -30,18 +33,22 @@ import (
 type CommitteeObserver struct {
 	sync.Mutex
 
-	msgID             spectypes.MessageID
-	logger            *zap.Logger
-	Storage           *storage.ParticipantStores
-	beaconConfig      *networkconfig.Beacon
-	ValidatorStore    registrystorage.ValidatorStore
-	newDecidedHandler qbftcontroller.NewDecidedHandler
-	attesterRoots     *ttlcache.Cache[phase0.Root, struct{}]
-	syncCommRoots     *ttlcache.Cache[phase0.Root, struct{}]
-	domainCache       *DomainCache
+	msgID                spectypes.MessageID
+	logger               *zap.Logger
+	Storage              *storage.ParticipantStores
+	beaconConfig         *networkconfig.Beacon
+	ValidatorStore       registrystorage.ValidatorStore
+	newDecidedHandler    qbftcontroller.NewDecidedHandler
+	attesterRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	aggregatorRoots      *ttlcache.Cache[phase0.Root, struct{}]
+	syncCommRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	syncCommContribRoots *ttlcache.Cache[phase0.Root, struct{}]
+	domainCache          *DomainCache
 
 	// cache to identify and skip duplicate computations of attester/sync committee roots
 	beaconVoteRoots *ttlcache.Cache[BeaconVoteCacheKey, struct{}]
+	// cache to identify and skip duplicate computations of aggregator/sync committee contribution roots
+	aggregatorCommitteeRoots *ttlcache.Cache[AggregatorCommitteeCacheKey, struct{}]
 
 	// TODO: consider using round-robin container as []map[phase0.ValidatorIndex]*ssv.PartialSigContainer similar to what is used in OperatorState
 	postConsensusContainer map[phase0.Slot]map[phase0.ValidatorIndex]*ssv.PartialSigContainer
@@ -54,35 +61,48 @@ type BeaconVoteCacheKey struct {
 	height specqbft.Height
 }
 
+// AggregatorCommitteeCacheKey is a composite key for identifying a unique call
+// to computing aggregator committee roots.
+type AggregatorCommitteeCacheKey struct {
+	root   phase0.Root
+	height specqbft.Height
+}
+
 type CommitteeObserverOptions struct {
-	FullNode          bool
-	Logger            *zap.Logger
-	BeaconConfig      *networkconfig.Beacon
-	Network           specqbft.Network
-	Storage           *storage.ParticipantStores
-	OperatorSigner    ssvtypes.OperatorSigner
-	NewDecidedHandler qbftcontroller.NewDecidedHandler
-	ValidatorStore    registrystorage.ValidatorStore
-	AttesterRoots     *ttlcache.Cache[phase0.Root, struct{}]
-	SyncCommRoots     *ttlcache.Cache[phase0.Root, struct{}]
-	BeaconVoteRoots   *ttlcache.Cache[BeaconVoteCacheKey, struct{}]
-	DomainCache       *DomainCache
+	FullNode             bool
+	Logger               *zap.Logger
+	BeaconConfig         *networkconfig.Beacon
+	Network              protocolp2p.Network
+	Storage              *storage.ParticipantStores
+	OperatorSigner       ssvtypes.OperatorSigner
+	NewDecidedHandler    qbftcontroller.NewDecidedHandler
+	ValidatorStore       registrystorage.ValidatorStore
+	AttesterRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	AggregatorRoots      *ttlcache.Cache[phase0.Root, struct{}]
+	SyncCommRoots        *ttlcache.Cache[phase0.Root, struct{}]
+	SyncCommContribRoots *ttlcache.Cache[phase0.Root, struct{}]
+	BeaconVoteRoots      *ttlcache.Cache[BeaconVoteCacheKey, struct{}]
+	AggregatorCommRoots  *ttlcache.Cache[AggregatorCommitteeCacheKey, struct{}]
+	DomainCache          *DomainCache
 }
 
 func NewCommitteeObserver(msgID spectypes.MessageID, opts CommitteeObserverOptions) *CommitteeObserver {
 	// TODO: does the specific operator matters?
 
 	co := &CommitteeObserver{
-		msgID:             msgID,
-		logger:            opts.Logger,
-		Storage:           opts.Storage,
-		beaconConfig:      opts.BeaconConfig,
-		ValidatorStore:    opts.ValidatorStore,
-		newDecidedHandler: opts.NewDecidedHandler,
-		attesterRoots:     opts.AttesterRoots,
-		syncCommRoots:     opts.SyncCommRoots,
-		domainCache:       opts.DomainCache,
-		beaconVoteRoots:   opts.BeaconVoteRoots,
+		msgID:                    msgID,
+		logger:                   opts.Logger,
+		Storage:                  opts.Storage,
+		beaconConfig:             opts.BeaconConfig,
+		ValidatorStore:           opts.ValidatorStore,
+		newDecidedHandler:        opts.NewDecidedHandler,
+		attesterRoots:            opts.AttesterRoots,
+		aggregatorRoots:          opts.AggregatorRoots,
+		syncCommRoots:            opts.SyncCommRoots,
+		syncCommContribRoots:     opts.SyncCommContribRoots,
+		domainCache:              opts.DomainCache,
+		beaconVoteRoots:          opts.BeaconVoteRoots,
+		aggregatorCommitteeRoots: opts.AggregatorCommRoots,
 	}
 
 	co.postConsensusContainer = make(map[phase0.Slot]map[phase0.ValidatorIndex]*ssv.PartialSigContainer, co.postConsensusContainerCapacity())
@@ -94,7 +114,7 @@ func (ncv *CommitteeObserver) ProcessMessage(msg *queue.SSVMessage) error {
 	role := msg.MsgID.GetRoleType()
 
 	logger := ncv.logger.With(fields.RunnerRole(role))
-	if role == spectypes.RoleCommittee {
+	if role == spectypes.RoleCommittee || role == spectypes.RoleAggregatorCommittee {
 		cid := spectypes.CommitteeID(msg.GetID().GetDutyExecutorID()[16:])
 		logger = logger.With(fields.CommitteeID(cid))
 	} else {
@@ -208,9 +228,20 @@ func (ncv *CommitteeObserver) getBeaconRoles(msg *queue.SSVMessage, root phase0.
 		default:
 			return nil
 		}
-	// TODO(convergence unit 5): enable AggregatorCommittee handling.
 	case spectypes.RoleAggregatorCommittee:
-		return nil
+		aggregator := ncv.aggregatorRoots.Get(root)
+		syncCommitteeContrib := ncv.syncCommContribRoots.Get(root)
+
+		switch {
+		case aggregator != nil && syncCommitteeContrib != nil:
+			return []spectypes.BeaconRole{spectypes.BNRoleAggregator, spectypes.BNRoleSyncCommitteeContribution}
+		case aggregator != nil:
+			return []spectypes.BeaconRole{spectypes.BNRoleAggregator}
+		case syncCommitteeContrib != nil:
+			return []spectypes.BeaconRole{spectypes.BNRoleSyncCommitteeContribution}
+		default:
+			return nil
+		}
 	case ssvtypes.RoleAggregator:
 		return []spectypes.BeaconRole{spectypes.BNRoleAggregator}
 	case spectypes.RoleProposer:
@@ -221,11 +252,9 @@ func (ncv *CommitteeObserver) getBeaconRoles(msg *queue.SSVMessage, root phase0.
 		return []spectypes.BeaconRole{spectypes.BNRoleValidatorRegistration}
 	case spectypes.RoleVoluntaryExit:
 		return []spectypes.BeaconRole{spectypes.BNRoleVoluntaryExit}
-	case spectypes.RoleUnknown:
+	default:
 		return nil
 	}
-
-	return nil
 }
 
 type validatorIndexAndRoot struct {
@@ -266,7 +295,7 @@ func (ncv *CommitteeObserver) VerifySig(partialMsgs *spectypes.PartialSignatureM
 			slotValidators[msg.ValidatorIndex] = container
 		}
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
-			if err := container.ResolveDuplicateSignature(msg, validator.Committee); err != nil {
+			if err := ncv.resolveDuplicateSignature(container, msg, validator); err != nil {
 				return err
 			}
 		} else {
@@ -302,7 +331,7 @@ func (ncv *CommitteeObserver) verifySigAndgetQuorums(
 			slotValidators[msg.ValidatorIndex] = container
 		}
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
-			_ = container.ResolveDuplicateSignature(msg, validator.Committee)
+			_ = ncv.resolveDuplicateSignature(container, msg, validator)
 		} else {
 			container.AddSignature(msg)
 		}
@@ -340,39 +369,118 @@ func (ncv *CommitteeObserver) pruneOldSlots(currentSlot phase0.Slot) {
 	}
 }
 
-func (ncv *CommitteeObserver) SaveRoots(ctx context.Context, msg *queue.SSVMessage) error {
-	beaconVote := &spectypes.BeaconVote{}
-	if err := beaconVote.Decode(msg.SignedSSVMessage.FullData); err != nil {
-		ncv.logger.Debug("❗ failed to get beacon vote data", zap.Error(err))
-		return err
+// Stores the container's existing signature or the new one, depending on their validity. If both are invalid, remove the existing one
+// copied from BaseRunner
+func (ncv *CommitteeObserver) resolveDuplicateSignature(container *ssv.PartialSigContainer, msg *spectypes.PartialSignatureMessage, share *ssvtypes.SSVShare) error {
+	// Check previous signature validity
+	previousSignature, err := container.GetSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
+	if err == nil {
+		err = ncv.verifyBeaconPartialSignature(msg.Signer, previousSignature, msg.SigningRoot, share)
+		if err == nil {
+			// Keep the previous signature since it's correct
+			return nil
+		}
 	}
 
+	// Previous signature is incorrect or doesn't exist
+	container.Remove(msg.ValidatorIndex, msg.Signer, msg.SigningRoot)
+
+	// Hold the new signature, if correct
+	err = ncv.verifyBeaconPartialSignature(msg.Signer, msg.PartialSignature, msg.SigningRoot, share)
+	if err == nil {
+		container.AddSignature(msg)
+	}
+
+	return err
+}
+
+// copied from BaseRunner
+func (ncv *CommitteeObserver) verifyBeaconPartialSignature(signer uint64, signature spectypes.Signature, root phase0.Root, share *ssvtypes.SSVShare) error {
+	for _, n := range share.Committee {
+		if n.Signer == signer {
+			pk, err := ssvtypes.DeserializeBLSPublicKey(n.SharePubKey)
+			if err != nil {
+				return fmt.Errorf("could not deserialized pk: %w", err)
+			}
+
+			sig := &bls.Sign{}
+			if err := sig.Deserialize(signature); err != nil {
+				return fmt.Errorf("could not deserialized Signature: %w", err)
+			}
+
+			if !sig.VerifyByte(&pk, root[:]) {
+				return fmt.Errorf("wrong signature")
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown signer")
+}
+
+func (ncv *CommitteeObserver) SaveRoots(ctx context.Context, msg *queue.SSVMessage) error {
 	qbftMsg, ok := msg.Body.(*specqbft.Message)
 	if !ok || qbftMsg == nil {
 		return fmt.Errorf("invalid qbft msg body, type: %T", msg.Body)
 	}
 
-	bnCacheKey := BeaconVoteCacheKey{root: beaconVote.BlockRoot, height: qbftMsg.Height}
-
-	// if the roots for this beacon vote hash and height have already been computed, skip
-	if ncv.beaconVoteRoots.Has(bnCacheKey) {
-		return nil
-	}
-
 	epoch := ncv.beaconConfig.EstimatedEpochAtSlot(phase0.Slot(qbftMsg.Height))
 
-	if err := ncv.saveAttesterRoots(ctx, epoch, beaconVote, qbftMsg); err != nil {
-		return err
+	switch msg.MsgID.GetRoleType() {
+	case spectypes.RoleCommittee:
+		beaconVote := &spectypes.BeaconVote{}
+		if err := beaconVote.Decode(msg.SignedSSVMessage.FullData); err != nil {
+			ncv.logger.Debug("❗ failed to decode beacon vote from proposal", zap.Error(err))
+			return err
+		}
+
+		bnCacheKey := BeaconVoteCacheKey{root: beaconVote.BlockRoot, height: qbftMsg.Height}
+		// if the roots for this beacon vote hash and height have already been computed, skip
+		if ncv.beaconVoteRoots.Has(bnCacheKey) {
+			return nil
+		}
+
+		if err := ncv.saveAttesterRoots(ctx, epoch, beaconVote, qbftMsg); err != nil {
+			return err
+		}
+		if err := ncv.saveSyncCommRoots(ctx, epoch, beaconVote); err != nil {
+			return err
+		}
+
+		// cache the roots for this beacon vote hash and height
+		ncv.beaconVoteRoots.Set(bnCacheKey, struct{}{}, ttlcache.DefaultTTL)
+		return nil
+
+	case spectypes.RoleAggregatorCommittee:
+		consData := &spectypes.AggregatorCommitteeConsensusData{}
+		if err := consData.Decode(msg.SignedSSVMessage.FullData); err != nil {
+			ncv.logger.Debug("❗ failed to decode aggregator committee consensus data from proposal", zap.Error(err))
+			return err
+		}
+
+		consRoot, err := consData.HashTreeRoot()
+		if err != nil {
+			ncv.logger.Debug("❗ failed to compute aggregator committee consensus data root", zap.Error(err))
+			return err
+		}
+		aggCacheKey := AggregatorCommitteeCacheKey{root: consRoot, height: qbftMsg.Height}
+		// if the roots for this consensus data and height have already been computed, skip
+		if ncv.aggregatorCommitteeRoots.Has(aggCacheKey) {
+			return nil
+		}
+
+		if err := ncv.saveAggregatorRoots(ctx, epoch, consData); err != nil {
+			return err
+		}
+		if err := ncv.saveSyncCommContribRoots(ctx, epoch, consData); err != nil {
+			return err
+		}
+
+		// cache the roots for this consensus data and height
+		ncv.aggregatorCommitteeRoots.Set(aggCacheKey, struct{}{}, ttlcache.DefaultTTL)
+		return nil
+	default:
+		return nil
 	}
-
-	if err := ncv.saveSyncCommRoots(ctx, epoch, beaconVote); err != nil {
-		return err
-	}
-
-	// cache the roots for this beacon vote hash and height
-	ncv.beaconVoteRoots.Set(bnCacheKey, struct{}{}, ttlcache.DefaultTTL)
-
-	return nil
 }
 
 func (ncv *CommitteeObserver) saveAttesterRoots(ctx context.Context, epoch phase0.Epoch, beaconVote *spectypes.BeaconVote, qbftMsg *specqbft.Message) error {
@@ -412,6 +520,64 @@ func (ncv *CommitteeObserver) saveSyncCommRoots(
 
 	ncv.syncCommRoots.Set(syncCommitteeRoot, struct{}{}, ttlcache.DefaultTTL)
 
+	return nil
+}
+
+func (ncv *CommitteeObserver) saveAggregatorRoots(
+	ctx context.Context,
+	epoch phase0.Epoch,
+	data *spectypes.AggregatorCommitteeConsensusData,
+) error {
+	aggregateAndProofs, err := data.GetAggregateAndProofs()
+	if err != nil {
+		return err
+	}
+
+	dAgg, err := ncv.domainCache.Get(ctx, epoch, spectypes.DomainAggregateAndProof)
+	if err != nil {
+		return err
+	}
+	for _, aggAndProof := range aggregateAndProofs {
+		hashRoot, err := spectypes.GetAggregateAndProofHashRoot(aggAndProof)
+		if err != nil {
+			continue
+		}
+		root, err := spectypes.ComputeETHSigningRoot(hashRoot, dAgg)
+		if err != nil {
+			return err
+		}
+		ncv.aggregatorRoots.Set(root, struct{}{}, ttlcache.DefaultTTL)
+	}
+	return nil
+}
+
+func (ncv *CommitteeObserver) saveSyncCommContribRoots(
+	ctx context.Context,
+	epoch phase0.Epoch,
+	data *spectypes.AggregatorCommitteeConsensusData,
+) error {
+	contribs, err := data.GetSyncCommitteeContributions()
+	if err != nil {
+		return err
+	}
+
+	dContrib, err := ncv.domainCache.Get(ctx, epoch, spectypes.DomainContributionAndProof)
+	if err != nil {
+		return err
+	}
+
+	for i, c := range contribs {
+		cp := &altair.ContributionAndProof{
+			AggregatorIndex: data.Contributors[i].ValidatorIndex,
+			Contribution:    &c.Contribution,
+			SelectionProof:  data.Contributors[i].SelectionProof,
+		}
+		root, err := spectypes.ComputeETHSigningRoot(cp, dContrib)
+		if err != nil {
+			return err
+		}
+		ncv.syncCommContribRoots.Set(root, struct{}{}, ttlcache.DefaultTTL)
+	}
 	return nil
 }
 

--- a/protocol/v2/ssv/validator/committee_queue.go
+++ b/protocol/v2/ssv/validator/committee_queue.go
@@ -24,6 +24,12 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
+// queueContainer wraps a queue with its corresponding state
+type queueContainer struct {
+	Q          queue.Queue
+	queueState *queue.State
+}
+
 // EnqueueMessage enqueues a spectypes.SSVMessage for processing.
 // TODO: accept DecodedSSVMessage once p2p is upgraded to decode messages during validation.
 func (c *Committee) EnqueueMessage(ctx context.Context, msg *queue.SSVMessage) {
@@ -40,7 +46,7 @@ func (c *Committee) EnqueueMessage(ctx context.Context, msg *queue.SSVMessage) {
 		logger.Error("❌ couldn't get message slot", zap.Error(err))
 		return
 	}
-	dutyID := fields.BuildCommitteeDutyID(types.OperatorIDsFromOperators(c.CommitteeMember.Committee), c.networkConfig.EstimatedEpochAtSlot(slot), slot)
+	dutyID := fields.BuildCommitteeDutyID(types.OperatorIDsFromOperators(c.CommitteeMember.Committee), c.networkConfig.EstimatedEpochAtSlot(slot), slot, msgID.GetRoleType())
 
 	logger = logger.
 		With(fields.Slot(slot)).
@@ -58,11 +64,13 @@ func (c *Committee) EnqueueMessage(ctx context.Context, msg *queue.SSVMessage) {
 	defer span.End()
 
 	c.mtx.Lock()
-	q := c.getQueue(logger, slot)
+	// Route to role-specific queue to avoid concurrent Pop calls on same queue
+	// when both committee and aggregator consumers are running for the slot.
+	q := c.getQueueForRole(logger, slot, msgID.GetRoleType())
 	c.mtx.Unlock()
 
 	span.AddEvent("pushing message to the queue")
-	if pushed := q.TryPush(msg); !pushed {
+	if pushed := q.Q.TryPush(msg); !pushed {
 		const errMsg = "❗ dropping message because the queue is full"
 		logger.Warn(errMsg, zap.String("drop_reason", queue.DropReasonBufferFull))
 		span.AddEvent(errMsg, trace.WithAttributes(attribute.String("drop_reason", queue.DropReasonBufferFull)))
@@ -78,9 +86,9 @@ func (c *Committee) EnqueueMessage(ctx context.Context, msg *queue.SSVMessage) {
 func (c *Committee) ConsumeQueue(
 	ctx context.Context,
 	logger *zap.Logger,
-	q queue.Queue,
+	q queueContainer,
 	handler MessageHandler, // should be c.ProcessMessage, it is a param so can be mocked out for testing
-	r *runner.CommitteeRunner,
+	r runner.Runner,
 ) {
 	logger.Debug("📬 queue consumer is running")
 	defer logger.Debug("📪 queue consumer is closed")
@@ -132,7 +140,7 @@ func (c *Committee) ConsumeQueue(
 		}
 
 		// Pop the highest priority message for the current state.
-		msg := q.Pop(ctx, queue.NewCommitteeQueuePrioritizer(&rState), filter)
+		msg := q.Q.Pop(ctx, queue.NewCommitteeQueuePrioritizer(&rState), filter)
 		if ctx.Err() != nil {
 			// Optimization: terminate fast if we can.
 			return
@@ -175,6 +183,7 @@ func (c *Committee) ConsumeQueue(
 					types.OperatorIDsFromOperators(c.CommitteeMember.Committee),
 					c.networkConfig.EstimatedEpochAtSlot(slot),
 					slot,
+					msg.GetID().GetRoleType(),
 				)
 				spanOpts = append(spanOpts, trace.WithAttributes(
 					observability.BeaconSlotAttribute(slot),
@@ -245,7 +254,7 @@ func (c *Committee) ConsumeQueue(
 					case <-msgState.ctx.Done():
 						return
 					}
-					if pushed := q.TryPush(msg); !pushed {
+					if pushed := q.Q.TryPush(msg); !pushed {
 						const droppingMsgDueToQueueIsFullEvent = "❗ not gonna replay message because the queue is full"
 						msgLogger.Error(droppingMsgDueToQueueIsFullEvent)
 						msgState.span.AddEvent(droppingMsgDueToQueueIsFullEvent, trace.WithAttributes(

--- a/protocol/v2/ssv/validator/committee_queue.go
+++ b/protocol/v2/ssv/validator/committee_queue.go
@@ -24,10 +24,9 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
-// queueContainer wraps a queue with its corresponding state
+// queueContainer wraps a queue for a duty role.
 type queueContainer struct {
-	Q          queue.Queue
-	queueState *queue.State
+	Q queue.Queue
 }
 
 // EnqueueMessage enqueues a spectypes.SSVMessage for processing.

--- a/protocol/v2/ssv/validator/committee_queue_test.go
+++ b/protocol/v2/ssv/validator/committee_queue_test.go
@@ -89,7 +89,7 @@ func runConsumeQueueAsync(
 	t.Helper()
 
 	go func() {
-		committee.ConsumeQueue(ctx, logger, q, handler, committeeRunner)
+		committee.ConsumeQueue(ctx, logger, queueContainer{Q: q}, handler, committeeRunner)
 	}()
 }
 
@@ -208,11 +208,12 @@ func TestHandleMessageCreatesQueue(t *testing.T) {
 	slot := phase0.Slot(123)
 
 	committee := &Committee{
-		logger:          logger,
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		logger:            logger,
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	msgID := spectypes.MessageID{1, 2, 3, 4}
@@ -229,10 +230,10 @@ func TestHandleMessageCreatesQueue(t *testing.T) {
 
 	require.True(t, ok)
 
-	assert.NotNil(t, q)
-	assert.Equal(t, 1, q.Len())
+	assert.NotNil(t, q.Q)
+	assert.Equal(t, 1, q.Q.Len())
 
-	queuedMsg := q.TryPop(
+	queuedMsg := q.Q.TryPop(
 		queue.NewCommitteeQueuePrioritizer(
 			newCommitteeQueueStateForTest(slot, 0, false, committee.CommitteeMember.GetQuorum()),
 		),
@@ -265,11 +266,12 @@ func TestConsumeQueueBasic(t *testing.T) {
 	defer cancel()
 
 	committee := &Committee{
-		logger:          logger,
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		logger:            logger,
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	slot := phase0.Slot(123)
@@ -331,10 +333,11 @@ func TestFilterNoProposalAccepted(t *testing.T) {
 	defer cancel()
 
 	committee := &Committee{
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	slot := phase0.Slot(123)
@@ -431,10 +434,11 @@ func TestFilterNotDecidedSkipsPartialSignatures(t *testing.T) {
 	defer cancel()
 
 	committee := &Committee{
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	slot := phase0.Slot(123)
@@ -491,10 +495,11 @@ func TestFilterDecidedAllowsAll(t *testing.T) {
 	defer cancel()
 
 	committee := &Committee{
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	slot := phase0.Slot(123)
@@ -591,7 +596,7 @@ func TestChangingFilterState(t *testing.T) {
 			networkConfig:   networkconfig.TestNetwork,
 			CommitteeMember: &spectypes.CommitteeMember{},
 		}
-		c.ConsumeQueue(ctx, logger, q, handler, rnr)
+		c.ConsumeQueue(ctx, logger, queueContainer{Q: q}, handler, rnr)
 		return seen
 	}
 
@@ -641,7 +646,7 @@ func TestFilterUsesCurrentRunnerRound(t *testing.T) {
 			CommitteeMember: &spectypes.CommitteeMember{},
 		}
 		r := newCommitteeRunnerForTest(slot, currentRound, false, nil)
-		c.ConsumeQueue(ctx, logger, q, handler, r)
+		c.ConsumeQueue(ctx, logger, queueContainer{Q: q}, handler, r)
 		return seen
 	}
 
@@ -677,7 +682,7 @@ func TestPostConsensusOutranksConsensusAtRunnerSlot(t *testing.T) {
 
 	committee := &Committee{
 		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
+		Queues:          make(map[phase0.Slot]queueContainer),
 		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 		CommitteeMember: &spectypes.CommitteeMember{},
 	}
@@ -786,7 +791,7 @@ func TestCommitteeQueueFilteringScenarios(t *testing.T) {
 
 			committee := &Committee{
 				networkConfig:   networkconfig.TestNetwork,
-				Queues:          make(map[phase0.Slot]queue.Queue),
+				Queues:          make(map[phase0.Slot]queueContainer),
 				Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 				CommitteeMember: &spectypes.CommitteeMember{},
 			}
@@ -928,7 +933,7 @@ func TestFilterPartialSignatureMessages(t *testing.T) {
 
 			committee := &Committee{
 				networkConfig:   networkconfig.TestNetwork,
-				Queues:          make(map[phase0.Slot]queue.Queue),
+				Queues:          make(map[phase0.Slot]queueContainer),
 				Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 				CommitteeMember: &spectypes.CommitteeMember{},
 			}
@@ -994,10 +999,11 @@ func TestConsumeQueuePrioritization(t *testing.T) {
 	defer cancel()
 
 	committee := &Committee{
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 
 	slot := phase0.Slot(123)
@@ -1106,14 +1112,14 @@ func TestHandleMessageQueueFullAndDropping(t *testing.T) {
 	committee := &Committee{
 		logger:          logger,
 		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
+		Queues:          make(map[phase0.Slot]queueContainer),
 		CommitteeMember: &spectypes.CommitteeMember{},
 	}
 
 	// Step 0: Create the queue container with the desired small capacity and add it to the committee
 	qContainer := queue.New(logger, queueCapacity)
 	qState := newCommitteeQueueStateForTest(slot, 0, false, committee.CommitteeMember.GetQuorum())
-	committee.Queues[slot] = qContainer
+	committee.Queues[slot] = queueContainer{Q: qContainer}
 
 	// Step 1: Fill the pre-made queue to its capacity by calling HandleMessage
 	// HandleMessage will find and use the qContainer we just set up.
@@ -1230,7 +1236,7 @@ func TestConsumeQueueStopsOnErrNoValidDuties(t *testing.T) {
 	// The ConsumeQueue method itself is designed to break its processing loop and return nil
 	// when its handler signals ErrNoValidDutiesToExecute, treating it as a normal stop condition for the queue.
 	// Thus, we expect no error from the ConsumeQueue call.
-	committee.ConsumeQueue(ctx, logger, q, handler, committeeRunner)
+	committee.ConsumeQueue(ctx, logger, queueContainer{Q: q}, handler, committeeRunner)
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&processedMessagesCount))
 	assert.Equal(t, 2, q.Len())
@@ -1258,13 +1264,14 @@ func TestConsumeQueueBurstTraffic(t *testing.T) {
 	// --- Setup a single-slot committee and its queue ---
 	slot := phase0.Slot(42)
 	committee := &Committee{
-		networkConfig:   networkconfig.TestNetwork,
-		Queues:          make(map[phase0.Slot]queue.Queue),
-		Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
-		CommitteeMember: &spectypes.CommitteeMember{},
+		networkConfig:     networkconfig.TestNetwork,
+		Queues:            make(map[phase0.Slot]queueContainer),
+		Runners:           make(map[phase0.Slot]*runner.CommitteeRunner),
+		AggregatorRunners: make(map[phase0.Slot]*runner.AggregatorCommitteeRunner),
+		CommitteeMember:   &spectypes.CommitteeMember{},
 	}
 	qc := queue.New(logger, 1000)
-	committee.Queues[slot] = qc
+	committee.Queues[slot] = queueContainer{Q: qc}
 
 	// --- Build 200 randomized messages and count expected per priority bucket ---
 	var (
@@ -1428,7 +1435,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 		committee := &Committee{
 			logger:          logger,
 			networkConfig:   networkconfig.TestNetwork,
-			Queues:          make(map[phase0.Slot]queue.Queue),
+			Queues:          make(map[phase0.Slot]queueContainer),
 			Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 			CommitteeMember: &spectypes.CommitteeMember{},
 		}
@@ -1439,7 +1446,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 
 		qContainer := queue.New(logger, queueCapacity)
 		qState := newCommitteeQueueStateForTest(slot, currentRound, true, committee.CommitteeMember.GetQuorum())
-		committee.Queues[slot] = qContainer
+		committee.Queues[slot] = queueContainer{Q: qContainer}
 
 		// 1. Fill the queue's inbox channel to capacity using HandleMessage.
 		for i := range queueCapacity {
@@ -1497,7 +1504,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 		committee := &Committee{
 			logger:          logger,
 			networkConfig:   networkconfig.TestNetwork,
-			Queues:          make(map[phase0.Slot]queue.Queue),
+			Queues:          make(map[phase0.Slot]queueContainer),
 			Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 			CommitteeMember: &spectypes.CommitteeMember{},
 		}
@@ -1507,7 +1514,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 
 		qContainer := queue.New(logger, queueCapacity)
 		qState := newCommitteeQueueStateForTest(slot, currentRound, true, committee.CommitteeMember.GetQuorum())
-		committee.Queues[slot] = qContainer
+		committee.Queues[slot] = queueContainer{Q: qContainer}
 
 		// 1. Fill the queue with low-priority consensus messages
 		for i := 0; i < queueCapacity; i++ {
@@ -1584,7 +1591,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 
 		committee := &Committee{
 			networkConfig:   networkconfig.TestNetwork,
-			Queues:          make(map[phase0.Slot]queue.Queue),
+			Queues:          make(map[phase0.Slot]queueContainer),
 			Runners:         make(map[phase0.Slot]*runner.CommitteeRunner),
 			CommitteeMember: &spectypes.CommitteeMember{},
 		}
@@ -1617,7 +1624,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 
 		go func() {
 			defer consumerWg.Done()
-			committee.ConsumeQueue(consumerCtx, logger, q, processFn, committeeRunner)
+			committee.ConsumeQueue(consumerCtx, logger, queueContainer{Q: q}, processFn, committeeRunner)
 		}()
 
 		// Fill with filtered Prepare messages
@@ -1672,7 +1679,7 @@ func TestQueueLoadAndSaturationScenarios(t *testing.T) {
 
 		go func() {
 			defer consumer2Wg.Done()
-			committee.ConsumeQueue(consumer2Ctx, logger, q, processFn, committeeRunner)
+			committee.ConsumeQueue(consumer2Ctx, logger, queueContainer{Q: q}, processFn, committeeRunner)
 		}()
 
 		// Observe how many of the old Prepares now drain

--- a/protocol/v2/ssv/validator/duty_executor.go
+++ b/protocol/v2/ssv/validator/duty_executor.go
@@ -19,7 +19,11 @@ import (
 )
 
 func (v *Validator) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *spectypes.ValidatorDuty) error {
-	ssvMsg, err := createDutyExecuteMsg(duty, duty.PubKey, v.NetworkConfig.DomainType)
+	isBooleFork := v.NetworkConfig.BooleForkAtSlot(duty.Slot)
+	role := types.RunnerRoleForValidatorDuty(duty, isBooleFork)
+
+	domain := v.NetworkConfig.DomainTypeAtSlot(duty.Slot)
+	ssvMsg, err := createDutyExecuteMsg(duty, duty.PubKey, domain, role)
 	if err != nil {
 		return fmt.Errorf("create duty execute msg: %w", err)
 	}
@@ -28,8 +32,7 @@ func (v *Validator) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *s
 		return fmt.Errorf("decode duty execute msg: %w", err)
 	}
 
-	// TODO(convergence unit 5): thread real fork bit instead of a literal false.
-	if pushed := v.Queues[types.RunnerRoleForValidatorDuty(duty, false)].TryPush(dec); !pushed {
+	if pushed := v.Queues[role].TryPush(dec); !pushed {
 		return fmt.Errorf("dropping ExecuteDuty message for validator %s because the queue is full", duty.PubKey.String())
 	}
 
@@ -52,8 +55,7 @@ func (v *Validator) OnExecuteDuty(ctx context.Context, logger *zap.Logger, msg *
 
 	span.SetAttributes(
 		observability.BeaconSlotAttribute(duty.Slot),
-		// TODO(convergence unit 5): thread real fork bit instead of a literal false.
-		observability.RunnerRoleAttribute(types.RunnerRoleForValidatorDuty(duty, false)),
+		observability.RunnerRoleAttribute(types.RunnerRoleForValidatorDuty(duty, v.NetworkConfig.BooleForkAtSlot(duty.Slot))),
 	)
 
 	// force the validator to be started (subscribed to validator's topic and synced)
@@ -72,15 +74,19 @@ func (v *Validator) OnExecuteDuty(ctx context.Context, logger *zap.Logger, msg *
 }
 
 // createDutyExecuteMsg returns ssvMsg with event type of execute duty
-func createDutyExecuteMsg(duty *spectypes.ValidatorDuty, pubKey phase0.BLSPubKey, domain spectypes.DomainType) (*spectypes.SSVMessage, error) {
+func createDutyExecuteMsg(
+	duty *spectypes.ValidatorDuty,
+	pubKey phase0.BLSPubKey,
+	domain spectypes.DomainType,
+	runnerRole spectypes.RunnerRole,
+) (*spectypes.SSVMessage, error) {
 	executeDutyData := types.ExecuteDutyData{Duty: duty}
 	data, err := json.Marshal(executeDutyData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal execute duty data: %w", err)
 	}
 
-	// TODO(convergence unit 5): thread real fork bit instead of a literal false.
-	return dutyDataToSSVMsg(domain, pubKey[:], types.RunnerRoleForValidatorDuty(duty, false), data)
+	return dutyDataToSSVMsg(domain, pubKey[:], runnerRole, data)
 }
 
 func dutyDataToSSVMsg(

--- a/protocol/v2/ssv/validator/timer.go
+++ b/protocol/v2/ssv/validator/timer.go
@@ -94,10 +94,15 @@ func (c *Committee) newQBFTRoundTimerF(runnerIdentifier spectypes.MessageID) ssv
 			// If the relevant queue hasn't been initialized yet, there isn't a running duty we can issue a
 			// timeout for, in practice this should never happen - but we need to handle this just in case.
 			// This is also possible if the queue got pruned already (due to becoming old and irrelevant).
-			// A map miss on c.Queues returns the zero value of the queue.Queue interface (nil), so the
-			// nil-check below covers both "slot absent" and "stored value is nil" cases in one go.
-			q := c.Queues[slot]
-			if q == nil {
+			// Route to the role-specific queue so committee and aggregator-committee timeouts land in
+			// their respective slot queues.
+			var q queueContainer
+			if runnerIdentifier.GetRoleType() == spectypes.RoleAggregatorCommittee {
+				q = c.AggregatorQueues[slot]
+			} else {
+				q = c.Queues[slot]
+			}
+			if q.Q == nil {
 				logger.Debug("couldn't schedule timeout event due to missing queue (likely was pruned)")
 				return
 			}
@@ -113,7 +118,7 @@ func (c *Committee) newQBFTRoundTimerF(runnerIdentifier spectypes.MessageID) ssv
 				return
 			}
 
-			if pushed := q.TryPush(dec); !pushed {
+			if pushed := q.Q.TryPush(dec); !pushed {
 				logger.Error("❗️ dropping timeout message because the queue is full", fields.RunnerRole(runnerIdentifier.GetRoleType()))
 			}
 		}

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/observability/traces"
 	"github.com/ssvlabs/ssv/protocol/v2/message"
+	protocolp2p "github.com/ssvlabs/ssv/protocol/v2/p2p"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
@@ -45,7 +46,7 @@ type Validator struct {
 	cancel context.CancelFunc
 
 	NetworkConfig *networkconfig.Network
-	Network       specqbft.Network
+	Network       protocolp2p.Network
 
 	Operator       *spectypes.CommitteeMember
 	Share          *ssvtypes.SSVShare
@@ -96,11 +97,11 @@ func NewValidator(ctx context.Context, cancel func(), logger *zap.Logger, option
 
 // StartDuty starts a duty for the validator
 func (v *Validator) StartDuty(ctx context.Context, logger *zap.Logger, duty spectypes.Duty) error {
-	// TODO(convergence unit 5): thread real fork bit instead of a literal false.
+	role := ssvtypes.RunnerRoleForDuty(duty, v.NetworkConfig.BooleForkAtSlot(duty.DutySlot()))
 	ctx, span := tracer.Start(ctx,
 		observability.InstrumentName(observabilityNamespace, "start_duty"),
 		trace.WithAttributes(
-			observability.RunnerRoleAttribute(ssvtypes.RunnerRoleForDuty(duty, false)),
+			observability.RunnerRoleAttribute(role),
 			observability.BeaconSlotAttribute(duty.DutySlot())),
 	)
 	defer span.End()
@@ -110,7 +111,7 @@ func (v *Validator) StartDuty(ctx context.Context, logger *zap.Logger, duty spec
 		return traces.Errorf(span, "expected ValidatorDuty, got %T", duty)
 	}
 
-	dutyRunner := v.DutyRunners[ssvtypes.RunnerRoleForValidatorDuty(vDuty, false)]
+	dutyRunner := v.DutyRunners[role]
 	if dutyRunner == nil {
 		return traces.Errorf(span, "no duty runner for role %s", vDuty.Type.String())
 	}

--- a/protocol/v2/ssv/value_check.go
+++ b/protocol/v2/ssv/value_check.go
@@ -78,6 +78,27 @@ func (v *voteChecker) CheckValue(value []byte) error {
 	return nil
 }
 
+type aggregatorCommitteeChecker struct{}
+
+func NewAggregatorCommitteeChecker() ValueChecker {
+	return &aggregatorCommitteeChecker{}
+}
+
+func (v *aggregatorCommitteeChecker) CheckValue(value []byte) error {
+	cd := &spectypes.AggregatorCommitteeConsensusData{}
+	if err := cd.Decode(value); err != nil {
+		return spectypes.WrapError(
+			spectypes.AggCommConsensusDataDecodeErrorCode,
+			fmt.Errorf("failed decoding aggregator committee consensus data: %w", err),
+		)
+	}
+	if err := cd.Validate(); err != nil {
+		return fmt.Errorf("invalid value: %w", err)
+	}
+
+	return nil
+}
+
 type proposerChecker struct {
 	signer         ekm.BeaconSigner
 	beaconConfig   *networkconfig.Beacon
@@ -181,12 +202,12 @@ func checkValidatorConsensusData(
 		return cd, spectypes.NewError(spectypes.QBFTValueInvalidErrorCode, "invalid value")
 	}
 
-	if beaconConfig.EstimatedEpochAtSlot(cd.Duty.Slot) > beaconConfig.EstimatedCurrentEpoch()+1 {
-		return cd, spectypes.NewError(spectypes.DutyEpochTooFarFutureErrorCode, "duty epoch is into far future")
-	}
-
 	if expectedType != cd.Duty.Type {
 		return cd, spectypes.NewError(spectypes.WrongBeaconRoleTypeErrorCode, "wrong beacon role type")
+	}
+
+	if beaconConfig.EstimatedEpochAtSlot(cd.Duty.Slot) > beaconConfig.EstimatedCurrentEpoch()+1 {
+		return cd, spectypes.NewError(spectypes.DutyEpochTooFarFutureErrorCode, "duty epoch is into far future")
 	}
 
 	if !bytes.Equal(validatorPK[:], cd.Duty.PubKey[:]) {

--- a/protocol/v2/testing/temp_testing_beacon_network.go
+++ b/protocol/v2/testing/temp_testing_beacon_network.go
@@ -50,6 +50,17 @@ func (bn *BeaconNodeWrapped) GetSyncCommitteeContribution(ctx context.Context, s
 func (bn *BeaconNodeWrapped) SubmitAggregateSelectionProof(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, index phase0.ValidatorIndex, slotSig []byte) (ssz.Marshaler, spec.DataVersion, error) {
 	return bn.Bn.SubmitAggregateSelectionProof(slot, committeeIndex, committeeLength, index, slotSig)
 }
+func (bn *BeaconNodeWrapped) IsAggregator(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex, committeeLength uint64, slotSig []byte) bool {
+	return bn.Bn.IsAggregator(slot, committeeIndex, committeeLength, slotSig)
+}
+func (bn *BeaconNodeWrapped) GetAggregateAttestation(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (ssz.Marshaler, spec.DataVersion, error) {
+	att, err := bn.Bn.GetAggregateAttestation(slot, committeeIndex)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return att, spectestingutils.VersionBySlot(slot), nil
+}
 func (bn *BeaconNodeWrapped) GetBeaconNetwork() spectypes.BeaconNetwork {
 	return bn.Bn.GetBeaconNetwork()
 }


### PR DESCRIPTION
## Unit 5c of the boole-fork → stage convergence: AggregatorCommitteeRunner + consensus wiring

Third slice of unit 5, **stacked on unit 5b** (#2932). This is the producer of `RoleAggregatorCommittee` duties — the net-new runner plus everything needed to construct, route, and test it. The exporter dutytracer query layer (~2,238 lines, verified decoupled) is a **separate follow-up PR**.

Three commits, each built + tested:

- **Group 1 — `32f2aae28` (runner)**: net-new `protocol/v2/ssv/runner/aggregator_committee.go` (ported verbatim from boole-fork, already in its final #2919-correct classify/errCh-drain form) + test, plus the deps to make it function: `ssv.NewAggregatorCommitteeChecker`, `beacon.IsAggregator`/`GetAggregateAttestation` (+ GoClient impl + regenerated mock), and the test harness (`testing/{runner,validator}.go`).
- **Group 2 — `1efd6ec7a` (validator wiring)**: `Committee` now runs `CommitteeDuty` and `AggregatorCommitteeDuty` side-by-side (parallel `Queues`/`AggregatorQueues`, `Runners`/`AggregatorRunners`, role-routed). Threads the **`committeeDuty.duty` widening** (`*spectypes.CommitteeDuty` → `spectypes.Duty`) through `operator/duties/*` and `controller.go`'s `ExecuteCommitteeDuty`/`ExecuteDuty` (+ regenerated scheduler mock); `fields.BuildCommitteeDutyID` gains a role param. Resolves 5b's "thread real fork bit" TODOs. Fixes a JSON nil-vs-`{}` encoding regression for the new `AggregatorRunners` field.
- **Group 3 — `ba1b61821` (controller construction)**: `SetupCommitteeRunners` constructs `AggregatorCommitteeRunner` for `*AggregatorCommitteeDuty` — **this is what makes the runner reachable** (satisfies deadcode). Legacy `NewAggregatorRunner`/`NewSyncCommitteeAggregatorRunner` construction guarded behind `!BooleFork()`. Controller aggregator/sync-contrib/agg-committee root caches wired.

### Deferrals (reported, not forced — out of scope)
- `message/validation/validation_test.go`'s ~900-line AggregatorCommittee test rewrite — blocked on the `commons.Subnet` rename (separate out-of-scope unit); the new validation branches remain dormant/covered-by-compile until then.
- `operator/dutytracer/*` — the exporter query layer, its own follow-up PR (decoupled).
- Various out-of-scope renames (`BeaconForkAtEpoch`, `qbft.Config` field removal, `FilterIndices` rename, `operator/node.go`).

### Testing
Full matrix green: `go build ./...`, `go vet` (main **+ ssvsigner**), `deadcode` ("No unused code found" — runner reachable), `gofmt`, `golangci-lint`, and `go test ./protocol/v2/... ./operator/validator/... ./operator/duties/... ./message/validation/... -count=1` (incl. `spectest`, and the un-skipped aggregator runner-construction vector).

> ⚠️ **Consensus-adjacent** (a new runner executing QBFT + the `ExecuteCommitteeDuty` widening through the Controller). A `code-reviewer-deep` pass is running in parallel. Also: this must land before Boole activation (it's the `RoleAggregatorCommittee` producer).
