### PR TITLE
Exporter refactoring #4: Decouple validator message tracing from exporter

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -378,6 +378,7 @@ func newNode(
 	// Exporter duty tracing. An invalid EXPORTER_MODE is rejected up front by resolveAndValidate,
 	// so res.mode here is always one of the known modes.
 	var collector *dutytracer.Collector
+	var messageTraceHandler validator.MessageTraceHandler
 	var exporterRead *exportercore.Exporter
 	switch res.mode {
 	case modeExporterArchive:
@@ -389,6 +390,7 @@ func newNode(
 			nodeStorage.ValidatorStore(), consensusClient,
 			dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 			dutyStore)
+		messageTraceHandler = collector.Collect
 
 		exporterRead = exportercore.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
 	case modeExporterStandard:
@@ -425,11 +427,12 @@ func newNode(
 	valOpts.Graffiti = []byte(cfg.Graffiti)
 	valOpts.ProposerDelay = cfg.ProposerDelay
 	valOpts.ValidatorSyncer = metadataSyncer
-	valOpts.DutyTraceCollector = collector
+	valOpts.ExporterMode = res.isExporter()
+	valOpts.MessageTraceHandler = messageTraceHandler
 	valOpts.DoppelgangerHandler = doppelgangerHandler
 	cfg.SSVOptions.ValidatorOptions = valOpts
 
-	validatorCtrl := validator.NewController(logger, valOpts, cfg.ExporterOptions)
+	validatorCtrl := validator.NewController(logger, valOpts)
 	cfg.SSVOptions.ValidatorController = validatorCtrl
 	cfg.SSVOptions.ValidatorStore = nodeStorage.ValidatorStore()
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -163,11 +163,14 @@ func Test_newNode_wiresExporterNode(t *testing.T) {
 			require.NotNil(t, a.validatorCtrl)
 			require.NotNil(t, a.operatorNode)
 			require.Nil(t, a.keyManager, "exporter nodes have no key manager")
+			require.True(t, cfg.SSVOptions.ValidatorOptions.ExporterMode)
 
 			if tc.wantCollector {
 				require.NotNil(t, a.collector, "archive mode wires a duty-trace collector")
+				require.NotNil(t, cfg.SSVOptions.ValidatorOptions.MessageTraceHandler, "archive mode wires the message trace handler")
 			} else {
 				require.Nil(t, a.collector, "standard mode has no duty-trace collector")
+				require.Nil(t, cfg.SSVOptions.ValidatorOptions.MessageTraceHandler, "standard mode has no message trace handler")
 			}
 
 			// Mirror production teardown ordering: cancel the ctx, then close (newNode starts no goroutines).

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ssvlabs/ssv/eth/eventhandler/mocks"
 	"github.com/ssvlabs/ssv/eth/eventparser"
 	"github.com/ssvlabs/ssv/eth/simulator"
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
@@ -213,7 +212,7 @@ func setupEventHandler(
 		BeaconSigner:      keyManager,
 		StorageMap:        storageMap,
 		OperatorDataStore: operatorDataStore,
-	}, exporterconfig.Options{})
+	})
 	// NewController starts ttlcache cleanup goroutines; stop them so they don't leak across tests.
 	t.Cleanup(validatorCtrl.Stop)
 

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/eth/simulator"
 	"github.com/ssvlabs/ssv/eth/simulator/simcontract"
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
@@ -1444,7 +1443,7 @@ func setupEventHandler(
 		StorageMap:        storageMap,
 		OperatorDataStore: operatorDataStore,
 		ValidatorsMap:     validators.New(ctx),
-	}, exporterconfig.Options{})
+	})
 	// NewController starts ttlcache cleanup goroutines; stop them so they don't leak across tests.
 	t.Cleanup(validatorCtrl.Stop)
 

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ssvlabs/ssv/eth/executionclient"
 	"github.com/ssvlabs/ssv/eth/simulator"
 	"github.com/ssvlabs/ssv/eth/simulator/simcontract"
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	"github.com/ssvlabs/ssv/networkconfig"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
@@ -211,7 +210,7 @@ func setupEventHandler(
 		RegistryStorage:   nodeStorage,
 		OperatorDataStore: operatorDataStore,
 		ValidatorsMap:     validators.New(ctx),
-	}, exporterconfig.Options{})
+	})
 	// NewController starts ttlcache cleanup goroutines; stop them so they don't leak across tests.
 	t.Cleanup(validatorCtrl.Stop)
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -18,8 +18,6 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
 	"github.com/ssvlabs/ssv/doppelganger"
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
-	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
 	"github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/network"
@@ -52,6 +50,13 @@ import (
 
 //go:generate go tool -modfile=../../tool.mod mockgen -package=mocks -destination=./mocks/controller.go -source=./controller.go
 
+// MessageTraceHandler traces consensus and partial-signature messages observed for validators this node does not run.
+type MessageTraceHandler func(
+	ctx context.Context,
+	msg *queue.SSVMessage,
+	verifySig func(*spectypes.PartialSignatureMessages) error,
+) error
+
 // ControllerOptions for creating a validator controller
 type ControllerOptions struct {
 	Context                        context.Context
@@ -63,6 +68,7 @@ type ControllerOptions struct {
 	Network                        P2PNetwork
 	Beacon                         beaconprotocol.BeaconNode
 	FullNode                       bool `yaml:"FullNode" env:"FULLNODE" env-description:"Store complete message history instead of just latest messages"`
+	ExporterMode                   bool
 	BeaconSigner                   ekm.BeaconSigner
 	OperatorSigner                 ssvtypes.OperatorSigner
 	OperatorDataStore              operatordatastore.OperatorDataStore
@@ -70,7 +76,7 @@ type ControllerOptions struct {
 	ValidatorRegistrationSubmitter runner.ValidatorRegistrationSubmitter
 	NewDecidedHandler              qbftcontroller.NewDecidedHandler
 	DutyRoles                      []spectypes.BeaconRole
-	DutyTraceCollector             *dutytracer.Collector
+	MessageTraceHandler            MessageTraceHandler
 	StorageMap                     *storage.ParticipantStores
 	ValidatorStore                 registrystorage.ValidatorStore
 	MessageValidator               validation.MessageValidator
@@ -170,11 +176,11 @@ type Controller struct {
 	validatorExitCh         chan duties.ExitDescriptor
 	feeRecipientChangeCh    chan struct{}
 
-	traceCollector *dutytracer.Collector
+	messageTraceHandler MessageTraceHandler
 }
 
 // NewController creates a new validator controller instance.
-func NewController(logger *zap.Logger, options ControllerOptions, exporterOptions exporterconfig.Options) *Controller {
+func NewController(logger *zap.Logger, options ControllerOptions) *Controller {
 	logger.Debug("setting up validator controller")
 
 	// lookup in a map that holds all relevant operators
@@ -195,7 +201,7 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 		options.DoppelgangerHandler,
 		options.NewDecidedHandler,
 		options.FullNode,
-		exporterOptions,
+		options.ExporterMode,
 		options.HistorySyncBatchSize,
 		options.GasLimit,
 		options.MessageValidator,
@@ -219,7 +225,7 @@ func NewController(logger *zap.Logger, options ControllerOptions, exporterOption
 		beaconSigner:                   options.BeaconSigner,
 		operatorSigner:                 options.OperatorSigner,
 		network:                        options.Network,
-		traceCollector:                 options.DutyTraceCollector,
+		messageTraceHandler:            options.MessageTraceHandler,
 
 		validatorsMap:       options.ValidatorsMap,
 		validatorCommonOpts: validatorCommonOpts,
@@ -342,7 +348,7 @@ func (c *Controller) handleRouterMessages() {
 				v.EnqueueMessage(c.ctx, m)
 			} else if vc, ok := c.validatorsMap.GetCommittee(cid); ok {
 				vc.EnqueueMessage(c.ctx, m)
-			} else if c.validatorCommonOpts.ExporterOptions.Enabled {
+			} else if c.validatorCommonOpts.ExporterMode {
 				if m.MsgType != spectypes.SSVConsensusMsgType && m.MsgType != spectypes.SSVPartialSignatureMsgType {
 					continue
 				}
@@ -398,12 +404,10 @@ func (c *Controller) handleWorkerMessages(ctx context.Context, msg network.Decod
 		ncv = item.Value()
 	}
 
-	if c.validatorCommonOpts.ExporterOptions.Mode == exporterconfig.ModeArchive {
-		// use new exporter functionality
-		return c.traceCollector.Collect(c.ctx, ssvMsg, ncv.VerifySig)
+	if c.messageTraceHandler != nil {
+		return c.messageTraceHandler(c.ctx, ssvMsg, ncv.VerifySig)
 	}
 
-	// use old exporter functionality
 	return c.handleNonCommitteeMessages(ctx, ssvMsg, ncv)
 }
 
@@ -481,7 +485,7 @@ func (c *Controller) startValidators(validators []*validator.Validator) (started
 func (c *Controller) InitValidators() ([]*validator.Validator, error) {
 	defer close(c.validatorsInitDone)
 
-	if c.validatorCommonOpts.ExporterOptions.Enabled {
+	if c.validatorCommonOpts.ExporterMode {
 		// For Exporter, there are no committee validators to set up.
 		return nil, nil
 	}
@@ -1030,7 +1034,7 @@ func SetupCommitteeRunners(
 	ctx context.Context,
 	options *validator.Options,
 ) validator.CommitteeRunnerFunc {
-	if options.ExporterOptions.Enabled {
+	if options.ExporterMode {
 		return func(
 			phase0.Slot,
 			map[phase0.ValidatorIndex]*spectypes.Share,
@@ -1094,7 +1098,7 @@ func SetupRunners(
 	validatorStore registrystorage.ValidatorStore,
 	options *validator.CommonOptions,
 ) (runner.ValidatorDutyRunners, error) {
-	if options.ExporterOptions.Enabled {
+	if options.ExporterMode {
 		return nil, fmt.Errorf("cannot set up duty runners in exporter mode")
 	}
 

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 
 	"github.com/ssvlabs/ssv/beacon/goclient"
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -94,7 +93,7 @@ func TestNewController(t *testing.T) {
 		RegistryStorage:   registryStorage,
 		Context:           t.Context(),
 	}
-	control := NewController(logger, controllerOptions, exporterconfig.Options{})
+	control := NewController(logger, controllerOptions)
 	// NewController starts ttlcache cleanup goroutines; stop them so they don't leak across tests.
 	defer control.Stop()
 	require.IsType(t, &Controller{}, control)
@@ -124,7 +123,7 @@ func TestNewControllerRouterConcurrencyOverride(t *testing.T) {
 		Context:              t.Context(),
 		MsgRouterConcurrency: 24,
 	}
-	control := NewController(logger, controllerOptions, exporterconfig.Options{})
+	control := NewController(logger, controllerOptions)
 	// NewController starts ttlcache cleanup goroutines; stop them so they don't leak across tests.
 	defer control.Stop()
 	require.Equal(t, 24, control.msgRouterConcurrency)
@@ -134,9 +133,7 @@ func TestSetupValidatorsExporter(t *testing.T) {
 	logger := log.TestLogger(t)
 	controllerOptions := MockControllerOptions{
 		validatorCommonOpts: &validator.CommonOptions{
-			ExporterOptions: exporterconfig.Options{
-				Enabled: true,
-			},
+			ExporterMode: true,
 		},
 	}
 	ctr := setupController(t, logger, controllerOptions)
@@ -153,9 +150,7 @@ func TestSetupRunnersExporter(t *testing.T) {
 		nil,
 		nil,
 		&validator.CommonOptions{
-			ExporterOptions: exporterconfig.Options{
-				Enabled: true,
-			},
+			ExporterMode: true,
 		},
 	)
 	require.Nil(t, runners)
@@ -165,9 +160,7 @@ func TestSetupRunnersExporter(t *testing.T) {
 func TestSetupCommitteeRunnersExporter(t *testing.T) {
 	committeeRunnerFunc := SetupCommitteeRunners(t.Context(), &validator.Options{
 		CommonOptions: validator.CommonOptions{
-			ExporterOptions: exporterconfig.Options{
-				Enabled: true,
-			},
+			ExporterMode: true,
 		},
 	})
 
@@ -186,7 +179,7 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 	ctr := setupController(t, logger, controllerOptions) // non-committee
 
 	// Only exporter handles non-committee messages
-	ctr.validatorCommonOpts.ExporterOptions.Enabled = true
+	ctr.validatorCommonOpts.ExporterMode = true
 
 	go ctr.handleRouterMessages()
 

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/jellydator/ttlcache/v3"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
@@ -246,6 +247,48 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 			require.Fail(t, "timed out waiting for all 3 messages to arrive")
 		}
 	}
+}
+
+func TestHandleWorkerMessagesUsesMessageTraceHandler(t *testing.T) {
+	logger := log.TestLogger(t)
+	ctr := setupController(t, logger, MockControllerOptions{
+		validatorCommonOpts: &validator.CommonOptions{},
+	})
+	ctr.committeesObservers = ttlcache.New(
+		ttlcache.WithTTL[spectypes.MessageID, *validator.CommitteeObserver](time.Minute),
+	)
+
+	sentinelErr := errors.New("message trace handler called")
+	var calls int
+	var gotCtx context.Context
+	var gotMsg *queue.SSVMessage
+	var gotVerifySig func(*spectypes.PartialSignatureMessages) error
+	ctr.messageTraceHandler = func(ctx context.Context, msg *queue.SSVMessage, verifySig func(*spectypes.PartialSignatureMessages) error) error {
+		calls++
+		gotCtx = ctx
+		gotMsg = msg
+		gotVerifySig = verifySig
+		return sentinelErr
+	}
+
+	msgID := spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, []byte("pk"), spectypes.RoleCommittee)
+	ssvMsg := &spectypes.SSVMessage{
+		MsgType: spectypes.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    []byte("invalid partial signature payload"),
+	}
+	msg := &queue.SSVMessage{
+		SignedSSVMessage: &spectypes.SignedSSVMessage{SSVMessage: ssvMsg},
+		SSVMessage:       ssvMsg,
+	}
+
+	err := ctr.handleWorkerMessages(t.Context(), msg)
+
+	require.ErrorIs(t, err, sentinelErr)
+	require.Equal(t, 1, calls)
+	require.True(t, gotCtx == ctr.ctx)
+	require.Same(t, msg, gotMsg)
+	require.NotNil(t, gotVerifySig)
 }
 
 func TestSetupValidators(t *testing.T) {

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
-	exporterconfig "github.com/ssvlabs/ssv/exporter/config"
 	"github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -46,7 +45,7 @@ type CommonOptions struct {
 	DoppelgangerHandler runner.DoppelgangerProvider
 	NewDecidedHandler   qbftctrl.NewDecidedHandler
 	FullNode            bool
-	ExporterOptions     exporterconfig.Options
+	ExporterMode        bool
 	QueueSize           int
 	GasLimit            uint64
 	MessageValidator    validation.MessageValidator
@@ -64,7 +63,7 @@ func NewCommonOptions(
 	doppelgangerHandler runner.DoppelgangerProvider,
 	newDecidedHandler qbftctrl.NewDecidedHandler,
 	fullNode bool,
-	exporterOptions exporterconfig.Options,
+	exporterMode bool,
 	historySyncBatchSize int,
 	gasLimit uint64,
 	messageValidator validation.MessageValidator,
@@ -81,7 +80,7 @@ func NewCommonOptions(
 		DoppelgangerHandler: doppelgangerHandler,
 		NewDecidedHandler:   newDecidedHandler,
 		FullNode:            fullNode,
-		ExporterOptions:     exporterOptions,
+		ExporterMode:        exporterMode,
 		QueueSize:           defaultValidatorQueueSize,
 		GasLimit:            gasLimit,
 		MessageValidator:    messageValidator,


### PR DESCRIPTION
This PR continues the exporter refactoring by removing exporter-specific types from the validator controller.

## What changed
- Replaced `operator/validator` dependencies on exporter config and `dutytracer.Collector` with a local `ExporterMode` flag and `MessageTraceHandler` callback.
- Kept archive exporter construction in `cli/operator`, where exporter components are already assembled, and pass only the callback into the validator controller.
- Updated validator common options and nearby tests to use the narrower boundary.

## Why
The validator controller only needs to know whether it is running in exporter mode and how to trace consensus / partial-signature messages for validators this node does not run. It should not depend on exporter implementation packages.

This keeps exporter details in exporter wiring, preserves the existing standard/archive behavior, and makes the diff mostly mechanical for review.

## Validation
- `go test -tags "blst_enabled lfs" ./operator/validator ./protocol/v2/ssv/validator ./cli/operator ./eth/ethtest ./eth/eventsyncer ./eth/eventhandler`
- `go test -tags "blst_enabled lfs" ./cli/operator ./operator/validator`
- `make lint`