### PR TITLE
boole-convergence follow-ups: pre-fork batch (#2952 items 1, 3, 4, 5, 6)

### DIFF
--- a/cli/generate_config.go
+++ b/cli/generate_config.go
@@ -4,10 +4,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"math"
 	"math/big"
 	"os"
 	"strings"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -40,10 +42,12 @@ var (
 	operatorPrivateKey      string
 	metricsAPIPort          int
 	ssvDomain               string
+	ssvNextDomain           string
 	ssvRegistrySyncOffset   uint64
 	ssvRegistryContractAddr string
 	ssvBootnodes            string
 	ssvDiscoveryProtocolID  string
+	ssvBooleForkEpoch       uint64
 )
 
 type SSVConfig struct {
@@ -80,6 +84,11 @@ var generateConfigCmd = &cobra.Command{
 			log.Fatalf("Failed to decode network domain: %v", err)
 		}
 
+		parsedNextDomain, err := hex.DecodeString(strings.TrimPrefix(ssvNextDomain, "0x"))
+		if err != nil {
+			log.Fatalf("Failed to decode next network domain: %v", err)
+		}
+
 		parsedDiscoveryProtocolID, err := hex.DecodeString(strings.TrimPrefix(ssvDiscoveryProtocolID, "0x"))
 		if err != nil {
 			log.Fatalf("Failed to decode discovery protocol ID: %v", err)
@@ -105,10 +114,14 @@ var generateConfigCmd = &cobra.Command{
 		config.MetricsAPIPort = metricsAPIPort
 		config.SSV.CustomNetwork = &networkconfig.SSV{
 			DomainType:           spectypes.DomainType(parsedDomain),
+			NextDomainType:       spectypes.DomainType(parsedNextDomain),
 			RegistrySyncOffset:   new(big.Int).SetUint64(ssvRegistrySyncOffset),
 			RegistryContractAddr: ethcommon.HexToAddress(ssvRegistryContractAddr),
 			Bootnodes:            bootnodes,
 			DiscoveryProtocolID:  parsedDiscoveryProtocolIDArr,
+			Forks: networkconfig.SSVForks{
+				Boole: phase0.Epoch(ssvBooleForkEpoch),
+			},
 		}
 
 		data, err := yaml.Marshal(&config)
@@ -140,11 +153,14 @@ func init() {
 
 	ssvDomainDefault := "0x" + hex.EncodeToString(defaultNetwork.DomainType[:])
 	generateConfigCmd.Flags().StringVar(&ssvDomain, "ssv-domain", ssvDomainDefault, "SSV domain type")
+	ssvNextDomainDefault := "0x" + hex.EncodeToString(defaultNetwork.NextDomainType[:])
+	generateConfigCmd.Flags().StringVar(&ssvNextDomain, "ssv-next-domain", ssvNextDomainDefault, "SSV next domain type")
 	generateConfigCmd.Flags().Uint64Var(&ssvRegistrySyncOffset, "ssv-registry-sync-offset", defaultNetwork.RegistrySyncOffset.Uint64(), "SSV registry sync offset")
 	generateConfigCmd.Flags().StringVar(&ssvRegistryContractAddr, "ssv-registry-contract-addr", defaultNetwork.RegistryContractAddr.String(), "SSV registry contract addr")
 	generateConfigCmd.Flags().StringVar(&ssvBootnodes, "ssv-bootnodes", strings.Join(defaultNetwork.Bootnodes, sliceSeparator), "SSV bootnodes (comma-separated)")
 	ssvDiscoveryProtocolIDDefault := "0x" + hex.EncodeToString(defaultNetwork.DiscoveryProtocolID[:])
 	generateConfigCmd.Flags().StringVar(&ssvDiscoveryProtocolID, "ssv-discovery-protocol-id", ssvDiscoveryProtocolIDDefault, "SSV discovery protocol ID")
+	generateConfigCmd.Flags().Uint64Var(&ssvBooleForkEpoch, "ssv-boole-fork-epoch", math.MaxUint64, "Epoch at which the Boole fork occurs in the network")
 
 	RootCmd.AddCommand(generateConfigCmd)
 }

--- a/cli/generate_config.go
+++ b/cli/generate_config.go
@@ -83,10 +83,16 @@ var generateConfigCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Failed to decode network domain: %v", err)
 		}
+		if len(parsedDomain) != 4 {
+			log.Fatalf("Invalid network domain length: expected 4 bytes, got %d", len(parsedDomain))
+		}
 
 		parsedNextDomain, err := hex.DecodeString(strings.TrimPrefix(ssvNextDomain, "0x"))
 		if err != nil {
 			log.Fatalf("Failed to decode next network domain: %v", err)
+		}
+		if len(parsedNextDomain) != 4 {
+			log.Fatalf("Invalid next network domain length: expected 4 bytes, got %d", len(parsedNextDomain))
 		}
 
 		parsedDiscoveryProtocolID, err := hex.DecodeString(strings.TrimPrefix(ssvDiscoveryProtocolID, "0x"))

--- a/cli/generate_config_test.go
+++ b/cli/generate_config_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+)
+
+// runGenerateConfig executes the generate-config command against a temp output
+// path and returns the parsed result. The command reads package-level flag
+// vars whose defaults are installed by init(); callers mutate specific vars
+// before invoking and this helper restores everything it touches.
+func runGenerateConfig(t *testing.T) SSVConfig {
+	t.Helper()
+
+	out := filepath.Join(t.TempDir(), "config.yaml")
+	origOutput, origConsensus, origExecution := outputPath, consensusClient, executionClient
+	t.Cleanup(func() {
+		outputPath, consensusClient, executionClient = origOutput, origConsensus, origExecution
+	})
+	outputPath, consensusClient, executionClient = out, "http://localhost:5052", "ws://localhost:8546"
+
+	generateConfigCmd.Run(generateConfigCmd, nil)
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	var cfg SSVConfig
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.NotNil(t, cfg.SSV.CustomNetwork)
+	return cfg
+}
+
+func TestGenerateConfigForkDefaults(t *testing.T) {
+	cfg := runGenerateConfig(t)
+
+	// Without flags the generated config must describe an unscheduled fork:
+	// Boole pinned to MaxUint64 and the default network's real next domain,
+	// never the zero values (a fork-at-genesis config with a zero domain).
+	require.Equal(t, phase0.Epoch(math.MaxUint64), cfg.SSV.CustomNetwork.Forks.Boole)
+	require.Equal(t, defaultNetwork.NextDomainType, cfg.SSV.CustomNetwork.NextDomainType)
+	require.Equal(t, defaultNetwork.DomainType, cfg.SSV.CustomNetwork.DomainType)
+}
+
+func TestGenerateConfigForkOverrides(t *testing.T) {
+	origEpoch, origNextDomain := ssvBooleForkEpoch, ssvNextDomain
+	t.Cleanup(func() {
+		ssvBooleForkEpoch, ssvNextDomain = origEpoch, origNextDomain
+	})
+	ssvBooleForkEpoch = 100
+	ssvNextDomain = "0x00000404"
+
+	cfg := runGenerateConfig(t)
+
+	require.Equal(t, phase0.Epoch(100), cfg.SSV.CustomNetwork.Forks.Boole)
+	require.Equal(t, spectypes.DomainType{0x00, 0x00, 0x04, 0x04}, cfg.SSV.CustomNetwork.NextDomainType)
+}

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -44,8 +44,8 @@ const (
 const (
 	partialSignatureSize           = 96
 	partialSignatureMsgSize        = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
-	maxPartialSignatureMessages    = 1000
-	partialSigMsgTypeSize          = 8 // uint64
+	maxPartialSignatureMessages    = 5048 // post-fork worst case (boole RoleAggregatorCommittee), see ssv-spec types/spectest/tests/maxmsgsize.MaxSizePartialSignatureMessages
+	partialSigMsgTypeSize          = 8    // uint64
 	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
 	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor + 4
 )

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -42,10 +42,13 @@ const (
 )
 
 const (
-	partialSignatureSize           = 96
-	partialSignatureMsgSize        = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
-	maxPartialSignatureMessages    = 5048 // post-fork worst case (boole RoleAggregatorCommittee), see ssv-spec types/spectest/tests/maxmsgsize.MaxSizePartialSignatureMessages
-	partialSigMsgTypeSize          = 8    // uint64
+	partialSignatureSize    = 96
+	partialSignatureMsgSize = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	// maxPartialSignatureMessages is the post-fork worst case (boole RoleAggregatorCommittee). The
+	// count derives from the inner ssv-spec types/spectest/tests/maxmsgsize.MaxSizePartialSignatureMessages;
+	// the drift guard in const_test.go checks the full envelope, MaxSizeSSVMessageFromPartialSignatureMessages.
+	maxPartialSignatureMessages    = 5048
+	partialSigMsgTypeSize          = 8 // uint64
 	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
 	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor + 4
 )

--- a/message/validation/const_test.go
+++ b/message/validation/const_test.go
@@ -1,0 +1,17 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/ssvlabs/ssv-spec/types/spectest/tests/maxmsgsize"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSizeCapsCoverSpecWorstCase guards against our hand-computed size caps
+// drifting below the pinned ssv-spec's worst-case message sizes. If this
+// fails after a spec bump, re-derive the corresponding const.go values.
+func TestSizeCapsCoverSpecWorstCase(t *testing.T) {
+	require.GreaterOrEqual(t, maxEncodedPartialSignatureSize, maxmsgsize.MaxSizeSSVMessageFromPartialSignatureMessages)
+	require.GreaterOrEqual(t, maxEncodedConsensusMsgSize, maxmsgsize.MaxSizeSSVMessageFromQBFTMessage)
+	require.GreaterOrEqual(t, MaxEncodedMsgSize, maxmsgsize.MaxSizeSignedSSVMessageFromQBFTWith2Justification)
+}

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -562,7 +562,9 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.FirstSlotAtEpoch(1)
 
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
-		signedSSVMessage.SSVMessage.Data = bytes.Repeat([]byte{1}, maxPayloadDataSize)
+		// This message is a consensus message, so its own type-specific size limit
+		// (maxEncodedConsensusMsgSize) applies before the generic maxPayloadDataSize check.
+		signedSSVMessage.SSVMessage.Data = bytes.Repeat([]byte{1}, maxEncodedConsensusMsgSize)
 
 		receivedAt := netCfg.SlotStartTime(slot)
 		topicID := commons.GetTopicFullName(commons.CommitteeTopicID(spectypes.CommitteeID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID()[16:]))[0])

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -267,6 +267,9 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 	}
 
 	// Get the peer's domain type, skipping if it mismatches ours.
+	// Discovery filtering intentionally stays on the static current domain: it's symmetric
+	// within a converged fleet, and real fork enforcement happens in the fork-aware handshake
+	// filter and per-slot message validation, not here.
 	peerDiscoveriesCounter.Add(ctx, 1)
 	nodeDomainType, err := records.GetDomainTypeEntry(e.Node.Record(), records.KeyDomainType)
 	if err != nil {
@@ -489,7 +492,10 @@ func (dvs *DiscV5Service) PublishENR() {
 		dvs.logger.Error("could not set domain type", zap.Error(err))
 		return
 	}
-	err = records.SetDomainTypeEntry(dvs.dv5Listener.LocalNode(), records.KeyNextDomainType, dvs.ssvConfig.DomainType)
+	// KeyNextDomainType carries the real upcoming domain (not the current one) so that
+	// fork-aware (boole-style) binaries and future dynamic domain flips can rely on it,
+	// even though our own peer filter only ever compares against the static current domain.
+	err = records.SetDomainTypeEntry(dvs.dv5Listener.LocalNode(), records.KeyNextDomainType, dvs.ssvConfig.NextDomainType)
 	if err != nil {
 		dvs.logger.Error("could not set next domain type", zap.Error(err))
 		return
@@ -560,8 +566,9 @@ func (dvs *DiscV5Service) createLocalNode(discOpts *Options, ipAddr net.IP) (*en
 		localNode,
 
 		// Satisfy decorations of forks supported by this node.
+		// KeyNextDomainType carries the real upcoming domain, not the current one (see PublishENR).
 		DecorateWithDomainType(records.KeyDomainType, dvs.ssvConfig.DomainType),
-		DecorateWithDomainType(records.KeyNextDomainType, dvs.ssvConfig.DomainType),
+		DecorateWithDomainType(records.KeyNextDomainType, dvs.ssvConfig.NextDomainType),
 		DecorateWithSubnets(opts.Subnets),
 	)
 	if err != nil {

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -141,7 +141,7 @@ func checkLocalNodeDomainTypeAlignment(t *testing.T, localNode *enode.LocalNode,
 	}
 	err = localNode.Node().Record().Load(&nextDomainEntry)
 	require.NoError(t, err)
-	require.Equal(t, netConfig.DomainType, nextDomainEntry.DomainType)
+	require.Equal(t, netConfig.NextDomainType, nextDomainEntry.DomainType)
 }
 
 func TestDiscV5Service_PublishENR(t *testing.T) {

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -67,6 +67,8 @@ func broadcastMessageSlot(msg *spectypes.SignedSSVMessage) (phase0.Slot, error) 
 		}
 		return psMsg.Slot, nil
 	default:
+		// Unlike queue.DecodeSignedSSVMessage, SSVEventMsgType lands here: event messages are
+		// internal loopback and never reach Broadcast.
 		return 0, queue.ErrUnknownMessageType
 	}
 }

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -57,13 +57,13 @@ func broadcastMessageSlot(msg *spectypes.SignedSSVMessage) (phase0.Slot, error) 
 	case spectypes.SSVConsensusMsgType:
 		qbftMsg := &specqbft.Message{}
 		if err := qbftMsg.Decode(msg.SSVMessage.Data); err != nil {
-			return 0, fmt.Errorf("failed to decode SignedMessage: %w", err)
+			return 0, fmt.Errorf("failed to decode qbft.Message: %w", err)
 		}
 		return phase0.Slot(qbftMsg.Height), nil
 	case spectypes.SSVPartialSignatureMsgType:
 		psMsg := &spectypes.PartialSignatureMessages{}
 		if err := psMsg.Decode(msg.SSVMessage.Data); err != nil {
-			return 0, fmt.Errorf("failed to decode SignedPartialSignatureMessage: %w", err)
+			return 0, fmt.Errorf("failed to decode PartialSignatureMessages: %w", err)
 		}
 		return psMsg.Slot, nil
 	default:

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -12,6 +12,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.uber.org/zap"
 
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/network"
@@ -40,16 +41,34 @@ func (n *p2pNetwork) UseMessageRouter(router network.MessageRouter) {
 
 // Broadcast publishes the message to all peers in subnet
 func (n *p2pNetwork) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedSSVMessage) error {
-	decodedMsg, err := queue.DecodeSignedSSVMessage(msg)
-	if err != nil {
-		return fmt.Errorf("could not decode signed ssv message: %w", err)
-	}
-	msgSlot, err := decodedMsg.Slot()
+	msgSlot, err := broadcastMessageSlot(msg)
 	if err != nil {
 		return fmt.Errorf("could not resolve message slot: %w", err)
 	}
 
 	return n.BroadcastAtSlot(msg, msgSlot)
+}
+
+// broadcastMessageSlot resolves the slot of a message that's about to be broadcast, decoding only
+// the message body type actually sent over the wire (consensus or partial-signature), rather than
+// building a full queue.DecodedSSVMessage wrapper that Broadcast has no other use for.
+func broadcastMessageSlot(msg *spectypes.SignedSSVMessage) (phase0.Slot, error) {
+	switch msg.SSVMessage.MsgType {
+	case spectypes.SSVConsensusMsgType:
+		qbftMsg := &specqbft.Message{}
+		if err := qbftMsg.Decode(msg.SSVMessage.Data); err != nil {
+			return 0, fmt.Errorf("failed to decode SignedMessage: %w", err)
+		}
+		return phase0.Slot(qbftMsg.Height), nil
+	case spectypes.SSVPartialSignatureMsgType:
+		psMsg := &spectypes.PartialSignatureMessages{}
+		if err := psMsg.Decode(msg.SSVMessage.Data); err != nil {
+			return 0, fmt.Errorf("failed to decode SignedPartialSignatureMessage: %w", err)
+		}
+		return psMsg.Slot, nil
+	default:
+		return 0, queue.ErrUnknownMessageType
+	}
 }
 
 // BroadcastAtSlot behaves like Broadcast but takes the message's slot explicitly, so it can

--- a/network/p2p/p2p_pubsub_test.go
+++ b/network/p2p/p2p_pubsub_test.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/libp2p/go-libp2p/core/peer"
+	specqbft "github.com/ssvlabs/ssv-spec/qbft"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/topics"
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
@@ -173,5 +176,105 @@ func TestSubscribedSubnetsForCurrentEpoch(t *testing.T) {
 		alan, boole := newNet(booleCfg(0)).subscribedSubnetsForCurrentEpoch()
 		require.Equal(t, commons.ZeroSubnets, alan)
 		require.Equal(t, subnetsOf(1, 2, 7), boole)
+	})
+}
+
+// TestBroadcastMessageSlot verifies broadcastMessageSlot resolves the same slot as
+// queue.DecodeSignedSSVMessage(msg).Slot() for every message type Broadcast may see, without
+// building the full queue.DecodedSSVMessage wrapper.
+func TestBroadcastMessageSlot(t *testing.T) {
+	t.Run("consensus message", func(t *testing.T) {
+		qbftMsg := &specqbft.Message{
+			MsgType:    specqbft.ProposalMsgType,
+			Height:     123,
+			Round:      1,
+			Identifier: make([]byte, 56),
+			Root:       [32]byte{1, 2, 3},
+		}
+		data, err := qbftMsg.Encode()
+		require.NoError(t, err)
+
+		msg := &spectypes.SignedSSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.SSVConsensusMsgType,
+				MsgID:   spectypes.MessageID(qbftMsg.Identifier),
+				Data:    data,
+			},
+		}
+
+		slot, err := broadcastMessageSlot(msg)
+		require.NoError(t, err)
+		require.Equal(t, phase0.Slot(123), slot)
+
+		decoded, err := queue.DecodeSignedSSVMessage(msg)
+		require.NoError(t, err)
+		wantSlot, err := decoded.Slot()
+		require.NoError(t, err)
+		require.Equal(t, wantSlot, slot)
+	})
+
+	t.Run("partial signature message", func(t *testing.T) {
+		partialMsg := &spectypes.PartialSignatureMessages{
+			Type: spectypes.PostConsensusPartialSig,
+			Slot: 456,
+			Messages: []*spectypes.PartialSignatureMessage{{
+				PartialSignature: make([]byte, 96),
+				SigningRoot:      [32]byte{},
+				Signer:           1,
+				ValidatorIndex:   1,
+			}},
+		}
+		data, err := partialMsg.Encode()
+		require.NoError(t, err)
+
+		msg := &spectypes.SignedSSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.SSVPartialSignatureMsgType,
+				MsgID:   spectypes.MessageID(make([]byte, 56)),
+				Data:    data,
+			},
+		}
+
+		slot, err := broadcastMessageSlot(msg)
+		require.NoError(t, err)
+		require.Equal(t, phase0.Slot(456), slot)
+
+		decoded, err := queue.DecodeSignedSSVMessage(msg)
+		require.NoError(t, err)
+		wantSlot, err := decoded.Slot()
+		require.NoError(t, err)
+		require.Equal(t, wantSlot, slot)
+	})
+
+	t.Run("unknown message type returns error matching decode path", func(t *testing.T) {
+		msg := &spectypes.SignedSSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: 99,
+				MsgID:   spectypes.MessageID(make([]byte, 56)),
+				Data:    []byte{1},
+			},
+		}
+
+		_, err := broadcastMessageSlot(msg)
+		require.ErrorIs(t, err, queue.ErrUnknownMessageType)
+
+		_, decodeErr := queue.DecodeSignedSSVMessage(msg)
+		require.ErrorIs(t, decodeErr, queue.ErrUnknownMessageType)
+	})
+
+	t.Run("invalid consensus message data returns error", func(t *testing.T) {
+		msg := &spectypes.SignedSSVMessage{
+			SSVMessage: &spectypes.SSVMessage{
+				MsgType: spectypes.SSVConsensusMsgType,
+				MsgID:   spectypes.MessageID(make([]byte, 56)),
+				Data:    []byte{1, 2, 3},
+			},
+		}
+
+		_, err := broadcastMessageSlot(msg)
+		require.Error(t, err)
+
+		_, decodeErr := queue.DecodeSignedSSVMessage(msg)
+		require.Error(t, decodeErr)
 	})
 }

--- a/observability/log/fields/duty_id_test.go
+++ b/observability/log/fields/duty_id_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
+
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 func TestBuildDutyID(t *testing.T) {
@@ -13,6 +15,20 @@ func TestBuildDutyID(t *testing.T) {
 
 	got := BuildDutyID(phase0.Epoch(3), phase0.Slot(100), spectypes.RoleCommittee, phase0.ValidatorIndex(42))
 	require.Equal(t, "COMMITTEE-e3-s100-v42", got)
+}
+
+func TestBuildDutyID_PreForkLegacyRoles(t *testing.T) {
+	t.Parallel()
+
+	// Pre-fork aggregator and sync committee contribution duties must render distinct,
+	// human-readable duty IDs rather than colliding on "UNDEFINED".
+	aggregatorID := BuildDutyID(phase0.Epoch(3), phase0.Slot(100), ssvtypes.RoleAggregator, phase0.ValidatorIndex(42))
+	require.Equal(t, "AGGREGATOR-e3-s100-v42", aggregatorID)
+
+	syncCommitteeContributionID := BuildDutyID(phase0.Epoch(3), phase0.Slot(100), ssvtypes.RoleSyncCommitteeContribution, phase0.ValidatorIndex(42))
+	require.Equal(t, "SYNC_COMMITTEE_CONTRIBUTION-e3-s100-v42", syncCommitteeContributionID)
+
+	require.NotEqual(t, aggregatorID, syncCommitteeContributionID)
 }
 
 func TestBuildCommitteeDutyID(t *testing.T) {

--- a/observability/utils/format.go
+++ b/observability/utils/format.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 func FormatRunnerRole(runnerRole spectypes.RunnerRole) string {
-	return strings.TrimSuffix(runnerRole.String(), "_RUNNER")
+	return strings.TrimSuffix(ssvtypes.RunnerRoleToString(runnerRole), "_RUNNER")
 }
 
 func FormatCommittee(operators []spectypes.OperatorID) string {

--- a/observability/utils/format_test.go
+++ b/observability/utils/format_test.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+func TestFormatRunnerRole(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		role spectypes.RunnerRole
+		want string
+	}{
+		{
+			name: "deprecated aggregator role",
+			role: ssvtypes.RoleAggregator,
+			want: "AGGREGATOR",
+		},
+		{
+			name: "deprecated sync committee contribution role",
+			role: ssvtypes.RoleSyncCommitteeContribution,
+			want: "SYNC_COMMITTEE_CONTRIBUTION",
+		},
+		{
+			name: "committee role",
+			role: spectypes.RoleCommittee,
+			want: "COMMITTEE",
+		},
+		{
+			name: "proposer role",
+			role: spectypes.RoleProposer,
+			want: "PROPOSER",
+		},
+		{
+			name: "validator registration role",
+			role: spectypes.RoleValidatorRegistration,
+			want: "VALIDATOR_REGISTRATION",
+		},
+		{
+			name: "voluntary exit role",
+			role: spectypes.RoleVoluntaryExit,
+			want: "VOLUNTARY_EXIT",
+		},
+		{
+			name: "aggregator committee role",
+			role: spectypes.RoleAggregatorCommittee,
+			want: "AGGREGATOR_COMMITTEE",
+		},
+		{
+			name: "unknown role",
+			role: spectypes.RoleUnknown,
+			want: "UNDEFINED",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FormatRunnerRole(tc.role)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	// The deprecated legacy roles must never collapse to "UNDEFINED", or they'd collide
+	// with each other and with genuinely unknown roles.
+	t.Run("legacy roles never collide with UNDEFINED", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotEqual(t, "UNDEFINED", FormatRunnerRole(ssvtypes.RoleAggregator))
+		require.NotEqual(t, "UNDEFINED", FormatRunnerRole(ssvtypes.RoleSyncCommitteeContribution))
+		require.NotEqual(t, FormatRunnerRole(ssvtypes.RoleAggregator), FormatRunnerRole(ssvtypes.RoleSyncCommitteeContribution))
+	})
+}

--- a/protocol/v2/ssv/validator/duty_executor.go
+++ b/protocol/v2/ssv/validator/duty_executor.go
@@ -37,7 +37,7 @@ func (v *Validator) ExecuteDuty(ctx context.Context, logger *zap.Logger, duty *s
 	// a nil queue (same as queue_validator.go and timer.go).
 	q, ok := v.Queues[role]
 	if !ok {
-		return fmt.Errorf("no queue for role %s", role.String())
+		return fmt.Errorf("no queue for role %s", types.RunnerRoleToString(role))
 	}
 
 	if pushed := q.TryPush(dec); !pushed {

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -92,7 +92,7 @@ func (v *Validator) StartQueueConsumer(
 			var ok bool
 			q, ok = v.Queues[msgID.GetRoleType()]
 			if !ok {
-				return fmt.Errorf("queue not found for role %s", msgID.GetRoleType().String())
+				return fmt.Errorf("queue not found for role %s", types.RunnerRoleToString(msgID.GetRoleType()))
 			}
 			return nil
 		}()


### PR DESCRIPTION
Follow-ups to #2941, tracked in #2952. Five independent items, one commit each:

- **Item 1 / fixes #2955** — `observability`: `FormatRunnerRole` now routes through the shim-aware `ssvtypes.RunnerRoleToString`, so pre-fork AGGREGATOR / SYNC_COMMITTEE_CONTRIBUTION duties no longer render as `UNDEFINED` (colliding duty IDs, merged `ssv.runner.role` metrics). Regression tests cover all roles + `BuildDutyID` non-collision.
- **Item 3** — `cli`: `generate-config` no longer emits fork-at-genesis configs; `Forks.Boole` defaults to `MaxUint64`, `NextDomainType` to the default network's value, with new `--ssv-boole-fork-epoch` / `--ssv-next-domain` flags (ported from boole-fork).
- **Item 4** — `network/discovery`: the `next_domaintype` ENR key now carries the real `NextDomainType` (both in `PublishENR` and the initial local-node decoration). The static-domain peer filter is kept per the resolution recorded in #2952; decision documented in code comments.
- **Item 5** — `message/validation`: `maxPartialSignatureMessages` 1000 → 5048. The old value under-sized `maxEncodedPartialSignatureSize` (151,220) vs the boole spec's AggregatorCommittee worst case (727,000 bytes / 5048 msgs), so a large valid post-fork message would have been rejected with `ErrSSVDataTooBig` pre-decode. A new test-only guard pins the hand-computed caps to the spec's `maxmsgsize` values (that spec package isn't importable from prod code — it pulls in `testing`/testify, which is presumably why the convergence dropped boole's derivation).
- **Item 6** — `network/p2p`: legacy `Broadcast` resolves the slot with a minimal per-type decode instead of the full `queue.DecodeSignedSSVMessage`, preserving exact slot/error semantics (cross-checked in tests).

Items 2 (fork-aware metadata syncer) and 7 (validation hot-path subnet cache) land separately.

**Note on `broadcastMessageSlot` semantics (item 6):** unlike the replaced `queue.DecodeSignedSSVMessage`, it does not handle `SSVEventMsgType` (falls through to `ErrUnknownMessageType`). Event messages are internal loopback and are never network-broadcast, so `Broadcast` cannot receive one — exact slot/error parity holds for the two wire types that can actually be broadcast.
