### PR TITLE
convergence(unit 5c-exporter): aggregator-committee duty-trace query layer

### DIFF
--- a/api/handlers/exporter/committee_model.go
+++ b/api/handlers/exporter/committee_model.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ssvlabs/ssv/api"
 	exportercore "github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/traces"
-	obsutils "github.com/ssvlabs/ssv/observability/utils"
+	"github.com/ssvlabs/ssv/protocol/v2/message"
 )
 
 type CommitteeIDLengthError struct {
@@ -116,7 +116,7 @@ func toCommitteeTrace(t *traces.CommitteeDutyTrace) CommitteeTrace {
 	return CommitteeTrace{
 		// consensus trace
 		Slot:          uint64(t.Slot),
-		Role:          obsutils.FormatRunnerRole(t.Role),
+		Role:          message.RunnerRoleToString(t.Role),
 		Consensus:     toRounds(t.Rounds),
 		Decideds:      toDecideds(t.Decideds),
 		SyncCommittee: toCommitteePost(t.SyncCommittee),

--- a/api/handlers/exporter/committee_model.go
+++ b/api/handlers/exporter/committee_model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ssvlabs/ssv/api"
 	exportercore "github.com/ssvlabs/ssv/exporter"
 	"github.com/ssvlabs/ssv/exporter/traces"
+	obsutils "github.com/ssvlabs/ssv/observability/utils"
 )
 
 type CommitteeIDLengthError struct {
@@ -23,6 +24,8 @@ type CommitteeTracesRequest struct {
 	From uint64 `json:"from" format:"int64" minimum:"0"`
 	// To is the ending slot (inclusive).
 	To uint64 `json:"to" format:"int64" minimum:"0"`
+	// Roles is a comma-separated list of committee runner roles to include.
+	Roles api.RunnerRoleSlice `json:"roles" swaggertype:"array,string" enums:"COMMITTEE,AGGREGATOR_COMMITTEE"`
 	// CommitteeIDs is a comma-separated list of committee IDs (hex, 64 chars per ID).
 	CommitteeIDs api.HexSlice `json:"committeeIDs" swaggertype:"array,string" format:"hex" minLength:"64" maxLength:"64" pattern:"^[0-9a-f]{64}$"`
 }
@@ -46,6 +49,7 @@ func toCommitteeTracesQuery(r *CommitteeTracesRequest) (*exportercore.CommitteeT
 	q := &exportercore.CommitteeTracesQuery{
 		From:         r.From,
 		To:           r.To,
+		Roles:        toRunnerRoles(r.Roles),
 		CommitteeIDs: r.parseCommitteeIds(),
 	}
 
@@ -78,14 +82,18 @@ func toCommitteeTraceResponse(result *exportercore.CommitteeTracesResult, errs *
 type CommitteeTrace struct {
 	// Slot is the duty slot for this committee trace.
 	Slot uint64 `json:"slot" format:"int64"`
+	// Role is the committee runner role for this duty (e.g., COMMITTEE).
+	Role string `json:"role" example:"COMMITTEE" enums:"COMMITTEE,AGGREGATOR_COMMITTEE"`
 	// Consensus lists per-round QBFT messages observed for this committee.
 	Consensus []Round `json:"consensus"`
 	// Decideds lists decided messages emitted for this duty.
 	Decideds []Decided `json:"decideds"`
 
-	// SyncCommittee contains post-consensus messages for sync-committee duties.
+	// SyncCommittee contains post-consensus messages for sync-committee duties,
+	// including sync committee contribution signers.
 	SyncCommittee []CommitteeMessage `json:"sync_committee"`
-	// Attester contains post-consensus messages for attester duties.
+	// Attester contains post-consensus messages for attester duties,
+	// including aggregator signers.
 	Attester []CommitteeMessage `json:"attester"`
 
 	// CommitteeID is the 32-byte committee identifier (hex).
@@ -108,6 +116,7 @@ func toCommitteeTrace(t *traces.CommitteeDutyTrace) CommitteeTrace {
 	return CommitteeTrace{
 		// consensus trace
 		Slot:          uint64(t.Slot),
+		Role:          obsutils.FormatRunnerRole(t.Role),
 		Consensus:     toRounds(t.Rounds),
 		Decideds:      toDecideds(t.Decideds),
 		SyncCommittee: toCommitteePost(t.SyncCommittee),

--- a/api/handlers/exporter/common_model.go
+++ b/api/handlers/exporter/common_model.go
@@ -184,6 +184,16 @@ func toBeaconRoles(rs []api.Role) []spectypes.BeaconRole {
 	return out
 }
 
+// toRunnerRoles converts an API RunnerRoleSlice into a slice of runner roles.
+// It is used by HTTP adapters when constructing core query models.
+func toRunnerRoles(rs api.RunnerRoleSlice) []spectypes.RunnerRole {
+	out := make([]spectypes.RunnerRole, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, spectypes.RunnerRole(r))
+	}
+	return out
+}
+
 // toValidatorIndices converts an API Uint64Slice into a slice of
 // phase0.ValidatorIndex for use by core query models.
 func toValidatorIndices(indices api.Uint64Slice) []phase0.ValidatorIndex {

--- a/api/handlers/exporter/exporter.go
+++ b/api/handlers/exporter/exporter.go
@@ -34,8 +34,8 @@ func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantS
 type dutyTraceStore interface {
 	GetValidatorDuty(role spectypes.BeaconRole, slot phase0.Slot, index phase0.ValidatorIndex) (*traces.ValidatorDutyTrace, error)
 	GetValidatorDuties(role spectypes.BeaconRole, slot phase0.Slot) ([]*traces.ValidatorDutyTrace, error)
-	GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role ...spectypes.BeaconRole) (*traces.CommitteeDutyTrace, error)
-	GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]*traces.CommitteeDutyTrace, error)
+	GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error)
+	GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error)
 	GetCommitteeID(slot phase0.Slot, index phase0.ValidatorIndex) (spectypes.CommitteeID, error)
 	GetCommitteeDutyLinks(slot phase0.Slot) ([]*traces.CommitteeDutyLink, error)
 	GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error)

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -1414,6 +1414,18 @@ func TestExporterCommitteeTraces(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid request - non-committee role in filter",
+			request: map[string]any{
+				"from":  100,
+				"to":    100,
+				"roles": []string{"AGGREGATOR"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateErrResp: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "unsupported committee runner role")
+			},
+		},
+		{
 			name: "invalid request - invalid committee ID length",
 			request: map[string]any{
 				"from":         100,

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -491,12 +491,12 @@ type mockTraceStore struct {
 	committeeDecideds           map[string][]dutytracer.ParticipantsRangeIndexEntry
 	GetValidatorDutyFunc        func(role spectypes.BeaconRole, slot phase0.Slot, index phase0.ValidatorIndex) (*traces.ValidatorDutyTrace, error)
 	GetValidatorDutiesFunc      func(role spectypes.BeaconRole, slot phase0.Slot) ([]*traces.ValidatorDutyTrace, error)
-	GetCommitteeDutyFunc        func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error)
-	GetCommitteeDutiesFunc      func(slot phase0.Slot) ([]*traces.CommitteeDutyTrace, error)
+	GetCommitteeDutyFunc        func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error)
+	GetCommitteeDutiesFunc      func(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error)
 	GetCommitteeIDFunc          func(slot phase0.Slot, index phase0.ValidatorIndex) (spectypes.CommitteeID, error)
 	GetValidatorDecidedsFunc    func(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error)
 	GetCommitteeDecidedsFunc    func(slot phase0.Slot, index phase0.ValidatorIndex, _ ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error)
-	GetAllCommitteeDecidedsFunc func(slot phase0.Slot) ([]dutytracer.ParticipantsRangeIndexEntry, error)
+	GetAllCommitteeDecidedsFunc func(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error)
 	GetAllValidatorDecidedsFunc func(role spectypes.BeaconRole, slot phase0.Slot) ([]dutytracer.ParticipantsRangeIndexEntry, error)
 	// added to satisfy dutyTraceStore interface for schedule and committee links
 	GetCommitteeDutyLinksFunc func(slot phase0.Slot) ([]*traces.CommitteeDutyLink, error)
@@ -524,16 +524,16 @@ func (m *mockTraceStore) GetValidatorDuties(role spectypes.BeaconRole, slot phas
 	return nil, nil
 }
 
-func (m *mockTraceStore) GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role ...spectypes.BeaconRole) (*traces.CommitteeDutyTrace, error) {
+func (m *mockTraceStore) GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 	if m.GetCommitteeDutyFunc != nil {
-		return m.GetCommitteeDutyFunc(slot, committeeID)
+		return m.GetCommitteeDutyFunc(slot, committeeID, role)
 	}
-	return nil, nil
+	return nil, estore.ErrNotFound
 }
 
-func (m *mockTraceStore) GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]*traces.CommitteeDutyTrace, error) {
+func (m *mockTraceStore) GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 	if m.GetCommitteeDutiesFunc != nil {
-		return m.GetCommitteeDutiesFunc(slot)
+		return m.GetCommitteeDutiesFunc(slot, roles...)
 	}
 	return nil, nil
 }
@@ -574,7 +574,7 @@ func (m *mockTraceStore) GetCommitteeDecideds(slot phase0.Slot, index phase0.Val
 
 func (m *mockTraceStore) GetAllCommitteeDecideds(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
 	if m.GetAllCommitteeDecidedsFunc != nil {
-		return m.GetAllCommitteeDecidedsFunc(slot)
+		return m.GetAllCommitteeDecidedsFunc(slot, roles...)
 	}
 	key := fmt.Sprintf("%d", slot)
 	src := m.committeeDecideds[key]
@@ -855,7 +855,7 @@ func TestExporterTraceDecideds(t *testing.T) {
 						{Slot: slot, Index: 2, Signers: []uint64{4, 5, 6}},
 					}, nil
 				}
-				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
 					return []dutytracer.ParticipantsRangeIndexEntry{
 						{Slot: slot, Index: 1, Signers: []uint64{1, 2, 3}},
 					}, nil
@@ -947,7 +947,7 @@ func TestExporterTraceDecideds(t *testing.T) {
 				"roles": []string{"ATTESTER"},
 			},
 			setupMock: func(store *mockTraceStore) {
-				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
 					return nil, fmt.Errorf("forced error on GetAllCommitteeDecideds")
 				}
 			},
@@ -1118,7 +1118,7 @@ func TestExporterTraceDecideds(t *testing.T) {
 				pkBytes := common.Hex2Bytes("b24454393691331ee6eba4ffa2dbb2600b9859f908c3e648b6c6de9e1dea3e9329866015d08355c8d451427762b913d1")
 				var pk spectypes.ValidatorPK
 				copy(pk[:], pkBytes)
-				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
+				store.GetAllCommitteeDecidedsFunc = func(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]dutytracer.ParticipantsRangeIndexEntry, error) {
 					return []dutytracer.ParticipantsRangeIndexEntry{
 						{Slot: slot, Index: 1, Signers: []uint64{}},
 					}, nil
@@ -1262,6 +1262,7 @@ func TestExporterTraceDecideds_InvalidJSON(t *testing.T) {
 func makeCommitteeDutyTrace(slot phase0.Slot) *traces.CommitteeDutyTrace {
 	return &traces.CommitteeDutyTrace{
 		Slot:        slot,
+		Role:        spectypes.RoleCommittee,
 		CommitteeID: spectypes.CommitteeID{1},
 		ConsensusTrace: traces.ConsensusTrace{
 			Rounds: []*traces.RoundTrace{
@@ -1316,7 +1317,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
 				var committeeID spectypes.CommitteeID
 				committeeID[0] = 1
-				store.GetCommitteeDutiesFunc = func(slot phase0.Slot) (duties []*traces.CommitteeDutyTrace, err error) {
+				store.GetCommitteeDutiesFunc = func(slot phase0.Slot, roles ...spectypes.RunnerRole) (duties []*traces.CommitteeDutyTrace, err error) {
 					duties = []*traces.CommitteeDutyTrace{
 						makeCommitteeDutyTrace(slot),
 					}
@@ -1353,6 +1354,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 				require.Len(t, resp.Data, 1)
 				assert.Equal(t, uint64(100), resp.Data[0].Slot)
+				assert.Equal(t, "COMMITTEE", resp.Data[0].Role)
 				assert.Len(t, resp.Data[0].Decideds, 1)
 				assert.Len(t, resp.Data[0].Consensus, 1)
 				assert.Len(t, resp.Data[0].SyncCommittee, 1)
@@ -1378,8 +1380,13 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"committeeIDs": []string{"0eb9655577d1af04ff5d382848be15d1454b04838713bfb1ac209808fe3e9f7f"},
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
-					return makeCommitteeDutyTrace(slot), nil
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, cID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
+					if role != spectypes.RoleCommittee {
+						return nil, dutytracer.ErrNotFound
+					}
+					duty := makeCommitteeDutyTrace(slot)
+					duty.CommitteeID = cID
+					return duty, nil
 				}
 			},
 			expectedStatus: http.StatusOK,
@@ -1388,6 +1395,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 				require.Len(t, resp.Data, 1)
 				assert.Equal(t, uint64(100), resp.Data[0].Slot)
+				assert.Equal(t, "COMMITTEE", resp.Data[0].Role)
 				assert.Len(t, resp.Data[0].Decideds, 1)
 				assert.Len(t, resp.Data[0].Consensus, 1)
 				assert.Len(t, resp.Data[0].SyncCommittee, 1)
@@ -1425,7 +1433,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"committeeIDs": []string{"0eb9655577d1af04ff5d382848be15d1454b04838713bfb1ac209808fe3e9f7f"},
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 					return nil, fmt.Errorf("forced error on GetCommitteeDuty")
 				}
 			},
@@ -1442,7 +1450,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"committeeIDs": []string{"0eb9655577d1af04ff5d382848be15d1454b04838713bfb1ac209808fe3e9f7f"},
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 					return nil, dutytracer.ErrNotFound
 				}
 			},
@@ -1461,7 +1469,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"to":   100,
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutiesFunc = func(slot phase0.Slot) ([]*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutiesFunc = func(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 					return nil, fmt.Errorf("forced error on GetCommitteeDuties")
 				}
 			},
@@ -1477,7 +1485,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"to":   100,
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutiesFunc = func(slot phase0.Slot) ([]*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutiesFunc = func(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 					return nil, multierror.Append(dutytracer.ErrNotFound, estore.ErrNotFound)
 				}
 			},
@@ -1496,7 +1504,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				"to":   100,
 			},
 			setupMock: func(store *mockTraceStore, validatorStore *mockValidatorStore) {
-				store.GetCommitteeDutiesFunc = func(slot phase0.Slot) ([]*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutiesFunc = func(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 					return []*traces.CommitteeDutyTrace{
 						makeCommitteeDutyTrace(slot),
 					}, multierror.Append(nil, fmt.Errorf("forced error on GetCommitteeDuties"), dutytracer.ErrNotFound)
@@ -1542,6 +1550,60 @@ func TestExporterCommitteeTraces(t *testing.T) {
 			tt.validateResp(t, rec)
 		})
 	}
+}
+
+func TestExporterCommitteeTraces_AggregatorCommitteeScheduleNotEmpty(t *testing.T) {
+	store := newMockTraceStore()
+	validatorStore := newMockValidatorStore()
+	exp := newTestExporterForV2(store, validatorStore)
+
+	var committeeID spectypes.CommitteeID
+	committeeID[0] = 1
+
+	store.GetCommitteeDutiesFunc = func(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
+		require.ElementsMatch(t, []spectypes.RunnerRole{spectypes.RoleAggregatorCommittee}, roles)
+		return []*traces.CommitteeDutyTrace{
+			{
+				Slot:        slot,
+				Role:        spectypes.RoleAggregatorCommittee,
+				CommitteeID: committeeID,
+			},
+		}, nil
+	}
+	store.GetScheduledFunc = func(slot phase0.Slot) (map[phase0.ValidatorIndex]rolemask.Mask, error) {
+		return map[phase0.ValidatorIndex]rolemask.Mask{
+			1: rolemask.BitAttester | rolemask.BitSyncCommittee,
+		}, nil
+	}
+	store.GetCommitteeDutyLinksFunc = func(slot phase0.Slot) ([]*traces.CommitteeDutyLink, error) {
+		return []*traces.CommitteeDutyLink{
+			{
+				ValidatorIndex: 1,
+				CommitteeID:    committeeID,
+			},
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/traces/committee", buildJSONBody(t, map[string]any{
+		"from":  100,
+		"to":    100,
+		"roles": []string{"AGGREGATOR_COMMITTEE"},
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	err := exp.CommitteeTraces(rec, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp CommitteeTracesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	require.Equal(t, "AGGREGATOR_COMMITTEE", resp.Data[0].Role)
+	require.Len(t, resp.Schedule, 1)
+	require.NotEmpty(t, resp.Schedule[0].Roles)
+	require.Contains(t, resp.Schedule[0].Roles, "ATTESTER")
+	require.Contains(t, resp.Schedule[0].Roles, "SYNC_COMMITTEE")
 }
 
 func TestExporterBuildValidatorSchedule_AllIndices(t *testing.T) {
@@ -1664,7 +1726,7 @@ func TestExporter_GetValidatorCommitteeDutiesForRoleAndSlot_MembershipGating(t *
 	}
 
 	// Case 1: Attester signer data does NOT include the requested index -> filtered out
-	store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+	store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 		assert.Equal(t, slot, s)
 		assert.Equal(t, cmt, id)
 		return &traces.CommitteeDutyTrace{
@@ -1692,7 +1754,7 @@ func TestExporter_GetValidatorCommitteeDutiesForRoleAndSlot_MembershipGating(t *
 	assert.Len(t, resp.Data, 0)
 
 	// Case 2: Attester signer data includes the requested index -> returned
-	store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+	store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 		return &traces.CommitteeDutyTrace{
 			Slot:        s,
 			CommitteeID: id,
@@ -1914,7 +1976,7 @@ func TestExporterValidatorTraces(t *testing.T) {
 				}
 
 				// Mock GetCommitteeDuty to return a committee duty
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 					return &traces.CommitteeDutyTrace{
 						Slot: slot,
 						ConsensusTrace: traces.ConsensusTrace{
@@ -1969,7 +2031,7 @@ func TestExporterValidatorTraces(t *testing.T) {
 				}
 
 				// Mock GetCommitteeDuty to return ErrNotFound
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 					return nil, dutytracer.ErrNotFound
 				}
 			},
@@ -1999,7 +2061,7 @@ func TestExporterValidatorTraces(t *testing.T) {
 				}
 
 				// Mock GetCommitteeDuty to return ErrNotFound
-				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+				store.GetCommitteeDutyFunc = func(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
 					return nil, fmt.Errorf("forced error on GetCommitteeDuty")
 				}
 			},

--- a/api/types.go
+++ b/api/types.go
@@ -119,3 +119,44 @@ func (rs *RoleSlice) Bind(value string) error {
 	}
 	return nil
 }
+
+type RunnerRole spectypes.RunnerRole
+
+func (r *RunnerRole) Bind(value string) error {
+	role, err := message.RunnerRoleFromString(value)
+	if err != nil {
+		return err
+	}
+	*r = RunnerRole(role)
+	return nil
+}
+
+func (r RunnerRole) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + message.RunnerRoleToString(spectypes.RunnerRole(r)) + `"`), nil
+}
+
+func (r *RunnerRole) UnmarshalJSON(data []byte) error {
+	var role string
+	err := json.Unmarshal(data, &role)
+	if err != nil {
+		return err
+	}
+	return r.Bind(role)
+}
+
+type RunnerRoleSlice []RunnerRole
+
+func (rs *RunnerRoleSlice) Bind(value string) error {
+	if value == "" {
+		return nil
+	}
+	for s := range strings.SplitSeq(value, ",") {
+		var r RunnerRole
+		err := r.Bind(s)
+		if err != nil {
+			return err
+		}
+		*rs = append(*rs, r)
+	}
+	return nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -123,7 +123,7 @@ func (rs *RoleSlice) Bind(value string) error {
 type RunnerRole spectypes.RunnerRole
 
 func (r *RunnerRole) Bind(value string) error {
-	role, err := message.RunnerRoleFromString(value)
+	role, err := message.CommitteeRunnerRoleFromString(value)
 	if err != nil {
 		return err
 	}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -463,6 +463,199 @@ func TestRoleSliceBind(t *testing.T) {
 	}
 }
 
+// TestRunnerRoleBind tests binding string to RunnerRole.
+func TestRunnerRoleBind(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected RunnerRole
+		hasError bool
+	}{
+		{
+			name:     "committee role",
+			input:    "COMMITTEE",
+			expected: RunnerRole(spectypes.RoleCommittee),
+			hasError: false,
+		},
+		{
+			name:     "aggregator committee role",
+			input:    "AGGREGATOR_COMMITTEE",
+			expected: RunnerRole(spectypes.RoleAggregatorCommittee),
+			hasError: false,
+		},
+		{
+			name:     "unknown role",
+			input:    "UNKNOWN_ROLE",
+			expected: RunnerRole(0),
+			hasError: true,
+		},
+		{
+			name:     "empty string is unknown",
+			input:    "",
+			expected: RunnerRole(0),
+			hasError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var r RunnerRole
+			err := r.Bind(tc.input)
+
+			if tc.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, r)
+			}
+		})
+	}
+}
+
+// TestRunnerRoleMarshalJSON tests marshaling RunnerRole to JSON.
+func TestRunnerRoleMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		role     RunnerRole
+		expected string
+	}{
+		{
+			name:     "committee role",
+			role:     RunnerRole(spectypes.RoleCommittee),
+			expected: `"COMMITTEE"`,
+		},
+		{
+			name:     "aggregator committee role",
+			role:     RunnerRole(spectypes.RoleAggregatorCommittee),
+			expected: `"AGGREGATOR_COMMITTEE"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data, err := tc.role.MarshalJSON()
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(data))
+		})
+	}
+}
+
+// TestRunnerRoleUnmarshalJSON tests unmarshaling RunnerRole from JSON.
+func TestRunnerRoleUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		json     string
+		expected RunnerRole
+		hasError bool
+	}{
+		{
+			name:     "committee role",
+			json:     `"COMMITTEE"`,
+			expected: RunnerRole(spectypes.RoleCommittee),
+			hasError: false,
+		},
+		{
+			name:     "aggregator committee role",
+			json:     `"AGGREGATOR_COMMITTEE"`,
+			expected: RunnerRole(spectypes.RoleAggregatorCommittee),
+			hasError: false,
+		},
+		{
+			name:     "invalid role",
+			json:     `"INVALID_ROLE"`,
+			expected: RunnerRole(0),
+			hasError: true,
+		},
+		{
+			name:     "non-string value",
+			json:     `123`,
+			expected: RunnerRole(0),
+			hasError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var r RunnerRole
+			err := r.UnmarshalJSON([]byte(tc.json))
+
+			if tc.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, r)
+			}
+		})
+	}
+}
+
+// TestRunnerRoleSliceBind tests binding a comma-separated string to RunnerRoleSlice.
+func TestRunnerRoleSliceBind(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected RunnerRoleSlice
+		hasError bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+			hasError: false,
+		},
+		{
+			name:     "single role",
+			input:    "COMMITTEE",
+			expected: RunnerRoleSlice{RunnerRole(spectypes.RoleCommittee)},
+			hasError: false,
+		},
+		{
+			name:  "multiple roles",
+			input: "COMMITTEE,AGGREGATOR_COMMITTEE",
+			expected: RunnerRoleSlice{
+				RunnerRole(spectypes.RoleCommittee),
+				RunnerRole(spectypes.RoleAggregatorCommittee),
+			},
+			hasError: false,
+		},
+		{
+			name:     "invalid role in list",
+			input:    "COMMITTEE,INVALID_ROLE",
+			expected: nil,
+			hasError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var rs RunnerRoleSlice
+			err := rs.Bind(tc.input)
+
+			if tc.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, rs)
+			}
+		})
+	}
+}
+
 // TestStructWithHexAndRole tests marshaling and unmarshaling a struct with Hex and Role fields.
 func TestStructWithHexAndRole(t *testing.T) {
 	t.Parallel()

--- a/docs/api/ssvnode.openapi.json
+++ b/docs/api/ssvnode.openapi.json
@@ -260,6 +260,20 @@
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "items": {
+                            "enum": [
+                                "COMMITTEE",
+                                "AGGREGATOR_COMMITTEE"
+                            ],
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Roles is a comma-separated list of committee runner roles to include.",
+                        "name": "roles",
+                        "in": "query"
+                    },
+                    {
                         "minimum": 0,
                         "type": "integer",
                         "format": "int64",
@@ -332,6 +346,20 @@
                         "format": "int64",
                         "description": "From is the starting slot (inclusive).",
                         "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "enum": [
+                                "COMMITTEE",
+                                "AGGREGATOR_COMMITTEE"
+                            ],
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Roles is a comma-separated list of committee runner roles to include.",
+                        "name": "roles",
                         "in": "query"
                     },
                     {
@@ -733,7 +761,7 @@
             "type": "object",
             "properties": {
                 "attester": {
-                    "description": "Attester contains post-consensus messages for attester duties.",
+                    "description": "Attester contains post-consensus messages for attester duties,\nincluding aggregator signers.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/exporter.CommitteeMessage"
@@ -763,13 +791,22 @@
                     "type": "string",
                     "format": "hex"
                 },
+                "role": {
+                    "description": "Role is the committee runner role for this duty (e.g., COMMITTEE).",
+                    "type": "string",
+                    "enum": [
+                        "COMMITTEE",
+                        "AGGREGATOR_COMMITTEE"
+                    ],
+                    "example": "COMMITTEE"
+                },
                 "slot": {
                     "description": "Slot is the duty slot for this committee trace.",
                     "type": "integer",
                     "format": "int64"
                 },
                 "sync_committee": {
-                    "description": "SyncCommittee contains post-consensus messages for sync-committee duties.",
+                    "description": "SyncCommittee contains post-consensus messages for sync-committee duties,\nincluding sync committee contribution signers.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/exporter.CommitteeMessage"
@@ -795,6 +832,17 @@
                     "type": "integer",
                     "format": "int64",
                     "minimum": 0
+                },
+                "roles": {
+                    "description": "Roles is a comma-separated list of committee runner roles to include.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "COMMITTEE",
+                            "AGGREGATOR_COMMITTEE"
+                        ]
+                    }
                 },
                 "to": {
                     "description": "To is the ending slot (inclusive).",

--- a/docs/api/ssvnode.openapi.yaml
+++ b/docs/api/ssvnode.openapi.yaml
@@ -61,7 +61,9 @@ definitions:
   exporter.CommitteeTrace:
     properties:
       attester:
-        description: Attester contains post-consensus messages for attester duties.
+        description: |-
+          Attester contains post-consensus messages for attester duties,
+          including aggregator signers.
         items:
           $ref: '#/definitions/exporter.CommitteeMessage'
         type: array
@@ -84,13 +86,21 @@ definitions:
           available.
         format: hex
         type: string
+      role:
+        description: Role is the committee runner role for this duty (e.g., COMMITTEE).
+        enum:
+        - COMMITTEE
+        - AGGREGATOR_COMMITTEE
+        example: COMMITTEE
+        type: string
       slot:
         description: Slot is the duty slot for this committee trace.
         format: int64
         type: integer
       sync_committee:
-        description: SyncCommittee contains post-consensus messages for sync-committee
-          duties.
+        description: |-
+          SyncCommittee contains post-consensus messages for sync-committee duties,
+          including sync committee contribution signers.
         items:
           $ref: '#/definitions/exporter.CommitteeMessage'
         type: array
@@ -111,6 +121,15 @@ definitions:
         format: int64
         minimum: 0
         type: integer
+      roles:
+        description: Roles is a comma-separated list of committee runner roles to
+          include.
+        items:
+          enum:
+          - COMMITTEE
+          - AGGREGATOR_COMMITTEE
+          type: string
+        type: array
       to:
         description: To is the ending slot (inclusive).
         format: int64
@@ -738,6 +757,17 @@ paths:
         minimum: 0
         name: from
         type: integer
+      - collectionFormat: csv
+        description: Roles is a comma-separated list of committee runner roles to
+          include.
+        in: query
+        items:
+          enum:
+          - COMMITTEE
+          - AGGREGATOR_COMMITTEE
+          type: string
+        name: roles
+        type: array
       - description: To is the ending slot (inclusive).
         format: int64
         in: query
@@ -790,6 +820,17 @@ paths:
         minimum: 0
         name: from
         type: integer
+      - collectionFormat: csv
+        description: Roles is a comma-separated list of committee runner roles to
+          include.
+        in: query
+        items:
+          enum:
+          - COMMITTEE
+          - AGGREGATOR_COMMITTEE
+          type: string
+        name: roles
+        type: array
       - description: To is the ending slot (inclusive).
         format: int64
         in: query

--- a/exporter/committee.go
+++ b/exporter/committee.go
@@ -25,7 +25,7 @@ func (e *Exporter) CommitteeTracesCore(request *CommitteeTracesQuery) (*Committe
 	cids := request.CommitteeIDs
 	for s := request.From; s <= request.To; s++ {
 		slot := phase0.Slot(s)
-		duties, err := e.getCommitteeDutiesForSlot(slot, cids)
+		duties, err := e.getCommitteeDutiesForSlot(slot, cids, request.Roles...)
 		all = append(all, duties...)
 		errs = multierror.Append(errs, err)
 	}
@@ -46,23 +46,30 @@ func validateCommitteeRequest(request *CommitteeTracesQuery) error {
 	return nil
 }
 
-func (e *Exporter) getCommitteeDutiesForSlot(slot phase0.Slot, committeeIDs []spectypes.CommitteeID) ([]*traces.CommitteeDutyTrace, error) {
+func (e *Exporter) getCommitteeDutiesForSlot(slot phase0.Slot, committeeIDs []spectypes.CommitteeID, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 	if len(committeeIDs) == 0 {
-		duties, err := e.traceStore.GetCommitteeDuties(slot)
-		return duties, err
+		return e.traceStore.GetCommitteeDuties(slot, roles...)
+	}
+
+	if len(roles) == 0 {
+		roles = []spectypes.RunnerRole{
+			spectypes.RoleCommittee,
+			spectypes.RoleAggregatorCommittee,
+		}
 	}
 
 	duties := make([]*traces.CommitteeDutyTrace, 0, len(committeeIDs))
 
 	var errs *multierror.Error
 	for _, cmtID := range committeeIDs {
-		duty, err := e.traceStore.GetCommitteeDuty(slot, cmtID)
-		if err != nil {
-			e.logger.Error("error getting committee duty", zap.Error(err), fields.Slot(slot), fields.CommitteeID(cmtID))
-			errs = multierror.Append(errs, err)
-			continue
+		for _, role := range roles {
+			duty, err := e.traceStore.GetCommitteeDuty(slot, cmtID, role)
+			if err != nil {
+				errs = multierror.Append(errs, err)
+				continue
+			}
+			duties = append(duties, duty)
 		}
-		duties = append(duties, duty)
 	}
 	return duties, errs.ErrorOrNil()
 }

--- a/exporter/committee.go
+++ b/exporter/committee.go
@@ -65,6 +65,11 @@ func (e *Exporter) getCommitteeDutiesForSlot(slot phase0.Slot, committeeIDs []sp
 		for _, role := range roles {
 			duty, err := e.traceStore.GetCommitteeDuty(slot, cmtID, role)
 			if err != nil {
+				// not-found is expected (we probe every role per committee) and is
+				// filtered upstream; only log genuine storage failures.
+				if !isNotFoundError(err) {
+					e.logger.Error("error getting committee duty", zap.Error(err), fields.Slot(slot), fields.CommitteeID(cmtID))
+				}
 				errs = multierror.Append(errs, err)
 				continue
 			}

--- a/exporter/dutytracer/collector.go
+++ b/exporter/dutytracer/collector.go
@@ -899,14 +899,7 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 						c.checkQuorumAfterFlush(c.logger, committeeID, slot, trace)
 					} else {
 						// CRITICAL: If we fail to compute role roots, pending signatures will be dropped.
-						pendingCount := 0
-						for _, perSigner := range trace.pendingByRoot {
-							for _, byTs := range perSigner {
-								for _, idxs := range byTs {
-									pendingCount += len(idxs)
-								}
-							}
-						}
+						pendingCount := countPending(trace.pendingByRoot)
 						c.logger.Error("CRITICAL: failed to compute role roots from proposal - pending signatures will be dropped",
 							zap.Error(err),
 							fields.Slot(slot),
@@ -924,14 +917,7 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 						c.checkQuorumAfterFlush(c.logger, committeeID, slot, trace)
 					} else {
 						// CRITICAL: If we fail to compute role roots, pending signatures will be dropped.
-						pendingCount := 0
-						for _, perSigner := range trace.pendingByRoot {
-							for _, byTs := range perSigner {
-								for _, idxs := range byTs {
-									pendingCount += len(idxs)
-								}
-							}
-						}
+						pendingCount := countPending(trace.pendingByRoot)
 						c.logger.Error("CRITICAL: failed to compute aggregator committee roots from proposal - pending signatures will be dropped",
 							zap.Error(err),
 							fields.Slot(slot),
@@ -1049,7 +1035,7 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 		if isCommitteeRunnerRole(verifyCtx.runnerRole) {
 			var aggSelectionRoot phase0.Root
 			aggSelectionRootReady := false
-			if pSigMessages.Type == spectypes.AggregatorCommitteePartialSig {
+			if verifyCtx.runnerRole == spectypes.RoleAggregatorCommittee && pSigMessages.Type == spectypes.AggregatorCommitteePartialSig {
 				root, err := c.getAggregatorSelectionRoot(ctx, verifyCtx.slot)
 				if err != nil {
 					c.logger.Warn("failed to compute aggregator selection root",

--- a/exporter/dutytracer/collector.go
+++ b/exporter/dutytracer/collector.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jellydator/ttlcache/v3"
 	"go.uber.org/zap"
@@ -39,11 +41,16 @@ type DecidedInfo struct {
 	Signers []spectypes.OperatorID
 }
 
+type committeeTraceKey struct {
+	id   spectypes.CommitteeID
+	role spectypes.RunnerRole
+}
+
 type Collector struct {
 	logger *zap.Logger
 
-	// committeeID:slot:committeeDutyTrace
-	committeeTraces *hashmap.Map[spectypes.CommitteeID, *hashmap.Map[phase0.Slot, *committeeDutyTrace]]
+	// committeeID+role:slot:committeeDutyTrace (role separates committee vs aggregator-committee duties).
+	committeeTraces *hashmap.Map[committeeTraceKey, *hashmap.Map[phase0.Slot, *committeeDutyTrace]]
 
 	// validatorIndex:slot:validatorDutyTrace
 	validatorTraces *hashmap.Map[phase0.ValidatorIndex, *hashmap.Map[phase0.Slot, *validatorDutyTrace]]
@@ -54,6 +61,9 @@ type Collector struct {
 	syncCommitteeRootsCache *ttlcache.Cache[scRootKey, phase0.Root]
 	syncCommitteeRootsSf    singleflight.Group
 
+	aggregatorSelectionRootsCache *ttlcache.Cache[phase0.Slot, phase0.Root]
+	aggregatorSelectionRootsSf    singleflight.Group
+
 	beacon *networkconfig.Beacon
 
 	store      DutyTraceStore
@@ -62,7 +72,7 @@ type Collector struct {
 
 	lastEvictedSlot atomic.Uint64
 
-	inFlightCommittee hashmap.Map[spectypes.CommitteeID, struct{}]
+	inFlightCommittee hashmap.Map[committeeTraceKey, struct{}]
 	inFlightValidator hashmap.Map[phase0.ValidatorIndex, struct{}]
 
 	decidedListenerFunc func(msg DecidedInfo)
@@ -105,11 +115,12 @@ func New(
 		client:                         client,
 		beacon:                         beaconNetwork,
 		validators:                     validators,
-		committeeTraces:                hashmap.New[spectypes.CommitteeID, *hashmap.Map[phase0.Slot, *committeeDutyTrace]](),
+		committeeTraces:                hashmap.New[committeeTraceKey, *hashmap.Map[phase0.Slot, *committeeDutyTrace]](),
 		validatorTraces:                hashmap.New[phase0.ValidatorIndex, *hashmap.Map[phase0.Slot, *validatorDutyTrace]](),
 		validatorIndexToCommitteeLinks: hashmap.New[phase0.ValidatorIndex, *hashmap.Map[phase0.Slot, spectypes.CommitteeID]](),
 		syncCommitteeRootsCache:        ttlcache.New(ttlcache.WithTTL[scRootKey, phase0.Root](ttl)),
-		inFlightCommittee:              hashmap.Map[spectypes.CommitteeID, struct{}]{},
+		aggregatorSelectionRootsCache:  ttlcache.New(ttlcache.WithTTL[phase0.Slot, phase0.Root](ttl)),
+		inFlightCommittee:              hashmap.Map[committeeTraceKey, struct{}]{},
 		inFlightValidator:              hashmap.Map[phase0.ValidatorIndex, struct{}]{},
 		decidedListenerFunc:            decidedListenerFunc,
 		duties:                         duties,
@@ -189,8 +200,9 @@ func (c *Collector) evict(currentSlot phase0.Slot) {
 	evicted = c.dumpLinkToDBPeriodically(threshold)
 	c.logger.Info("evicted validator mappings to disk", fields.Slot(threshold), zap.Int("count", evicted), fields.Took(time.Since(start)))
 
-	// remove old SC roots
+	// remove expired signing-root caches
 	c.syncCommitteeRootsCache.DeleteExpired()
+	c.aggregatorSelectionRootsCache.DeleteExpired()
 }
 
 func (c *Collector) getOrCreateValidatorTrace(slot phase0.Slot, role spectypes.BeaconRole, index phase0.ValidatorIndex) (*validatorDutyTrace, bool, error) {
@@ -247,30 +259,27 @@ func (c *Collector) getOrCreateValidatorTrace(slot phase0.Slot, role spectypes.B
 
 var errInFlight = errors.New("in flight")
 
-func (c *Collector) getOrCreateCommitteeTrace(slot phase0.Slot, committeeID spectypes.CommitteeID) (*committeeDutyTrace, bool, error) {
+func (c *Collector) getOrCreateCommitteeTrace(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*committeeDutyTrace, bool, error) {
+	key := committeeTraceKey{id: committeeID, role: role}
 	// check late arrival
 	if uint64(slot) <= c.lastEvictedSlot.Load() {
-		if _, found := c.inFlightCommittee.GetOrSet(committeeID, struct{}{}); found {
+		if _, found := c.inFlightCommittee.GetOrSet(key, struct{}{}); found {
 			return nil, false, errInFlight
 		}
 
-		diskTrace, err := c.getCommitteeDutyFromDisk(slot, committeeID)
+		diskTrace, err := c.getCommitteeDutyFromDisk(slot, role, committeeID)
 		if errors.Is(err, store.ErrNotFound) {
 			trace := &committeeDutyTrace{
 				CommitteeDutyTrace: traces.CommitteeDutyTrace{
 					CommitteeID: committeeID,
 					Slot:        slot,
-					// Set Role explicitly so the stored value matches its role-aware key byte,
-					// rather than relying on RoleCommittee being the zero value (unit-5 will add
-					// the AggregatorCommittee path, which must set Role: RoleAggregatorCommittee here;
-					// the store derives the key-prefix byte from it via CommitteeRunnerRoleToPrefix).
-					Role: spectypes.RoleCommittee,
+					Role:        role,
 				},
 			}
 			return trace, true, nil
 		}
 		if err != nil {
-			_ = c.inFlightCommittee.Delete(committeeID)
+			_ = c.inFlightCommittee.Delete(key)
 			return nil, false, fmt.Errorf("get late committee duty data: %w", err)
 		}
 
@@ -281,9 +290,9 @@ func (c *Collector) getOrCreateCommitteeTrace(slot phase0.Slot, committeeID spec
 		return trace, true, nil
 	}
 
-	committeeSlots, found := c.committeeTraces.Get(committeeID)
+	committeeSlots, found := c.committeeTraces.Get(key)
 	if !found {
-		committeeSlots, _ = c.committeeTraces.GetOrSet(committeeID, hashmap.New[phase0.Slot, *committeeDutyTrace]())
+		committeeSlots, _ = c.committeeTraces.GetOrSet(key, hashmap.New[phase0.Slot, *committeeDutyTrace]())
 	}
 
 	committeeTrace, found := committeeSlots.Get(slot)
@@ -293,6 +302,7 @@ func (c *Collector) getOrCreateCommitteeTrace(slot phase0.Slot, committeeID spec
 			CommitteeDutyTrace: traces.CommitteeDutyTrace{
 				CommitteeID: committeeID,
 				Slot:        slot,
+				Role:        role,
 			},
 		}
 
@@ -424,9 +434,15 @@ func (c *Collector) processConsensus(receivedAt uint64, msg *specqbft.Message, s
 	return nil // we're exhausting all cases in the switch
 }
 
-func (c *Collector) processPartialSigCommittee(receivedAt uint64, msg *spectypes.PartialSignatureMessages, committeeID spectypes.CommitteeID, trace *committeeDutyTrace) {
+func (c *Collector) processPartialSigCommittee(
+	receivedAt uint64,
+	msg *spectypes.PartialSignatureMessages,
+	trace *committeeDutyTrace,
+	aggSelectionRoot phase0.Root,
+	aggSelectionRootReady bool,
+) {
 	// add operator ids to the trace
-	cmt, found := c.validators.Committee(committeeID)
+	cmt, found := c.validators.Committee(trace.CommitteeID)
 	if found && len(cmt.Operators) > 0 {
 		trace.OperatorIDs = cmt.Operators
 	}
@@ -435,18 +451,32 @@ func (c *Collector) processPartialSigCommittee(receivedAt uint64, msg *spectypes
 	var attIdxs []phase0.ValidatorIndex
 	var scIdxs []phase0.ValidatorIndex
 
+	if msg.Type == spectypes.AggregatorCommitteePartialSig && aggSelectionRootReady && !trace.aggSelectionRootReady {
+		trace.aggSelectionRoot = aggSelectionRoot
+		trace.aggSelectionRootReady = true
+	}
+
 	for _, partialSigMsg := range msg.Messages {
 		root := partialSigMsg.SigningRoot
-		if trace.roleRootsReady {
-			if bytes.Equal(trace.syncCommitteeRoot[:], root[:]) {
-				scIdxs = append(scIdxs, partialSigMsg.ValidatorIndex)
-			} else if bytes.Equal(trace.attestationRoot[:], root[:]) {
+		trace.addRootSigner(root, partialSigMsg.ValidatorIndex, signer)
+		if msg.Type == spectypes.AggregatorCommitteePartialSig && trace.aggSelectionRootReady {
+			if bytes.Equal(trace.aggSelectionRoot[:], root[:]) {
 				attIdxs = append(attIdxs, partialSigMsg.ValidatorIndex)
 			} else {
-				trace.addPending(root, signer, partialSigMsg.ValidatorIndex, receivedAt)
+				scIdxs = append(scIdxs, partialSigMsg.ValidatorIndex)
 			}
 			continue
 		}
+
+		if role, ok := trace.classifyRootForPending(root); ok {
+			if role == spectypes.BNRoleSyncCommittee || role == spectypes.BNRoleSyncCommitteeContribution {
+				scIdxs = append(scIdxs, partialSigMsg.ValidatorIndex)
+			} else {
+				attIdxs = append(attIdxs, partialSigMsg.ValidatorIndex)
+			}
+			continue
+		}
+
 		// Not ready: buffer for later classification
 		trace.addPending(root, signer, partialSigMsg.ValidatorIndex, receivedAt)
 	}
@@ -519,6 +549,110 @@ func (c *Collector) getSyncCommitteeRoot(ctx context.Context, slot phase0.Slot, 
 	}
 
 	return val.(phase0.Root), nil
+}
+
+func (c *Collector) getAggregatorSelectionRoot(ctx context.Context, slot phase0.Slot) (phase0.Root, error) {
+	if item := c.aggregatorSelectionRootsCache.Get(slot); item != nil {
+		return item.Value(), nil
+	}
+
+	val, err, _ := c.aggregatorSelectionRootsSf.Do(strconv.FormatUint(uint64(slot), 10), func() (any, error) {
+		if item := c.aggregatorSelectionRootsCache.Get(slot); item != nil {
+			return item.Value(), nil
+		}
+
+		epoch := c.beacon.EstimatedEpochAtSlot(slot)
+		domain, domainErr := c.client.DomainData(ctx, epoch, spectypes.DomainSelectionProof)
+		if domainErr != nil {
+			return phase0.Root{}, fmt.Errorf("get aggregator selection domain data: %w", domainErr)
+		}
+		root, rootErr := spectypes.ComputeETHSigningRoot(spectypes.SSZUint64(slot), domain)
+		if rootErr != nil {
+			return phase0.Root{}, fmt.Errorf("compute aggregator selection root: %w", rootErr)
+		}
+
+		_ = c.aggregatorSelectionRootsCache.Set(slot, root, ttlcache.DefaultTTL)
+		return root, nil
+	})
+	if err != nil {
+		return phase0.Root{}, err
+	}
+
+	return val.(phase0.Root), nil
+}
+
+// computeAggregatorCommitteePostConsensusRoles derives the beacon role for each
+// signing root present in an AggregatorCommittee proposal's consensus data, so
+// post-consensus partial signatures can be classified into Attester/SyncCommittee
+// buckets (Aggregator -> Attester bucket, SyncCommitteeContribution -> SyncCommittee bucket).
+func (c *Collector) computeAggregatorCommitteePostConsensusRoles(
+	ctx context.Context,
+	slot phase0.Slot,
+	in []byte,
+) (map[phase0.Root]spectypes.BeaconRole, error) {
+	data := &spectypes.AggregatorCommitteeConsensusData{}
+	if err := data.Decode(in); err != nil {
+		return nil, fmt.Errorf("decode aggregator committee consensus data: %w", err)
+	}
+
+	epoch := c.beacon.EstimatedEpochAtSlot(slot)
+	roleByRoot := make(map[phase0.Root]spectypes.BeaconRole)
+
+	aggregateAndProofs, err := data.GetAggregateAndProofs()
+	if err != nil {
+		return nil, fmt.Errorf("get aggregate and proofs: %w", err)
+	}
+
+	dAgg, err := c.client.DomainData(ctx, epoch, spectypes.DomainAggregateAndProof)
+	if err != nil {
+		return nil, fmt.Errorf("get aggregate and proof domain data: %w", err)
+	}
+	for _, aggAndProof := range aggregateAndProofs {
+		hashRoot, err := spectypes.GetAggregateAndProofHashRoot(aggAndProof)
+		if err != nil {
+			c.logger.Warn("failed to get aggregate-and-proof hash root",
+				zap.Error(err),
+				fields.Slot(slot))
+			continue
+		}
+		root, err := spectypes.ComputeETHSigningRoot(hashRoot, dAgg)
+		if err != nil {
+			c.logger.Warn("failed to compute aggregate-and-proof signing root",
+				zap.Error(err),
+				fields.Slot(slot))
+			continue
+		}
+		roleByRoot[root] = spectypes.BNRoleAggregator
+	}
+
+	contribs, err := data.GetSyncCommitteeContributions()
+	if err != nil {
+		return nil, fmt.Errorf("get sync committee contributions: %w", err)
+	}
+
+	dContrib, err := c.client.DomainData(ctx, epoch, spectypes.DomainContributionAndProof)
+	if err != nil {
+		return nil, fmt.Errorf("get contribution and proof domain data: %w", err)
+	}
+
+	for i, contrib := range contribs {
+		cp := &altair.ContributionAndProof{
+			AggregatorIndex: data.Contributors[i].ValidatorIndex,
+			Contribution:    &contrib.Contribution,
+			SelectionProof:  data.Contributors[i].SelectionProof,
+		}
+		root, err := spectypes.ComputeETHSigningRoot(cp, dContrib)
+		if err != nil {
+			c.logger.Warn("failed to compute sync-committee-contribution signing root",
+				zap.Error(err),
+				fields.Slot(slot),
+				zap.Int("contribution_index", i))
+			continue
+		}
+		roleByRoot[root] = spectypes.BNRoleSyncCommitteeContribution
+	}
+
+	return roleByRoot, nil
 }
 
 // computeRoleRoots derives both sync-committee and attestation signing roots
@@ -653,7 +787,7 @@ func (c *Collector) newPartialSigVerifyCtx(msg *queue.SSVMessage, pSigMessages *
 		partialMsgsSize: len(pSigMessages.Messages),
 	}
 
-	if runnerRole == spectypes.RoleCommittee {
+	if isCommitteeRunnerRole(runnerRole) {
 		executorID := msg.MsgID.GetDutyExecutorID()
 		if len(executorID) >= 32 {
 			// committeeID is the last 16 bytes of the executorID
@@ -687,7 +821,7 @@ func (c *Collector) wrapVerifyPartialSigErr(ctx partialSigVerifyCtx, pSigMessage
 		zap.Int("missing_validator_index_count", missingCount),
 	)
 
-	if ctx.runnerRole == spectypes.RoleCommittee {
+	if isCommitteeRunnerRole(ctx.runnerRole) {
 		return fmt.Errorf(
 			"verify partial sig (slot=%d committee_id=%x signer=%d root=%x partial_msgs=%d missing_first_validator_index=%d missing_validator_index_count=%d): %w",
 			ctx.slot,
@@ -734,13 +868,13 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 		msgID := spectypes.MessageID(subMsg.Identifier[:])
 		executorID := msgID.GetDutyExecutorID()
 
-		switch role := msgID.GetRoleType(); role {
-		case spectypes.RoleCommittee:
+		role := msgID.GetRoleType()
+		if isCommitteeRunnerRole(role) {
 			var committeeID spectypes.CommitteeID
 			// committeeID is the last 16 bytes of the executorID
 			copy(committeeID[:], executorID[16:])
 
-			trace, late, err := c.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, late, err := c.getOrCreateCommitteeTrace(slot, committeeID, role)
 			if err != nil {
 				return err
 			}
@@ -752,31 +886,61 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 				// save proposal data and compute role roots
 				trace.ProposalData = msg.SignedSSVMessage.FullData
 
-				if syncRoot, attRoot, err := c.computeRoleRoots(ctx, slot, msg.SignedSSVMessage.FullData); err == nil {
-					trace.syncCommitteeRoot = syncRoot
-					trace.attestationRoot = attRoot
-					trace.roleRootsReady = true
-					trace.flushPending()
-					// Check quorum for all validators after flushing pending signatures.
-					// This ensures quorum detection happens immediately when signatures that
-					// arrived before the proposal are reclassified into role buckets.
-					c.checkQuorumAfterFlush(c.logger, committeeID, slot, trace)
-				} else {
-					// CRITICAL: If we fail to compute role roots, pending signatures will be dropped.
-					pendingCount := 0
-					for _, perSigner := range trace.pendingByRoot {
-						for _, byTs := range perSigner {
-							for _, idxs := range byTs {
-								pendingCount += len(idxs)
+				switch role {
+				case spectypes.RoleCommittee:
+					if syncRoot, attRoot, err := c.computeRoleRoots(ctx, slot, msg.SignedSSVMessage.FullData); err == nil {
+						trace.syncCommitteeRoot = syncRoot
+						trace.attestationRoot = attRoot
+						trace.roleRootsReady = true
+						trace.flushPending()
+						// Check quorum for all validators after flushing pending signatures.
+						// This ensures quorum detection happens immediately when signatures that
+						// arrived before the proposal are reclassified into role buckets.
+						c.checkQuorumAfterFlush(c.logger, committeeID, slot, trace)
+					} else {
+						// CRITICAL: If we fail to compute role roots, pending signatures will be dropped.
+						pendingCount := 0
+						for _, perSigner := range trace.pendingByRoot {
+							for _, byTs := range perSigner {
+								for _, idxs := range byTs {
+									pendingCount += len(idxs)
+								}
 							}
 						}
+						c.logger.Error("CRITICAL: failed to compute role roots from proposal - pending signatures will be dropped",
+							zap.Error(err),
+							fields.Slot(slot),
+							fields.CommitteeID(committeeID),
+							zap.Int("pending_signature_count", pendingCount),
+							pendingDetails(trace.pendingByRoot))
 					}
-					c.logger.Error("CRITICAL: failed to compute role roots from proposal - pending signatures will be dropped",
-						zap.Error(err),
-						fields.Slot(slot),
-						fields.CommitteeID(committeeID),
-						zap.Int("pending_signature_count", pendingCount),
-						pendingDetails(trace.pendingByRoot))
+				case spectypes.RoleAggregatorCommittee:
+					if rolesByRoot, err := c.computeAggregatorCommitteePostConsensusRoles(ctx, slot, msg.SignedSSVMessage.FullData); err == nil {
+						trace.aggPostConsensusRoles = rolesByRoot
+						trace.flushPending()
+						// Check quorum for all validators after flushing pending signatures.
+						// This ensures quorum detection happens immediately when signatures that
+						// arrived before the proposal are reclassified into role buckets.
+						c.checkQuorumAfterFlush(c.logger, committeeID, slot, trace)
+					} else {
+						// CRITICAL: If we fail to compute role roots, pending signatures will be dropped.
+						pendingCount := 0
+						for _, perSigner := range trace.pendingByRoot {
+							for _, byTs := range perSigner {
+								for _, idxs := range byTs {
+									pendingCount += len(idxs)
+								}
+							}
+						}
+						c.logger.Error("CRITICAL: failed to compute aggregator committee roots from proposal - pending signatures will be dropped",
+							zap.Error(err),
+							fields.Slot(slot),
+							fields.CommitteeID(committeeID),
+							zap.Int("pending_signature_count", pendingCount),
+							pendingDetails(trace.pendingByRoot))
+					}
+				default:
+					c.logger.Warn("unexpected committee role on committee trace path", zap.Int32("role", int32(role)))
 				}
 			}
 
@@ -788,75 +952,74 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 			}
 
 			if late {
-				err := c.store.SaveCommitteeDuty(spectypes.RoleCommittee, &trace.CommitteeDutyTrace)
-				_ = c.inFlightCommittee.Delete(committeeID)
-				return err
-			}
-
-			return nil
-
-		default:
-			var validatorPK spectypes.ValidatorPK
-			copy(validatorPK[:], executorID)
-
-			bnRole, err := toBNRole(role)
-			if err != nil {
-				return err
-			}
-
-			// map pubkey to validator index for internal storage
-			index, found := c.validators.ValidatorIndex(validatorPK)
-			if !found {
-				c.logger.Error("validator not found by pubkey", fields.Validator(validatorPK[:]))
-				return fmt.Errorf("validator not found by pubkey: %x", validatorPK[:])
-			}
-
-			trace, late, err := c.getOrCreateValidatorTrace(slot, bnRole, index)
-			if err != nil {
-				return err
-			}
-
-			var qbftMsg = new(specqbft.Message)
-			if err = qbftMsg.Decode(msg.Data); err == nil {
-				if qbftMsg.MsgType == specqbft.ProposalMsgType {
-					var data = new(spectypes.ProposerConsensusData)
-					if err := data.Decode(msg.SignedSSVMessage.FullData); err == nil {
-						func() {
-							trace.Lock()
-							defer trace.Unlock()
-
-							roleDutyTrace := trace.getOrCreate(slot, bnRole)
-
-							if roleDutyTrace.Validator == 0 {
-								roleDutyTrace.Validator = data.Duty.ValidatorIndex
-							}
-							// non-committee duty will contain the proposal data
-							roleDutyTrace.ProposalData = data.DataSSZ
-						}()
-					}
-				}
-			}
-
-			trace.Lock()
-			defer trace.Unlock()
-
-			roleDutyTrace := trace.getOrCreate(slot, bnRole)
-
-			round := getOrCreateRound(&roleDutyTrace.ConsensusTrace, uint64(subMsg.Round))
-
-			decided := c.processConsensus(startTime, subMsg, msg.SignedSSVMessage, round)
-			if decided != nil {
-				roleDutyTrace.Decideds = append(roleDutyTrace.Decideds, decided)
-			}
-
-			if late {
-				err := c.store.SaveValidatorDuty(roleDutyTrace)
-				_ = c.inFlightValidator.Delete(index)
+				err := c.store.SaveCommitteeDuty(role, &trace.CommitteeDutyTrace)
+				_ = c.inFlightCommittee.Delete(committeeTraceKey{id: committeeID, role: role})
 				return err
 			}
 
 			return nil
 		}
+
+		var validatorPK spectypes.ValidatorPK
+		copy(validatorPK[:], executorID)
+
+		bnRole, err := toBNRole(role)
+		if err != nil {
+			return err
+		}
+
+		// map pubkey to validator index for internal storage
+		index, found := c.validators.ValidatorIndex(validatorPK)
+		if !found {
+			c.logger.Error("validator not found by pubkey", fields.Validator(validatorPK[:]))
+			return fmt.Errorf("validator not found by pubkey: %x", validatorPK[:])
+		}
+
+		trace, late, err := c.getOrCreateValidatorTrace(slot, bnRole, index)
+		if err != nil {
+			return err
+		}
+
+		var qbftMsg = new(specqbft.Message)
+		if err = qbftMsg.Decode(msg.Data); err == nil {
+			if qbftMsg.MsgType == specqbft.ProposalMsgType {
+				var data = new(spectypes.ProposerConsensusData)
+				if err := data.Decode(msg.SignedSSVMessage.FullData); err == nil {
+					func() {
+						trace.Lock()
+						defer trace.Unlock()
+
+						roleDutyTrace := trace.getOrCreate(slot, bnRole)
+
+						if roleDutyTrace.Validator == 0 {
+							roleDutyTrace.Validator = data.Duty.ValidatorIndex
+						}
+						// non-committee duty will contain the proposal data
+						roleDutyTrace.ProposalData = data.DataSSZ
+					}()
+				}
+			}
+		}
+
+		trace.Lock()
+		defer trace.Unlock()
+
+		roleDutyTrace := trace.getOrCreate(slot, bnRole)
+
+		round := getOrCreateRound(&roleDutyTrace.ConsensusTrace, uint64(subMsg.Round))
+
+		decided := c.processConsensus(startTime, subMsg, msg.SignedSSVMessage, round)
+		if decided != nil {
+			roleDutyTrace.Decideds = append(roleDutyTrace.Decideds, decided)
+		}
+
+		if late {
+			err := c.store.SaveValidatorDuty(roleDutyTrace)
+			_ = c.inFlightValidator.Delete(index)
+			return err
+		}
+
+		return nil
 	}
 
 	if msg.MsgType == spectypes.SSVPartialSignatureMsgType {
@@ -883,8 +1046,23 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 		}
 
 		// process partial sig for committee
-		if verifyCtx.runnerRole == spectypes.RoleCommittee {
-			trace, late, err := c.getOrCreateCommitteeTrace(verifyCtx.slot, verifyCtx.committeeID)
+		if isCommitteeRunnerRole(verifyCtx.runnerRole) {
+			var aggSelectionRoot phase0.Root
+			aggSelectionRootReady := false
+			if pSigMessages.Type == spectypes.AggregatorCommitteePartialSig {
+				root, err := c.getAggregatorSelectionRoot(ctx, verifyCtx.slot)
+				if err != nil {
+					c.logger.Warn("failed to compute aggregator selection root",
+						zap.Error(err),
+						fields.Slot(verifyCtx.slot),
+						fields.CommitteeID(verifyCtx.committeeID))
+				} else {
+					aggSelectionRoot = root
+					aggSelectionRootReady = true
+				}
+			}
+
+			trace, late, err := c.getOrCreateCommitteeTrace(verifyCtx.slot, verifyCtx.committeeID, verifyCtx.runnerRole)
 			if err != nil {
 				return err
 			}
@@ -892,12 +1070,12 @@ func (c *Collector) collect(ctx context.Context, msg *queue.SSVMessage, verifySi
 			trace.Lock()
 			defer trace.Unlock()
 
-			c.processPartialSigCommittee(startTime, pSigMessages, verifyCtx.committeeID, trace)
+			c.processPartialSigCommittee(startTime, pSigMessages, trace, aggSelectionRoot, aggSelectionRootReady)
 			c.checkAndPublishQuorum(verifyCtx.logger, pSigMessages, verifyCtx.committeeID, trace)
 
 			if late {
-				err := c.store.SaveCommitteeDuty(spectypes.RoleCommittee, &trace.CommitteeDutyTrace)
-				_ = c.inFlightCommittee.Delete(verifyCtx.committeeID)
+				err := c.store.SaveCommitteeDuty(verifyCtx.runnerRole, &trace.CommitteeDutyTrace)
+				_ = c.inFlightCommittee.Delete(committeeTraceKey{id: verifyCtx.committeeID, role: verifyCtx.runnerRole})
 				return err
 			}
 
@@ -953,7 +1131,6 @@ func toBNRole(r spectypes.RunnerRole) (bnRole spectypes.BeaconRole, err error) {
 	switch r {
 	case spectypes.RoleCommittee:
 		return spectypes.BNRoleUnknown, errors.New("unexpected committee role")
-	// TODO(convergence unit 5): enable AggregatorCommittee handling.
 	case spectypes.RoleAggregatorCommittee:
 		return spectypes.BNRoleUnknown, errors.New("unexpected aggregator committee role")
 	case spectypes.RoleProposer:
@@ -971,6 +1148,12 @@ func toBNRole(r spectypes.RunnerRole) (bnRole spectypes.BeaconRole, err error) {
 	}
 
 	return
+}
+
+// isCommitteeRunnerRole reports whether the runner role represents a committee-keyed
+// duty trace (Committee or AggregatorCommittee), as opposed to a per-validator duty.
+func isCommitteeRunnerRole(role spectypes.RunnerRole) bool {
+	return role == spectypes.RoleCommittee || role == spectypes.RoleAggregatorCommittee
 }
 
 type validatorDutyTrace struct {
@@ -1013,6 +1196,10 @@ type committeeDutyTrace struct {
 	syncCommitteeRoot phase0.Root
 	attestationRoot   phase0.Root
 	roleRootsReady    bool
+	// Aggregator committee root metadata
+	aggSelectionRoot      phase0.Root
+	aggSelectionRootReady bool
+	aggPostConsensusRoles map[phase0.Root]spectypes.BeaconRole
 	traces.CommitteeDutyTrace
 
 	// Track published quorums to avoid duplicates (validator -> role -> signers hash)
@@ -1022,6 +1209,10 @@ type committeeDutyTrace struct {
 	// Pending signatures grouped by SigningRoot and signer until role roots are known.
 	// Shape: pendingByRoot[root][signer][receivedAt] = []validatorIndices
 	pendingByRoot map[phase0.Root]map[spectypes.OperatorID]map[uint64][]phase0.ValidatorIndex
+
+	// Root-specific signer sets used for quorum checks that must not mix multiple roots
+	// for the same role (e.g., sync committee contribution in aggregator-committee duties).
+	signersByRoot map[phase0.Root]map[phase0.ValidatorIndex]map[spectypes.OperatorID]struct{}
 }
 
 // safeDeepCopy returns a deep copy of the trace data with internal locking.
@@ -1050,6 +1241,26 @@ func (dt *committeeDutyTrace) addPending(root phase0.Root, signer spectypes.Oper
 	buckets[receivedAt] = append(buckets[receivedAt], idx)
 }
 
+// addRootSigner records that signer signed for a given (root, validatorIndex) pair,
+// used for root-scoped quorum checks that must not mix signatures for distinct roots
+// sharing the same beacon-role bucket (e.g. aggregator committee's two selection roots).
+func (dt *committeeDutyTrace) addRootSigner(root phase0.Root, idx phase0.ValidatorIndex, signer spectypes.OperatorID) {
+	if dt.signersByRoot == nil {
+		dt.signersByRoot = make(map[phase0.Root]map[phase0.ValidatorIndex]map[spectypes.OperatorID]struct{})
+	}
+	perValidator, ok := dt.signersByRoot[root]
+	if !ok {
+		perValidator = make(map[phase0.ValidatorIndex]map[spectypes.OperatorID]struct{})
+		dt.signersByRoot[root] = perValidator
+	}
+	signers, ok := perValidator[idx]
+	if !ok {
+		signers = make(map[spectypes.OperatorID]struct{})
+		perValidator[idx] = signers
+	}
+	signers[signer] = struct{}{}
+}
+
 // flushPending routes buffered entries into Attester/SyncCommittee buckets
 // according to derived role roots. Caller must hold dt.Lock().
 func (dt *committeeDutyTrace) flushPending() {
@@ -1057,13 +1268,8 @@ func (dt *committeeDutyTrace) flushPending() {
 		return
 	}
 	for root, perSigner := range dt.pendingByRoot {
-		var role spectypes.BeaconRole
-		switch root {
-		case dt.syncCommitteeRoot:
-			role = spectypes.BNRoleSyncCommittee
-		case dt.attestationRoot:
-			role = spectypes.BNRoleAttester
-		default:
+		role, ok := dt.classifyRootForPending(root)
+		if !ok {
 			// Unknown root; keep buffered
 			continue
 		}
@@ -1079,7 +1285,7 @@ func (dt *committeeDutyTrace) flushPending() {
 				slices.Sort(idxs)
 				idxs = slices.Compact(idxs)
 				sd := &traces.SignerData{Signer: signer, ValidatorIdx: idxs, ReceivedTime: ts}
-				if role == spectypes.BNRoleSyncCommittee {
+				if role == spectypes.BNRoleSyncCommittee || role == spectypes.BNRoleSyncCommitteeContribution {
 					dt.SyncCommittee = append(dt.SyncCommittee, sd)
 				} else {
 					dt.Attester = append(dt.Attester, sd)
@@ -1088,6 +1294,28 @@ func (dt *committeeDutyTrace) flushPending() {
 		}
 		delete(dt.pendingByRoot, root)
 	}
+}
+
+// classifyRootForPending resolves the beacon role a given signing root belongs to,
+// using either the RoleCommittee-derived roots (sync committee / attestation) or the
+// AggregatorCommittee-derived post-consensus roles (aggregator / sync committee contribution).
+func (dt *committeeDutyTrace) classifyRootForPending(root phase0.Root) (spectypes.BeaconRole, bool) {
+	if dt.roleRootsReady {
+		if root == dt.syncCommitteeRoot {
+			return spectypes.BNRoleSyncCommittee, true
+		}
+		if root == dt.attestationRoot {
+			return spectypes.BNRoleAttester, true
+		}
+	}
+
+	if dt.aggPostConsensusRoles != nil {
+		if role, ok := dt.aggPostConsensusRoles[root]; ok {
+			return role, true
+		}
+	}
+
+	return spectypes.BNRoleUnknown, false
 }
 
 func getOrCreateRound(trace *traces.ConsensusTrace, rnd uint64) *traces.RoundTrace {
@@ -1133,17 +1361,16 @@ func (c *Collector) checkAndPublishQuorum(logger *zap.Logger, msg *spectypes.Par
 
 		// Determine role from the signing root and check quorum only for that role.
 		// This prevents false positives where signatures for one role are counted toward another.
-		if trace.roleRootsReady {
-			// Compare against derived per-duty roots
-			if bytes.Equal(trace.syncCommitteeRoot[:], partialMsg.SigningRoot[:]) {
-				c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleSyncCommittee, msg, partialMsg, threshold)
-				continue
+		if msg.Type == spectypes.AggregatorCommitteePartialSig && trace.aggSelectionRootReady {
+			if bytes.Equal(trace.aggSelectionRoot[:], partialMsg.SigningRoot[:]) {
+				c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleAggregator, msg, partialMsg, threshold)
+			} else {
+				c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleSyncCommitteeContribution, msg, partialMsg, threshold)
 			}
-			if bytes.Equal(trace.attestationRoot[:], partialMsg.SigningRoot[:]) {
-				c.checkAndPublishQuorumForRole(logger, trace, spectypes.BNRoleAttester, msg, partialMsg, threshold)
-				continue
-			}
-			// Unknown root; skip quorum check (signature will be in pending)
+			continue
+		}
+		if role, ok := trace.classifyRootForPending(partialMsg.SigningRoot); ok {
+			c.checkAndPublishQuorumForRole(logger, trace, role, msg, partialMsg, threshold)
 			continue
 		}
 		// If roots are not ready yet, signatures are in pending buffer.
@@ -1163,15 +1390,15 @@ func (c *Collector) checkAndPublishQuorumForRole(
 	var signerData []*traces.SignerData
 
 	switch role {
-	case spectypes.BNRoleAttester:
+	case spectypes.BNRoleAttester, spectypes.BNRoleAggregator:
 		signerData = trace.Attester
-	case spectypes.BNRoleSyncCommittee:
+	case spectypes.BNRoleSyncCommittee, spectypes.BNRoleSyncCommitteeContribution:
 		signerData = trace.SyncCommittee
 	default:
 		return
 	}
 
-	signers := c.countUniqueSignersForValidatorAndRoot(logger, signerData, partialMsg.ValidatorIndex, partialMsg.SigningRoot)
+	signers := c.countUniqueSignersForValidatorAndRoot(trace, signerData, partialMsg.ValidatorIndex, partialMsg.SigningRoot)
 	if uint64(len(signers)) < threshold {
 		return
 	}
@@ -1193,10 +1420,9 @@ func (c *Collector) checkAndPublishQuorumForRole(
 	}
 }
 
-// countUniqueSignersForValidatorAndRoot counts unique signers for a specific validator and signing root
-// Note: signerData should already be filtered by role (Attester or SyncCommittee bucket), ensuring
-// all signatures are for the expected root as validated during classification.
-func (c *Collector) countUniqueSignersForValidatorAndRoot(logger *zap.Logger, signerData []*traces.SignerData, validatorIndex phase0.ValidatorIndex, _ phase0.Root) []spectypes.OperatorID {
+// countUniqueSignersForValidator counts unique signers for a specific validator across the
+// given role-bucket signer data, without root-scoping.
+func (c *Collector) countUniqueSignersForValidator(signerData []*traces.SignerData, validatorIndex phase0.ValidatorIndex) []spectypes.OperatorID {
 	signers := make(map[spectypes.OperatorID]struct{})
 
 	for _, data := range signerData {
@@ -1205,13 +1431,38 @@ func (c *Collector) countUniqueSignersForValidatorAndRoot(logger *zap.Logger, si
 		}
 	}
 
-	// Convert map to sorted slice
+	return sortedSigners(signers)
+}
+
+// countUniqueSignersForValidatorAndRoot counts signers for a specific validator and signing root.
+// If root-scoped data is unavailable, it falls back to role-bucket signerData.
+func (c *Collector) countUniqueSignersForValidatorAndRoot(
+	trace *committeeDutyTrace,
+	signerData []*traces.SignerData,
+	validatorIndex phase0.ValidatorIndex,
+	root phase0.Root,
+) []spectypes.OperatorID {
+	if root == (phase0.Root{}) || trace == nil {
+		return c.countUniqueSignersForValidator(signerData, validatorIndex)
+	}
+
+	byValidator, found := trace.signersByRoot[root]
+	if !found {
+		return c.countUniqueSignersForValidator(signerData, validatorIndex)
+	}
+	if signers, found := byValidator[validatorIndex]; found {
+		return sortedSigners(signers)
+	}
+
+	return nil
+}
+
+func sortedSigners(signers map[spectypes.OperatorID]struct{}) []spectypes.OperatorID {
 	result := make([]spectypes.OperatorID, 0, len(signers))
 	for signer := range signers {
 		result = append(result, signer)
 	}
 	slices.Sort(result)
-
 	return result
 }
 
@@ -1243,9 +1494,14 @@ func (c *Collector) checkQuorumAfterFlush(logger *zap.Logger, committeeID specty
 		trace.publishedQuorums = make(map[phase0.ValidatorIndex]map[spectypes.BeaconRole]string)
 	}
 
-	// Check quorum for both roles
-	c.checkRoleQuorumForValidators(logger, trace, spectypes.BNRoleAttester, trace.Attester, slot, threshold)
-	c.checkRoleQuorumForValidators(logger, trace, spectypes.BNRoleSyncCommittee, trace.SyncCommittee, slot, threshold)
+	switch trace.Role {
+	case spectypes.RoleAggregatorCommittee:
+		c.checkRoleQuorumForValidatorsByRoot(logger, trace, spectypes.BNRoleAggregator, slot, threshold)
+		c.checkRoleQuorumForValidatorsByRoot(logger, trace, spectypes.BNRoleSyncCommitteeContribution, slot, threshold)
+	default:
+		c.checkRoleQuorumForValidators(logger, trace, spectypes.BNRoleAttester, trace.Attester, slot, threshold)
+		c.checkRoleQuorumForValidators(logger, trace, spectypes.BNRoleSyncCommittee, trace.SyncCommittee, slot, threshold)
+	}
 }
 
 // checkRoleQuorumForValidators checks quorum for all validators in the given role's signer data.
@@ -1283,6 +1539,38 @@ func (c *Collector) checkRoleQuorumForValidators(
 	}
 }
 
+// checkRoleQuorumForValidatorsByRoot checks quorum for all validators in a specific role and root.
+// IMPORTANT: trace must be locked by the caller before calling this function.
+func (c *Collector) checkRoleQuorumForValidatorsByRoot(
+	logger *zap.Logger,
+	trace *committeeDutyTrace,
+	role spectypes.BeaconRole,
+	slot phase0.Slot,
+	threshold uint64,
+) {
+	for root, byValidator := range trace.signersByRoot {
+		classifiedRole, ok := trace.classifyRootForPending(root)
+		if !ok || classifiedRole != role {
+			continue
+		}
+
+		for validatorIndex := range byValidator {
+			_, exists := c.validators.ValidatorByIndex(validatorIndex)
+			if !exists {
+				logger.Debug("validator not found by index during root-specific quorum check after flush",
+					zap.Uint64("validator_index", uint64(validatorIndex)),
+					fields.BeaconRole(role),
+					fields.Slot(slot))
+				continue
+			}
+			if trace.publishedQuorums[validatorIndex] == nil {
+				trace.publishedQuorums[validatorIndex] = make(map[spectypes.BeaconRole]string)
+			}
+			c.checkAndPublishQuorumForRoleByIndexAndRoot(logger, trace, role, slot, validatorIndex, root, threshold)
+		}
+	}
+}
+
 // checkAndPublishQuorumForRoleByIndex checks quorum for a specific validator and role after flush.
 // Similar to checkAndPublishQuorumForRole but works with validator index directly.
 // IMPORTANT: trace must be locked by the caller before calling this function.
@@ -1294,18 +1582,45 @@ func (c *Collector) checkAndPublishQuorumForRoleByIndex(
 	validatorIndex phase0.ValidatorIndex,
 	threshold uint64,
 ) {
+	c.checkAndPublishQuorumForRoleByIndexCommon(logger, trace, role, slot, validatorIndex, phase0.Root{}, threshold)
+}
+
+// checkAndPublishQuorumForRoleByIndexAndRoot checks quorum for a specific validator and role after
+// flush, scoped to a specific signing root.
+// IMPORTANT: trace must be locked by the caller before calling this function.
+func (c *Collector) checkAndPublishQuorumForRoleByIndexAndRoot(
+	logger *zap.Logger,
+	trace *committeeDutyTrace,
+	role spectypes.BeaconRole,
+	slot phase0.Slot,
+	validatorIndex phase0.ValidatorIndex,
+	root phase0.Root,
+	threshold uint64,
+) {
+	c.checkAndPublishQuorumForRoleByIndexCommon(logger, trace, role, slot, validatorIndex, root, threshold)
+}
+
+func (c *Collector) checkAndPublishQuorumForRoleByIndexCommon(
+	logger *zap.Logger,
+	trace *committeeDutyTrace,
+	role spectypes.BeaconRole,
+	slot phase0.Slot,
+	validatorIndex phase0.ValidatorIndex,
+	root phase0.Root,
+	threshold uint64,
+) {
 	var signerData []*traces.SignerData
 
 	switch role {
-	case spectypes.BNRoleAttester:
+	case spectypes.BNRoleAttester, spectypes.BNRoleAggregator:
 		signerData = trace.Attester
-	case spectypes.BNRoleSyncCommittee:
+	case spectypes.BNRoleSyncCommittee, spectypes.BNRoleSyncCommitteeContribution:
 		signerData = trace.SyncCommittee
 	default:
 		return
 	}
 
-	signers := c.countUniqueSignersForValidatorAndRoot(logger, signerData, validatorIndex, phase0.Root{})
+	signers := c.countUniqueSignersForValidatorAndRoot(trace, signerData, validatorIndex, root)
 	if uint64(len(signers)) < threshold {
 		return
 	}

--- a/exporter/dutytracer/collector_aggregator_test.go
+++ b/exporter/dutytracer/collector_aggregator_test.go
@@ -1,0 +1,343 @@
+package dutytracer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+	"github.com/ssvlabs/ssv/registry/storage"
+	registrystoragemocks "github.com/ssvlabs/ssv/registry/storage/mocks"
+)
+
+// buildAggregatorCommitteeConsensusData builds a minimal, structurally valid
+// AggregatorCommitteeConsensusData with one aggregator duty and one sync-committee
+// contribution duty, and returns its SSZ encoding.
+func buildAggregatorCommitteeConsensusData(t *testing.T) []byte {
+	t.Helper()
+
+	att := &phase0.Attestation{
+		AggregationBits: []byte{0x01},
+		Data: &phase0.AttestationData{
+			Slot:            1,
+			Index:           0,
+			BeaconBlockRoot: phase0.Root{1},
+			Source:          &phase0.Checkpoint{Root: phase0.Root{1}},
+			Target:          &phase0.Checkpoint{Root: phase0.Root{1}},
+		},
+		Signature: phase0.BLSSignature{},
+	}
+	attBytes, err := att.MarshalSSZ()
+	require.NoError(t, err)
+
+	data := &spectypes.AggregatorCommitteeConsensusData{
+		Version:                     spec.DataVersionPhase0,
+		Aggregators:                 []spectypes.AssignedAggregator{{ValidatorIndex: 10, CommitteeIndex: 0, SelectionProof: phase0.BLSSignature{}}},
+		AggregatorsCommitteeIndexes: []uint64{0},
+		AggregatedAttestations:      [][]byte{attBytes},
+		Contributors:                []spectypes.AssignedAggregator{{ValidatorIndex: 20, CommitteeIndex: 0, SelectionProof: phase0.BLSSignature{}}},
+		SyncCommitteeContributions: []altair.SyncCommitteeContribution{
+			{Slot: 1, BeaconBlockRoot: phase0.Root{1}, SubcommitteeIndex: 0, AggregationBits: make([]byte, 16)},
+		},
+	}
+
+	enc, err := data.Encode()
+	require.NoError(t, err)
+	return enc
+}
+
+func TestCollector_computeAggregatorCommitteePostConsensusRoles(t *testing.T) {
+	collector := New(zap.NewNop(), nil, mockclient{}, nil, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	t.Run("success: aggregator and contribution roots classified distinctly", func(t *testing.T) {
+		encoded := buildAggregatorCommitteeConsensusData(t)
+
+		roleByRoot, err := collector.computeAggregatorCommitteePostConsensusRoles(t.Context(), phase0.Slot(1), encoded)
+		require.NoError(t, err)
+		require.Len(t, roleByRoot, 2)
+
+		var aggCount, sccCount int
+		for _, role := range roleByRoot {
+			switch role {
+			case spectypes.BNRoleAggregator:
+				aggCount++
+			case spectypes.BNRoleSyncCommitteeContribution:
+				sccCount++
+			default:
+				t.Fatalf("unexpected role %v", role)
+			}
+		}
+		assert.Equal(t, 1, aggCount)
+		assert.Equal(t, 1, sccCount)
+	})
+
+	t.Run("failure: malformed consensus data returns decode error", func(t *testing.T) {
+		_, err := collector.computeAggregatorCommitteePostConsensusRoles(t.Context(), phase0.Slot(1), []byte{1, 2, 3})
+		require.Error(t, err)
+	})
+}
+
+func TestCollector_getAggregatorSelectionRoot(t *testing.T) {
+	collector := New(zap.NewNop(), nil, mockclient{}, nil, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	root1, err := collector.getAggregatorSelectionRoot(t.Context(), phase0.Slot(5))
+	require.NoError(t, err)
+	assert.NotEqual(t, phase0.Root{}, root1)
+
+	// Cached lookup for the same slot must be deterministic.
+	root2, err := collector.getAggregatorSelectionRoot(t.Context(), phase0.Slot(5))
+	require.NoError(t, err)
+	assert.Equal(t, root1, root2)
+
+	// A different slot must yield a different root (distinct SSZUint64 input).
+	root3, err := collector.getAggregatorSelectionRoot(t.Context(), phase0.Slot(6))
+	require.NoError(t, err)
+	assert.NotEqual(t, root1, root3)
+}
+
+type errDomainClient struct{}
+
+func (errDomainClient) DomainData(ctx context.Context, epoch phase0.Epoch, domain phase0.DomainType) (phase0.Domain, error) {
+	return phase0.Domain{}, assert.AnError
+}
+
+func TestCollector_getAggregatorSelectionRoot_DomainDataError(t *testing.T) {
+	collector := New(zap.NewNop(), nil, errDomainClient{}, nil, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	_, err := collector.getAggregatorSelectionRoot(t.Context(), phase0.Slot(5))
+	require.Error(t, err)
+}
+
+func TestCommitteeDutyTrace_classifyRootForPending(t *testing.T) {
+	rootA := phase0.Root{1}
+	rootB := phase0.Root{2}
+	rootUnknown := phase0.Root{9, 9, 9}
+
+	t.Run("roleRootsReady takes precedence for sync/attestation roots", func(t *testing.T) {
+		dt := &committeeDutyTrace{
+			roleRootsReady:    true,
+			syncCommitteeRoot: rootA,
+			attestationRoot:   rootB,
+		}
+		role, ok := dt.classifyRootForPending(rootA)
+		require.True(t, ok)
+		assert.Equal(t, spectypes.BNRoleSyncCommittee, role)
+
+		role, ok = dt.classifyRootForPending(rootB)
+		require.True(t, ok)
+		assert.Equal(t, spectypes.BNRoleAttester, role)
+	})
+
+	t.Run("falls back to aggPostConsensusRoles when roleRootsReady is false", func(t *testing.T) {
+		dt := &committeeDutyTrace{
+			aggPostConsensusRoles: map[phase0.Root]spectypes.BeaconRole{
+				rootA: spectypes.BNRoleAggregator,
+				rootB: spectypes.BNRoleSyncCommitteeContribution,
+			},
+		}
+		role, ok := dt.classifyRootForPending(rootA)
+		require.True(t, ok)
+		assert.Equal(t, spectypes.BNRoleAggregator, role)
+
+		role, ok = dt.classifyRootForPending(rootB)
+		require.True(t, ok)
+		assert.Equal(t, spectypes.BNRoleSyncCommitteeContribution, role)
+	})
+
+	t.Run("unknown root is not classified", func(t *testing.T) {
+		dt := &committeeDutyTrace{
+			aggPostConsensusRoles: map[phase0.Root]spectypes.BeaconRole{
+				rootA: spectypes.BNRoleAggregator,
+			},
+		}
+		_, ok := dt.classifyRootForPending(rootUnknown)
+		require.False(t, ok)
+	})
+
+	t.Run("empty/nil trace never classifies", func(t *testing.T) {
+		dt := &committeeDutyTrace{}
+		_, ok := dt.classifyRootForPending(rootA)
+		require.False(t, ok)
+	})
+}
+
+// TestCollector_AggregatorCommitteeDuty_PostConsensusQuorum exercises the full
+// AggregatorCommittee post-consensus classification+quorum pipeline through Collect():
+// signatures arriving both before and after the proposal must be classified into the
+// correct beacon-role bucket (aggregator vs sync-committee-contribution) using distinct
+// signing roots, and quorum must only publish once per validator/role once the threshold
+// of unique signers for that exact root is met.
+func TestCollector_AggregatorCommitteeDuty_PostConsensusQuorum(t *testing.T) {
+	logger := zap.NewNop()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	const (
+		slot        = phase0.Slot(1)
+		vIndexAgg   = phase0.ValidatorIndex(10)
+		vIndexContr = phase0.ValidatorIndex(20)
+		operator1   = spectypes.OperatorID(1)
+		operator2   = spectypes.OperatorID(2)
+		operator3   = spectypes.OperatorID(3)
+		operator4   = spectypes.OperatorID(4)
+	)
+
+	identifier := spectypes.NewMsgID([4]byte{}, []byte("agg_committee_pk"), spectypes.RoleAggregatorCommittee)
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], identifier.GetDutyExecutorID()[16:])
+
+	committee := &storage.Committee{
+		ID:        committeeID,
+		Operators: []spectypes.OperatorID{operator1, operator2, operator3, operator4}, // 4 ops -> quorum at 3
+	}
+
+	shareAgg := &ssvtypes.SSVShare{}
+	shareAgg.ValidatorPubKey = spectypes.ValidatorPK{1}
+	shareContr := &ssvtypes.SSVShare{}
+	shareContr.ValidatorPubKey = spectypes.ValidatorPK{2}
+
+	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
+	validators.EXPECT().Committee(committeeID).Return(committee, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndexAgg).Return(shareAgg, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndexContr).Return(shareContr, true).AnyTimes()
+
+	listener := &mockDecidedListener{}
+	dutyStore := new(mockDutyTraceStore)
+	tracer := New(logger, validators, mockclient{}, dutyStore, networkconfig.TestNetwork.Beacon, listener.OnDecided, nil)
+
+	encodedConsensusData := buildAggregatorCommitteeConsensusData(t)
+	roleByRoot, err := tracer.computeAggregatorCommitteePostConsensusRoles(t.Context(), slot, encodedConsensusData)
+	require.NoError(t, err)
+	require.Len(t, roleByRoot, 2)
+
+	var aggregatorRoot, contributionRoot phase0.Root
+	for root, role := range roleByRoot {
+		switch role {
+		case spectypes.BNRoleAggregator:
+			aggregatorRoot = root
+		case spectypes.BNRoleSyncCommitteeContribution:
+			contributionRoot = root
+		}
+	}
+	require.NotEqual(t, phase0.Root{}, aggregatorRoot)
+	require.NotEqual(t, phase0.Root{}, contributionRoot)
+	require.NotEqual(t, aggregatorRoot, contributionRoot)
+
+	fakeSig := [96]byte{}
+
+	sendPostConsensus := func(vIdx phase0.ValidatorIndex, op spectypes.OperatorID, root phase0.Root) {
+		msgs := &spectypes.PartialSignatureMessages{
+			Type: spectypes.PostConsensusPartialSig,
+			Slot: slot,
+			Messages: []*spectypes.PartialSignatureMessage{
+				{ValidatorIndex: vIdx, Signer: op, PartialSignature: fakeSig[:], SigningRoot: root},
+			},
+		}
+		data, encErr := msgs.Encode()
+		require.NoError(t, encErr)
+		require.NoError(t, tracer.Collect(t.Context(), buildPartialSigMessage(identifier, data), dummyVerify))
+	}
+
+	// Step 1: two signers for each duty arrive BEFORE the proposal (below quorum, buffered as pending).
+	sendPostConsensus(vIndexAgg, operator1, aggregatorRoot)
+	sendPostConsensus(vIndexAgg, operator2, aggregatorRoot)
+	sendPostConsensus(vIndexContr, operator1, contributionRoot)
+	sendPostConsensus(vIndexContr, operator2, contributionRoot)
+
+	require.Empty(t, listener.GetCalls(), "no quorum should be published before proposal classifies pending roots")
+
+	// Step 2: proposal arrives, deriving post-consensus roles and flushing pending signatures.
+	proposalMsg := buildConsensusMsg(identifier, specqbft.ProposalMsgType, slot, nil)
+	proposalMsg.SignedSSVMessage.FullData = encodedConsensusData
+	require.NoError(t, tracer.Collect(t.Context(), proposalMsg, dummyVerify))
+
+	duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.NotNil(t, duty)
+	assert.Equal(t, spectypes.RoleAggregatorCommittee, duty.Role)
+	// Aggregator role is bucketed under Attester; SyncCommitteeContribution under SyncCommittee.
+	require.NotEmpty(t, duty.Attester)
+	require.NotEmpty(t, duty.SyncCommittee)
+
+	// Still below quorum (2/4, need 3).
+	require.Empty(t, listener.GetCalls(), "2 signers is below quorum threshold")
+
+	// Step 3: third signer arrives for the aggregator duty only -> reaches quorum for vIndexAgg/Aggregator.
+	sendPostConsensus(vIndexAgg, operator3, aggregatorRoot)
+
+	calls := listener.GetCalls()
+	require.Len(t, calls, 1, "only the aggregator duty should have reached quorum")
+	assert.Equal(t, vIndexAgg, calls[0].Index)
+	assert.Equal(t, spectypes.BNRoleAggregator, calls[0].Role)
+	assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, calls[0].Signers)
+
+	// The sync-committee-contribution duty must remain unpublished (still 2/4).
+	for _, c := range calls {
+		assert.NotEqual(t, spectypes.BNRoleSyncCommitteeContribution, c.Role)
+	}
+
+	// Step 4: third signer arrives for the contribution duty -> reaches quorum for vIndexContr/SCC.
+	listener.Reset()
+	sendPostConsensus(vIndexContr, operator3, contributionRoot)
+
+	calls = listener.GetCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, vIndexContr, calls[0].Index)
+	assert.Equal(t, spectypes.BNRoleSyncCommitteeContribution, calls[0].Role)
+	assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, calls[0].Signers)
+}
+
+// TestCollector_AggregatorCommitteeDuty_UnknownRootBuffersUntilProposal ensures that
+// post-consensus signatures with a signing root that doesn't match either derived
+// AggregatorCommittee role root are buffered (not misclassified) and remain buffered
+// even after the proposal arrives, since they don't match any known root.
+func TestCollector_AggregatorCommitteeDuty_UnknownRootBuffersUntilProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	const slot = phase0.Slot(2)
+	identifier := spectypes.NewMsgID([4]byte{}, []byte("agg_committee_pk_2"), spectypes.RoleAggregatorCommittee)
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], identifier.GetDutyExecutorID()[16:])
+
+	committee := &storage.Committee{ID: committeeID, Operators: []spectypes.OperatorID{1, 2, 3, 4}}
+	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
+	validators.EXPECT().Committee(committeeID).Return(committee, true).AnyTimes()
+
+	dutyStore := new(mockDutyTraceStore)
+	tracer := New(zap.NewNop(), validators, mockclient{}, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	encodedConsensusData := buildAggregatorCommitteeConsensusData(t)
+	unknownRoot := phase0.Root{123, 123, 123}
+	fakeSig := [96]byte{}
+
+	msgs := &spectypes.PartialSignatureMessages{
+		Type: spectypes.PostConsensusPartialSig,
+		Slot: slot,
+		Messages: []*spectypes.PartialSignatureMessage{
+			{ValidatorIndex: 99, Signer: 1, PartialSignature: fakeSig[:], SigningRoot: unknownRoot},
+		},
+	}
+	data, err := msgs.Encode()
+	require.NoError(t, err)
+	require.NoError(t, tracer.Collect(t.Context(), buildPartialSigMessage(identifier, data), dummyVerify))
+
+	proposalMsg := buildConsensusMsg(identifier, specqbft.ProposalMsgType, slot, nil)
+	proposalMsg.SignedSSVMessage.FullData = encodedConsensusData
+	require.NoError(t, tracer.Collect(t.Context(), proposalMsg, dummyVerify))
+
+	duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.Empty(t, duty.Attester, "unknown root must not be classified as an aggregator signer")
+	require.Empty(t, duty.SyncCommittee, "unknown root must not be classified as a sync-committee-contribution signer")
+}

--- a/exporter/dutytracer/collector_aggregator_test.go
+++ b/exporter/dutytracer/collector_aggregator_test.go
@@ -299,6 +299,109 @@ func TestCollector_AggregatorCommitteeDuty_PostConsensusQuorum(t *testing.T) {
 	assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, calls[0].Signers)
 }
 
+// TestCollector_AggregatorCommitteeDuty_PreConsensusQuorum exercises the AggregatorCommittee
+// PRE-consensus (selection-proof) classification+quorum pipeline through Collect(): partial
+// signatures of type AggregatorCommitteePartialSig are classified by comparing their signing
+// root against the derived aggregator selection root — a match buckets the validator under
+// Attester (aggregator), everything else under SyncCommittee (contribution). No proposal is
+// required, since the selection root is derived on the fly. Quorum must publish once per
+// validator/role once the threshold of unique signers for that exact root is met.
+func TestCollector_AggregatorCommitteeDuty_PreConsensusQuorum(t *testing.T) {
+	logger := zap.NewNop()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	const (
+		slot        = phase0.Slot(3)
+		vIndexAgg   = phase0.ValidatorIndex(10)
+		vIndexContr = phase0.ValidatorIndex(20)
+		operator1   = spectypes.OperatorID(1)
+		operator2   = spectypes.OperatorID(2)
+		operator3   = spectypes.OperatorID(3)
+		operator4   = spectypes.OperatorID(4)
+	)
+
+	identifier := spectypes.NewMsgID([4]byte{}, []byte("agg_committee_pk_pre"), spectypes.RoleAggregatorCommittee)
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], identifier.GetDutyExecutorID()[16:])
+
+	committee := &storage.Committee{
+		ID:        committeeID,
+		Operators: []spectypes.OperatorID{operator1, operator2, operator3, operator4}, // 4 ops -> quorum at 3
+	}
+
+	shareAgg := &ssvtypes.SSVShare{}
+	shareAgg.ValidatorPubKey = spectypes.ValidatorPK{1}
+	shareContr := &ssvtypes.SSVShare{}
+	shareContr.ValidatorPubKey = spectypes.ValidatorPK{2}
+
+	validators := registrystoragemocks.NewMockValidatorStore(ctrl)
+	validators.EXPECT().Committee(committeeID).Return(committee, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndexAgg).Return(shareAgg, true).AnyTimes()
+	validators.EXPECT().ValidatorByIndex(vIndexContr).Return(shareContr, true).AnyTimes()
+
+	listener := &mockDecidedListener{}
+	dutyStore := new(mockDutyTraceStore)
+	tracer := New(logger, validators, mockclient{}, dutyStore, networkconfig.TestNetwork.Beacon, listener.OnDecided, nil)
+
+	// The aggregator selection root is derived on the fly (no proposal needed). Signatures
+	// carrying it are aggregator duties; any other root is a sync-committee contribution.
+	selectionRoot, err := tracer.getAggregatorSelectionRoot(t.Context(), slot)
+	require.NoError(t, err)
+	contributionRoot := phase0.Root{0xAB, 0xCD}
+	require.NotEqual(t, selectionRoot, contributionRoot)
+
+	fakeSig := [96]byte{}
+
+	sendPreConsensus := func(vIdx phase0.ValidatorIndex, op spectypes.OperatorID, root phase0.Root) {
+		msgs := &spectypes.PartialSignatureMessages{
+			Type: spectypes.AggregatorCommitteePartialSig,
+			Slot: slot,
+			Messages: []*spectypes.PartialSignatureMessage{
+				{ValidatorIndex: vIdx, Signer: op, PartialSignature: fakeSig[:], SigningRoot: root},
+			},
+		}
+		data, encErr := msgs.Encode()
+		require.NoError(t, encErr)
+		require.NoError(t, tracer.Collect(t.Context(), buildPartialSigMessage(identifier, data), dummyVerify))
+	}
+
+	// Step 1: two signers for each duty (below quorum). Classification is immediate — no proposal.
+	sendPreConsensus(vIndexAgg, operator1, selectionRoot)
+	sendPreConsensus(vIndexAgg, operator2, selectionRoot)
+	sendPreConsensus(vIndexContr, operator1, contributionRoot)
+	sendPreConsensus(vIndexContr, operator2, contributionRoot)
+
+	require.Empty(t, listener.GetCalls(), "2 signers is below quorum threshold")
+
+	// The selection root must bucket into Attester; the other root into SyncCommittee.
+	duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.NotNil(t, duty)
+	assert.Equal(t, spectypes.RoleAggregatorCommittee, duty.Role)
+	require.NotEmpty(t, duty.Attester, "selection-root signatures must bucket under Attester (aggregator)")
+	require.NotEmpty(t, duty.SyncCommittee, "non-selection-root signatures must bucket under SyncCommittee (contribution)")
+
+	// Step 2: third signer for the aggregator duty only -> quorum for vIndexAgg/Aggregator.
+	sendPreConsensus(vIndexAgg, operator3, selectionRoot)
+
+	calls := listener.GetCalls()
+	require.Len(t, calls, 1, "only the aggregator duty should have reached quorum")
+	assert.Equal(t, vIndexAgg, calls[0].Index)
+	assert.Equal(t, spectypes.BNRoleAggregator, calls[0].Role)
+	assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, calls[0].Signers)
+
+	// Step 3: third signer for the contribution duty -> quorum for vIndexContr/SCC.
+	listener.Reset()
+	sendPreConsensus(vIndexContr, operator3, contributionRoot)
+
+	calls = listener.GetCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, vIndexContr, calls[0].Index)
+	assert.Equal(t, spectypes.BNRoleSyncCommitteeContribution, calls[0].Role)
+	assert.ElementsMatch(t, []spectypes.OperatorID{operator1, operator2, operator3}, calls[0].Signers)
+}
+
 // TestCollector_AggregatorCommitteeDuty_UnknownRootBuffersUntilProposal ensures that
 // post-consensus signatures with a signing root that doesn't match either derived
 // AggregatorCommittee role root are buffered (not misclassified) and remain buffered

--- a/exporter/dutytracer/collector_aggregator_test.go
+++ b/exporter/dutytracer/collector_aggregator_test.go
@@ -227,6 +227,8 @@ func TestCollector_AggregatorCommitteeDuty_PostConsensusQuorum(t *testing.T) {
 			aggregatorRoot = root
 		case spectypes.BNRoleSyncCommitteeContribution:
 			contributionRoot = root
+		default:
+			t.Fatalf("unexpected beacon role %v", role)
 		}
 	}
 	require.NotEqual(t, phase0.Root{}, aggregatorRoot)

--- a/exporter/dutytracer/collector_quorum_test.go
+++ b/exporter/dutytracer/collector_quorum_test.go
@@ -89,7 +89,7 @@ func TestCollector_QuorumAfterFlush(t *testing.T) {
 		require.Len(t, calls, 0, "no quorum should be detected before proposal arrives")
 
 		// Step 2: Proposal arrives with attestation and sync committee roots
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 
 		trace.Lock()
@@ -165,7 +165,7 @@ func TestCollector_RoleSpecificQuorum(t *testing.T) {
 		listener.Reset()
 
 		// Set up roots
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = attestationRoot
 		trace.syncCommitteeRoot = syncCommitteeRoot
@@ -285,7 +285,7 @@ func TestCollector_MixedTimingQuorum(t *testing.T) {
 		require.Len(t, calls, 0)
 
 		// Step 2: Proposal arrives
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 
 		trace.Lock()
@@ -374,7 +374,7 @@ func TestCollector_UnknownRootQuorum(t *testing.T) {
 		listener.Reset()
 
 		// Set up roots
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = attestationRoot
 		trace.syncCommitteeRoot = syncCommitteeRoot
@@ -417,7 +417,7 @@ func TestCollector_UnknownRootQuorum(t *testing.T) {
 		require.Len(t, calls, 0, "unknown root signatures should not contribute to quorum")
 
 		// Verify unknown root is in pending
-		trace, _, err = collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err = collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.Lock()
 		assert.Contains(t, trace.pendingByRoot, unknownRoot, "unknown root should be in pending")
@@ -477,7 +477,7 @@ func TestCollector_MultipleValidatorsAndRoles(t *testing.T) {
 		listener.Reset()
 
 		// Set up roots
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = attestationRoot
 		trace.syncCommitteeRoot = syncCommitteeRoot
@@ -566,7 +566,7 @@ func TestCollector_checkAndPublishQuorumForRoleByIndex(t *testing.T) {
 		listener.Reset()
 
 		// Manually populate trace with signer data
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 
 		trace.Lock()
@@ -598,7 +598,7 @@ func TestCollector_checkAndPublishQuorumForRoleByIndex(t *testing.T) {
 	t.Run("no duplicate publication on subsequent calls", func(t *testing.T) {
 		listener.Reset()
 
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 
 		trace.Lock()

--- a/exporter/dutytracer/collector_test.go
+++ b/exporter/dutytracer/collector_test.go
@@ -486,7 +486,7 @@ func TestCommitteeDuty(t *testing.T) {
 		partSigMsg := buildPartialSigMessage(identifier, partSigMessagesData)
 		tracer.Collect(t.Context(), partSigMsg, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -506,7 +506,7 @@ func TestCommitteeDuty(t *testing.T) {
 		proposal := buildCommitteeProposalWithBeaconVote(identifier, slot, testBVData)
 		tracer.Collect(t.Context(), proposal, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -527,7 +527,7 @@ func TestCommitteeDuty(t *testing.T) {
 		proposalMsg := buildConsensusMsg(identifier, specqbft.ProposalMsgType, slot, nil)
 		tracer.Collect(t.Context(), proposalMsg, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -553,7 +553,7 @@ func TestCommitteeDuty(t *testing.T) {
 		prepareMsg := buildConsensusMsg(identifier, specqbft.PrepareMsgType, slot, nil)
 		tracer.Collect(t.Context(), prepareMsg, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -579,7 +579,7 @@ func TestCommitteeDuty(t *testing.T) {
 		decided := buildConsensusMsg(identifier, specqbft.CommitMsgType, slot, generateDecidedMessage(t, identifier))
 		tracer.Collect(t.Context(), decided, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -620,7 +620,7 @@ func TestCommitteeDuty(t *testing.T) {
 
 		tracer.Collect(t.Context(), commitMsg, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -643,7 +643,7 @@ func TestCommitteeDuty(t *testing.T) {
 		roundChangeMsg1 := buildConsensusMsg(identifier, specqbft.RoundChangeMsgType, slot, nil)
 		tracer.Collect(t.Context(), roundChangeMsg1, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -671,7 +671,7 @@ func TestCommitteeDuty(t *testing.T) {
 
 		tracer.Collect(t.Context(), roundChangeMsg2, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -700,7 +700,7 @@ func TestCommitteeDuty(t *testing.T) {
 
 		tracer.Collect(t.Context(), proposalMsg, dummyVerify)
 
-		duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+		duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		require.NotNil(t, duty)
 		assert.Equal(t, slot, duty.Slot)
@@ -723,7 +723,7 @@ func TestCommitteeDuty(t *testing.T) {
 		require.Empty(t, round1.Commits)
 	}
 
-	duties, err := tracer.GetCommitteeDuties(slot, spectypes.BNRoleAttester)
+	duties, err := tracer.GetCommitteeDuties(slot, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	require.NotNil(t, duties)
 	require.Len(t, duties, 1)
@@ -745,27 +745,77 @@ func TestCollector_GetCommitteeDuty(t *testing.T) {
 	committeeID := spectypes.CommitteeID{1}
 	slot := phase0.Slot(10)
 
-	_, err := collector.GetCommitteeDuty(slot, committeeID, spectypes.BNRoleAttester)
-	require.ErrorIs(t, err, ErrNotFound)
-	dutyStore.committeeDutyTrace.Attester = append(dutyStore.committeeDutyTrace.Attester,
-		&traces.SignerData{
-			Signer: 1,
-		})
-
-	duty, err := collector.GetCommitteeDuty(slot, committeeID, spectypes.BNRoleAttester)
+	duty, err := collector.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	require.NotNil(t, duty)
 	require.Equal(t, slot, duty.Slot)
 	require.Equal(t, committeeID, duty.CommitteeID)
 
-	dutyStore.committeeDutyTrace.SyncCommittee = append(dutyStore.committeeDutyTrace.SyncCommittee,
-		&traces.SignerData{
-			Signer: 1,
-		})
+	// Requesting the aggregator-committee role must not return the committee-role trace.
+	_, err = collector.GetCommitteeDuty(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.ErrorIs(t, err, ErrNotFound)
+}
 
-	duty, err = collector.GetCommitteeDuty(slot, committeeID, spectypes.BNRoleSyncCommittee)
+// TestCollector_CommitteeAndAggregatorCommitteeTracesCoexist is a regression guard: Committee and
+// AggregatorCommittee duty traces for the SAME committeeID+slot must be kept as two distinct
+// in-memory cache entries (keyed by {committeeID, role}), not overwrite one another.
+func TestCollector_CommitteeAndAggregatorCommitteeTracesCoexist(t *testing.T) {
+	logger := zap.NewNop()
+	ctrl := gomock.NewController(t)
+	vstore := registrystoragemocks.NewMockValidatorStore(ctrl)
+	dutyStore := new(mockDutyTraceStore)
+
+	collector := New(logger, vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	slot := phase0.Slot(50)
+	committeeID := spectypes.CommitteeID{7}
+
+	committeeTrace, lateC, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 	require.NoError(t, err)
-	require.NotNil(t, duty)
+	require.False(t, lateC)
+	require.NotNil(t, committeeTrace)
+	committeeTrace.OperatorIDs = []uint64{1, 2, 3}
+
+	aggTrace, lateA, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.False(t, lateA)
+	require.NotNil(t, aggTrace)
+	aggTrace.OperatorIDs = []uint64{4, 5, 6}
+
+	// The two traces must be distinct objects, not aliases of the same underlying trace.
+	require.NotSame(t, committeeTrace, aggTrace)
+	require.Equal(t, spectypes.RoleCommittee, committeeTrace.Role)
+	require.Equal(t, spectypes.RoleAggregatorCommittee, aggTrace.Role)
+	require.Equal(t, []uint64{1, 2, 3}, committeeTrace.OperatorIDs)
+	require.Equal(t, []uint64{4, 5, 6}, aggTrace.OperatorIDs)
+
+	// Re-fetching by role must yield the same (unmutated-by-the-other-role) trace.
+	committeeTraceAgain, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3}, committeeTraceAgain.OperatorIDs)
+
+	aggTraceAgain, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{4, 5, 6}, aggTraceAgain.OperatorIDs)
+
+	// Both keys must be present in the committeeTraces cache.
+	var foundRoles []spectypes.RunnerRole
+	collector.committeeTraces.Range(func(key committeeTraceKey, _ *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+		if key.id == committeeID {
+			foundRoles = append(foundRoles, key.role)
+		}
+		return true
+	})
+	require.ElementsMatch(t, []spectypes.RunnerRole{spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee}, foundRoles)
+
+	// GetCommitteeDuty must resolve each role independently.
+	duty, err := collector.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3}, duty.OperatorIDs)
+
+	aggDuty, err := collector.GetCommitteeDuty(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{4, 5, 6}, aggDuty.OperatorIDs)
 }
 
 func buildPartialSigMessage(identifier spectypes.MessageID, data []byte) *queue.SSVMessage {
@@ -935,7 +985,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		collector.lastEvictedSlot.Store(uint64(5))
 
 		t.Run("committee not found", func(t *testing.T) {
-			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.False(t, late)
 			require.NotNil(t, trace)
@@ -944,10 +994,10 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		})
 
 		t.Run("committee found, slot not found", func(t *testing.T) {
-			_, _, err := collector.getOrCreateCommitteeTrace(slot-1, committeeID) // create for committee
+			_, _, err := collector.getOrCreateCommitteeTrace(slot-1, committeeID, spectypes.RoleCommittee) // create for committee
 			require.NoError(t, err)
 
-			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.False(t, late)
 			require.NotNil(t, trace)
@@ -955,10 +1005,10 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		})
 
 		t.Run("committee and slot found", func(t *testing.T) {
-			trace1, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace1, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 
-			trace2, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace2, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.False(t, late)
 			require.Same(t, trace1, trace2)
@@ -972,9 +1022,9 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		t.Run("committeeID is in flight", func(t *testing.T) {
 			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
-			_, _ = collector.inFlightCommittee.GetOrSet(committeeID, struct{}{})
+			_, _ = collector.inFlightCommittee.GetOrSet(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}, struct{}{})
 
-			_, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			_, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.ErrorIs(t, err, errInFlight)
 			require.False(t, late)
 		})
@@ -983,7 +1033,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
-			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.True(t, late)
 			require.NotNil(t, trace)
@@ -994,13 +1044,13 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 		t.Run("committeeID found on disk", func(t *testing.T) {
 			collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
 			// Setup: Create a collector, save a trace, and then evict it to disk.
-			trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			trace.OperatorIDs = []uint64{1, 2, 3}
 			collector.store.SaveCommitteeDuties(slot, spectypes.RoleCommittee, []*traces.CommitteeDutyTrace{trace.safeDeepCopy()})
 			collector.lastEvictedSlot.Store(uint64(slot))
 			// Test: Create a new collector to ensure cache is empty and get the trace.
-			diskTrace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			diskTrace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.True(t, late)
 			require.NotNil(t, diskTrace)
@@ -1016,11 +1066,11 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 			collector := New(zap.NewNop(), vstore, nil, dutyTraceStore, networkconfig.TestNetwork.Beacon, nil, nil)
 			collector.lastEvictedSlot.Store(uint64(evictionSlot))
 
-			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+			trace, late, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 			require.ErrorIs(t, err, innerErr)
 			require.False(t, late)
 			require.Nil(t, trace)
-			require.False(t, collector.inFlightCommittee.Has(committeeID))
+			require.False(t, collector.inFlightCommittee.Has(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}))
 		})
 	})
 }
@@ -1046,7 +1096,7 @@ func TestCollector_processPartialSigCommittee_UnknownRootBuffers(t *testing.T) {
 	validators.EXPECT().Committee(committeeID).Return(committee, true).AnyTimes()
 
 	// Prepare the trace with known roots so the message root is treated as unknown
-	trace, _, err := tracer.getOrCreateCommitteeTrace(slot, committeeID)
+	trace, _, err := tracer.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	trace.Lock()
 	trace.roleRootsReady = true
@@ -1073,7 +1123,7 @@ func TestCollector_processPartialSigCommittee_UnknownRootBuffers(t *testing.T) {
 	require.NoError(t, tracer.Collect(t.Context(), msg, dummyVerify))
 
 	// Inspect internal pending buffer; nothing should be classified yet
-	trace2, _, err := tracer.getOrCreateCommitteeTrace(slot, committeeID)
+	trace2, _, err := tracer.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	trace2.Lock()
 	defer trace2.Unlock()
@@ -1151,7 +1201,7 @@ func TestCollector_FlushPending_Timestamps(t *testing.T) {
 	require.NoError(t, tracer.Collect(t.Context(), proposal, dummyVerify))
 
 	// Now the committee duty should contain two signer records for the same signer with distinct timestamps
-	duty, err := tracer.GetCommitteeDuty(slot, committeeID)
+	duty, err := tracer.GetCommitteeDuty(slot, committeeID, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	require.NotNil(t, duty)
 
@@ -1501,12 +1551,12 @@ func TestCollector_lateMessage(t *testing.T) {
 
 		var committeeID spectypes.CommitteeID
 		copy(committeeID[:], msgID.GetDutyExecutorID()[16:])
-		collector.inFlightCommittee.Set(committeeID, struct{}{})
+		collector.inFlightCommittee.Set(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}, struct{}{})
 		collector.lastEvictedSlot.Store(uint64(1))
 
 		go func() {
 			time.Sleep(time.Millisecond * 400)
-			collector.inFlightCommittee.Delete(committeeID)
+			collector.inFlightCommittee.Delete(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee})
 		}()
 
 		dutyStore.err = errors.New("error")
@@ -1540,7 +1590,7 @@ func TestCollector_lateMessage(t *testing.T) {
 
 		var committeeID spectypes.CommitteeID
 		copy(committeeID[:], msgID.GetDutyExecutorID()[16:])
-		collector.inFlightCommittee.Set(committeeID, struct{}{})
+		collector.inFlightCommittee.Set(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}, struct{}{})
 		collector.lastEvictedSlot.Store(uint64(1))
 		collector.collectLateMessage(t.Context(), msg, nil)
 
@@ -1581,7 +1631,7 @@ func buildInFlightLateMsg(c *Collector) *queue.SSVMessage {
 	msgID := spectypes.NewMsgID(spectypes.DomainType{1}, []byte{1}, spectypes.RoleCommittee)
 	var committeeID spectypes.CommitteeID
 	copy(committeeID[:], msgID.GetDutyExecutorID()[16:])
-	c.inFlightCommittee.Set(committeeID, struct{}{})
+	c.inFlightCommittee.Set(committeeTraceKey{id: committeeID, role: spectypes.RoleCommittee}, struct{}{})
 	c.lastEvictedSlot.Store(uint64(1))
 	return &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
@@ -1773,7 +1823,7 @@ func TestCollector_PublishDecidedsToListener(t *testing.T) {
 		listener.Reset()
 
 		// Pre-derive attester root so classification is active
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = signingRoot
 		trace.roleRootsReady = true
@@ -1836,7 +1886,7 @@ func TestCollector_PublishDecidedsToListener(t *testing.T) {
 		listener.Reset()
 
 		// Prepare roots for the same committee at the slot
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = signingRoot
 		trace.roleRootsReady = true
@@ -1875,7 +1925,7 @@ func TestCollector_PublishDecidedsToListener(t *testing.T) {
 		listener.Reset()
 
 		// Prepare roots for slot+1 as well
-		trace, _, err := collector.getOrCreateCommitteeTrace(slot+1, committeeID)
+		trace, _, err := collector.getOrCreateCommitteeTrace(slot+1, committeeID, spectypes.RoleCommittee)
 		require.NoError(t, err)
 		trace.attestationRoot = signingRoot
 		trace.roleRootsReady = true
@@ -1955,6 +2005,9 @@ func (m *mockDutyTraceStore) SaveCommitteeDuty(role spectypes.RunnerRole, duty *
 }
 
 func (m *mockDutyTraceStore) GetCommitteeDuty(slot phase0.Slot, role spectypes.RunnerRole, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+	if role != spectypes.RoleCommittee {
+		return nil, ErrNotFound
+	}
 	return m.committeeDutyTrace, m.err
 }
 

--- a/exporter/dutytracer/eviction.go
+++ b/exporter/dutytracer/eviction.go
@@ -131,6 +131,20 @@ func (c *Collector) dumpValidatorToDBPeriodically(slot phase0.Slot) (totalSaved 
 }
 
 // pendingDetails constructs a single zap field named "pending_signers_by_root"
+// countPending returns the total number of pending validator-index entries
+// held in a pendingByRoot map, across all roots, signers and timestamps.
+func countPending(data map[phase0.Root]map[spectypes.OperatorID]map[uint64][]phase0.ValidatorIndex) int {
+	count := 0
+	for _, perSigner := range data {
+		for _, byTs := range perSigner {
+			for _, idxs := range byTs {
+				count += len(idxs)
+			}
+		}
+	}
+	return count
+}
+
 // that logs the content of pendingByRoot in a JSON-friendly structure.
 func pendingDetails(data map[phase0.Root]map[spectypes.OperatorID]map[uint64][]phase0.ValidatorIndex) zap.Field {
 	out := make(map[string]map[string]any, len(data))

--- a/exporter/dutytracer/eviction.go
+++ b/exporter/dutytracer/eviction.go
@@ -43,9 +43,9 @@ func (c *Collector) dumpLinkToDBPeriodically(slot phase0.Slot) (totalSaved int) 
 }
 
 func (c *Collector) dumpCommitteeToDBPeriodically(slot phase0.Slot) (totalSaved int) {
-	var duties []*traces.CommitteeDutyTrace
+	dutiesByRole := make(map[spectypes.RunnerRole][]*traces.CommitteeDutyTrace)
 
-	c.committeeTraces.Range(func(key spectypes.CommitteeID, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+	c.committeeTraces.Range(func(key committeeTraceKey, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
 		trace, found := slotToTraceMap.Get(slot)
 		if !found {
 			return true
@@ -68,7 +68,7 @@ func (c *Collector) dumpCommitteeToDBPeriodically(slot phase0.Slot) (totalSaved 
 		}
 		if pendingCount > 0 {
 			c.logger.Error("dropping buffered pending signatures during eviction (proposal never arrived or failed to establish role roots)",
-				fields.Slot(slot), fields.CommitteeID(key),
+				fields.Slot(slot), fields.CommitteeID(key.id),
 				zap.Int("pending_entries", pendingCount),
 				pendingDetails(trace.pendingByRoot))
 			// We intentionally drop pending entries here; they are not persisted.
@@ -79,16 +79,21 @@ func (c *Collector) dumpCommitteeToDBPeriodically(slot phase0.Slot) (totalSaved 
 		data := trace.DeepCopy()
 		trace.Unlock()
 
-		duties = append(duties, data)
+		dutiesByRole[key.role] = append(dutiesByRole[key.role], data)
 		return true
 	})
 
-	if err := c.store.SaveCommitteeDuties(slot, spectypes.RoleCommittee, duties); err != nil {
-		c.logger.Error("save committee duties to disk", zap.Error(err))
-		return 0
+	for role, duties := range dutiesByRole {
+		if len(duties) == 0 {
+			continue
+		}
+		if err := c.store.SaveCommitteeDuties(slot, role, duties); err != nil {
+			c.logger.Error("save committee duties to disk", zap.Error(err), fields.RunnerRole(role))
+			continue
+		}
+		totalSaved += len(duties)
 	}
 
-	totalSaved = len(duties)
 	return totalSaved
 }
 

--- a/exporter/dutytracer/eviction_test.go
+++ b/exporter/dutytracer/eviction_test.go
@@ -65,7 +65,7 @@ func TestEviction(t *testing.T) {
 		return true
 	})
 
-	collector.committeeTraces.Range(func(committeeID spectypes.CommitteeID, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+	collector.committeeTraces.Range(func(key committeeTraceKey, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
 		_, found := slotToTraceMap.Get(slot1)
 		if found {
 			t.Fatalf("committee: slot %d not evicted", slot1)

--- a/exporter/dutytracer/store.go
+++ b/exporter/dutytracer/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ssvlabs/ssv/exporter/rolemask"
 	"github.com/ssvlabs/ssv/exporter/traces"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
@@ -128,11 +129,14 @@ func (c *Collector) getValidatorDutyFromDiskIndex(role spectypes.BeaconRole, slo
 	return trace, nil
 }
 
-func (c *Collector) GetCommitteeDuties(wantSlot phase0.Slot, roles ...spectypes.BeaconRole) ([]*traces.CommitteeDutyTrace, error) {
+func (c *Collector) GetCommitteeDuties(wantSlot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error) {
 	var duties []*traces.CommitteeDutyTrace
 	var errs *multierror.Error
 
-	c.committeeTraces.Range(func(committeeID spectypes.CommitteeID, committeeSlots *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+	c.committeeTraces.Range(func(key committeeTraceKey, committeeSlots *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+		if len(roles) > 0 && !slices.Contains(roles, key.role) {
+			return true
+		}
 		dt, found := committeeSlots.Get(wantSlot)
 		if found {
 			duties = append(duties, dt.safeDeepCopy())
@@ -140,84 +144,58 @@ func (c *Collector) GetCommitteeDuties(wantSlot phase0.Slot, roles ...spectypes.
 		return true // keep iterating
 	})
 
-	diskDuties, err := c.store.GetCommitteeDuties(wantSlot, spectypes.RoleCommittee)
+	diskDuties, err := c.store.GetCommitteeDuties(wantSlot, roles...)
 	duties = append(duties, diskDuties...)
 	errs = multierror.Append(errs, err)
-
-	var filteredDuties []*traces.CommitteeDutyTrace
-	for _, duty := range duties {
-		if hasSignersForRoles(duty, roles...) {
-			filteredDuties = append(filteredDuties, duty)
-		}
-	}
-
-	return filteredDuties, errs.ErrorOrNil()
+	return duties, errs.ErrorOrNil()
 }
 
-func (c *Collector) GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, roles ...spectypes.BeaconRole) (*traces.CommitteeDutyTrace, error) {
-	committeeSlots, found := c.committeeTraces.Get(committeeID)
-	if !found {
-		trace, err := c.getCommitteeDutyFromDisk(slot, committeeID)
-		if err != nil {
-			return nil, err
+func (c *Collector) GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
+	key := committeeTraceKey{id: committeeID, role: role}
+	if committeeSlots, found := c.committeeTraces.Get(key); found {
+		if trace, found := committeeSlots.Get(slot); found {
+			return trace.safeDeepCopy(), nil
 		}
-
-		if hasSignersForRoles(trace, roles...) {
-			return trace, nil
-		}
-
-		return nil, ErrNotFound
 	}
 
-	trace, found := committeeSlots.Get(slot)
-	if !found {
-		trace, err := c.getCommitteeDutyFromDisk(slot, committeeID)
-		if err != nil {
-			return nil, err
-		}
-
-		if hasSignersForRoles(trace, roles...) {
-			return trace, nil
-		}
-
-		return nil, ErrNotFound
+	trace, err := c.getCommitteeDutyFromDisk(slot, role, committeeID)
+	if err != nil {
+		return nil, err
 	}
 
-	clone := trace.safeDeepCopy()
-
-	if !hasSignersForRoles(clone, roles...) {
-		return nil, ErrNotFound
-	}
-
-	return clone, nil
+	return trace, nil
 }
 
-// hasSignersForRoles checks if the duty has signers for the given role
-// since we don't store a boolean flag to separate duties by their role in the db
-// we rely on the fact that during collection we separate the signers in their
-// corresponding fields (Attester and SyncCommittee) based on the role
+// hasSignersForRoles checks if the duty has signers for the given beacon role(s).
+// Committee duties are keyed by runner role, but we still use the per-role signer
+// buckets to distinguish between attester vs aggregator and sync committee vs SCC.
+// Callers should handle the "no role filter" case before invoking this helper.
 func hasSignersForRoles(duty *traces.CommitteeDutyTrace, roles ...spectypes.BeaconRole) bool {
-	if len(roles) == 0 {
-		return true
-	}
+	// Signer buckets are role-specific; use them to ensure the duty matches the requested beacon roles.
 	for _, role := range roles {
-		if role == spectypes.BNRoleAttester {
+		bucket, ok := ssvtypes.CommitteeSignerBucketForBeaconRole(role)
+		if !ok {
+			continue
+		}
+		switch bucket {
+		case ssvtypes.CommitteeSignerBucketAttester:
 			if len(duty.Attester) == 0 {
 				return false
 			}
-		}
-		if role == spectypes.BNRoleSyncCommittee {
+		case ssvtypes.CommitteeSignerBucketSyncCommittee:
 			if len(duty.SyncCommittee) == 0 {
 				return false
 			}
+		case ssvtypes.CommitteeSignerBucketUnknown:
+			// Not a committee signer bucket.
 		}
 	}
 	return true
 }
 
-func (c *Collector) getCommitteeDutyFromDisk(slot phase0.Slot, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
-	ctx := fmt.Sprintf("slot=%d committeeID=%x", slot, committeeID)
-	trace, err := c.store.GetCommitteeDuty(slot, spectypes.RoleCommittee, committeeID)
+func (c *Collector) getCommitteeDutyFromDisk(slot phase0.Slot, role spectypes.RunnerRole, committeeID spectypes.CommitteeID) (*traces.CommitteeDutyTrace, error) {
+	ctx := fmt.Sprintf("slot=%d role=%d committeeID=%x", slot, role, committeeID)
+	trace, err := c.store.GetCommitteeDuty(slot, role, committeeID)
 	if err != nil {
 		return nil, fmt.Errorf("get committee duty from disk (%s): %w", ctx, err)
 	}
@@ -225,13 +203,54 @@ func (c *Collector) getCommitteeDutyFromDisk(slot phase0.Slot, committeeID spect
 	return trace, nil
 }
 
+func committeeRunnerRolesForBeaconRoles(roles ...spectypes.BeaconRole) []spectypes.RunnerRole {
+	if len(roles) == 0 {
+		return nil
+	}
+	var wantCommittee bool
+	var wantAggregator bool
+	for _, role := range roles {
+		runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
+		if !ok {
+			continue
+		}
+		switch runnerRole {
+		case spectypes.RoleCommittee:
+			wantCommittee = true
+		case spectypes.RoleAggregatorCommittee:
+			wantAggregator = true
+		default:
+			// Not a committee runner role.
+		}
+	}
+	out := make([]spectypes.RunnerRole, 0, 2)
+	if wantCommittee {
+		out = append(out, spectypes.RoleCommittee)
+	}
+	if wantAggregator {
+		out = append(out, spectypes.RoleAggregatorCommittee)
+	}
+	return out
+}
+
 func (c *Collector) GetAllCommitteeDecideds(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]ParticipantsRangeIndexEntry, error) {
 	var errs *multierror.Error
 
-	duties, err := c.GetCommitteeDuties(slot, roles...)
+	runnerRoles := committeeRunnerRolesForBeaconRoles(roles...)
+	duties, err := c.GetCommitteeDuties(slot, runnerRoles...)
 	errs = multierror.Append(errs, err)
 	if len(duties) == 0 {
 		return nil, errs.ErrorOrNil()
+	}
+
+	if len(roles) > 0 {
+		filtered := make([]*traces.CommitteeDutyTrace, 0, len(duties))
+		for _, duty := range duties {
+			if hasSignersForRoles(duty, roles...) {
+				filtered = append(filtered, duty)
+			}
+		}
+		duties = filtered
 	}
 
 	out := make([]ParticipantsRangeIndexEntry, 0, len(duties))
@@ -301,9 +320,27 @@ func (c *Collector) GetCommitteeDecideds(slot phase0.Slot, index phase0.Validato
 		return nil, fmt.Errorf("get committee ID by slot(%d) and index(%d): %w", slot, index, err)
 	}
 
-	duty, err := c.GetCommitteeDuty(slot, committeeID, roles...)
-	if err != nil {
-		return nil, fmt.Errorf("get committee duty: %w", err)
+	runnerRoles := committeeRunnerRolesForBeaconRoles(roles...)
+	if len(runnerRoles) == 0 {
+		runnerRoles = []spectypes.RunnerRole{spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee}
+	}
+
+	var duty *traces.CommitteeDutyTrace
+	for _, role := range runnerRoles {
+		d, dutyErr := c.GetCommitteeDuty(slot, committeeID, role)
+		if dutyErr != nil {
+			if errors.Is(dutyErr, ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("get committee duty: %w", dutyErr)
+		}
+		if len(roles) == 0 || hasSignersForRoles(d, roles...) {
+			duty = d
+			break
+		}
+	}
+	if duty == nil {
+		return nil, fmt.Errorf("get committee duty: %w", ErrNotFound)
 	}
 
 	signers := make([]spectypes.OperatorID, 0, len(duty.Decideds)+len(duty.SyncCommittee)+len(duty.Attester))

--- a/exporter/dutytracer/store.go
+++ b/exporter/dutytracer/store.go
@@ -237,6 +237,12 @@ func (c *Collector) GetAllCommitteeDecideds(slot phase0.Slot, roles ...spectypes
 	var errs *multierror.Error
 
 	runnerRoles := committeeRunnerRolesForBeaconRoles(roles...)
+	if len(roles) > 0 && len(runnerRoles) == 0 {
+		// A role filter was requested but none of the roles map to a committee
+		// runner role, so nothing can match. Return empty rather than querying
+		// with no filter (which would return every committee duty).
+		return nil, nil
+	}
 	duties, err := c.GetCommitteeDuties(slot, runnerRoles...)
 	errs = multierror.Append(errs, err)
 	if len(duties) == 0 {
@@ -321,6 +327,11 @@ func (c *Collector) GetCommitteeDecideds(slot phase0.Slot, index phase0.Validato
 	}
 
 	runnerRoles := committeeRunnerRolesForBeaconRoles(roles...)
+	if len(roles) > 0 && len(runnerRoles) == 0 {
+		// A role filter was requested but none of the roles map to a committee
+		// runner role, so nothing can match.
+		return nil, fmt.Errorf("get committee duty: %w", ErrNotFound)
+	}
 	if len(runnerRoles) == 0 {
 		runnerRoles = []spectypes.RunnerRole{spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee}
 	}

--- a/exporter/dutytracer/store_test.go
+++ b/exporter/dutytracer/store_test.go
@@ -298,6 +298,160 @@ func TestCommitteeDutyStore(t *testing.T) {
 	require.Equal(t, []spectypes.OperatorID{1, 2, 3}, signers)
 }
 
+// TestCommitteeDutyStore_RoleFilteringAndEvictionGrouping is a regression guard for the
+// {committeeID, role} keyed collector cache: Committee and AggregatorCommittee traces for
+// the SAME committeeID+slot must (a) be filterable independently via GetCommitteeDuties'
+// role argument, and (b) be evicted to disk as two distinct per-role groups without
+// cross-contaminating each other's persisted data.
+func TestCommitteeDutyStore_RoleFilteringAndEvictionGrouping(t *testing.T) {
+	db, err := kv.NewInMemory(zap.NewNop(), basedb.Options{})
+	require.NoError(t, err)
+	dutyStore := store.New(db)
+	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, dummyGetFeeRecipient, nil)
+
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	committeeID := spectypes.CommitteeID{9}
+	slot := phase0.Slot(20)
+
+	committeeTrace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
+	require.NoError(t, err)
+	committeeTrace.OperatorIDs = []uint64{1, 2, 3}
+
+	aggTrace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	aggTrace.OperatorIDs = []uint64{4, 5, 6}
+
+	// GetCommitteeDuties with no role filter must return both traces.
+	all, err := collector.GetCommitteeDuties(slot)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	// GetCommitteeDuties filtered by a single role must return only that role's trace.
+	onlyCommittee, err := collector.GetCommitteeDuties(slot, spectypes.RoleCommittee)
+	require.NoError(t, err)
+	require.Len(t, onlyCommittee, 1)
+	require.Equal(t, []uint64{1, 2, 3}, onlyCommittee[0].OperatorIDs)
+
+	onlyAgg, err := collector.GetCommitteeDuties(slot, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	require.Len(t, onlyAgg, 1)
+	require.Equal(t, []uint64{4, 5, 6}, onlyAgg[0].OperatorIDs)
+
+	// Evict: both roles at this slot must be dumped, grouped independently per role.
+	saved := collector.dumpCommitteeToDBPeriodically(slot)
+	require.Equal(t, 2, saved, "one duty per role should be saved")
+
+	diskCommittee, err := dutyStore.GetCommitteeDuty(slot, spectypes.RoleCommittee, committeeID)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3}, diskCommittee.OperatorIDs)
+
+	diskAgg, err := dutyStore.GetCommitteeDuty(slot, spectypes.RoleAggregatorCommittee, committeeID)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{4, 5, 6}, diskAgg.OperatorIDs)
+}
+
+// TestCommitteeRunnerRolesForBeaconRoles covers the beacon-role -> committee-runner-role
+// conversion used by GetCommitteeDecideds/GetAllCommitteeDecideds to pick the correct
+// {committeeID, role}-keyed trace(s).
+func TestCommitteeRunnerRolesForBeaconRoles(t *testing.T) {
+	testCases := []struct {
+		name  string
+		roles []spectypes.BeaconRole
+		want  []spectypes.RunnerRole
+	}{
+		{
+			name:  "no roles returns nil",
+			roles: nil,
+			want:  nil,
+		},
+		{
+			name:  "attester maps to committee",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleAttester},
+			want:  []spectypes.RunnerRole{spectypes.RoleCommittee},
+		},
+		{
+			name:  "sync committee maps to committee",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleSyncCommittee},
+			want:  []spectypes.RunnerRole{spectypes.RoleCommittee},
+		},
+		{
+			name:  "aggregator maps to aggregator committee",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator},
+			want:  []spectypes.RunnerRole{spectypes.RoleAggregatorCommittee},
+		},
+		{
+			name:  "sync committee contribution maps to aggregator committee",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleSyncCommitteeContribution},
+			want:  []spectypes.RunnerRole{spectypes.RoleAggregatorCommittee},
+		},
+		{
+			name:  "mixed roles map to both runner roles, committee first",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator, spectypes.BNRoleAttester},
+			want:  []spectypes.RunnerRole{spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee},
+		},
+		{
+			name:  "duplicate roles for the same bucket are deduplicated",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleAttester, spectypes.BNRoleSyncCommittee},
+			want:  []spectypes.RunnerRole{spectypes.RoleCommittee},
+		},
+		{
+			name:  "non-committee-backed role is ignored",
+			roles: []spectypes.BeaconRole{spectypes.BNRoleProposer},
+			want:  []spectypes.RunnerRole{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := committeeRunnerRolesForBeaconRoles(tc.roles...)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCollector_GetCommitteeDecideds_RoleFiltering verifies that GetCommitteeDecideds
+// resolves the correct {committeeID, role}-keyed trace for the requested beacon role(s),
+// distinguishing a Committee trace from an AggregatorCommittee trace at the same
+// committeeID+slot.
+func TestCollector_GetCommitteeDecideds_RoleFiltering(t *testing.T) {
+	db, err := kv.NewInMemory(zap.NewNop(), basedb.Options{})
+	require.NoError(t, err)
+	dutyStore := store.New(db)
+	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, dummyGetFeeRecipient, nil)
+
+	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
+
+	committeeID := spectypes.CommitteeID{11}
+	slot := phase0.Slot(30)
+	index := phase0.ValidatorIndex(1)
+	setCommitteeLink(collector, slot, index, committeeID)
+
+	committeeTrace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleCommittee)
+	require.NoError(t, err)
+	committeeTrace.Attester = append(committeeTrace.Attester, &traces.SignerData{Signer: 1})
+
+	aggTrace, _, err := collector.getOrCreateCommitteeTrace(slot, committeeID, spectypes.RoleAggregatorCommittee)
+	require.NoError(t, err)
+	aggTrace.Attester = append(aggTrace.Attester, &traces.SignerData{Signer: 2})
+
+	// Requesting the attester (committee) role must resolve to the RoleCommittee trace.
+	dd, err := collector.GetCommitteeDecideds(slot, index, spectypes.BNRoleAttester)
+	require.NoError(t, err)
+	require.Len(t, dd, 1)
+	require.Equal(t, []spectypes.OperatorID{1}, dd[0].Signers)
+
+	// Requesting the aggregator role must resolve to the RoleAggregatorCommittee trace, not the committee one.
+	dd, err = collector.GetCommitteeDecideds(slot, index, spectypes.BNRoleAggregator)
+	require.NoError(t, err)
+	require.Len(t, dd, 1)
+	require.Equal(t, []spectypes.OperatorID{2}, dd[0].Signers)
+
+	// Requesting the sync-committee-contribution role must miss (no signers under that bucket for the AC trace).
+	_, err = collector.GetCommitteeDecideds(slot, index, spectypes.BNRoleSyncCommitteeContribution)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 	validatorPK7 := spectypes.ValidatorPK{7}
 	committeeID1 := spectypes.CommitteeID{1}

--- a/exporter/dutytracer/store_test.go
+++ b/exporter/dutytracer/store_test.go
@@ -143,27 +143,27 @@ func TestCommitteeDutyStore(t *testing.T) {
 	// three slots X two committees
 	slot4 := phase0.Slot(4)
 
-	dutyTrace3, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID1)
+	dutyTrace3, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID1, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	dutyTrace3.Decideds = append(dutyTrace3.Decideds, &traces.DecidedTrace{
 		Signers: []spectypes.OperatorID{1},
 	})
 	require.NotNil(t, dutyTrace3)
 
-	dutyTrace4, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID2)
+	dutyTrace4, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID2, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	require.NotNil(t, dutyTrace4)
 
 	slot7 := phase0.Slot(7)
 
-	dutyTrace5, _, err := collector.getOrCreateCommitteeTrace(slot7, committeeID1)
+	dutyTrace5, _, err := collector.getOrCreateCommitteeTrace(slot7, committeeID1, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	dutyTrace5.Decideds = append(dutyTrace5.Decideds, &traces.DecidedTrace{
 		Signers: []spectypes.OperatorID{1},
 	})
 	require.NotNil(t, dutyTrace5)
 
-	dutyTrace6, _, err := collector.getOrCreateCommitteeTrace(slot7, committeeID2)
+	dutyTrace6, _, err := collector.getOrCreateCommitteeTrace(slot7, committeeID2, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	require.NotNil(t, dutyTrace6)
 
@@ -174,14 +174,14 @@ func TestCommitteeDutyStore(t *testing.T) {
 	// assert that traces are in available (in memory)
 	{
 		for i, slot := range []phase0.Slot{slot4, slot7} {
-			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID1)
+			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID1, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.NotNil(t, dutyTrace)
 			assert.Equal(t, slot, dutyTrace.Slot)
 			assert.Equal(t, slot, dutiesC1[i].Slot)
 		}
 		for i, slot := range []phase0.Slot{slot4, slot7} {
-			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID2)
+			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID2, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.NotNil(t, dutyTrace)
 			assert.Equal(t, slot, dutyTrace.Slot)
@@ -209,7 +209,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 	// step 3: retrieve trace from disk (4) and memory (7)
 	{
 		for i, slot := range []phase0.Slot{slot4, slot7} {
-			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID1)
+			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID1, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.NotNil(t, dutyTrace)
 			assert.Equal(t, slot, dutyTrace.Slot)
@@ -217,7 +217,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 			assert.Equal(t, committeeID1, dutiesC1[i].CommitteeID)
 		}
 		for i, slot := range []phase0.Slot{slot4, slot7} {
-			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID2)
+			dutyTrace, err := collector.GetCommitteeDuty(slot, committeeID2, spectypes.RoleCommittee)
 			require.NoError(t, err)
 			require.NotNil(t, dutyTrace)
 			assert.Equal(t, slot, dutyTrace.Slot)
@@ -236,7 +236,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 
 	// assert that only slot 7 is in memory
 	var inMem = make(map[phase0.Slot]struct{})
-	collector.committeeTraces.Range(func(key spectypes.CommitteeID, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
+	collector.committeeTraces.Range(func(key committeeTraceKey, slotToTraceMap *hashmap.Map[phase0.Slot, *committeeDutyTrace]) bool {
 		slotToTraceMap.Range(func(slot phase0.Slot, dutyTrace *committeeDutyTrace) bool {
 			inMem[slot] = struct{}{}
 			return true
@@ -322,7 +322,7 @@ func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil, nil)
 
 	// Create a new trace
-	dutyTrace, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID1)
+	dutyTrace, _, err := collector.getOrCreateCommitteeTrace(slot4, committeeID1, spectypes.RoleCommittee)
 	require.NoError(t, err)
 	dutyTrace.Decideds = append(dutyTrace.Decideds, &traces.DecidedTrace{
 		Signers: []spectypes.OperatorID{1},

--- a/exporter/dutytracer/store_test.go
+++ b/exporter/dutytracer/store_test.go
@@ -505,6 +505,14 @@ func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 		require.Len(t, dd, 1)
 		require.Equal(t, index1, dd[0].Index)
 	}
+
+	// A role filter with only non-committee-backed beacon roles must match nothing,
+	// not widen to every committee duty.
+	{
+		dd, err := collector.GetAllCommitteeDecideds(slot4, spectypes.BNRoleProposer)
+		require.NoError(t, err)
+		require.Empty(t, dd)
+	}
 }
 
 func setupValidatorStoreMock(store *registrymocks.MockValidatorStore, idx int) phase0.ValidatorIndex {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -38,8 +38,8 @@ func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantS
 type dutyTraceStore interface {
 	GetValidatorDuty(role spectypes.BeaconRole, slot phase0.Slot, index phase0.ValidatorIndex) (*traces.ValidatorDutyTrace, error)
 	GetValidatorDuties(role spectypes.BeaconRole, slot phase0.Slot) ([]*traces.ValidatorDutyTrace, error)
-	GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role ...spectypes.BeaconRole) (*traces.CommitteeDutyTrace, error)
-	GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.BeaconRole) ([]*traces.CommitteeDutyTrace, error)
+	GetCommitteeDuty(slot phase0.Slot, committeeID spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error)
+	GetCommitteeDuties(slot phase0.Slot, roles ...spectypes.RunnerRole) ([]*traces.CommitteeDutyTrace, error)
 	GetCommitteeID(slot phase0.Slot, index phase0.ValidatorIndex) (spectypes.CommitteeID, error)
 	GetCommitteeDutyLinks(slot phase0.Slot) ([]*traces.CommitteeDutyLink, error)
 	GetValidatorDecideds(role spectypes.BeaconRole, slot phase0.Slot, indices []phase0.ValidatorIndex) ([]dutytracer.ParticipantsRangeIndexEntry, error)

--- a/exporter/models.go
+++ b/exporter/models.go
@@ -89,6 +89,7 @@ type CommitteeTracesQuery struct {
 	From         uint64
 	To           uint64
 	CommitteeIDs []spectypes.CommitteeID
+	Roles        []spectypes.RunnerRole
 }
 
 // CommitteeScheduleEntry represents a single per-committee schedule entry.

--- a/exporter/validator.go
+++ b/exporter/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter/rolemask"
 	"github.com/ssvlabs/ssv/exporter/traces"
 	"github.com/ssvlabs/ssv/observability/log/fields"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 // ValidatorTracesCore contains the core logic for ValidatorTraces without any HTTP concerns.
@@ -120,6 +121,13 @@ func (e *Exporter) getValidatorCommitteeDutiesForRoleAndSlot(role spectypes.Beac
 	results := make([]ValidatorCommitteeTrace, 0, len(indices))
 	var errs *multierror.Error
 
+	// This helper is only reached for committee-backed beacon roles (see isCommitteeDuty),
+	// which today always resolve to the RoleCommittee runner role.
+	runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
+	if !ok {
+		return nil, fmt.Errorf("unexpected committee-backed beacon role: %s", role.String())
+	}
+
 	for _, index := range indices {
 		committeeID, err := e.traceStore.GetCommitteeID(slot, index)
 		if err != nil {
@@ -128,7 +136,7 @@ func (e *Exporter) getValidatorCommitteeDutiesForRoleAndSlot(role spectypes.Beac
 			continue
 		}
 
-		duty, err := e.traceStore.GetCommitteeDuty(slot, committeeID, role)
+		duty, err := e.traceStore.GetCommitteeDuty(slot, committeeID, runnerRole)
 		if err != nil {
 			e.logger.Error("error getting committee duty", zap.Error(err), fields.Slot(slot), fields.BeaconRole(role), fields.ValidatorIndex(index))
 			errs = multierror.Append(errs, err)

--- a/protocol/v2/message/msg.go
+++ b/protocol/v2/message/msg.go
@@ -65,10 +65,34 @@ func BeaconRoleFromString(s string) (spectypes.BeaconRole, error) {
 	}
 }
 
+// RunnerRoleFromString returns RunnerRole from string.
+func RunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
+	switch s {
+	case "COMMITTEE":
+		return spectypes.RoleCommittee, nil
+	case "AGGREGATOR_COMMITTEE":
+		return spectypes.RoleAggregatorCommittee, nil
+	case "AGGREGATOR":
+		return ssvtypes.RoleAggregator, nil
+	case "PROPOSER":
+		return spectypes.RoleProposer, nil
+	case "SYNC_COMMITTEE_CONTRIBUTION":
+		return ssvtypes.RoleSyncCommitteeContribution, nil
+	case "VALIDATOR_REGISTRATION":
+		return spectypes.RoleValidatorRegistration, nil
+	case "VOLUNTARY_EXIT":
+		return spectypes.RoleVoluntaryExit, nil
+	default:
+		return 0, fmt.Errorf("unknown role: %s", s)
+	}
+}
+
 func RunnerRoleToString(r spectypes.RunnerRole) string {
 	switch r {
 	case spectypes.RoleCommittee:
 		return "COMMITTEE"
+	case spectypes.RoleAggregatorCommittee:
+		return "AGGREGATOR_COMMITTEE"
 	case ssvtypes.RoleAggregator:
 		return "AGGREGATOR"
 	case spectypes.RoleProposer:

--- a/protocol/v2/message/msg.go
+++ b/protocol/v2/message/msg.go
@@ -12,6 +12,16 @@ import (
 const (
 	// SSVEventMsgType extends spec msg type
 	SSVEventMsgType spectypes.MsgType = 200
+
+	roleAttester                  = "ATTESTER"
+	roleAggregator                = "AGGREGATOR"
+	roleProposer                  = "PROPOSER"
+	roleSyncCommittee             = "SYNC_COMMITTEE"
+	roleSyncCommitteeContribution = "SYNC_COMMITTEE_CONTRIBUTION"
+	roleValidatorRegistration     = "VALIDATOR_REGISTRATION"
+	roleVoluntaryExit             = "VOLUNTARY_EXIT"
+	roleCommittee                 = "COMMITTEE"
+	roleAggregatorCommittee       = "AGGREGATOR_COMMITTEE"
 )
 
 // MsgTypeToString extension for spec msg type. convert spec msg type to string
@@ -46,19 +56,19 @@ func QBFTMsgTypeToString(mt specqbft.MessageType) string {
 // BeaconRoleFromString returns BeaconRole from string
 func BeaconRoleFromString(s string) (spectypes.BeaconRole, error) {
 	switch s {
-	case "ATTESTER":
+	case roleAttester:
 		return spectypes.BNRoleAttester, nil
-	case "AGGREGATOR":
+	case roleAggregator:
 		return spectypes.BNRoleAggregator, nil
-	case "PROPOSER":
+	case roleProposer:
 		return spectypes.BNRoleProposer, nil
-	case "SYNC_COMMITTEE":
+	case roleSyncCommittee:
 		return spectypes.BNRoleSyncCommittee, nil
-	case "SYNC_COMMITTEE_CONTRIBUTION":
+	case roleSyncCommitteeContribution:
 		return spectypes.BNRoleSyncCommitteeContribution, nil
-	case "VALIDATOR_REGISTRATION":
+	case roleValidatorRegistration:
 		return spectypes.BNRoleValidatorRegistration, nil
-	case "VOLUNTARY_EXIT":
+	case roleVoluntaryExit:
 		return spectypes.BNRoleVoluntaryExit, nil
 	default:
 		return 0, fmt.Errorf("unknown role: %s", s)
@@ -68,19 +78,19 @@ func BeaconRoleFromString(s string) (spectypes.BeaconRole, error) {
 // RunnerRoleFromString returns RunnerRole from string.
 func RunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
 	switch s {
-	case "COMMITTEE":
+	case roleCommittee:
 		return spectypes.RoleCommittee, nil
-	case "AGGREGATOR_COMMITTEE":
+	case roleAggregatorCommittee:
 		return spectypes.RoleAggregatorCommittee, nil
-	case "AGGREGATOR":
+	case roleAggregator:
 		return ssvtypes.RoleAggregator, nil
-	case "PROPOSER":
+	case roleProposer:
 		return spectypes.RoleProposer, nil
-	case "SYNC_COMMITTEE_CONTRIBUTION":
+	case roleSyncCommitteeContribution:
 		return ssvtypes.RoleSyncCommitteeContribution, nil
-	case "VALIDATOR_REGISTRATION":
+	case roleValidatorRegistration:
 		return spectypes.RoleValidatorRegistration, nil
-	case "VOLUNTARY_EXIT":
+	case roleVoluntaryExit:
 		return spectypes.RoleVoluntaryExit, nil
 	default:
 		return 0, fmt.Errorf("unknown role: %s", s)
@@ -90,19 +100,19 @@ func RunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
 func RunnerRoleToString(r spectypes.RunnerRole) string {
 	switch r {
 	case spectypes.RoleCommittee:
-		return "COMMITTEE"
+		return roleCommittee
 	case spectypes.RoleAggregatorCommittee:
-		return "AGGREGATOR_COMMITTEE"
+		return roleAggregatorCommittee
 	case ssvtypes.RoleAggregator:
-		return "AGGREGATOR"
+		return roleAggregator
 	case spectypes.RoleProposer:
-		return "PROPOSER"
+		return roleProposer
 	case ssvtypes.RoleSyncCommitteeContribution:
-		return "SYNC_COMMITTEE_CONTRIBUTION"
+		return roleSyncCommitteeContribution
 	case spectypes.RoleValidatorRegistration:
-		return "VALIDATOR_REGISTRATION"
+		return roleValidatorRegistration
 	case spectypes.RoleVoluntaryExit:
-		return "VOLUNTARY_EXIT"
+		return roleVoluntaryExit
 	default:
 		return fmt.Sprintf("unknown(%d)", r)
 	}

--- a/protocol/v2/message/msg.go
+++ b/protocol/v2/message/msg.go
@@ -97,6 +97,21 @@ func RunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
 	}
 }
 
+// CommitteeRunnerRoleFromString returns a committee-backed RunnerRole from
+// string. Unlike RunnerRoleFromString it only accepts the two committee runner
+// roles (COMMITTEE, AGGREGATOR_COMMITTEE); any other value is rejected so the
+// committee-traces filter cannot bind a role the store has no key prefix for.
+func CommitteeRunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
+	switch s {
+	case roleCommittee:
+		return spectypes.RoleCommittee, nil
+	case roleAggregatorCommittee:
+		return spectypes.RoleAggregatorCommittee, nil
+	default:
+		return 0, fmt.Errorf("unsupported committee runner role: %s", s)
+	}
+}
+
 func RunnerRoleToString(r spectypes.RunnerRole) string {
 	switch r {
 	case spectypes.RoleCommittee:

--- a/protocol/v2/message/msg.go
+++ b/protocol/v2/message/msg.go
@@ -102,11 +102,13 @@ func RunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
 // roles (COMMITTEE, AGGREGATOR_COMMITTEE); any other value is rejected so the
 // committee-traces filter cannot bind a role the store has no key prefix for.
 func CommitteeRunnerRoleFromString(s string) (spectypes.RunnerRole, error) {
-	switch s {
-	case roleCommittee:
-		return spectypes.RoleCommittee, nil
-	case roleAggregatorCommittee:
-		return spectypes.RoleAggregatorCommittee, nil
+	role, err := RunnerRoleFromString(s)
+	if err != nil {
+		return 0, err
+	}
+	switch role {
+	case spectypes.RoleCommittee, spectypes.RoleAggregatorCommittee:
+		return role, nil
 	default:
 		return 0, fmt.Errorf("unsupported committee runner role: %s", s)
 	}

--- a/protocol/v2/message/msg_test.go
+++ b/protocol/v2/message/msg_test.go
@@ -1,0 +1,118 @@
+package message
+
+import (
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+func TestBeaconRoleFromString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected spectypes.BeaconRole
+		hasError bool
+	}{
+		{name: "attester", input: "ATTESTER", expected: spectypes.BNRoleAttester},
+		{name: "aggregator", input: "AGGREGATOR", expected: spectypes.BNRoleAggregator},
+		{name: "proposer", input: "PROPOSER", expected: spectypes.BNRoleProposer},
+		{name: "sync committee", input: "SYNC_COMMITTEE", expected: spectypes.BNRoleSyncCommittee},
+		{name: "sync committee contribution", input: "SYNC_COMMITTEE_CONTRIBUTION", expected: spectypes.BNRoleSyncCommitteeContribution},
+		{name: "validator registration", input: "VALIDATOR_REGISTRATION", expected: spectypes.BNRoleValidatorRegistration},
+		{name: "voluntary exit", input: "VOLUNTARY_EXIT", expected: spectypes.BNRoleVoluntaryExit},
+		{name: "unknown role errors", input: "COMMITTEE", hasError: true},
+		{name: "empty string errors", input: "", hasError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, err := BeaconRoleFromString(tc.input)
+			if tc.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, role)
+		})
+	}
+}
+
+func TestRunnerRoleFromString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected spectypes.RunnerRole
+		hasError bool
+	}{
+		{name: "committee", input: "COMMITTEE", expected: spectypes.RoleCommittee},
+		{name: "aggregator committee", input: "AGGREGATOR_COMMITTEE", expected: spectypes.RoleAggregatorCommittee},
+		{name: "aggregator", input: "AGGREGATOR", expected: ssvtypes.RoleAggregator},
+		{name: "proposer", input: "PROPOSER", expected: spectypes.RoleProposer},
+		{name: "sync committee contribution", input: "SYNC_COMMITTEE_CONTRIBUTION", expected: ssvtypes.RoleSyncCommitteeContribution},
+		{name: "validator registration", input: "VALIDATOR_REGISTRATION", expected: spectypes.RoleValidatorRegistration},
+		{name: "voluntary exit", input: "VOLUNTARY_EXIT", expected: spectypes.RoleVoluntaryExit},
+		{name: "sync committee (deprecated bare role) errors", input: "SYNC_COMMITTEE", hasError: true},
+		{name: "unknown role errors", input: "NOT_A_ROLE", hasError: true},
+		{name: "empty string errors", input: "", hasError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, err := RunnerRoleFromString(tc.input)
+			if tc.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, role)
+		})
+	}
+}
+
+func TestRunnerRoleToString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     spectypes.RunnerRole
+		expected string
+	}{
+		{name: "committee", role: spectypes.RoleCommittee, expected: "COMMITTEE"},
+		{name: "aggregator committee", role: spectypes.RoleAggregatorCommittee, expected: "AGGREGATOR_COMMITTEE"},
+		{name: "aggregator", role: ssvtypes.RoleAggregator, expected: "AGGREGATOR"},
+		{name: "proposer", role: spectypes.RoleProposer, expected: "PROPOSER"},
+		{name: "sync committee contribution", role: ssvtypes.RoleSyncCommitteeContribution, expected: "SYNC_COMMITTEE_CONTRIBUTION"},
+		{name: "validator registration", role: spectypes.RoleValidatorRegistration, expected: "VALIDATOR_REGISTRATION"},
+		{name: "voluntary exit", role: spectypes.RoleVoluntaryExit, expected: "VOLUNTARY_EXIT"},
+		{name: "unknown role", role: spectypes.RunnerRole(999), expected: "unknown(999)"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, RunnerRoleToString(tc.role))
+		})
+	}
+}
+
+// TestRunnerRoleFromString_ToString_RoundTrip guards against the two functions drifting
+// apart (e.g. a new role added to one but not the other).
+func TestRunnerRoleFromString_ToString_RoundTrip(t *testing.T) {
+	roles := []spectypes.RunnerRole{
+		spectypes.RoleCommittee,
+		spectypes.RoleAggregatorCommittee,
+		ssvtypes.RoleAggregator,
+		spectypes.RoleProposer,
+		ssvtypes.RoleSyncCommitteeContribution,
+		spectypes.RoleValidatorRegistration,
+		spectypes.RoleVoluntaryExit,
+	}
+
+	for _, role := range roles {
+		s := RunnerRoleToString(role)
+		got, err := RunnerRoleFromString(s)
+		require.NoError(t, err, "round-trip failed for role %v (string %q)", role, s)
+		assert.Equal(t, role, got)
+	}
+}

--- a/protocol/v2/types/runner_role.go
+++ b/protocol/v2/types/runner_role.go
@@ -9,6 +9,16 @@ const (
 	RoleSyncCommitteeContribution = spectypes.RunnerRole(3) // Deprecated
 )
 
+// CommitteeSignerBucket identifies the committee-duty signer slice that should
+// be used for a given beacon role.
+type CommitteeSignerBucket uint8
+
+const (
+	CommitteeSignerBucketUnknown CommitteeSignerBucket = iota
+	CommitteeSignerBucketAttester
+	CommitteeSignerBucketSyncCommittee
+)
+
 // RunnerRoleForValidatorDuty resolves the runner role for validator duties,
 // mapping Alan fork aggregator duties to Alan runner roles.
 func RunnerRoleForValidatorDuty(duty *spectypes.ValidatorDuty, isBooleFork bool) spectypes.RunnerRole {
@@ -38,6 +48,32 @@ func RunnerRoleForDuty(duty spectypes.Duty, isBooleFork bool) spectypes.RunnerRo
 		return RunnerRoleForValidatorDuty(vd, isBooleFork)
 	}
 	return duty.RunnerRole()
+}
+
+// CommitteeRunnerRoleForBeaconRole maps committee-backed beacon roles to the
+// corresponding committee runner role.
+func CommitteeRunnerRoleForBeaconRole(role spectypes.BeaconRole) (spectypes.RunnerRole, bool) {
+	switch role {
+	case spectypes.BNRoleAttester, spectypes.BNRoleSyncCommittee:
+		return spectypes.RoleCommittee, true
+	case spectypes.BNRoleAggregator, spectypes.BNRoleSyncCommitteeContribution:
+		return spectypes.RoleAggregatorCommittee, true
+	default:
+		return spectypes.RoleUnknown, false
+	}
+}
+
+// CommitteeSignerBucketForBeaconRole maps committee-backed beacon roles to the
+// signer bucket used in CommitteeDutyTrace.
+func CommitteeSignerBucketForBeaconRole(role spectypes.BeaconRole) (CommitteeSignerBucket, bool) {
+	switch role {
+	case spectypes.BNRoleAttester, spectypes.BNRoleAggregator:
+		return CommitteeSignerBucketAttester, true
+	case spectypes.BNRoleSyncCommittee, spectypes.BNRoleSyncCommitteeContribution:
+		return CommitteeSignerBucketSyncCommittee, true
+	default:
+		return CommitteeSignerBucketUnknown, false
+	}
 }
 
 // RunnerRoleToString is a workaround for Alan runner roles.

--- a/protocol/v2/types/runner_role_test.go
+++ b/protocol/v2/types/runner_role_test.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitteeRunnerRoleForBeaconRole(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     spectypes.BeaconRole
+		wantRole spectypes.RunnerRole
+		wantOK   bool
+	}{
+		{name: "attester maps to committee", role: spectypes.BNRoleAttester, wantRole: spectypes.RoleCommittee, wantOK: true},
+		{name: "sync committee maps to committee", role: spectypes.BNRoleSyncCommittee, wantRole: spectypes.RoleCommittee, wantOK: true},
+		{name: "aggregator maps to aggregator committee", role: spectypes.BNRoleAggregator, wantRole: spectypes.RoleAggregatorCommittee, wantOK: true},
+		{name: "sync committee contribution maps to aggregator committee", role: spectypes.BNRoleSyncCommitteeContribution, wantRole: spectypes.RoleAggregatorCommittee, wantOK: true},
+		{name: "proposer is not committee-backed", role: spectypes.BNRoleProposer, wantOK: false},
+		{name: "validator registration is not committee-backed", role: spectypes.BNRoleValidatorRegistration, wantOK: false},
+		{name: "voluntary exit is not committee-backed", role: spectypes.BNRoleVoluntaryExit, wantOK: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := CommitteeRunnerRoleForBeaconRole(tc.role)
+			require.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantRole, got)
+			}
+		})
+	}
+}
+
+func TestCommitteeSignerBucketForBeaconRole(t *testing.T) {
+	testCases := []struct {
+		name       string
+		role       spectypes.BeaconRole
+		wantBucket CommitteeSignerBucket
+		wantOK     bool
+	}{
+		{name: "attester maps to attester bucket", role: spectypes.BNRoleAttester, wantBucket: CommitteeSignerBucketAttester, wantOK: true},
+		{name: "aggregator maps to attester bucket", role: spectypes.BNRoleAggregator, wantBucket: CommitteeSignerBucketAttester, wantOK: true},
+		{name: "sync committee maps to sync committee bucket", role: spectypes.BNRoleSyncCommittee, wantBucket: CommitteeSignerBucketSyncCommittee, wantOK: true},
+		{name: "sync committee contribution maps to sync committee bucket", role: spectypes.BNRoleSyncCommitteeContribution, wantBucket: CommitteeSignerBucketSyncCommittee, wantOK: true},
+		{name: "proposer is not a committee signer bucket", role: spectypes.BNRoleProposer, wantOK: false},
+		{name: "voluntary exit is not a committee signer bucket", role: spectypes.BNRoleVoluntaryExit, wantOK: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := CommitteeSignerBucketForBeaconRole(tc.role)
+			require.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantBucket, got)
+			} else {
+				assert.Equal(t, CommitteeSignerBucketUnknown, got)
+			}
+		})
+	}
+}
+
+func TestRunnerRoleForDuty_CommitteeDuty(t *testing.T) {
+	// CommitteeRunnerRoleForBeaconRole must be self-consistent with the runner-role
+	// constants used elsewhere in the codebase to key committee traces.
+	role, ok := CommitteeRunnerRoleForBeaconRole(spectypes.BNRoleAttester)
+	require.True(t, ok)
+	assert.Equal(t, spectypes.RoleCommittee, role)
+
+	role, ok = CommitteeRunnerRoleForBeaconRole(spectypes.BNRoleAggregator)
+	require.True(t, ok)
+	assert.Equal(t, spectypes.RoleAggregatorCommittee, role)
+}


### PR DESCRIPTION
## convergence(unit 5c-exporter): aggregator-committee duty-trace query layer

Adds the **reader** half of the aggregator-committee duty-trace feature (the producer/runner, disk-store role-keying, SSZ model and migration_9 landed in units 3/5c). Ported from `boole-fork` PR #2683 (commit `d405c1a36`), adapted onto stage's `exporter/dutytracer` + `exporter/traces` structure (boole keeps it under `operator/dutytracer` as `package validator`).

### What changed
- **Collector** (`exporter/dutytracer/collector.go`): re-key `committeeTraces`/`inFlightCommittee` by `committeeTraceKey{committeeID, runnerRole}` so a `Committee` and an `AggregatorCommittee` duty for the same committee+slot no longer collide in cache. Ports the AC post-consensus root classification (`computeAggregatorCommitteePostConsensusRoles`, `getAggregatorSelectionRoot`, root-scoped quorum via `signersByRoot`/`classifyRootForPending`).
- **Store** (`store.go`): `GetCommitteeDuty`/`GetCommitteeDuties` now take `RunnerRole`; `GetCommitteeDecideds` keeps `BeaconRole` at the boundary and converts internally (signer-bucket filtering). **Eviction** groups flushed duties by role and persists under the correct per-role disk prefix.
- **Exporter core + HTTP API**: `roles` query filter + `role` response field on committee-traces; new `RunnerRole`/`RunnerRoleSlice` api type; `RunnerRoleFromString` + the `AGGREGATOR_COMMITTEE` case in `RunnerRoleToString`. OpenAPI regenerated.

### Scope / deferred
- `networkConfig` threading into `NewExporter` (validator-path fork gating only) is **deliberately deferred** — `NewExporter` signature unchanged.

### Review
- **code-reviewer-deep: PASS** — ported classification logic byte-faithful to `d405c1a36`; keying collision-free; role axes (`RunnerRole` vs `BeaconRole`) distinct; per-role eviction correct; caller fix preserves behavior.
- Coverage raised on the classification paths (0→71–88%) + a regression guard that Committee and AggregatorCommittee traces coexist for the same committeeID+slot.

### Known / faithful-to-reference (non-blocking)
1. ~~`RunnerRoleFromString` accepts non-committee role strings in the filter → they match nothing~~ **Fixed in `bf5b32e7d`:** the committee-traces `roles` filter now binds through `CommitteeRunnerRoleFromString` (COMMITTEE / AGGREGATOR_COMMITTEE only), so a non-committee role is rejected at the boundary as a 400 instead of surfacing the store's `unsupported committee runner role` error as a 500.
2. `computeAggregatorCommitteePostConsensusRoles` indexes `Contributors[i]` — relies on the AC consensus-data SSZ invariant (not introduced here).
3. `GetCommitteeDuties` can duplicate a duty during the eviction window — pre-existing in the base.

Stacks directly on `integration/boole-convergence`; no dependency on unit 5d.

