### PR TITLE
convergence: aggregator-committee message-validation test coverage

### DIFF
--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -167,23 +167,11 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		slot := postBooleCfg.FirstSlotAtEpoch(1)
 		booleIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), encodedCommitteeID, committeeRole)
-		qbftMessage := &specqbft.Message{
-			MsgType:                  specqbft.ProposalMsgType,
-			Height:                   specqbft.Height(slot),
-			Round:                    specqbft.FirstRound,
-			Identifier:               booleIdentifier[:],
-			Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
-			RoundChangeJustification: [][]byte{},
-			PrepareJustification:     [][]byte{},
-		}
-		// Post-fork proposals must be signed by the fork-aware round-robin leader.
-		leader := qbft.RoundRobinProposer(specqbft.Height(slot), specqbft.FirstRound, committee, postBooleCfg)
-		signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
-		signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, booleIdentifier, slot)
 
 		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 		require.NoError(t, err)
-		booleTopic := commons.BooleTopic(postBooleCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+		booleTopic := expectedCommitteeTopic(postBooleCfg, committeeInfo, slot)
 
 		receivedAt := postBooleCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
@@ -690,11 +678,13 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := postBooleCfg.FirstSlotAtEpoch(1)
 
 		badIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], ssvtypes.RoleAggregator)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+		// Leader-signed so the subtest keeps asserting the role rejection even if the
+		// validation order between the role and leader checks ever changes.
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, badIdentifier, slot)
 
 		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 		require.NoError(t, err)
-		booleTopic := commons.BooleTopic(postBooleCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+		booleTopic := expectedCommitteeTopic(postBooleCfg, committeeInfo, slot)
 
 		receivedAt := postBooleCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
@@ -708,11 +698,12 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := postBooleCfg.FirstSlotAtEpoch(1)
 
 		badIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], ssvtypes.RoleSyncCommitteeContribution)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+		// Leader-signed for the same reason as the aggregator post-fork subtest above.
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, badIdentifier, slot)
 
 		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 		require.NoError(t, err)
-		booleTopic := commons.BooleTopic(postBooleCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+		booleTopic := expectedCommitteeTopic(postBooleCfg, committeeInfo, slot)
 
 		receivedAt := postBooleCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
@@ -1562,19 +1553,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			acSlot := postBooleCfg.FirstSlotAtEpoch(epoch)
 
 			msgID := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(acSlot), encodedCommitteeID, spectypes.RoleAggregatorCommittee)
-			qbftMessage := &specqbft.Message{
-				MsgType:                  specqbft.ProposalMsgType,
-				Height:                   specqbft.Height(acSlot),
-				Round:                    specqbft.FirstRound,
-				Identifier:               msgID[:],
-				Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
-				RoundChangeJustification: [][]byte{},
-				PrepareJustification:     [][]byte{},
-			}
-			// Post-fork proposals must be signed by the fork-aware round-robin leader.
-			leader := qbft.RoundRobinProposer(specqbft.Height(acSlot), specqbft.FirstRound, committee, postBooleCfg)
-			signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
-			signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
+			signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, msgID, acSlot)
 
 			committeeInfo, err := postBooleValidator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
 			require.NoError(t, err)
@@ -2486,4 +2465,29 @@ func expectedCommitteeTopic(netCfg *networkconfig.Network, committeeInfo Committ
 		return commons.BooleTopic(netCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
 	}
 	return commons.GetTopicFullName(commons.CommitteeTopicID(committeeInfo.committeeID)[0])
+}
+
+// buildBooleProposal builds a first-round QBFT proposal for the given message ID, signed by
+// the fork-aware round-robin leader for that height. Post-fork proposals must be leader-signed,
+// and the leader is not necessarily operator 1 (which generateSignedMessage hardcodes).
+func buildBooleProposal(
+	netCfg *networkconfig.Network,
+	ks *spectestingutils.TestKeySet,
+	committee []spectypes.OperatorID,
+	msgID spectypes.MessageID,
+	slot phase0.Slot,
+) *spectypes.SignedSSVMessage {
+	qbftMessage := &specqbft.Message{
+		MsgType:                  specqbft.ProposalMsgType,
+		Height:                   specqbft.Height(slot),
+		Round:                    specqbft.FirstRound,
+		Identifier:               msgID[:],
+		Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
+		RoundChangeJustification: [][]byte{},
+		PrepareJustification:     [][]byte{},
+	}
+	leader := qbft.RoundRobinProposer(specqbft.Height(slot), specqbft.FirstRound, committee, netCfg)
+	signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
+	signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
+	return signedSSVMessage
 }

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -668,6 +668,57 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidRole)
 	})
 
+	// Pre-fork, RoleAggregatorCommittee is not yet a valid role (AC only exists post-Boole).
+	t.Run("aggregator committee pre-fork", func(t *testing.T) {
+		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := netCfg.FirstSlotAtEpoch(1)
+
+		badIdentifier := spectypes.NewMsgID(netCfg.DomainType, encodedCommitteeID, spectypes.RoleAggregatorCommittee)
+		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+
+		topicID := commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
+		receivedAt := netCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrInvalidRole)
+	})
+
+	// Post-fork, the old (pre-Boole) RoleAggregator is superseded by RoleAggregatorCommittee.
+	t.Run("aggregator post-fork", func(t *testing.T) {
+		validator := New(postBooleCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := postBooleCfg.FirstSlotAtEpoch(1)
+
+		badIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], ssvtypes.RoleAggregator)
+		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+		booleTopic := commons.BooleTopic(postBooleCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+
+		receivedAt := postBooleCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrInvalidRole)
+	})
+
+	// Post-fork, the old (pre-Boole) RoleSyncCommitteeContribution is likewise invalid.
+	t.Run("sync committee contribution post-fork", func(t *testing.T) {
+		validator := New(postBooleCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := postBooleCfg.FirstSlotAtEpoch(1)
+
+		badIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], ssvtypes.RoleSyncCommitteeContribution)
+		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+		booleTopic := commons.BooleTopic(postBooleCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+
+		receivedAt := postBooleCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrInvalidRole)
+	})
+
 	// Perform validator registration or voluntary exit with a consensus type message will give an error
 	t.Run("unexpected consensus message", func(t *testing.T) {
 		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
@@ -1505,6 +1556,34 @@ func Test_ValidateSSVMessage(t *testing.T) {
 				require.ErrorContains(t, err, ErrLateSlotMessage.Error())
 			})
 		}
+
+		t.Run(message.RunnerRoleToString(spectypes.RoleAggregatorCommittee), func(t *testing.T) {
+			postBooleValidator := New(postBooleCfg, validatorStore, operators, ds, signatureVerifier).(*messageValidator)
+			acSlot := postBooleCfg.FirstSlotAtEpoch(epoch)
+
+			msgID := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(acSlot), encodedCommitteeID, spectypes.RoleAggregatorCommittee)
+			qbftMessage := &specqbft.Message{
+				MsgType:                  specqbft.ProposalMsgType,
+				Height:                   specqbft.Height(acSlot),
+				Round:                    specqbft.FirstRound,
+				Identifier:               msgID[:],
+				Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
+				RoundChangeJustification: [][]byte{},
+				PrepareJustification:     [][]byte{},
+			}
+			// Post-fork proposals must be signed by the fork-aware round-robin leader.
+			leader := qbft.RoundRobinProposer(specqbft.Height(acSlot), specqbft.FirstRound, committee, postBooleCfg)
+			signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
+			signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
+
+			committeeInfo, err := postBooleValidator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+			require.NoError(t, err)
+			booleTopic := expectedCommitteeTopic(postBooleCfg, committeeInfo, acSlot)
+
+			receivedAt := postBooleCfg.SlotStartTime(acSlot + 35)
+			_, err = postBooleValidator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+			require.ErrorContains(t, err, ErrLateSlotMessage.Error())
+		})
 	})
 
 	// Send early message for all roles before the duty start and receive early message error


### PR DESCRIPTION
## convergence: aggregator-committee message-validation test coverage

Closes the coverage hole unit 5b left: `validRoleAtSlot`'s three Boole-gated branches (`signed_ssv_message.go`) had **zero dedicated tests** — only the always-valid roles were hit indirectly. Test-only; the production branches already landed in 5b. Blocker (`commons.Subnet` rename) is moot — adapted to integration's `uint64`-subnet idiom.

### Added (4 subtests, `message/validation/validation_test.go`)
1. `RoleAggregatorCommittee` **pre-fork** → `ErrInvalidRole` (AC only exists post-Boole).
2. old `RoleAggregator` **post-fork** → `ErrInvalidRole` (superseded by AC).
3. old `RoleSyncCommitteeContribution` **post-fork** → `ErrInvalidRole`.
4. `RoleAggregatorCommittee` **late-slot** → `ErrLateSlotMessage`.

Subtest #4 signs its proposal with the fork-aware `RoundRobinProposer` leader (post-Boole leader selection is round-robin — a static op-1 signature would fail the leader-check before reaching the late-slot check), mirroring the existing post-fork committee-consensus pattern in the same file. No new helpers.

Test-only (+79/−0, single file). build/gofmt/golangci-lint green; the 4 subtests run+pass.
