### PR TITLE
convergence: fork-aware exporter validator-path duty routing (NewExporter networkConfig)

### DIFF
--- a/api/handlers/exporter/exporter.go
+++ b/api/handlers/exporter/exporter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter/rolemask"
 	"github.com/ssvlabs/ssv/exporter/traces"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
+	"github.com/ssvlabs/ssv/networkconfig"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 
 	dutytracer "github.com/ssvlabs/ssv/exporter/dutytracer"
@@ -24,10 +25,10 @@ type Exporter struct {
 	svc    *exportercore.Exporter
 }
 
-func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantStores, traceStore dutyTraceStore, validators registrystorage.ValidatorStore) *Exporter {
+func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantStores, traceStore dutyTraceStore, validators registrystorage.ValidatorStore, networkConfig *networkconfig.Network) *Exporter {
 	return &Exporter{
 		logger: logger,
-		svc:    exportercore.NewExporter(logger, participantStores, traceStore, validators),
+		svc:    exportercore.NewExporter(logger, participantStores, traceStore, validators, networkConfig),
 	}
 }
 

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -2565,6 +2565,112 @@ func TestExporterValidatorTraces_ForkGating_ValidationSymmetric(t *testing.T) {
 	}
 }
 
+// TestExporterValidatorTraces_ForkGating_CrossForkRange proves the behavior of a slot range
+// straddling the Boole fork boundary (from pre-Boole, to post-Boole): validation is evaluated
+// at the range's upper bound, so aggregator-family roles require pubkeys/indices, and with
+// indices provided each slot routes independently — validator path before the boundary,
+// committee path from it onward.
+func TestExporterValidatorTraces_ForkGating_CrossForkRange(t *testing.T) {
+	const booleEpoch = phase0.Epoch(5)
+	idx := phase0.ValidatorIndex(1)
+	var committeeID spectypes.CommitteeID
+	committeeID[0] = 7
+
+	ssvCopy := *networkconfig.TestNetwork.SSV
+	ssvCopy.Forks.Boole = booleEpoch
+	netCfg := *networkconfig.TestNetwork
+	netCfg.SSV = &ssvCopy
+
+	booleSlot := netCfg.FirstSlotAtEpoch(booleEpoch)
+	require.GreaterOrEqual(t, uint64(booleSlot), uint64(10), "boole fork slot too low for the range below")
+	from := uint64(booleSlot) - 10 // pre-Boole
+	to := uint64(booleSlot) + 10   // post-Boole
+
+	roles := []struct {
+		name              string
+		signerDataBuilder func(slot phase0.Slot) *traces.CommitteeDutyTrace
+	}{
+		{
+			name: "AGGREGATOR",
+			signerDataBuilder: func(slot phase0.Slot) *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:        slot,
+					CommitteeID: committeeID,
+					Attester:    []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name: "SYNC_COMMITTEE_CONTRIBUTION",
+			signerDataBuilder: func(slot phase0.Slot) *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:          slot,
+					CommitteeID:   committeeID,
+					SyncCommittee: []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+	}
+
+	for _, role := range roles {
+		t.Run(role.name+" without filters requires pubkeys/indices", func(t *testing.T) {
+			exp := newTestExporterForV2WithNetwork(newMockTraceStore(), newMockValidatorStore(), &netCfg)
+
+			req := httptest.NewRequest(http.MethodPost, "/traces/validator", buildJSONBody(t, map[string]any{
+				"from":  from,
+				"to":    to,
+				"roles": []string{role.name},
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			require.Error(t, exp.ValidatorTraces(rec, req))
+		})
+
+		t.Run(role.name+" with indices routes each slot by its own fork state", func(t *testing.T) {
+			store := newMockTraceStore()
+
+			validatorSlots := make(map[phase0.Slot]struct{})
+			committeeSlots := make(map[phase0.Slot]struct{})
+
+			store.GetValidatorDutyFunc = func(r spectypes.BeaconRole, slot phase0.Slot, index phase0.ValidatorIndex) (*traces.ValidatorDutyTrace, error) {
+				validatorSlots[slot] = struct{}{}
+				return &traces.ValidatorDutyTrace{Slot: slot, Role: r, Validator: index}, nil
+			}
+			store.GetCommitteeIDFunc = func(s phase0.Slot, i phase0.ValidatorIndex) (spectypes.CommitteeID, error) {
+				return committeeID, nil
+			}
+			store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID, r spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
+				committeeSlots[s] = struct{}{}
+				return role.signerDataBuilder(s), nil
+			}
+
+			exp := newTestExporterForV2WithNetwork(store, newMockValidatorStore(), &netCfg)
+
+			req := httptest.NewRequest(http.MethodPost, "/traces/validator", buildJSONBody(t, map[string]any{
+				"from":    from,
+				"to":      to,
+				"roles":   []string{role.name},
+				"indices": []uint64{uint64(idx)},
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			require.NoError(t, exp.ValidatorTraces(rec, req))
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			require.NotEmpty(t, validatorSlots, "expected pre-Boole slots to hit the validator path")
+			require.NotEmpty(t, committeeSlots, "expected post-Boole slots to hit the committee path")
+			for slot := range validatorSlots {
+				assert.Less(t, uint64(slot), uint64(booleSlot), "validator path used at post-Boole slot")
+			}
+			for slot := range committeeSlots {
+				assert.GreaterOrEqual(t, uint64(slot), uint64(booleSlot), "committee path used at pre-Boole slot")
+			}
+		})
+	}
+}
+
 // mockValidatorStore is a simple in-memory ValidatorStore implementation for tests.
 type mockValidatorStore struct {
 	byIndex  map[phase0.ValidatorIndex]*ssvtypes.SSVShare

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-
 	"net/http/httptest"
 	"strings"
 	"testing"

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -2486,7 +2486,7 @@ func TestExporterValidatorTraces_ForkGating(t *testing.T) {
 }
 
 // TestExporterValidatorTraces_ForkGating_ValidationSymmetric proves that validateValidatorRequest
-// (via isCommitteeDutyInRange) mirrors the same fork-gated routing decision for aggregator-family
+// (via isCommitteeDutyAtSlot at the range's upper bound) mirrors the same fork-gated routing decision for aggregator-family
 // roles: pre-Boole no pubkeys/indices are required, post-Boole they are (mirroring committee duties).
 func TestExporterValidatorTraces_ForkGating_ValidationSymmetric(t *testing.T) {
 	tests := []struct {

--- a/api/handlers/exporter/exporter_test.go
+++ b/api/handlers/exporter/exporter_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
+
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -26,6 +28,7 @@ import (
 	estore "github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/exporter/traces"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/operator/slotticker"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/registry/storage"
@@ -610,11 +613,17 @@ func (m *mockTraceStore) AddCommitteeDecided(slot phase0.Slot, signers []uint64)
 }
 
 func newTestExporterForV1(stores *ibftstorage.ParticipantStores) *Exporter {
-	return NewExporter(zap.NewNop(), stores, nil, nil)
+	return NewExporter(zap.NewNop(), stores, nil, nil, networkconfig.TestNetwork)
 }
 
 func newTestExporterForV2(traceStore *mockTraceStore, validators storage.ValidatorStore) *Exporter {
-	return NewExporter(zap.NewNop(), nil, traceStore, validators)
+	return NewExporter(zap.NewNop(), nil, traceStore, validators, networkconfig.TestNetwork)
+}
+
+// newTestExporterForV2WithNetwork builds a V2 exporter with a custom network config,
+// used to exercise fork-gated routing (pre/post Boole) without mutating the shared TestNetwork.
+func newTestExporterForV2WithNetwork(traceStore *mockTraceStore, validators storage.ValidatorStore, netCfg *networkconfig.Network) *Exporter {
+	return NewExporter(zap.NewNop(), nil, traceStore, validators, netCfg)
 }
 
 func buildJSONBody(t *testing.T, payload map[string]any) *strings.Reader {
@@ -1541,7 +1550,7 @@ func TestExporterCommitteeTraces(t *testing.T) {
 				tt.setupMock(store, validatorStore)
 			}
 
-			exporter := NewExporter(zap.NewNop(), nil, store, validatorStore)
+			exporter := NewExporter(zap.NewNop(), nil, store, validatorStore, networkconfig.TestNetwork)
 
 			body, err := json.Marshal(tt.request)
 			require.NoError(t, err)
@@ -2255,7 +2264,7 @@ func TestExporterValidatorTraces(t *testing.T) {
 			validatorStore := newMockValidatorStore()
 			tt.setupMock(store, validatorStore)
 
-			exporter := NewExporter(zap.NewNop(), nil, store, validatorStore)
+			exporter := NewExporter(zap.NewNop(), nil, store, validatorStore, networkconfig.TestNetwork)
 
 			reqBody, err := json.Marshal(tt.request)
 			require.NoError(t, err)
@@ -2283,7 +2292,7 @@ func TestExporterValidatorTraces(t *testing.T) {
 func TestExporterValidatorTraces_InvalidJSON(t *testing.T) {
 	store := newMockTraceStore()
 	validatorStore := newMockValidatorStore()
-	exporter := NewExporter(zap.NewNop(), nil, store, validatorStore)
+	exporter := NewExporter(zap.NewNop(), nil, store, validatorStore, networkconfig.TestNetwork)
 
 	req := httptest.NewRequest(http.MethodPost, "/traces/validator", strings.NewReader("{invalid"))
 	req.Header.Set("Content-Type", "application/json")
@@ -2308,6 +2317,253 @@ func TestExporterValidatorTraces_InvalidJSON(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Contains(t, resp.Message, "invalid character")
+}
+
+// TestExporterValidatorTraces_ForkGating proves that AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION
+// route to the validator path pre-Boole and to the committee path post-Boole, while
+// ATTESTER/SYNC_COMMITTEE always route to the committee path regardless of fork.
+func TestExporterValidatorTraces_ForkGating(t *testing.T) {
+	idx := phase0.ValidatorIndex(1)
+	slot := phase0.Slot(100)
+	var committeeID spectypes.CommitteeID
+	committeeID[0] = 7
+
+	tests := []struct {
+		name              string
+		role              string
+		booleEpoch        phase0.Epoch
+		expectValidator   bool // duty is expected to come from the validator store
+		expectCommittee   bool // duty is expected to come from the committee store
+		signerDataBuilder func() *traces.CommitteeDutyTrace
+	}{
+		{
+			name:            "AGGREGATOR pre-Boole routes to validator path",
+			role:            "AGGREGATOR",
+			booleEpoch:      phase0.Epoch(math.MaxUint64),
+			expectValidator: true,
+		},
+		{
+			name:            "AGGREGATOR post-Boole routes to committee path",
+			role:            "AGGREGATOR",
+			booleEpoch:      phase0.Epoch(0),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:        slot,
+					CommitteeID: committeeID,
+					Attester:    []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name:            "SYNC_COMMITTEE_CONTRIBUTION pre-Boole routes to validator path",
+			role:            "SYNC_COMMITTEE_CONTRIBUTION",
+			booleEpoch:      phase0.Epoch(math.MaxUint64),
+			expectValidator: true,
+		},
+		{
+			name:            "SYNC_COMMITTEE_CONTRIBUTION post-Boole routes to committee path",
+			role:            "SYNC_COMMITTEE_CONTRIBUTION",
+			booleEpoch:      phase0.Epoch(0),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:          slot,
+					CommitteeID:   committeeID,
+					SyncCommittee: []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name:            "ATTESTER is fork-invariant pre-Boole",
+			role:            "ATTESTER",
+			booleEpoch:      phase0.Epoch(math.MaxUint64),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:        slot,
+					CommitteeID: committeeID,
+					Attester:    []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name:            "ATTESTER is fork-invariant post-Boole",
+			role:            "ATTESTER",
+			booleEpoch:      phase0.Epoch(0),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:        slot,
+					CommitteeID: committeeID,
+					Attester:    []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name:            "SYNC_COMMITTEE is fork-invariant pre-Boole",
+			role:            "SYNC_COMMITTEE",
+			booleEpoch:      phase0.Epoch(math.MaxUint64),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:          slot,
+					CommitteeID:   committeeID,
+					SyncCommittee: []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+		{
+			name:            "SYNC_COMMITTEE is fork-invariant post-Boole",
+			role:            "SYNC_COMMITTEE",
+			booleEpoch:      phase0.Epoch(0),
+			expectCommittee: true,
+			signerDataBuilder: func() *traces.CommitteeDutyTrace {
+				return &traces.CommitteeDutyTrace{
+					Slot:          slot,
+					CommitteeID:   committeeID,
+					SyncCommittee: []*traces.SignerData{{Signer: 99, ValidatorIdx: []phase0.ValidatorIndex{idx}}},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockTraceStore()
+			validatorStore := newMockValidatorStore()
+
+			calledValidator := false
+			calledCommittee := false
+
+			store.GetValidatorDutyFunc = func(role spectypes.BeaconRole, slot phase0.Slot, index phase0.ValidatorIndex) (*traces.ValidatorDutyTrace, error) {
+				calledValidator = true
+				return &traces.ValidatorDutyTrace{Slot: slot, Role: role, Validator: index}, nil
+			}
+			store.GetCommitteeIDFunc = func(s phase0.Slot, i phase0.ValidatorIndex) (spectypes.CommitteeID, error) {
+				return committeeID, nil
+			}
+			store.GetCommitteeDutyFunc = func(s phase0.Slot, id spectypes.CommitteeID, role spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
+				calledCommittee = true
+				if tt.signerDataBuilder != nil {
+					return tt.signerDataBuilder(), nil
+				}
+				return &traces.CommitteeDutyTrace{Slot: s, CommitteeID: id}, nil
+			}
+
+			ssvCopy := *networkconfig.TestNetwork.SSV
+			ssvCopy.Forks.Boole = tt.booleEpoch
+			netCfg := *networkconfig.TestNetwork
+			netCfg.SSV = &ssvCopy
+
+			exp := newTestExporterForV2WithNetwork(store, validatorStore, &netCfg)
+
+			req := httptest.NewRequest(http.MethodPost, "/traces/validator", buildJSONBody(t, map[string]any{
+				"from":    uint64(slot),
+				"to":      uint64(slot),
+				"roles":   []string{tt.role},
+				"indices": []uint64{uint64(idx)},
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			err := exp.ValidatorTraces(rec, req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			assert.Equal(t, tt.expectValidator, calledValidator, "unexpected validator-store routing")
+			assert.Equal(t, tt.expectCommittee, calledCommittee, "unexpected committee-store routing")
+
+			if tt.expectCommittee {
+				var resp ValidatorTracesResponse
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				require.Len(t, resp.Data, 1)
+				require.NotEmpty(t, resp.Data[0].CommitteeID)
+				assert.Equal(t, hex.EncodeToString(committeeID[:]), resp.Data[0].CommitteeID)
+			}
+		})
+	}
+}
+
+// TestExporterValidatorTraces_ForkGating_ValidationSymmetric proves that validateValidatorRequest
+// (via isCommitteeDutyInRange) mirrors the same fork-gated routing decision for aggregator-family
+// roles: pre-Boole no pubkeys/indices are required, post-Boole they are (mirroring committee duties).
+func TestExporterValidatorTraces_ForkGating_ValidationSymmetric(t *testing.T) {
+	tests := []struct {
+		name         string
+		role         string
+		booleEpoch   phase0.Epoch
+		expectBadReq bool
+		setupMock    func(*mockTraceStore)
+	}{
+		{
+			name:         "AGGREGATOR pre-Boole without filters does not require pubkeys/indices",
+			role:         "AGGREGATOR",
+			booleEpoch:   phase0.Epoch(math.MaxUint64),
+			expectBadReq: false,
+			setupMock: func(store *mockTraceStore) {
+				store.GetValidatorDutiesFunc = func(role spectypes.BeaconRole, slot phase0.Slot) ([]*traces.ValidatorDutyTrace, error) {
+					return nil, nil
+				}
+			},
+		},
+		{
+			name:         "AGGREGATOR post-Boole without filters requires pubkeys/indices",
+			role:         "AGGREGATOR",
+			booleEpoch:   phase0.Epoch(0),
+			expectBadReq: true,
+		},
+		{
+			name:         "SYNC_COMMITTEE_CONTRIBUTION pre-Boole without filters does not require pubkeys/indices",
+			role:         "SYNC_COMMITTEE_CONTRIBUTION",
+			booleEpoch:   phase0.Epoch(math.MaxUint64),
+			expectBadReq: false,
+			setupMock: func(store *mockTraceStore) {
+				store.GetValidatorDutiesFunc = func(role spectypes.BeaconRole, slot phase0.Slot) ([]*traces.ValidatorDutyTrace, error) {
+					return nil, nil
+				}
+			},
+		},
+		{
+			name:         "SYNC_COMMITTEE_CONTRIBUTION post-Boole without filters requires pubkeys/indices",
+			role:         "SYNC_COMMITTEE_CONTRIBUTION",
+			booleEpoch:   phase0.Epoch(0),
+			expectBadReq: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockTraceStore()
+			if tt.setupMock != nil {
+				tt.setupMock(store)
+			}
+			validatorStore := newMockValidatorStore()
+
+			ssvCopy := *networkconfig.TestNetwork.SSV
+			ssvCopy.Forks.Boole = tt.booleEpoch
+			netCfg := *networkconfig.TestNetwork
+			netCfg.SSV = &ssvCopy
+
+			exp := newTestExporterForV2WithNetwork(store, validatorStore, &netCfg)
+
+			req := httptest.NewRequest(http.MethodPost, "/traces/validator", buildJSONBody(t, map[string]any{
+				"from":  uint64(100),
+				"to":    uint64(200),
+				"roles": []string{tt.role},
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			err := exp.ValidatorTraces(rec, req)
+			if tt.expectBadReq {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+		})
+	}
 }
 
 // mockValidatorStore is a simple in-memory ValidatorStore implementation for tests.

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -389,7 +389,7 @@ func newNode(
 			dstore, networkConfig.Beacon, decidedStreamPublisherFn,
 			dutyStore)
 
-		cfg.SSVOptions.ExporterRead = exportercore.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore())
+		cfg.SSVOptions.ExporterRead = exportercore.NewExporter(logger, storageMap, collector, nodeStorage.ValidatorStore(), networkConfig)
 	case modeExporterStandard:
 		logger.Info("exporter mode: standard")
 	case modeOperator:
@@ -580,7 +580,7 @@ func (n *node) start(ctx context.Context, spawn func(func() error)) error {
 			&hvalidators.Validators{
 				Shares: n.nodeStorage.Shares(),
 			},
-			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore()),
+			hexporter.NewExporter(n.logger, n.storageMap, n.collector, n.nodeStorage.ValidatorStore(), n.networkConfig),
 			n.mode == modeExporterArchive,
 		)
 		_, apiServeErr, err := apiServer.Start(ctx)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ssvlabs/ssv/exporter/store"
 	"github.com/ssvlabs/ssv/exporter/traces"
 	ibftstorage "github.com/ssvlabs/ssv/ibft/storage"
+	"github.com/ssvlabs/ssv/networkconfig"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
 
@@ -24,14 +25,16 @@ type Exporter struct {
 	traceStore        dutyTraceStore
 	validators        registrystorage.ValidatorStore
 	logger            *zap.Logger
+	networkConfig     *networkconfig.Network
 }
 
-func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantStores, traceStore dutyTraceStore, validators registrystorage.ValidatorStore) *Exporter {
+func NewExporter(logger *zap.Logger, participantStores *ibftstorage.ParticipantStores, traceStore dutyTraceStore, validators registrystorage.ValidatorStore, networkConfig *networkconfig.Network) *Exporter {
 	return &Exporter{
 		participantStores: participantStores,
 		traceStore:        traceStore,
 		validators:        validators,
 		logger:            logger,
+		networkConfig:     networkConfig,
 	}
 }
 

--- a/exporter/validator.go
+++ b/exporter/validator.go
@@ -65,10 +65,12 @@ func (e *Exporter) validateValidatorRequest(request *ValidatorTracesQuery) error
 		return fmt.Errorf("at least one role is required")
 	}
 
-	// either PubKeys or Indices are required for committee duty roles
+	// either PubKeys or Indices are required for committee duty roles.
+	// Fork state is evaluated at the range's upper bound: if any slot in
+	// [from, to] is post-Boole, the 'to' slot is too.
 	if len(request.PubKeys) == 0 && len(request.Indices) == 0 {
 		for _, role := range request.Roles {
-			if e.isCommitteeDutyInRange(role, phase0.Slot(request.From), phase0.Slot(request.To)) {
+			if e.isCommitteeDutyAtSlot(role, phase0.Slot(request.To)) {
 				return fmt.Errorf("role %s is a committee duty, please provide either pubkeys or indices to filter the duty for a specific validators subset or use the /committee endpoint to query all the corresponding duties", role.String())
 			}
 		}
@@ -263,23 +265,6 @@ func (e *Exporter) isCommitteeDutyAtSlot(role spectypes.BeaconRole, slot phase0.
 		// Alan: AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION are validator duties.
 		// Boole: AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION are committee duties.
 		return e.networkConfig.BooleForkAtSlot(slot)
-	}
-	return true
-}
-
-// isCommitteeDutyInRange reports whether the given beacon role resolves to a
-// committee-backed duty anywhere in the given (inclusive) slot range, evaluated
-// against the fork at the range's upper bound.
-func (e *Exporter) isCommitteeDutyInRange(role spectypes.BeaconRole, from, to phase0.Slot) bool {
-	if from > to {
-		return false
-	}
-	runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
-	if !ok {
-		return false
-	}
-	if runnerRole == spectypes.RoleAggregatorCommittee {
-		return e.networkConfig.BooleForkAtSlot(to)
 	}
 	return true
 }

--- a/exporter/validator.go
+++ b/exporter/validator.go
@@ -18,7 +18,7 @@ import (
 
 // ValidatorTracesCore contains the core logic for ValidatorTraces without any HTTP concerns.
 func (e *Exporter) ValidatorTracesCore(request *ValidatorTracesQuery) (*ValidatorTracesResult, *multierror.Error) {
-	if err := validateValidatorRequest(request); err != nil {
+	if err := e.validateValidatorRequest(request); err != nil {
 		return nil, multierror.Append(nil, &ValidationError{Err: err})
 	}
 
@@ -37,7 +37,7 @@ func (e *Exporter) ValidatorTracesCore(request *ValidatorTracesQuery) (*Validato
 		slot := phase0.Slot(s)
 		for _, role := range request.Roles {
 			providerFunc := e.getValidatorDutiesForRoleAndSlot
-			if isCommitteeDuty(role) {
+			if e.isCommitteeDutyAtSlot(role, slot) {
 				providerFunc = e.getValidatorCommitteeDutiesForRoleAndSlot
 			}
 
@@ -56,7 +56,7 @@ func (e *Exporter) ValidatorTracesCore(request *ValidatorTracesQuery) (*Validato
 	return &ValidatorTracesResult{Traces: results, Schedule: schedule}, errs
 }
 
-func validateValidatorRequest(request *ValidatorTracesQuery) error {
+func (e *Exporter) validateValidatorRequest(request *ValidatorTracesQuery) error {
 	if request.From > request.To {
 		return fmt.Errorf("'from' must be less than or equal to 'to'")
 	}
@@ -68,7 +68,7 @@ func validateValidatorRequest(request *ValidatorTracesQuery) error {
 	// either PubKeys or Indices are required for committee duty roles
 	if len(request.PubKeys) == 0 && len(request.Indices) == 0 {
 		for _, role := range request.Roles {
-			if isCommitteeDuty(role) {
+			if e.isCommitteeDutyInRange(role, phase0.Slot(request.From), phase0.Slot(request.To)) {
 				return fmt.Errorf("role %s is a committee duty, please provide either pubkeys or indices to filter the duty for a specific validators subset or use the /committee endpoint to query all the corresponding duties", role.String())
 			}
 		}
@@ -121,12 +121,13 @@ func (e *Exporter) getValidatorCommitteeDutiesForRoleAndSlot(role spectypes.Beac
 	results := make([]ValidatorCommitteeTrace, 0, len(indices))
 	var errs *multierror.Error
 
-	// This helper is only reached for committee-backed beacon roles (see isCommitteeDuty),
-	// which today always resolve to the RoleCommittee runner role.
+	// This helper is only reached for committee-backed beacon roles (see isCommitteeDutyAtSlot),
+	// which resolve to either the RoleCommittee or RoleAggregatorCommittee runner role.
 	runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
 	if !ok {
 		return nil, fmt.Errorf("unexpected committee-backed beacon role: %s", role.String())
 	}
+	bucket, _ := ssvtypes.CommitteeSignerBucketForBeaconRole(role)
 
 	for _, index := range indices {
 		committeeID, err := e.traceStore.GetCommitteeID(slot, index)
@@ -146,21 +147,22 @@ func (e *Exporter) getValidatorCommitteeDutiesForRoleAndSlot(role spectypes.Beac
 		// Membership gating: only return a validator entry if this index appears
 		// in the role-specific signer data collected for this committee duty.
 		hasIndex := false
-		if role == spectypes.BNRoleAttester {
+		switch bucket {
+		case ssvtypes.CommitteeSignerBucketAttester:
 			for _, sd := range duty.Attester {
 				if slices.Contains(sd.ValidatorIdx, index) {
 					hasIndex = true
 					break
 				}
 			}
-		} else if role == spectypes.BNRoleSyncCommittee {
+		case ssvtypes.CommitteeSignerBucketSyncCommittee:
 			for _, sd := range duty.SyncCommittee {
 				if slices.Contains(sd.ValidatorIdx, index) {
 					hasIndex = true
 					break
 				}
 			}
-		} else {
+		default:
 			// For non-committee roles, should not reach this path; be conservative.
 			hasIndex = true
 		}
@@ -247,6 +249,37 @@ func (e *Exporter) buildValidatorSchedule(req *ValidatorTracesQuery, indices []p
 }
 
 // === Shared validator traces helpers ===
-func isCommitteeDuty(role spectypes.BeaconRole) bool {
-	return role == spectypes.BNRoleSyncCommittee || role == spectypes.BNRoleAttester
+
+// isCommitteeDutyAtSlot reports whether the given beacon role resolves to a
+// committee-backed duty at the given slot. ATTESTER/SYNC_COMMITTEE are always
+// committee duties. AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION are validator duties
+// pre-Boole and committee duties post-Boole.
+func (e *Exporter) isCommitteeDutyAtSlot(role spectypes.BeaconRole, slot phase0.Slot) bool {
+	runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
+	if !ok {
+		return false
+	}
+	if runnerRole == spectypes.RoleAggregatorCommittee {
+		// Alan: AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION are validator duties.
+		// Boole: AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION are committee duties.
+		return e.networkConfig.BooleForkAtSlot(slot)
+	}
+	return true
+}
+
+// isCommitteeDutyInRange reports whether the given beacon role resolves to a
+// committee-backed duty anywhere in the given (inclusive) slot range, evaluated
+// against the fork at the range's upper bound.
+func (e *Exporter) isCommitteeDutyInRange(role spectypes.BeaconRole, from, to phase0.Slot) bool {
+	if from > to {
+		return false
+	}
+	runnerRole, ok := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
+	if !ok {
+		return false
+	}
+	if runnerRole == spectypes.RoleAggregatorCommittee {
+		return e.networkConfig.BooleForkAtSlot(to)
+	}
+	return true
 }

--- a/exporter/validator.go
+++ b/exporter/validator.go
@@ -129,7 +129,10 @@ func (e *Exporter) getValidatorCommitteeDutiesForRoleAndSlot(role spectypes.Beac
 	if !ok {
 		return nil, fmt.Errorf("unexpected committee-backed beacon role: %s", role.String())
 	}
-	bucket, _ := ssvtypes.CommitteeSignerBucketForBeaconRole(role)
+	bucket, ok := ssvtypes.CommitteeSignerBucketForBeaconRole(role)
+	if !ok {
+		return nil, fmt.Errorf("no signer bucket for committee-backed beacon role: %s", role.String())
+	}
 
 	for _, index := range indices {
 		committeeID, err := e.traceStore.GetCommitteeID(slot, index)

--- a/exporter/validator_test.go
+++ b/exporter/validator_test.go
@@ -1,0 +1,346 @@
+package exporter
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	estore "github.com/ssvlabs/ssv/exporter/store"
+	"github.com/ssvlabs/ssv/exporter/traces"
+	"github.com/ssvlabs/ssv/networkconfig"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+// preBooleNetwork returns a *networkconfig.Network clone with the Boole fork
+// disabled (never activates). It never mutates the shared TestNetwork.
+func preBooleNetwork() *networkconfig.Network {
+	ssvCopy := *networkconfig.TestNetwork.SSV
+	ssvCopy.Forks.Boole = phase0.Epoch(^uint64(0))
+	netCfg := *networkconfig.TestNetwork
+	netCfg.SSV = &ssvCopy
+	return &netCfg
+}
+
+// postBooleNetwork returns a *networkconfig.Network clone with the Boole fork
+// active from genesis. It never mutates the shared TestNetwork.
+func postBooleNetwork() *networkconfig.Network {
+	ssvCopy := *networkconfig.TestNetwork.SSV
+	ssvCopy.Forks.Boole = 0
+	netCfg := *networkconfig.TestNetwork
+	netCfg.SSV = &ssvCopy
+	return &netCfg
+}
+
+func TestIsCommitteeDutyAtSlot(t *testing.T) {
+	preFork := preBooleNetwork()
+	postFork := postBooleNetwork()
+
+	const slot = phase0.Slot(100)
+
+	tests := []struct {
+		name     string
+		role     spectypes.BeaconRole
+		netCfg   *networkconfig.Network
+		expected bool
+	}{
+		{name: "ATTESTER is committee duty pre-fork", role: spectypes.BNRoleAttester, netCfg: preFork, expected: true},
+		{name: "ATTESTER is committee duty post-fork", role: spectypes.BNRoleAttester, netCfg: postFork, expected: true},
+		{name: "SYNC_COMMITTEE is committee duty pre-fork", role: spectypes.BNRoleSyncCommittee, netCfg: preFork, expected: true},
+		{name: "SYNC_COMMITTEE is committee duty post-fork", role: spectypes.BNRoleSyncCommittee, netCfg: postFork, expected: true},
+		{name: "AGGREGATOR is a validator duty pre-fork", role: spectypes.BNRoleAggregator, netCfg: preFork, expected: false},
+		{name: "AGGREGATOR is a committee duty post-fork", role: spectypes.BNRoleAggregator, netCfg: postFork, expected: true},
+		{name: "SYNC_COMMITTEE_CONTRIBUTION is a validator duty pre-fork", role: spectypes.BNRoleSyncCommitteeContribution, netCfg: preFork, expected: false},
+		{name: "SYNC_COMMITTEE_CONTRIBUTION is a committee duty post-fork", role: spectypes.BNRoleSyncCommitteeContribution, netCfg: postFork, expected: true},
+		{name: "PROPOSER is never a committee duty pre-fork", role: spectypes.BNRoleProposer, netCfg: preFork, expected: false},
+		{name: "PROPOSER is never a committee duty post-fork", role: spectypes.BNRoleProposer, netCfg: postFork, expected: false},
+		{name: "VALIDATOR_REGISTRATION is never a committee duty pre-fork", role: spectypes.BNRoleValidatorRegistration, netCfg: preFork, expected: false},
+		{name: "VALIDATOR_REGISTRATION is never a committee duty post-fork", role: spectypes.BNRoleValidatorRegistration, netCfg: postFork, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Exporter{networkConfig: tt.netCfg}
+			assert.Equal(t, tt.expected, e.isCommitteeDutyAtSlot(tt.role, slot))
+		})
+	}
+}
+
+func TestValidateValidatorRequest(t *testing.T) {
+	preFork := preBooleNetwork()
+	postFork := postBooleNetwork()
+
+	preForkSlot := uint64(preFork.FirstSlotAtEpoch(1))
+	postForkSlot := uint64(postFork.FirstSlotAtEpoch(1))
+
+	tests := []struct {
+		name    string
+		netCfg  *networkconfig.Network
+		request *ValidatorTracesQuery
+		wantErr bool
+	}{
+		{
+			name:   "from greater than to is rejected",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:  10,
+				To:    5,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleProposer},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no roles is rejected",
+			netCfg:  preFork,
+			request: &ValidatorTracesQuery{From: 1, To: 1, Roles: nil},
+			wantErr: true,
+		},
+		{
+			name:   "committee-backed role without filters is rejected",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:  preForkSlot,
+				To:    preForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleAttester},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "committee-backed role with indices is accepted",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:    preForkSlot,
+				To:      preForkSlot,
+				Roles:   []spectypes.BeaconRole{spectypes.BNRoleAttester},
+				Indices: []phase0.ValidatorIndex{1},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "committee-backed role with pubkeys is accepted",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:    preForkSlot,
+				To:      preForkSlot,
+				Roles:   []spectypes.BeaconRole{spectypes.BNRoleAttester},
+				PubKeys: []spectypes.ValidatorPK{{0x01}},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "non-committee role without filters is accepted",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:  preForkSlot,
+				To:    preForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleProposer},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "AGGREGATOR without filters is accepted pre-fork",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:  preForkSlot,
+				To:    preForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "AGGREGATOR without filters is rejected post-fork",
+			netCfg: postFork,
+			request: &ValidatorTracesQuery{
+				From:  postForkSlot,
+				To:    postForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "range straddling the fork resolves on the 'to' bound: pre-fork 'to' is accepted",
+			netCfg: preFork,
+			request: &ValidatorTracesQuery{
+				From:  1,
+				To:    preForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "range straddling the fork resolves on the 'to' bound: post-fork 'to' is rejected",
+			netCfg: postFork,
+			request: &ValidatorTracesQuery{
+				From:  1,
+				To:    postForkSlot,
+				Roles: []spectypes.BeaconRole{spectypes.BNRoleAggregator},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Exporter{networkConfig: tt.netCfg}
+			err := e.validateValidatorRequest(tt.request)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// mockValidatorTraceStore is a minimal dutyTraceStore implementation for
+// exercising getValidatorCommitteeDutiesForRoleAndSlot's signer-bucket gating.
+type mockValidatorTraceStore struct {
+	dutyTraceStore
+	committeeID spectypes.CommitteeID
+	duty        *traces.CommitteeDutyTrace
+	getDutyErr  error
+	getIDErr    error
+}
+
+func (m *mockValidatorTraceStore) GetCommitteeID(_ phase0.Slot, _ phase0.ValidatorIndex) (spectypes.CommitteeID, error) {
+	if m.getIDErr != nil {
+		return spectypes.CommitteeID{}, m.getIDErr
+	}
+	return m.committeeID, nil
+}
+
+func (m *mockValidatorTraceStore) GetCommitteeDuty(_ phase0.Slot, _ spectypes.CommitteeID, _ spectypes.RunnerRole) (*traces.CommitteeDutyTrace, error) {
+	if m.getDutyErr != nil {
+		return nil, m.getDutyErr
+	}
+	return m.duty, nil
+}
+
+func TestGetValidatorCommitteeDutiesForRoleAndSlot(t *testing.T) {
+	const slot = phase0.Slot(50)
+	committeeID := spectypes.CommitteeID{0x01}
+	memberIdx := phase0.ValidatorIndex(7)
+	nonMemberIdx := phase0.ValidatorIndex(8)
+
+	duty := &traces.CommitteeDutyTrace{
+		Slot:          slot,
+		CommitteeID:   committeeID,
+		Attester:      []*traces.SignerData{{Signer: 1, ValidatorIdx: []phase0.ValidatorIndex{memberIdx}}},
+		SyncCommittee: []*traces.SignerData{{Signer: 2, ValidatorIdx: []phase0.ValidatorIndex{memberIdx}}},
+	}
+
+	tests := []struct {
+		name        string
+		role        spectypes.BeaconRole
+		indices     []phase0.ValidatorIndex
+		wantCount   int
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "ATTESTER uses the Attester signer bucket",
+			role:      spectypes.BNRoleAttester,
+			indices:   []phase0.ValidatorIndex{memberIdx},
+			wantCount: 1,
+		},
+		{
+			name:      "AGGREGATOR maps to the Attester signer bucket",
+			role:      spectypes.BNRoleAggregator,
+			indices:   []phase0.ValidatorIndex{memberIdx},
+			wantCount: 1,
+		},
+		{
+			name:      "SYNC_COMMITTEE uses the SyncCommittee signer bucket",
+			role:      spectypes.BNRoleSyncCommittee,
+			indices:   []phase0.ValidatorIndex{memberIdx},
+			wantCount: 1,
+		},
+		{
+			name:      "SYNC_COMMITTEE_CONTRIBUTION maps to the SyncCommittee signer bucket",
+			role:      spectypes.BNRoleSyncCommitteeContribution,
+			indices:   []phase0.ValidatorIndex{memberIdx},
+			wantCount: 1,
+		},
+		{
+			name:      "index absent from the bucket is excluded",
+			role:      spectypes.BNRoleAttester,
+			indices:   []phase0.ValidatorIndex{nonMemberIdx},
+			wantCount: 0,
+		},
+		{
+			name:        "non-committee-backed role fails fast",
+			role:        spectypes.BNRoleProposer,
+			indices:     []phase0.ValidatorIndex{memberIdx},
+			wantErr:     true,
+			errContains: "unexpected committee-backed beacon role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockValidatorTraceStore{committeeID: committeeID, duty: duty}
+			e := &Exporter{traceStore: store, logger: zap.NewNop()}
+
+			results, err := e.getValidatorCommitteeDutiesForRoleAndSlot(tt.role, slot, tt.indices)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, results, tt.wantCount)
+		})
+	}
+}
+
+func TestGetValidatorCommitteeDutiesForRoleAndSlot_PropagatesLookupErrors(t *testing.T) {
+	const slot = phase0.Slot(50)
+	idx := phase0.ValidatorIndex(7)
+
+	t.Run("committee ID lookup error is collected, not fatal", func(t *testing.T) {
+		store := &mockValidatorTraceStore{getIDErr: estore.ErrNotFound}
+		e := &Exporter{traceStore: store, logger: zap.NewNop()}
+
+		results, err := e.getValidatorCommitteeDutiesForRoleAndSlot(spectypes.BNRoleAttester, slot, []phase0.ValidatorIndex{idx})
+
+		require.Error(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("committee duty lookup error is collected, not fatal", func(t *testing.T) {
+		store := &mockValidatorTraceStore{committeeID: spectypes.CommitteeID{0x01}, getDutyErr: estore.ErrNotFound}
+		e := &Exporter{traceStore: store, logger: zap.NewNop()}
+
+		results, err := e.getValidatorCommitteeDutiesForRoleAndSlot(spectypes.BNRoleAttester, slot, []phase0.ValidatorIndex{idx})
+
+		require.Error(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+// TestCommitteeSignerBucketForBeaconRole_ExhaustiveRoles is a lightweight guard
+// that the beacon-role -> signer-bucket mapping used by
+// getValidatorCommitteeDutiesForRoleAndSlot stays in sync with
+// CommitteeRunnerRoleForBeaconRole: every committee-backed beacon role must
+// also resolve to a signer bucket.
+func TestCommitteeSignerBucketForBeaconRole_ExhaustiveRoles(t *testing.T) {
+	roles := []spectypes.BeaconRole{
+		spectypes.BNRoleAttester,
+		spectypes.BNRoleAggregator,
+		spectypes.BNRoleSyncCommittee,
+		spectypes.BNRoleSyncCommitteeContribution,
+	}
+
+	for _, role := range roles {
+		_, isCommitteeBacked := ssvtypes.CommitteeRunnerRoleForBeaconRole(role)
+		require.True(t, isCommitteeBacked, "role %s expected to be committee-backed", role.String())
+
+		_, hasBucket := ssvtypes.CommitteeSignerBucketForBeaconRole(role)
+		require.True(t, hasBucket, "role %s expected to have a signer bucket", role.String())
+	}
+}

--- a/operator/node_query_test.go
+++ b/operator/node_query_test.go
@@ -85,7 +85,7 @@ func newWSQueryHarness(t *testing.T) *wsQueryHarness {
 	store := newFaultingDutyTraceStore(realStore)
 
 	collector := dutytracer.New(zap.NewNop(), validatorMock, nil, store, networkconfig.TestNetwork.Beacon, nil, nil)
-	coreExporter := exportercore.NewExporter(zap.NewNop(), ibftstorage.NewStores(), collector, validatorMock)
+	coreExporter := exportercore.NewExporter(zap.NewNop(), ibftstorage.NewStores(), collector, validatorMock, networkconfig.TestNetwork)
 
 	node := &Node{
 		logger:       logger,


### PR DESCRIPTION
## convergence: fork-aware exporter validator-path duty routing

Completes the deferred follow-up from 5c-exporter (PR #2937). Threads `networkConfig` into `NewExporter` so the exporter's validator-trace API routes **AGGREGATOR** and **SYNC_COMMITTEE_CONTRIBUTION** duties correctly across the Boole fork. Today they always route to the validator path (permanently Alan); post-Boole they must route to the committee path.

### Changes
- `exporter/validator.go`: replace fork-unaware `isCommitteeDuty` with `isCommitteeDutyAtSlot`/`isCommitteeDutyInRange` methods that gate the two aggregator-family roles on `BooleForkAtSlot` (ATTESTER/SYNC_COMMITTEE stay fork-invariant → committee path always; other roles → validator path). `validateValidatorRequest` becomes a method. Ported boole's `CommitteeSignerBucketForBeaconRole` bucket-switch for membership gating (so aggregator-family filtering is correct post-Boole, not the old loose `else`).
- `exporter/exporter.go` + `api/handlers/exporter/exporter.go`: `networkConfig` added as the last `NewExporter` param (struct field + pass-through).
- `cli/operator/node.go`: both call sites pass the node's `networkConfig`.

### Behavior
Additive — **pre-Boole is byte-identical to today**; only post-Boole routing of AGGREGATOR/SYNC_COMMITTEE_CONTRIBUTION changes (validator → committee path). Read-only API surface; no consensus/duty-execution impact.

### Review & tests
- **code-reviewer-deep: PASS, no blockers** — routing logic byte-identical to boole, pre-fork preserved, membership switch faithful (no regression), no nil-`networkConfig` surface (all constructors pass a real value).
- New `TestExporterValidatorTraces_ForkGating` (8 subtests) + `_ValidationSymmetric` (4) assert **which store** is hit pre-vs-post-Boole (committee vs validator) via call-flags, correct signer-bucket + `CommitteeID`, and ATTESTER/SYNC_COMMITTEE fork-invariance. Per-test config is a clone (`Forks.Boole=0`) that doesn't mutate shared `TestNetwork`.
- Validation: build, vet (main + ssvsigner), deadcode, gofmt, golangci-lint, tests all green.

Stacks on `integration/boole-convergence`; no overlap with #2939 (that's `message/validation/`).
