### PR TITLE
fix(qbft): resolve controller identifier per-height so post-Boole consensus carries the correct domain (#2947)

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1088,8 +1088,15 @@ func SetupCommitteeRunners(
 			CutOffRound: roundtimer.CutOffRound,
 		}
 
-		identifier := spectypes.NewMsgID(options.NetworkConfig.DomainType, options.Operator.CommitteeID[:], role)
-		qbftCtrl := qbftcontroller.NewController(identifier[:], options.Operator, config, options.OperatorSigner, options.FullNode)
+		committeeID := options.Operator.CommitteeID
+		identifierFn := func(height specqbft.Height) []byte {
+			domain := options.NetworkConfig.DomainTypeAtSlot(phase0.Slot(height))
+			id := spectypes.NewMsgID(domain, committeeID[:], role)
+			return id[:]
+		}
+		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
+		qbftCtrl := qbftcontroller.NewController(identifier, options.Operator, config, options.OperatorSigner, options.FullNode)
+		qbftCtrl.IdentifierFn = identifierFn
 		return qbftCtrl
 	}
 
@@ -1174,8 +1181,15 @@ func SetupRunners(
 			CutOffRound: roundtimer.CutOffRound,
 		}
 
-		identifier := spectypes.NewMsgID(options.NetworkConfig.DomainType, share.ValidatorPubKey[:], role)
-		qbftCtrl := qbftcontroller.NewController(identifier[:], operator, config, options.OperatorSigner, options.FullNode)
+		validatorPubKey := share.ValidatorPubKey
+		identifierFn := func(height specqbft.Height) []byte {
+			domain := options.NetworkConfig.DomainTypeAtSlot(phase0.Slot(height))
+			id := spectypes.NewMsgID(domain, validatorPubKey[:], role)
+			return id[:]
+		}
+		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
+		qbftCtrl := qbftcontroller.NewController(identifier, operator, config, options.OperatorSigner, options.FullNode)
+		qbftCtrl.IdentifierFn = identifierFn
 		return qbftCtrl
 	}
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1061,6 +1061,16 @@ func (c *Controller) ReportValidatorStatuses(ctx context.Context) {
 	}
 }
 
+// newIdentifierFn returns a per-height QBFT identifier resolver for the given executor
+// (committee ID or validator public key), carrying the fork-correct SSV domain for the
+// height's slot.
+func newIdentifierFn(cfg *networkconfig.Network, executorID []byte, role spectypes.RunnerRole) func(specqbft.Height) []byte {
+	return func(height specqbft.Height) []byte {
+		id := spectypes.NewMsgID(cfg.DomainTypeAtSlot(phase0.Slot(height)), executorID, role)
+		return id[:]
+	}
+}
+
 func SetupCommitteeRunners(
 	ctx context.Context,
 	options *validator.Options,
@@ -1089,11 +1099,7 @@ func SetupCommitteeRunners(
 		}
 
 		committeeID := options.Operator.CommitteeID
-		identifierFn := func(height specqbft.Height) []byte {
-			domain := options.NetworkConfig.DomainTypeAtSlot(phase0.Slot(height))
-			id := spectypes.NewMsgID(domain, committeeID[:], role)
-			return id[:]
-		}
+		identifierFn := newIdentifierFn(options.NetworkConfig, committeeID[:], role)
 		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
 		qbftCtrl := qbftcontroller.NewController(identifier, options.Operator, config, options.OperatorSigner, options.FullNode)
 		qbftCtrl.IdentifierFn = identifierFn
@@ -1182,11 +1188,7 @@ func SetupRunners(
 		}
 
 		validatorPubKey := share.ValidatorPubKey
-		identifierFn := func(height specqbft.Height) []byte {
-			domain := options.NetworkConfig.DomainTypeAtSlot(phase0.Slot(height))
-			id := spectypes.NewMsgID(domain, validatorPubKey[:], role)
-			return id[:]
-		}
+		identifierFn := newIdentifierFn(options.NetworkConfig, validatorPubKey[:], role)
 		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
 		qbftCtrl := qbftcontroller.NewController(identifier, operator, config, options.OperatorSigner, options.FullNode)
 		qbftCtrl.IdentifierFn = identifierFn

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1100,7 +1100,7 @@ func SetupCommitteeRunners(
 
 		committeeID := options.Operator.CommitteeID
 		identifierFn := newIdentifierFn(options.NetworkConfig, committeeID[:], role)
-		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
+		identifier := identifierFn(specqbft.FirstHeight) // domain at slot 0; used as Controller.Identifier (diagnostics only, not persisted)
 		qbftCtrl := qbftcontroller.NewController(identifier, options.Operator, config, options.OperatorSigner, options.FullNode)
 		qbftCtrl.IdentifierFn = identifierFn
 		return qbftCtrl
@@ -1189,7 +1189,7 @@ func SetupRunners(
 
 		validatorPubKey := share.ValidatorPubKey
 		identifierFn := newIdentifierFn(options.NetworkConfig, validatorPubKey[:], role)
-		identifier := identifierFn(specqbft.FirstHeight) // pre-fork domain; used as Controller.Identifier (diagnostics only, not persisted)
+		identifier := identifierFn(specqbft.FirstHeight) // domain at slot 0; used as Controller.Identifier (diagnostics only, not persisted)
 		qbftCtrl := qbftcontroller.NewController(identifier, operator, config, options.OperatorSigner, options.FullNode)
 		qbftCtrl.IdentifierFn = identifierFn
 		return qbftCtrl

--- a/operator/validator/identifier_fn_test.go
+++ b/operator/validator/identifier_fn_test.go
@@ -1,0 +1,55 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+// TestNewIdentifierFn_ForkDomain verifies that the identifier resolver wired into QBFT
+// controllers by SetupCommitteeRunners/SetupRunners switches the SSV domain at the Boole
+// fork boundary: heights before the fork slot carry DomainType (Alan), heights at/after
+// it carry NextDomainType (Boole), with the executor ID and role preserved.
+func TestNewIdentifierFn_ForkDomain(t *testing.T) {
+	// Build a fork-spanning config explicitly (Boole at epoch 10) rather than aliasing the
+	// package-global TestNetwork, whose Boole epoch can be flipped by SSV_TEST_BOOLE_FORK.
+	forkEpoch := phase0.Epoch(10)
+	ssvCfg := *networkconfig.TestNetwork.SSV
+	ssvCfg.Forks = networkconfig.SSVForks{Boole: forkEpoch}
+	cfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &ssvCfg}
+
+	slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.SlotsPerEpoch)
+	preForkHeight := specqbft.Height(phase0.Slot(forkEpoch)*slotsPerEpoch - 1)
+	postForkHeight := specqbft.Height(phase0.Slot(forkEpoch) * slotsPerEpoch)
+
+	committeeID := spectypes.CommitteeID{0x11, 0x22, 0x33}
+	validatorPubKey := spectypes.ValidatorPK{0xaa, 0xbb, 0xcc}
+
+	for _, tc := range []struct {
+		name       string
+		executorID []byte
+		role       spectypes.RunnerRole
+	}{
+		{name: "committee executor", executorID: committeeID[:], role: spectypes.RoleCommittee},
+		{name: "validator executor", executorID: validatorPubKey[:], role: spectypes.RoleProposer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			identifierFn := newIdentifierFn(cfg, tc.executorID, tc.role)
+
+			expectedPreFork := spectypes.NewMsgID(cfg.DomainType, tc.executorID, tc.role)
+			expectedPostFork := spectypes.NewMsgID(cfg.NextDomainType, tc.executorID, tc.role)
+			require.NotEqual(t, expectedPreFork, expectedPostFork,
+				"sanity: pre- and post-fork identifiers must differ in domain")
+
+			require.Equal(t, expectedPreFork[:], identifierFn(preForkHeight),
+				"height before the fork slot must carry the Alan domain")
+			require.Equal(t, expectedPostFork[:], identifierFn(postForkHeight),
+				"height at/after the fork slot must carry the Boole domain")
+		})
+	}
+}

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -34,7 +34,7 @@ type Controller struct {
 	// IdentifierFn, when non-nil, resolves the QBFT message identifier at a given height.
 	// It is used on both send (StartNewInstance) and receive (ProcessMsg) paths to produce
 	// the fork-correct SSV domain for the height/slot. When nil, falls back to Identifier.
-	// JSON-tagged as "-" because funcs are not JSON-serialisable; Controller is only marshalled
+	// JSON-tagged as "-" because funcs are not JSON-serialisable; Controller is only marshaled
 	// in spec-test fixtures and is never persisted and rehydrated in production.
 	IdentifierFn func(height specqbft.Height) []byte `json:"-"`
 

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -31,6 +31,13 @@ type NewDecidedHandler func(msg qbftstorage.Participation)
 type Controller struct {
 	Identifier []byte
 
+	// IdentifierFn, when non-nil, resolves the QBFT message identifier at a given height.
+	// It is used on both send (StartNewInstance) and receive (ProcessMsg) paths to produce
+	// the fork-correct SSV domain for the height/slot. When nil, falls back to Identifier.
+	// JSON-tagged as "-" because funcs are not JSON-serialisable; Controller is only marshalled
+	// in spec-test fixtures and is never persisted and rehydrated in production.
+	IdentifierFn func(height specqbft.Height) []byte `json:"-"`
+
 	// LatestInstanceHeight is the height of the latest Instance Controller spun up. That latest instance
 	// is the "relevant" one currently driving consensus.
 	// JSON-tagged as "Height" to preserve compatibility with existing spec-test fixtures.
@@ -45,6 +52,16 @@ type Controller struct {
 	NewDecidedHandler NewDecidedHandler       `json:"-"`
 	config            qbft.IConfig
 	fullNode          bool
+}
+
+// identifierAtHeight returns the QBFT message identifier for the given height.
+// When IdentifierFn is set it delegates to it (producing the fork-correct domain);
+// otherwise it falls back to the static Identifier field.
+func (c *Controller) identifierAtHeight(height specqbft.Height) []byte {
+	if c.IdentifierFn != nil {
+		return c.IdentifierFn(height)
+	}
+	return c.Identifier
 }
 
 func NewController(
@@ -110,7 +127,7 @@ func (c *Controller) StartNewInstance(
 		logger,
 		c.GetConfig(),
 		c.CommitteeMember,
-		c.Identifier,
+		c.identifierAtHeight(height),
 		height,
 		c.OperatorSigner,
 		roundTimerF,
@@ -143,7 +160,7 @@ func (c *Controller) ProcessMsg(
 		return nil, fmt.Errorf("could not create ProcessingMessage from signed message: %w", err)
 	}
 
-	if !bytes.Equal(c.Identifier, msg.QBFTMessage.Identifier) {
+	if !bytes.Equal(c.identifierAtHeight(msg.QBFTMessage.Height), msg.QBFTMessage.Identifier) {
 		return nil, spectypes.NewError(spectypes.MessageIdentifierInvalidErrorCode, "message doesn't belong to Identifier")
 	}
 

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -29,6 +29,10 @@ type NewDecidedHandler func(msg qbftstorage.Participation)
 
 // Controller is a QBFT coordinator responsible for starting and following the entire life cycle of multiple QBFT Instances
 type Controller struct {
+	// Identifier is the static QBFT message identifier fixed at construction time, carrying
+	// the domain at slot 0. When IdentifierFn is set, live traffic switches domains per
+	// height, so this field no longer matches what's on the wire post-fork — resolve via
+	// identifierAtHeight instead of reading this field (or GetIdentifier) directly.
 	Identifier []byte
 
 	// IdentifierFn, when non-nil, resolves the QBFT message identifier at a given height.
@@ -205,7 +209,9 @@ func (c *Controller) UponExistingInstanceMsg(ctx context.Context, logger *zap.Lo
 	return decidedMsg, nil
 }
 
-// GetIdentifier returns QBFT Identifier, used to identify messages
+// GetIdentifier returns the static QBFT Identifier fixed at construction time (domain at
+// slot 0). It does not reflect per-height fork domains — use identifierAtHeight for the
+// identifier actually carried on the wire at a given height.
 func (c *Controller) GetIdentifier() []byte {
 	return c.Identifier
 }

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -103,7 +103,7 @@ func TestController_IdentifierAtHeight(t *testing.T) {
 		ctrl := NewController(identifier, member, nil, nil, false)
 		ctrl.IdentifierFn = identifierFn
 
-		slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.Beacon.SlotsPerEpoch)
+		slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.SlotsPerEpoch)
 
 		preForkSlot := phase0.Slot(forkEpoch)*slotsPerEpoch - 1
 		postForkSlot := phase0.Slot(forkEpoch) * slotsPerEpoch
@@ -145,7 +145,6 @@ func TestController_IdentifierAtHeight(t *testing.T) {
 		require.NotEqual(t, expectedBooleDomain[:], resolvedID.GetDomain(),
 			"unpatched controller must NOT produce Boole domain (proves the bug exists without fix)")
 	})
-
 }
 
 // makeSignedQBFTMsg builds a minimal SignedSSVMessage carrying a RoundChange QBFT message
@@ -175,7 +174,7 @@ func TestController_ProcessMsg_ForkDomainCheck(t *testing.T) {
 	midBooleSSV.Forks = networkconfig.SSVForks{Boole: forkEpoch}
 	midBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &midBooleSSV}
 
-	slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.Beacon.SlotsPerEpoch)
+	slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.SlotsPerEpoch)
 	preForkSlot := phase0.Slot(forkEpoch)*slotsPerEpoch - 1
 	postForkSlot := phase0.Slot(forkEpoch) * slotsPerEpoch
 

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"errors"
 	"math"
 	"testing"
@@ -15,6 +16,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft/roundtimer"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv"
 )
 
 // TestController_IdentifierAtHeight verifies that the per-height identifier resolves to the
@@ -298,4 +302,163 @@ func TestController_NilIdentifierFn_ByteIdenticalToStatic(t *testing.T) {
 		require.True(t, bytes.Equal(staticID[:], got),
 			"nil-fn controller must return byte-identical static Identifier at height %d", height)
 	}
+}
+
+// okValueChecker accepts any value. Defined locally (rather than reusing
+// protocol/v2/testing.TestingValueChecker) to avoid an import cycle: protocol/v2/testing
+// imports this package.
+type okValueChecker struct{}
+
+func (okValueChecker) CheckValue([]byte) error { return nil }
+
+// forkTestHarness bundles the fixtures shared by the send-path fork tests: a config with
+// Boole activating at epoch 10, the fork-boundary heights, a fork-aware identifier function
+// and a static identifier frozen at the pre-fork (Alan) domain.
+type forkTestHarness struct {
+	ks             *spectestingutils.TestKeySet
+	member         *spectypes.CommitteeMember
+	cfg            *networkconfig.Network
+	preForkHeight  specqbft.Height
+	postForkHeight specqbft.Height
+	identifierFn   func(specqbft.Height) []byte
+	staticID       spectypes.MessageID
+	roundTimerF    ssv.QBFTRoundTimerF
+}
+
+func newForkTestHarness() *forkTestHarness {
+	ks := spectestingutils.Testing4SharesSet()
+	member := spectestingutils.TestingCommitteeMember(ks)
+	role := spectypes.RoleCommittee
+	committeeID := member.CommitteeID
+
+	forkEpoch := phase0.Epoch(10)
+	midBooleSSV := *networkconfig.TestNetwork.SSV
+	midBooleSSV.Forks = networkconfig.SSVForks{Boole: forkEpoch}
+	midBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &midBooleSSV}
+
+	slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.SlotsPerEpoch)
+
+	identifierFn := func(height specqbft.Height) []byte {
+		domain := midBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
+		id := spectypes.NewMsgID(domain, committeeID[:], role)
+		return id[:]
+	}
+
+	return &forkTestHarness{
+		ks:             ks,
+		member:         member,
+		cfg:            midBooleCfg,
+		preForkHeight:  specqbft.Height(phase0.Slot(forkEpoch)*slotsPerEpoch - 1),
+		postForkHeight: specqbft.Height(phase0.Slot(forkEpoch) * slotsPerEpoch),
+		identifierFn:   identifierFn,
+		staticID:       spectypes.NewMsgID(midBooleCfg.DomainType, committeeID[:], role),
+		roundTimerF: func(ctx context.Context, logger *zap.Logger, slot phase0.Slot) ssv.QBFTRoundTimer {
+			return roundtimer.NewTestingTimer()
+		},
+	}
+}
+
+func (h *forkTestHarness) newController() *Controller {
+	cfg := &qbft.Config{
+		// Some other operator is the round-1 proposer so Start doesn't attempt to create and
+		// broadcast a proposal — irrelevant to the identifier under test.
+		ProposerF: func(*specqbft.State, specqbft.Round) spectypes.OperatorID {
+			return 2
+		},
+		CutOffRound: spectestingutils.TestingCutOffRound,
+	}
+	ctrl := NewController(h.staticID[:], h.member, cfg, nil, false)
+	ctrl.IdentifierFn = h.identifierFn
+	return ctrl
+}
+
+// instanceDomain extracts the SSV domain from an instance's State.ID.
+func instanceDomain(t *testing.T, id []byte) []byte {
+	t.Helper()
+	require.Len(t, id, 56)
+	return spectypes.MessageID(id).GetDomain()
+}
+
+// TestController_StartNewInstance_ForkDomain drives the real send path: StartNewInstance must
+// create instances whose State.ID carries the fork-correct domain, even though the controller's
+// static Identifier stays frozen at the pre-fork (Alan) domain. This guards the exact regression
+// this fix addresses — reverting StartNewInstance to c.Identifier fails these assertions.
+func TestController_StartNewInstance_ForkDomain(t *testing.T) {
+	h := newForkTestHarness()
+	logger := zap.NewNop()
+
+	t.Run("post-fork height starts instance with Boole domain", func(t *testing.T) {
+		ctrl := h.newController()
+
+		inst, err := ctrl.StartNewInstance(context.Background(), logger, h.postForkHeight,
+			spectestingutils.TestingQBFTFullData, okValueChecker{}, h.roundTimerF)
+		require.NoError(t, err)
+
+		domain := instanceDomain(t, inst.State.ID)
+		require.Equal(t, h.cfg.NextDomainType[:], domain,
+			"instance started at post-fork height must carry the Boole domain")
+		require.NotEqual(t, h.staticID.GetDomain(), domain,
+			"instance identifier must not fall back to the static (Alan) controller Identifier")
+	})
+
+	t.Run("pre-fork height starts instance with Alan domain", func(t *testing.T) {
+		ctrl := h.newController()
+
+		inst, err := ctrl.StartNewInstance(context.Background(), logger, h.preForkHeight,
+			spectestingutils.TestingQBFTFullData, okValueChecker{}, h.roundTimerF)
+		require.NoError(t, err)
+
+		require.Equal(t, h.cfg.DomainType[:], instanceDomain(t, inst.State.ID),
+			"instance started at pre-fork height must carry the Alan domain")
+	})
+}
+
+// TestController_UponDecided_ForkDomain drives the decided fast-forward path: when UponDecided
+// sees a quorum-decided message for an unknown height, the instance it creates must carry the
+// fork-correct domain rather than the controller's static Identifier.
+func TestController_UponDecided_ForkDomain(t *testing.T) {
+	h := newForkTestHarness()
+	logger := zap.NewNop()
+
+	signers := []*rsa.PrivateKey{h.ks.OperatorKeys[1], h.ks.OperatorKeys[2], h.ks.OperatorKeys[3]}
+	ids := []spectypes.OperatorID{1, 2, 3}
+
+	t.Run("post-fork decided message fast-forwards instance with Boole domain", func(t *testing.T) {
+		ctrl := h.newController()
+
+		decidedMsg := spectestingutils.TestingCommitMultiSignerMessageWithHeightAndIdentifier(
+			signers, ids, h.postForkHeight, h.identifierFn(h.postForkHeight))
+		pmsg, err := specqbft.NewProcessingMessage(decidedMsg)
+		require.NoError(t, err)
+
+		decided, err := ctrl.UponDecided(logger, pmsg, h.roundTimerF)
+		require.NoError(t, err)
+		require.NotNil(t, decided, "quorum-decided message for unknown height must be newly decided")
+
+		inst := ctrl.RecentInstances.FindInstance(h.postForkHeight)
+		require.NotNil(t, inst)
+		domain := instanceDomain(t, inst.State.ID)
+		require.Equal(t, h.cfg.NextDomainType[:], domain,
+			"fast-forwarded instance at post-fork height must carry the Boole domain")
+		require.NotEqual(t, h.staticID.GetDomain(), domain,
+			"fast-forwarded instance must not fall back to the static (Alan) controller Identifier")
+	})
+
+	t.Run("pre-fork decided message fast-forwards instance with Alan domain", func(t *testing.T) {
+		ctrl := h.newController()
+
+		decidedMsg := spectestingutils.TestingCommitMultiSignerMessageWithHeightAndIdentifier(
+			signers, ids, h.preForkHeight, h.identifierFn(h.preForkHeight))
+		pmsg, err := specqbft.NewProcessingMessage(decidedMsg)
+		require.NoError(t, err)
+
+		decided, err := ctrl.UponDecided(logger, pmsg, h.roundTimerF)
+		require.NoError(t, err)
+		require.NotNil(t, decided)
+
+		inst := ctrl.RecentInstances.FindInstance(h.preForkHeight)
+		require.NotNil(t, inst)
+		require.Equal(t, h.cfg.DomainType[:], instanceDomain(t, inst.State.ID),
+			"fast-forwarded instance at pre-fork height must carry the Alan domain")
+	})
 }

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 // TestController_IdentifierAtHeight verifies that the per-height identifier resolves to the
-// fork-correct SSV domain. Pre-Boole heights must yield DomainType (Alan, 0x...3114) and
-// post-Boole heights must yield NextDomainType (Boole, 0x...3115).
+// fork-correct SSV domain. Pre-Boole heights must yield the config's DomainType (Alan) and
+// post-Boole heights must yield its NextDomainType (Boole).
 //
 // The test also confirms the regression: without IdentifierFn the controller uses the static
 // Identifier frozen at construction time, causing post-fork heights to still carry the pre-fork

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -1,0 +1,297 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+// TestController_IdentifierAtHeight verifies that the per-height identifier resolves to the
+// fork-correct SSV domain. Pre-Boole heights must yield DomainType (Alan, 0x...3114) and
+// post-Boole heights must yield NextDomainType (Boole, 0x...3115).
+//
+// The test also confirms the regression: without IdentifierFn the controller uses the static
+// Identifier frozen at construction time, causing post-fork heights to still carry the pre-fork
+// domain.
+func TestController_IdentifierAtHeight(t *testing.T) {
+	ks := spectestingutils.Testing4SharesSet()
+	member := spectestingutils.TestingCommitteeMember(ks)
+	role := spectypes.RoleCommittee
+
+	// Build a post-Boole config: Boole active from genesis (epoch 0).
+	postBooleSSV := *networkconfig.TestNetwork.SSV
+	postBooleSSV.Forks = networkconfig.SSVForks{Boole: 0}
+	postBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &postBooleSSV}
+
+	// Build a pre-Boole config: Boole disabled (epoch MaxUint64).
+	preBooleCfg := networkconfig.TestNetwork // Boole = MaxUint64 by default
+
+	committeeID := member.CommitteeID
+
+	t.Run("post-Boole height yields Boole domain", func(t *testing.T) {
+		identifierFn := func(height specqbft.Height) []byte {
+			domain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
+			id := spectypes.NewMsgID(domain, committeeID[:], role)
+			return id[:]
+		}
+
+		// height 1 is slot 1, which in an epoch-0 Boole fork is already post-fork.
+		postBooleHeight := specqbft.Height(1)
+		identifier := identifierFn(specqbft.FirstHeight)
+
+		ctrl := NewController(identifier, member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+
+		resolvedID := ctrl.identifierAtHeight(postBooleHeight)
+		msgID := spectypes.MessageID(resolvedID[0:56])
+
+		expectedDomain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(postBooleHeight))
+		require.Equal(t, expectedDomain[:], msgID.GetDomain(),
+			"post-Boole height must use NextDomainType (Boole)")
+		require.Equal(t, postBooleCfg.NextDomainType[:], msgID.GetDomain(),
+			"post-Boole domain must equal cfg.NextDomainType")
+	})
+
+	t.Run("pre-Boole height yields Alan domain", func(t *testing.T) {
+		identifierFn := func(height specqbft.Height) []byte {
+			domain := preBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
+			id := spectypes.NewMsgID(domain, committeeID[:], role)
+			return id[:]
+		}
+
+		// With Boole at MaxUint64, any normal slot is pre-fork.
+		preForkHeight := specqbft.Height(1000)
+		identifier := identifierFn(specqbft.FirstHeight)
+
+		ctrl := NewController(identifier, member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+
+		resolvedID := ctrl.identifierAtHeight(preForkHeight)
+		msgID := spectypes.MessageID(resolvedID[0:56])
+
+		expectedDomain := preBooleCfg.DomainTypeAtSlot(phase0.Slot(preForkHeight))
+		require.Equal(t, expectedDomain[:], msgID.GetDomain(),
+			"pre-Boole height must use DomainType (Alan)")
+		require.Equal(t, preBooleCfg.DomainType[:], msgID.GetDomain(),
+			"pre-Boole domain must equal cfg.DomainType")
+	})
+
+	t.Run("fork-spanning controller switches domain at fork boundary", func(t *testing.T) {
+		// Build a config where Boole activates at epoch 10.
+		forkEpoch := phase0.Epoch(10)
+		midBooleSSV := *networkconfig.TestNetwork.SSV
+		midBooleSSV.Forks = networkconfig.SSVForks{Boole: forkEpoch}
+		midBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &midBooleSSV}
+
+		identifierFn := func(height specqbft.Height) []byte {
+			domain := midBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
+			id := spectypes.NewMsgID(domain, committeeID[:], role)
+			return id[:]
+		}
+		identifier := identifierFn(specqbft.FirstHeight)
+
+		ctrl := NewController(identifier, member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+
+		slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.Beacon.SlotsPerEpoch)
+
+		preForkSlot := phase0.Slot(forkEpoch)*slotsPerEpoch - 1
+		postForkSlot := phase0.Slot(forkEpoch) * slotsPerEpoch
+
+		preForkID := spectypes.MessageID(ctrl.identifierAtHeight(specqbft.Height(preForkSlot))[0:56])
+		postForkID := spectypes.MessageID(ctrl.identifierAtHeight(specqbft.Height(postForkSlot))[0:56])
+
+		require.Equal(t, midBooleCfg.DomainType[:], preForkID.GetDomain(),
+			"slot before fork must carry Alan domain")
+		require.Equal(t, midBooleCfg.NextDomainType[:], postForkID.GetDomain(),
+			"slot at/after fork must carry Boole domain")
+	})
+
+	t.Run("nil IdentifierFn falls back to static Identifier (regression guard)", func(t *testing.T) {
+		// Build a static identifier pinned to Alan domain.
+		staticID := spectypes.NewMsgID(preBooleCfg.DomainType, committeeID[:], role)
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+		// IdentifierFn intentionally left nil.
+
+		// Even for a post-Boole height, the fallback returns the static (Alan) identifier.
+		// This is the bug the fix addresses — demonstrated by checking that the domain does NOT
+		// change across heights when IdentifierFn is absent.
+		postBooleHeight := specqbft.Height(1)
+		resolvedID := spectypes.MessageID(ctrl.identifierAtHeight(postBooleHeight)[0:56])
+		require.Equal(t, preBooleCfg.DomainType[:], resolvedID.GetDomain(),
+			"without IdentifierFn, domain must be frozen at construction-time value (Alan)")
+	})
+
+	t.Run("unpatched controller (no IdentifierFn) fails post-Boole domain check", func(t *testing.T) {
+		// Demonstrate the regression: a controller WITHOUT IdentifierFn carries Alan domain at
+		// post-Boole heights. The Boole domain would NOT match, confirming the bug.
+		staticID := spectypes.NewMsgID(preBooleCfg.DomainType, committeeID[:], role)
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+
+		postBooleHeight := specqbft.Height(1)
+		resolvedID := spectypes.MessageID(ctrl.identifierAtHeight(postBooleHeight)[0:56])
+
+		expectedBooleDomain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(postBooleHeight))
+		require.NotEqual(t, expectedBooleDomain[:], resolvedID.GetDomain(),
+			"unpatched controller must NOT produce Boole domain (proves the bug exists without fix)")
+	})
+
+}
+
+// makeSignedQBFTMsg builds a minimal SignedSSVMessage carrying a RoundChange QBFT message
+// with the given identifier and height. It does not require a running instance; the
+// signature is produced with operator 1's RSA key from the supplied key set.
+func makeSignedQBFTMsg(ks *spectestingutils.TestKeySet, identifier []byte, height specqbft.Height) *spectypes.SignedSSVMessage {
+	qbftMsg := &specqbft.Message{
+		MsgType:    specqbft.RoundChangeMsgType,
+		Height:     height,
+		Round:      specqbft.FirstRound,
+		Identifier: identifier,
+	}
+	return spectestingutils.SignQBFTMsg(ks.OperatorKeys[1], 1, qbftMsg)
+}
+
+// TestController_ProcessMsg_ForkDomainCheck verifies that the ProcessMsg receive path
+// enforces per-height domain resolution via identifierAtHeight, not the static Identifier.
+func TestController_ProcessMsg_ForkDomainCheck(t *testing.T) {
+	ks := spectestingutils.Testing4SharesSet()
+	member := spectestingutils.TestingCommitteeMember(ks)
+	role := spectypes.RoleCommittee
+	committeeID := member.CommitteeID
+
+	// Config where Boole activates at epoch 10.
+	forkEpoch := phase0.Epoch(10)
+	midBooleSSV := *networkconfig.TestNetwork.SSV
+	midBooleSSV.Forks = networkconfig.SSVForks{Boole: forkEpoch}
+	midBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &midBooleSSV}
+
+	slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.Beacon.SlotsPerEpoch)
+	preForkSlot := phase0.Slot(forkEpoch)*slotsPerEpoch - 1
+	postForkSlot := phase0.Slot(forkEpoch) * slotsPerEpoch
+
+	preForkHeight := specqbft.Height(preForkSlot)
+	postForkHeight := specqbft.Height(postForkSlot)
+
+	alanDomain := midBooleCfg.DomainType
+	booleDomain := midBooleCfg.NextDomainType
+
+	identifierFn := func(height specqbft.Height) []byte {
+		domain := midBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
+		id := spectypes.NewMsgID(domain, committeeID[:], role)
+		return id[:]
+	}
+
+	// Static identifier frozen at pre-fork domain (simulates old code path).
+	staticID := spectypes.NewMsgID(alanDomain, committeeID[:], role)
+
+	logger := zap.NewNop()
+
+	// t.Run helper: build a controller pre-advanced to a height so a message at that
+	// height is not classified as a future message (avoids FutureMessageErrorCode).
+	advanceTo := func(ctrl *Controller, height specqbft.Height) {
+		ctrl.LatestInstanceHeight = height
+	}
+
+	// isIdentifierMismatch returns true if err is the specific identifier-invalid SSV error.
+	isIdentifierMismatch := func(err error) bool {
+		var ssverr *spectypes.Error
+		return err != nil && errors.As(err, &ssverr) &&
+			ssverr.Code == spectypes.MessageIdentifierInvalidErrorCode
+	}
+
+	t.Run("receive path accepts message with matching post-fork (Boole) domain", func(t *testing.T) {
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+		advanceTo(ctrl, postForkHeight)
+
+		booleID := spectypes.NewMsgID(booleDomain, committeeID[:], role)
+		signedMsg := makeSignedQBFTMsg(ks, booleID[:], postForkHeight)
+
+		_, err := ctrl.ProcessMsg(context.Background(), logger, signedMsg, nil)
+		// The identifier check passes; subsequent failure (instance not found, etc.) is expected.
+		// The one thing that must NOT happen is an identifier mismatch.
+		require.False(t, isIdentifierMismatch(err),
+			"post-fork message with correct Boole domain must pass the identifier check in ProcessMsg")
+	})
+
+	t.Run("receive path accepts message with matching pre-fork (Alan) domain", func(t *testing.T) {
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+		advanceTo(ctrl, preForkHeight)
+
+		alanID := spectypes.NewMsgID(alanDomain, committeeID[:], role)
+		signedMsg := makeSignedQBFTMsg(ks, alanID[:], preForkHeight)
+
+		_, err := ctrl.ProcessMsg(context.Background(), logger, signedMsg, nil)
+		require.False(t, isIdentifierMismatch(err),
+			"pre-fork message with correct Alan domain must pass the identifier check in ProcessMsg")
+	})
+
+	t.Run("receive path rejects post-fork message carrying stale pre-fork (Alan) domain", func(t *testing.T) {
+		// Controller has IdentifierFn, so post-fork height resolves to Boole domain.
+		// A message carrying Alan domain at that height must be rejected.
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+		advanceTo(ctrl, postForkHeight)
+
+		staleAlanID := spectypes.NewMsgID(alanDomain, committeeID[:], role)
+		signedMsg := makeSignedQBFTMsg(ks, staleAlanID[:], postForkHeight)
+
+		_, err := ctrl.ProcessMsg(context.Background(), logger, signedMsg, nil)
+		require.Error(t, err, "post-fork message with Alan domain must be rejected")
+		var ssverr *spectypes.Error
+		require.ErrorAs(t, err, &ssverr)
+		require.Equal(t, spectypes.MessageIdentifierInvalidErrorCode, ssverr.Code,
+			"rejection must be an identifier mismatch error, not a different failure")
+	})
+
+	t.Run("receive path rejects pre-fork message carrying wrong (Boole) domain", func(t *testing.T) {
+		// Controller has IdentifierFn, so pre-fork height resolves to Alan domain.
+		// A message carrying Boole domain at that height must be rejected.
+		ctrl := NewController(staticID[:], member, nil, nil, false)
+		ctrl.IdentifierFn = identifierFn
+		advanceTo(ctrl, preForkHeight)
+
+		wrongBooleID := spectypes.NewMsgID(booleDomain, committeeID[:], role)
+		signedMsg := makeSignedQBFTMsg(ks, wrongBooleID[:], preForkHeight)
+
+		_, err := ctrl.ProcessMsg(context.Background(), logger, signedMsg, nil)
+		require.Error(t, err, "pre-fork message with Boole domain must be rejected")
+		var ssverr *spectypes.Error
+		require.ErrorAs(t, err, &ssverr)
+		require.Equal(t, spectypes.MessageIdentifierInvalidErrorCode, ssverr.Code,
+			"rejection must be an identifier mismatch error")
+	})
+}
+
+// TestController_NilIdentifierFn_ByteIdenticalToStatic confirms that a controller without
+// IdentifierFn returns a byte-for-byte identical slice to the static Identifier field,
+// regardless of height. This is the nil-fn contract: no IdentifierFn == frozen domain.
+func TestController_NilIdentifierFn_ByteIdenticalToStatic(t *testing.T) {
+	ks := spectestingutils.Testing4SharesSet()
+	member := spectestingutils.TestingCommitteeMember(ks)
+	role := spectypes.RoleCommittee
+	committeeID := member.CommitteeID
+
+	preBooleCfg := networkconfig.TestNetwork // Boole at MaxUint64
+	staticID := spectypes.NewMsgID(preBooleCfg.DomainType, committeeID[:], role)
+
+	ctrl := NewController(staticID[:], member, nil, nil, false)
+	// IdentifierFn intentionally left nil.
+
+	for _, height := range []specqbft.Height{0, 1, 100, 10000, specqbft.Height(^uint64(0) >> 1)} {
+		got := ctrl.identifierAtHeight(height)
+		require.True(t, bytes.Equal(staticID[:], got),
+			"nil-fn controller must return byte-identical static Identifier at height %d", height)
+	}
+}

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -33,8 +34,12 @@ func TestController_IdentifierAtHeight(t *testing.T) {
 	postBooleSSV.Forks = networkconfig.SSVForks{Boole: 0}
 	postBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &postBooleSSV}
 
-	// Build a pre-Boole config: Boole disabled (epoch MaxUint64).
-	preBooleCfg := networkconfig.TestNetwork // Boole = MaxUint64 by default
+	// Build a pre-Boole config explicitly: Boole disabled (epoch MaxUint64). Built from an
+	// explicit copy rather than aliasing the package-global TestNetwork, whose Boole epoch can
+	// be flipped to 0 by SSV_TEST_BOOLE_FORK=post (see networkconfig/test-network.go init).
+	preBooleSSV := *networkconfig.TestNetwork.SSV
+	preBooleSSV.Forks = networkconfig.SSVForks{Boole: phase0.Epoch(math.MaxUint64)}
+	preBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &preBooleSSV}
 
 	committeeID := member.CommitteeID
 

--- a/protocol/v2/qbft/controller/controller_fork_test.go
+++ b/protocol/v2/qbft/controller/controller_fork_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
-	"math"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -21,139 +20,23 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/ssv"
 )
 
-// TestController_IdentifierAtHeight verifies that the per-height identifier resolves to the
-// fork-correct SSV domain. Pre-Boole heights must yield the config's DomainType (Alan) and
-// post-Boole heights must yield its NextDomainType (Boole).
-//
-// The test also confirms the regression: without IdentifierFn the controller uses the static
-// Identifier frozen at construction time, causing post-fork heights to still carry the pre-fork
-// domain.
+// TestController_IdentifierAtHeight verifies that identifierAtHeight switches the SSV domain
+// exactly at the Boole fork boundary: the slot before the fork carries DomainType (Alan), the
+// fork slot itself carries NextDomainType (Boole). The real send/receive paths are guarded by
+// TestController_StartNewInstance_ForkDomain, TestController_ProcessMsg_ForkDomainCheck and
+// TestController_UponDecided_ForkDomain; the nil-fn fallback by
+// TestController_NilIdentifierFn_ByteIdenticalToStatic.
 func TestController_IdentifierAtHeight(t *testing.T) {
-	ks := spectestingutils.Testing4SharesSet()
-	member := spectestingutils.TestingCommitteeMember(ks)
-	role := spectypes.RoleCommittee
+	h := newForkTestHarness()
+	ctrl := h.newController()
 
-	// Build a post-Boole config: Boole active from genesis (epoch 0).
-	postBooleSSV := *networkconfig.TestNetwork.SSV
-	postBooleSSV.Forks = networkconfig.SSVForks{Boole: 0}
-	postBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &postBooleSSV}
+	preForkID := spectypes.MessageID(ctrl.identifierAtHeight(h.preForkHeight)[0:56])
+	postForkID := spectypes.MessageID(ctrl.identifierAtHeight(h.postForkHeight)[0:56])
 
-	// Build a pre-Boole config explicitly: Boole disabled (epoch MaxUint64). Built from an
-	// explicit copy rather than aliasing the package-global TestNetwork, whose Boole epoch can
-	// be flipped to 0 by SSV_TEST_BOOLE_FORK=post (see networkconfig/test-network.go init).
-	preBooleSSV := *networkconfig.TestNetwork.SSV
-	preBooleSSV.Forks = networkconfig.SSVForks{Boole: phase0.Epoch(math.MaxUint64)}
-	preBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &preBooleSSV}
-
-	committeeID := member.CommitteeID
-
-	t.Run("post-Boole height yields Boole domain", func(t *testing.T) {
-		identifierFn := func(height specqbft.Height) []byte {
-			domain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
-			id := spectypes.NewMsgID(domain, committeeID[:], role)
-			return id[:]
-		}
-
-		// height 1 is slot 1, which in an epoch-0 Boole fork is already post-fork.
-		postBooleHeight := specqbft.Height(1)
-		identifier := identifierFn(specqbft.FirstHeight)
-
-		ctrl := NewController(identifier, member, nil, nil, false)
-		ctrl.IdentifierFn = identifierFn
-
-		resolvedID := ctrl.identifierAtHeight(postBooleHeight)
-		msgID := spectypes.MessageID(resolvedID[0:56])
-
-		expectedDomain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(postBooleHeight))
-		require.Equal(t, expectedDomain[:], msgID.GetDomain(),
-			"post-Boole height must use NextDomainType (Boole)")
-		require.Equal(t, postBooleCfg.NextDomainType[:], msgID.GetDomain(),
-			"post-Boole domain must equal cfg.NextDomainType")
-	})
-
-	t.Run("pre-Boole height yields Alan domain", func(t *testing.T) {
-		identifierFn := func(height specqbft.Height) []byte {
-			domain := preBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
-			id := spectypes.NewMsgID(domain, committeeID[:], role)
-			return id[:]
-		}
-
-		// With Boole at MaxUint64, any normal slot is pre-fork.
-		preForkHeight := specqbft.Height(1000)
-		identifier := identifierFn(specqbft.FirstHeight)
-
-		ctrl := NewController(identifier, member, nil, nil, false)
-		ctrl.IdentifierFn = identifierFn
-
-		resolvedID := ctrl.identifierAtHeight(preForkHeight)
-		msgID := spectypes.MessageID(resolvedID[0:56])
-
-		expectedDomain := preBooleCfg.DomainTypeAtSlot(phase0.Slot(preForkHeight))
-		require.Equal(t, expectedDomain[:], msgID.GetDomain(),
-			"pre-Boole height must use DomainType (Alan)")
-		require.Equal(t, preBooleCfg.DomainType[:], msgID.GetDomain(),
-			"pre-Boole domain must equal cfg.DomainType")
-	})
-
-	t.Run("fork-spanning controller switches domain at fork boundary", func(t *testing.T) {
-		// Build a config where Boole activates at epoch 10.
-		forkEpoch := phase0.Epoch(10)
-		midBooleSSV := *networkconfig.TestNetwork.SSV
-		midBooleSSV.Forks = networkconfig.SSVForks{Boole: forkEpoch}
-		midBooleCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &midBooleSSV}
-
-		identifierFn := func(height specqbft.Height) []byte {
-			domain := midBooleCfg.DomainTypeAtSlot(phase0.Slot(height))
-			id := spectypes.NewMsgID(domain, committeeID[:], role)
-			return id[:]
-		}
-		identifier := identifierFn(specqbft.FirstHeight)
-
-		ctrl := NewController(identifier, member, nil, nil, false)
-		ctrl.IdentifierFn = identifierFn
-
-		slotsPerEpoch := phase0.Slot(networkconfig.TestNetwork.SlotsPerEpoch)
-
-		preForkSlot := phase0.Slot(forkEpoch)*slotsPerEpoch - 1
-		postForkSlot := phase0.Slot(forkEpoch) * slotsPerEpoch
-
-		preForkID := spectypes.MessageID(ctrl.identifierAtHeight(specqbft.Height(preForkSlot))[0:56])
-		postForkID := spectypes.MessageID(ctrl.identifierAtHeight(specqbft.Height(postForkSlot))[0:56])
-
-		require.Equal(t, midBooleCfg.DomainType[:], preForkID.GetDomain(),
-			"slot before fork must carry Alan domain")
-		require.Equal(t, midBooleCfg.NextDomainType[:], postForkID.GetDomain(),
-			"slot at/after fork must carry Boole domain")
-	})
-
-	t.Run("nil IdentifierFn falls back to static Identifier (regression guard)", func(t *testing.T) {
-		// Build a static identifier pinned to Alan domain.
-		staticID := spectypes.NewMsgID(preBooleCfg.DomainType, committeeID[:], role)
-		ctrl := NewController(staticID[:], member, nil, nil, false)
-		// IdentifierFn intentionally left nil.
-
-		// Even for a post-Boole height, the fallback returns the static (Alan) identifier.
-		// This is the bug the fix addresses — demonstrated by checking that the domain does NOT
-		// change across heights when IdentifierFn is absent.
-		postBooleHeight := specqbft.Height(1)
-		resolvedID := spectypes.MessageID(ctrl.identifierAtHeight(postBooleHeight)[0:56])
-		require.Equal(t, preBooleCfg.DomainType[:], resolvedID.GetDomain(),
-			"without IdentifierFn, domain must be frozen at construction-time value (Alan)")
-	})
-
-	t.Run("unpatched controller (no IdentifierFn) fails post-Boole domain check", func(t *testing.T) {
-		// Demonstrate the regression: a controller WITHOUT IdentifierFn carries Alan domain at
-		// post-Boole heights. The Boole domain would NOT match, confirming the bug.
-		staticID := spectypes.NewMsgID(preBooleCfg.DomainType, committeeID[:], role)
-		ctrl := NewController(staticID[:], member, nil, nil, false)
-
-		postBooleHeight := specqbft.Height(1)
-		resolvedID := spectypes.MessageID(ctrl.identifierAtHeight(postBooleHeight)[0:56])
-
-		expectedBooleDomain := postBooleCfg.DomainTypeAtSlot(phase0.Slot(postBooleHeight))
-		require.NotEqual(t, expectedBooleDomain[:], resolvedID.GetDomain(),
-			"unpatched controller must NOT produce Boole domain (proves the bug exists without fix)")
-	})
+	require.Equal(t, h.cfg.DomainType[:], preForkID.GetDomain(),
+		"slot before fork must carry Alan domain")
+	require.Equal(t, h.cfg.NextDomainType[:], postForkID.GetDomain(),
+		"slot at/after fork must carry Boole domain")
 }
 
 // makeSignedQBFTMsg builds a minimal SignedSSVMessage carrying a RoundChange QBFT message

--- a/protocol/v2/qbft/controller/decided.go
+++ b/protocol/v2/qbft/controller/decided.go
@@ -36,7 +36,7 @@ func (c *Controller) UponDecided(
 			logger,
 			c.GetConfig(),
 			c.CommitteeMember,
-			c.Identifier,
+			c.identifierAtHeight(msg.QBFTMessage.Height),
 			msg.QBFTMessage.Height,
 			c.OperatorSigner,
 			roundTimerF,


### PR DESCRIPTION
## What

Fixes #2947 — post-Boole, every QBFT consensus message (proposal/prepare/commit/round-change) was stamped with the **pre-Boole** SSV domain instead of the post-Boole one. The node's own message validator rejected them (`wrong domain, got 00003114, want 00003115`) → publish dropped → QBFT never reached quorum → **all post-Boole consensus duties failed**. This surfaced only after the subscription-filter fix (#2944) landed — that bug was masking this one.

## Root cause

The QBFT controller's identifier was built **once at construction** from the static `NetworkConfig.DomainType` and frozen for the controller's whole lifetime, which spans the fork boundary:

- `operator/validator/controller.go` (committee + proposer `buildController`): `spectypes.NewMsgID(options.NetworkConfig.DomainType, …)` — the static field, not the fork-aware `DomainTypeAtSlot`.
- `protocol/v2/qbft/controller/controller.go`: `Identifier []byte` (static), passed unchanged into `StartNewInstance` → `instance.NewInstance` (which ignored the in-scope `height`) and used verbatim in the `ProcessMsg` receive-side match.

The receiver (`message/validation` `validateDomainAtSlot`) correctly expects `DomainTypeAtSlot(slot)`. The convergence work made message-validation, proposer-selection, and the pre-consensus partial-sig path (#2915) fork-aware, but did **not** port the per-height QBFT-controller identifier. That omission is the regression.

## Fix

Restore per-height domain resolution. Inject `IdentifierFn func(height specqbft.Height) []byte` that resolves via `DomainTypeAtSlot(phase0.Slot(height))`, and use it on:
- **send** — `StartNewInstance` (`c.identifierAtHeight(height)`),
- **receive** — `ProcessMsg` identifier match (`c.identifierAtHeight(msg.QBFTMessage.Height)`),
- **decided fast-forward** — `UponDecided` (`inst == nil` branch).

`NewController`'s signature is unchanged — `IdentifierFn` is set as a field after construction, so spec-test shims compile as-is. The static `Identifier` is kept as a serialized/diagnostic fallback (tagged `json:"-"`, so `Encode`/`GetRoot` round-trips are unaffected). When `IdentifierFn` is nil, behavior is byte-identical to before.

`height == slot` for all consensus runners (single `StartNewInstance` caller in `BaseRunner.StartNewConsensus`, passing `specqbft.Height(slot)`).

## Tests

New `protocol/v2/qbft/controller/controller_fork_test.go`:
- **send**: a fork-spanning controller yields the pre-Boole domain at pre-fork heights and the post-Boole domain at post-fork heights; the assertion fails against the unpatched (frozen-identifier) code.
- **receive**: `ProcessMsg` accepts a message whose domain matches its height on each side of the fork, and rejects one whose domain doesn't match its height.
- **fallback**: nil `IdentifierFn` is byte-identical to the static `Identifier` across heights.

`go build ./...`, `go vet`, and `go test ./protocol/v2/qbft/... ./operator/validator/... ./message/validation/... ./protocol/v2/ssv/spectest/... ./protocol/v2/ssv/runner/...` all pass.

## Verification (ssv-mini, Boole fork active, distinct domains 0x00000000 → 0x00000001 at epoch 3)

Drove a live 4-node committee across the fork:
- **`wrong domain` rejections post-fork: 0** (was thousands on the unpatched build).
- **COMMITTEE (attestation) consensus decides at round 1**; attestations submitted post-fork.
- **Subscription-filter errors: 0** (confirms #2944 too).

## Note / follow-up (not addressed here)

During verification, `AGGREGATOR_COMMITTEE` consensus was observed to never decide before **round 5** (with recurring `could not publish … validation ignored` on the Boole topic), though aggregates still submit. This is independent of the domain fix (0 `wrong domain`) and of #2939/#2940 (both merged). Flagging for a separate investigation/issue.
