### PR TITLE
fix(roundtimer): give RoleAggregatorCommittee a 2/3-slot head start

### DIFF
--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -132,9 +132,9 @@ func New(ctx context.Context, beaconConfig *networkconfig.Beacon, role spectypes
 // RoundTimeout calculates the timeout duration for a specific role, height, and round.
 //
 // Timeout Rules:
-// - For roles BNRoleAttester and BNRoleSyncCommittee, the base timeout is 1/3 of the slot duration.
-// - For roles BNRoleAggregator and BNRoleSyncCommitteeContribution, the base timeout is 2/3 of the slot duration.
-// - For role BNRoleProposer, the timeout is either quickTimeout or slowTimeout, depending on the round.
+// - For RoleCommittee, the base timeout (Round 1 head start) is 1/3 of the slot duration.
+// - For RoleAggregator, RoleSyncCommitteeContribution and RoleAggregatorCommittee, it is 2/3 of the slot duration.
+// - For RoleProposer, the timeout is either quickTimeout or slowTimeout, depending on the round.
 //
 // Additional Timeout:
 // - For rounds less than or equal to quickThreshold, the additional timeout is 'quick' seconds.

--- a/protocol/v2/qbft/roundtimer/timer.go
+++ b/protocol/v2/qbft/roundtimer/timer.go
@@ -48,8 +48,9 @@ func roundTimeoutForRound(role spectypes.RunnerRole, slotDuration time.Duration,
 
 // round1HeadStart returns the extra time, on top of Round 1's normal quick timeout, that
 // Round 1 is allowed to run for a given role. Committee gets 1/3 of the slot as head start
-// (time for the block to become available); aggregator and sync-committee-contribution get
-// 2/3 of the slot (time for attestations to arrive); proposer gets zero.
+// (time for the block to become available); aggregator, aggregator-committee and
+// sync-committee-contribution get 2/3 of the slot (time for attestations to arrive before
+// aggregating); proposer gets zero.
 //
 // Note: this is NOT the time at which Round 1 -> Round 2 transitions — that transition actually
 // happens at `slotStart + round1HeadStart + QuickTimeout`, because Round 1 still needs to run its
@@ -58,7 +59,7 @@ func round1HeadStart(role spectypes.RunnerRole, slotDuration time.Duration) time
 	switch role {
 	case spectypes.RoleCommittee:
 		return slotDuration / 3
-	case ssvtypes.RoleAggregator, ssvtypes.RoleSyncCommitteeContribution:
+	case ssvtypes.RoleAggregator, ssvtypes.RoleSyncCommitteeContribution, spectypes.RoleAggregatorCommittee:
 		return slotDuration / 3 * 2
 	default:
 		return 0

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -123,9 +123,10 @@ func TestEstimatedRoundAt(t *testing.T) {
 			want:         specqbft.FirstRound,
 		},
 		{
-			// Regression for the missing RoleAggregatorCommittee head start: with head start 0
-			// this returned round 5 at two-thirds into the slot (when aggregation data arrives),
-			// starting aggregator-committee consensus mid-round instead of at round 1.
+			// Basic behavioral parity with the aggregator case above. NOTE: at this 600ms slot the
+			// head-start difference (0 vs 400ms) is below one QuickTimeout (2s), so this case alone
+			// does NOT discriminate patched vs unpatched — see the realistic-slot regression assertion
+			// after the loop (and TestRoundTimeoutOffset) for the actual guard.
 			name:         "aggregator-committee keeps first round until two-third slot delay passes",
 			role:         spectypes.RoleAggregatorCommittee,
 			timeIntoSlot: slotDuration / 3 * 2,
@@ -146,6 +147,18 @@ func TestEstimatedRoundAt(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+
+	// Discriminating regression guard for the missing RoleAggregatorCommittee head start.
+	// At a realistic 12s slot, aggregation data arrives ~2/3 in (8s). With the fix (2/3-slot head
+	// start) the round is still 1 there; without it (head start 0) EstimatedRoundAt resolves to
+	// round 5 (1 + 8s/QuickTimeout), starting consensus mid-round. Unlike the 600ms table cases
+	// above, this assertion fails against the unpatched code.
+	t.Run("aggregator-committee resolves round 1 at two-thirds of a realistic 12s slot", func(t *testing.T) {
+		const realisticSlot = 12 * time.Second
+		round, err := EstimatedRoundAt(spectypes.RoleAggregatorCommittee, realisticSlot, realisticSlot/3*2)
+		require.NoError(t, err)
+		require.Equal(t, specqbft.FirstRound, round)
+	})
 }
 
 // TestRoundTimeoutOffset covers the pure helper directly, which is the single source of truth

--- a/protocol/v2/qbft/roundtimer/timer_test.go
+++ b/protocol/v2/qbft/roundtimer/timer_test.go
@@ -33,6 +33,7 @@ func TestTimeoutForRound(t *testing.T) {
 		ssvtypes.RoleAggregator,
 		spectypes.RoleProposer,
 		ssvtypes.RoleSyncCommitteeContribution,
+		spectypes.RoleAggregatorCommittee,
 	}
 
 	for _, role := range roles {
@@ -122,6 +123,15 @@ func TestEstimatedRoundAt(t *testing.T) {
 			want:         specqbft.FirstRound,
 		},
 		{
+			// Regression for the missing RoleAggregatorCommittee head start: with head start 0
+			// this returned round 5 at two-thirds into the slot (when aggregation data arrives),
+			// starting aggregator-committee consensus mid-round instead of at round 1.
+			name:         "aggregator-committee keeps first round until two-third slot delay passes",
+			role:         spectypes.RoleAggregatorCommittee,
+			timeIntoSlot: slotDuration / 3 * 2,
+			want:         specqbft.FirstRound,
+		},
+		{
 			name:         "sync committee contribution advances after two-third slot delay plus quick timeout",
 			role:         ssvtypes.RoleSyncCommitteeContribution,
 			timeIntoSlot: slotDuration/3*2 + QuickTimeout,
@@ -178,6 +188,10 @@ func TestRoundTimeoutOffset(t *testing.T) {
 
 		// Sync committee contribution uses the same 2/3-slot branch as aggregator.
 		{name: "sync_committee_contribution, round 1", role: ssvtypes.RoleSyncCommitteeContribution, round: 1, want: 8*time.Second + QuickTimeout},
+
+		// Aggregator-committee uses the same 2/3-slot branch as aggregator.
+		{name: "aggregator_committee, round 1", role: spectypes.RoleAggregatorCommittee, round: 1, want: 8*time.Second + QuickTimeout},
+		{name: "aggregator_committee, round 8", role: spectypes.RoleAggregatorCommittee, round: QuickTimeoutThreshold, want: 8*time.Second + quickPhase},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -208,6 +222,7 @@ func TestEstimatedRoundAtBoundaries(t *testing.T) {
 		{"committee", spectypes.RoleCommittee},
 		{"aggregator", ssvtypes.RoleAggregator},
 		{"sync_committee_contribution", ssvtypes.RoleSyncCommitteeContribution},
+		{"aggregator_committee", spectypes.RoleAggregatorCommittee},
 	}
 
 	for _, rc := range roles {
@@ -332,6 +347,7 @@ func TestEstimatedRoundAtMatchesRoundTimeout(t *testing.T) {
 		{"committee", spectypes.RoleCommittee},
 		{"aggregator", ssvtypes.RoleAggregator},
 		{"sync_committee_contribution", ssvtypes.RoleSyncCommitteeContribution},
+		{"aggregator_committee", spectypes.RoleAggregatorCommittee},
 	}
 
 	for _, rc := range roles {


### PR DESCRIPTION
## What

The merged aggregator-committee runner (`RoleAggregatorCommittee`, new in the Boole convergence) never starts consensus at round 1 — it consistently starts at **round ~5** every slot, wasting the entire quick-round budget and generating round-change churn (`could not publish … validation ignored` on the committee topic).

## Root cause

`round1HeadStart` (`protocol/v2/qbft/roundtimer/timer.go`) grants a per-role head start on the slot-relative round timer:

- `RoleCommittee` → 1/3 slot (block available)
- `RoleAggregator`, `RoleSyncCommitteeContribution` → 2/3 slot (attestations available to aggregate)
- everything else → `default: 0`

`RoleAggregatorCommittee` has **no case**, so it falls to `0`. But the aggregator-committee aggregates attestations, so its consensus can only start ~2/3 into the slot. Both the round timer (`RoundTimeout`) and the message validator (`EstimatedRoundAt`, `message/validation/consensus_validation.go`) derive from `round1HeadStart`, so at ~2/3-slot they compute:

```
EstimatedRoundAt(2/3-slot) = FirstRound + (2/3-slot - 0) / QuickTimeout = round 5   (12s slot, 2s quick)
```

i.e. consensus starts already at round 5 every slot. The legacy `RoleAggregator` got a 2/3-slot head start and started at round 1; the merged role lost it.

## Fix

Add `RoleAggregatorCommittee` to the 2/3-slot branch of `round1HeadStart`, mirroring the legacy aggregator. One-line change; both the timer and the validator pick it up (single source of truth).

## Tests

`protocol/v2/qbft/roundtimer/timer_test.go`: added `RoleAggregatorCommittee` cases to `TestRoundTimeoutOffset` (round 1 → `8s + quick`, round 8 → `8s + quickPhase`), `TestEstimatedRoundAt` (keeps round 1 at 2/3-slot), and the boundary/role sweeps. Confirmed the new offset assertions **fail against the unpatched code** (round 1: expected 10s, got 2s).

`go build ./...`, `go test ./protocol/v2/qbft/roundtimer/... ./message/validation/... ./protocol/v2/ssv/validator/... ./protocol/v2/ssv/runner/...` all pass.

## Verification (ssv-mini, Boole fork active)

Live 4-node committee, hot-swapped to a build carrying this fix (on top of the #2947 domain fix, needed for post-Boole consensus at all):

| | before fix | after fix |
|---|---|---|
| `AGGREGATOR_COMMITTEE` decide round | **5** (every slot) | **1** (every slot, e22 s715–722) |
| `validation ignored` publish errors | ~1 / slot | ~0 |
| `COMMITTEE` (attestation) decide round | 1 | 1 (unchanged) |

## Relationship to other fixes

Independent of #2947 (QBFT controller fork domain) — that fix makes post-Boole consensus *possible*; this one makes the aggregator-committee's consensus *efficient*. Both target `integration/boole-convergence`.
