### PR TITLE
cleanup(p2p): drop unused logger param and subsLimit field from newSubFilter

### DIFF
--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -127,7 +127,7 @@ func NewPubSub(
 	}
 
 	// Set up a SubFilter with a whitelist of known topics.
-	sf := newSubFilter(logger, subscriptionRequestLimit)
+	sf := newSubFilter()
 	for _, topic := range commons.Topics(cfg.NetworkConfig) {
 		sf.(Whitelist).Register(topic)
 	}

--- a/network/topics/sub_filter.go
+++ b/network/topics/sub_filter.go
@@ -4,7 +4,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/utils/hashmap"
@@ -20,13 +19,11 @@ type SubFilter interface {
 
 type subFilter struct {
 	whitelist *dynamicWhitelist
-	subsLimit int
 }
 
-func newSubFilter(logger *zap.Logger, subsLimit int) SubFilter {
+func newSubFilter() SubFilter {
 	return &subFilter{
 		whitelist: newWhitelist(),
-		subsLimit: subsLimit,
 	}
 }
 

--- a/network/topics/sub_filter_test.go
+++ b/network/topics/sub_filter_test.go
@@ -6,12 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ssvlabs/ssv/network/commons"
-	"github.com/ssvlabs/ssv/observability/log"
 )
 
 func TestSubFilter(t *testing.T) {
-	l := log.TestLogger(t)
-	sf := newSubFilter(l, 2)
+	sf := newSubFilter()
 
 	require.False(t, sf.CanSubscribe("xxx"))
 	require.False(t, sf.CanSubscribe(commons.GetTopicFullName("xxx")))
@@ -26,8 +24,7 @@ func TestSubFilter(t *testing.T) {
 // total post-Boole outage (self-subscribe crash-loop + QBFT broadcast failures).
 func TestSubFilter_CanSubscribeBoole(t *testing.T) {
 	const networkName = "hoodi-stage"
-	l := log.TestLogger(t)
-	sf := newSubFilter(l, 2)
+	sf := newSubFilter()
 
 	booleTopic := commons.BooleTopic(networkName, 51)
 


### PR DESCRIPTION
Closes #2945.

**Stacked on #2944** (`fix/2943-boole-subfilter-canfsubscribe`) — only the last commit (288f94c) is new here. Once #2944 merges and its branch is deleted, this retargets to `integration/boole-convergence` automatically.

## Summary

`newSubFilter` accepted a `logger` and a `subsLimit` that were never read — the subscription cap is enforced by the package-level `subscriptionRequestLimit` in `FilterIncomingSubscriptions`. Flagged by @iurii-ssv during review of #2944 as out-of-scope there.

## Changes

- `network/topics/sub_filter.go`: remove the `subsLimit` field and both constructor parameters (drops the now-unused `zap` import)
- `network/topics/pubsub.go`: update the single call site
- `network/topics/sub_filter_test.go`: update the two test constructions; the test logger setup existed only to feed the constructor, so it goes too

## Testing

- `go build ./...`, `go vet ./network/topics/`, `gofmt` — clean
- `go test -run TestSubFilter ./network/topics/` — pass
- `./scripts/deadcode.sh` — no unused code

No behavior change; the enforced subscription limit is identical before and after.