### PR TITLE
operator/validator/metadata: make syncer subnet selection fork-aware (#2952 item 2)

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -369,6 +369,7 @@ func newNode(
 
 	metadataSyncer := metadata.NewSyncer(
 		logger,
+		networkConfig,
 		nodeStorage.Shares(),
 		validatorProvider,
 		consensusClient,

--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -119,12 +119,6 @@ func BooleCommitteeSubnet(committee []spectypes.OperatorID) uint64 {
 	return result.Uint64()
 }
 
-// SetCommitteeSubnet returns the subnet for the given committee, it doesn't allocate memory but uses the passed in big.Int
-func SetCommitteeSubnet(bigInt *big.Int, cid spectypes.CommitteeID) {
-	bigInt.SetBytes(cid[:])
-	bigInt.Mod(bigInt, bigIntSubnetsCount)
-}
-
 // Topics returns the topic whitelist for the given network's fork state: Alan+Boole before the
 // fork (so a node started pre-fork can accept Boole subscriptions once the transition window
 // opens, without a pubsub rebuild), Boole-only after.

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -42,12 +42,12 @@ func TestAlanCommitteeSubnet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Get result from AlanCommitteeSubnet
-		expected := AlanCommitteeSubnet(cid)
+		actual := AlanCommitteeSubnet(cid)
 
-		// Get result from SetCommitteeSubnet
-		SetCommitteeSubnet(bigInst, cid)
-		actual := bigInst.Uint64()
+		// Cross-check against the reference big.Int math the memoized accessor must match.
+		bigInst.SetBytes(cid[:])
+		bigInst.Mod(bigInst, bigIntSubnetsCount)
+		expected := bigInst.Uint64()
 
 		require.Equal(t, expected, actual)
 	}

--- a/operator/validator/metadata/syncer.go
+++ b/operator/validator/metadata/syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"math/big"
 	"slices"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	networkcommons "github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -45,6 +45,7 @@ const (
 
 type Syncer struct {
 	logger            *zap.Logger
+	netCfg            *networkconfig.Network
 	shareStorage      shareStorage
 	validatorStore    selfValidatorStore
 	beaconNode        beacon.BeaconNode
@@ -66,6 +67,7 @@ type selfValidatorStore interface {
 
 func NewSyncer(
 	logger *zap.Logger,
+	netCfg *networkconfig.Network,
 	shareStorage shareStorage,
 	validatorStore selfValidatorStore,
 	beaconNode beacon.BeaconNode,
@@ -74,6 +76,7 @@ func NewSyncer(
 ) *Syncer {
 	u := &Syncer{
 		logger:            logger.Named(log.NameShareMetadataSyncer),
+		netCfg:            netCfg,
 		shareStorage:      shareStorage,
 		validatorStore:    validatorStore,
 		beaconNode:        beaconNode,
@@ -102,14 +105,11 @@ func WithSyncInterval(interval time.Duration) Option {
 // and triggers a full metadata synchronization for them.
 // It returns a mapping of validator public keys to their updated metadata.
 func (s *Syncer) SyncAll(ctx context.Context) (beacon.ValidatorMetadataMap, error) {
-	subnetsBuf := new(big.Int)
-	ownSubnets := s.selfSubnets(subnetsBuf)
+	ownSubnets := s.selfSubnets()
 
 	// Load non-liquidated shares.
 	shares := s.shareStorage.List(nil, registrystorage.ByNotLiquidated(), func(share *ssvtypes.SSVShare) bool {
-		networkcommons.SetCommitteeSubnet(subnetsBuf, share.CommitteeID())
-		subnet := subnetsBuf.Uint64()
-		return ownSubnets.IsSet(subnet)
+		return s.shareInOwnSubnets(share, ownSubnets)
 	})
 	if len(shares) == 0 {
 		s.logger.Info("could not find non-liquidated own subnets validator shares on initial metadata retrieval")
@@ -202,10 +202,8 @@ func (s *Syncer) Stream(ctx context.Context) <-chan SyncBatch {
 	go func() {
 		defer close(metadataUpdates)
 
-		subnetsBuf := new(big.Int)
-
 		for {
-			batch, done, err := s.syncNextBatch(ctx, subnetsBuf)
+			batch, done, err := s.syncNextBatch(ctx)
 			if err != nil {
 				s.logger.Warn("failed to prepare validators metadata",
 					zap.Error(err),
@@ -253,7 +251,7 @@ func (s *Syncer) Stream(ctx context.Context) <-chan SyncBatch {
 // It is used only by Stream method.
 // The maximal size is batchSize as we want to reduce the load while streaming.
 // Therefore, syncNextBatch should be called in a loop, so the rest will be prepared by next calls.
-func (s *Syncer) syncNextBatch(ctx context.Context, subnetsBuf *big.Int) (SyncBatch, bool, error) {
+func (s *Syncer) syncNextBatch(ctx context.Context) (SyncBatch, bool, error) {
 	// TODO: Methods called here don't handle context, so this is a workaround to handle done context. It should be removed once ctx is handled gracefully.
 	select {
 	case <-ctx.Done():
@@ -261,7 +259,7 @@ func (s *Syncer) syncNextBatch(ctx context.Context, subnetsBuf *big.Int) (SyncBa
 	default:
 	}
 
-	beforeMetadata := s.nextBatchFromDB(ctx, subnetsBuf)
+	beforeMetadata := s.nextBatchFromDB(ctx)
 	if len(beforeMetadata) == 0 {
 		return SyncBatch{}, false, nil
 	}
@@ -281,9 +279,9 @@ func (s *Syncer) syncNextBatch(ctx context.Context, subnetsBuf *big.Int) (SyncBa
 
 // nextBatchFromDB returns metadata for non-liquidated shares from DB that are most deserving of an update.
 // It prioritizes shares whose metadata was never fetched or became stale based on BeaconMetadataLastUpdated.
-func (s *Syncer) nextBatchFromDB(_ context.Context, subnetsBuf *big.Int) beacon.ValidatorMetadataMap {
+func (s *Syncer) nextBatchFromDB(_ context.Context) beacon.ValidatorMetadataMap {
 	// TODO: use context, return if it's done
-	ownSubnets := s.selfSubnets(subnetsBuf)
+	ownSubnets := s.selfSubnets()
 
 	var staleShares, newShares []*ssvtypes.SSVShare
 	s.shareStorage.Range(nil, func(share *ssvtypes.SSVShare) bool {
@@ -291,9 +289,7 @@ func (s *Syncer) nextBatchFromDB(_ context.Context, subnetsBuf *big.Int) beacon.
 			return true
 		}
 
-		networkcommons.SetCommitteeSubnet(subnetsBuf, share.CommitteeID())
-		subnet := subnetsBuf.Uint64()
-		if !ownSubnets.IsSet(subnet) {
+		if !s.shareInOwnSubnets(share, ownSubnets) {
 			return true
 		}
 
@@ -334,21 +330,35 @@ func (s *Syncer) sleep(ctx context.Context, d time.Duration) (slept bool) {
 
 // selfSubnets calculates the operator's subnets by adding up the fixed subnets and the active committees
 // it recvs big int buffer for memory reusing, if is nil it will allocate new
-func (s *Syncer) selfSubnets(buf *big.Int) networkcommons.Subnets {
+func (s *Syncer) selfSubnets() networkcommons.Subnets {
 	// Start off with a copy of the fixed subnets (e.g., exporter subscribed to all subnets).
-	localBuf := buf
-	if localBuf == nil {
-		localBuf = new(big.Int)
-	}
-
 	mySubnets := s.fixedSubnets
-
+	currentSlot := s.netCfg.EstimatedCurrentSlot()
 	// Compute the new subnets according to the active committees/validators.
 	myValidators := s.validatorStore.SelfValidators()
 	for _, v := range myValidators {
-		networkcommons.SetCommitteeSubnet(localBuf, v.CommitteeID())
-		mySubnets.Set(localBuf.Uint64())
+		switch {
+		case s.netCfg.InBooleTransitionWindow(currentSlot):
+			mySubnets.Set(v.AlanCommitteeSubnet())
+			mySubnets.Set(v.BooleCommitteeSubnet())
+		case s.netCfg.BooleForkAtSlot(currentSlot):
+			mySubnets.Set(v.BooleCommitteeSubnet())
+		default:
+			mySubnets.Set(v.AlanCommitteeSubnet())
+		}
 	}
 
 	return mySubnets
+}
+
+func (s *Syncer) shareInOwnSubnets(share *ssvtypes.SSVShare, ownSubnets networkcommons.Subnets) bool {
+	currentSlot := s.netCfg.EstimatedCurrentSlot()
+	switch {
+	case s.netCfg.InBooleTransitionWindow(currentSlot):
+		return ownSubnets.IsSet(share.AlanCommitteeSubnet()) || ownSubnets.IsSet(share.BooleCommitteeSubnet())
+	case s.netCfg.BooleForkAtSlot(currentSlot):
+		return ownSubnets.IsSet(share.BooleCommitteeSubnet())
+	default:
+		return ownSubnets.IsSet(share.AlanCommitteeSubnet())
+	}
 }

--- a/operator/validator/metadata/syncer.go
+++ b/operator/validator/metadata/syncer.go
@@ -329,7 +329,6 @@ func (s *Syncer) sleep(ctx context.Context, d time.Duration) (slept bool) {
 }
 
 // selfSubnets calculates the operator's subnets by adding up the fixed subnets and the active committees
-// it recvs big int buffer for memory reusing, if is nil it will allocate new
 func (s *Syncer) selfSubnets() networkcommons.Subnets {
 	// Start off with a copy of the fixed subnets (e.g., exporter subscribed to all subnets).
 	mySubnets := s.fixedSubnets

--- a/operator/validator/metadata/syncer.go
+++ b/operator/validator/metadata/syncer.go
@@ -105,11 +105,13 @@ func WithSyncInterval(interval time.Duration) Option {
 // and triggers a full metadata synchronization for them.
 // It returns a mapping of validator public keys to their updated metadata.
 func (s *Syncer) SyncAll(ctx context.Context) (beacon.ValidatorMetadataMap, error) {
-	ownSubnets := s.selfSubnets()
+	// Snapshot the slot once so subnet building and share filtering resolve to the same fork phase.
+	currentSlot := s.netCfg.EstimatedCurrentSlot()
+	ownSubnets := s.selfSubnets(currentSlot)
 
 	// Load non-liquidated shares.
 	shares := s.shareStorage.List(nil, registrystorage.ByNotLiquidated(), func(share *ssvtypes.SSVShare) bool {
-		return s.shareInOwnSubnets(share, ownSubnets)
+		return s.shareInOwnSubnets(share, ownSubnets, currentSlot)
 	})
 	if len(shares) == 0 {
 		s.logger.Info("could not find non-liquidated own subnets validator shares on initial metadata retrieval")
@@ -281,7 +283,9 @@ func (s *Syncer) syncNextBatch(ctx context.Context) (SyncBatch, bool, error) {
 // It prioritizes shares whose metadata was never fetched or became stale based on BeaconMetadataLastUpdated.
 func (s *Syncer) nextBatchFromDB(_ context.Context) beacon.ValidatorMetadataMap {
 	// TODO: use context, return if it's done
-	ownSubnets := s.selfSubnets()
+	// Snapshot the slot once so subnet building and share filtering resolve to the same fork phase.
+	currentSlot := s.netCfg.EstimatedCurrentSlot()
+	ownSubnets := s.selfSubnets(currentSlot)
 
 	var staleShares, newShares []*ssvtypes.SSVShare
 	s.shareStorage.Range(nil, func(share *ssvtypes.SSVShare) bool {
@@ -289,7 +293,7 @@ func (s *Syncer) nextBatchFromDB(_ context.Context) beacon.ValidatorMetadataMap 
 			return true
 		}
 
-		if !s.shareInOwnSubnets(share, ownSubnets) {
+		if !s.shareInOwnSubnets(share, ownSubnets, currentSlot) {
 			return true
 		}
 
@@ -329,18 +333,20 @@ func (s *Syncer) sleep(ctx context.Context, d time.Duration) (slept bool) {
 }
 
 // selfSubnets calculates the operator's subnets by adding up the fixed subnets and the active committees
-func (s *Syncer) selfSubnets() networkcommons.Subnets {
+func (s *Syncer) selfSubnets(currentSlot phase0.Slot) networkcommons.Subnets {
 	// Start off with a copy of the fixed subnets (e.g., exporter subscribed to all subnets).
 	mySubnets := s.fixedSubnets
-	currentSlot := s.netCfg.EstimatedCurrentSlot()
+	// The fork phase is invariant for the given slot, so decide it once before the loop.
+	inTransitionWindow := s.netCfg.InBooleTransitionWindow(currentSlot)
+	postBooleFork := s.netCfg.BooleForkAtSlot(currentSlot)
 	// Compute the new subnets according to the active committees/validators.
 	myValidators := s.validatorStore.SelfValidators()
 	for _, v := range myValidators {
 		switch {
-		case s.netCfg.InBooleTransitionWindow(currentSlot):
+		case inTransitionWindow:
 			mySubnets.Set(v.AlanCommitteeSubnet())
 			mySubnets.Set(v.BooleCommitteeSubnet())
-		case s.netCfg.BooleForkAtSlot(currentSlot):
+		case postBooleFork:
 			mySubnets.Set(v.BooleCommitteeSubnet())
 		default:
 			mySubnets.Set(v.AlanCommitteeSubnet())
@@ -350,8 +356,9 @@ func (s *Syncer) selfSubnets() networkcommons.Subnets {
 	return mySubnets
 }
 
-func (s *Syncer) shareInOwnSubnets(share *ssvtypes.SSVShare, ownSubnets networkcommons.Subnets) bool {
-	currentSlot := s.netCfg.EstimatedCurrentSlot()
+// shareInOwnSubnets reports whether the share belongs to ownSubnets. currentSlot must be the same
+// slot ownSubnets was built from, so both sides resolve to the same fork phase.
+func (s *Syncer) shareInOwnSubnets(share *ssvtypes.SSVShare, ownSubnets networkcommons.Subnets, currentSlot phase0.Slot) bool {
 	switch {
 	case s.netCfg.InBooleTransitionWindow(currentSlot):
 		return ownSubnets.IsSet(share.AlanCommitteeSubnet()) || ownSubnets.IsSet(share.BooleCommitteeSubnet())

--- a/operator/validator/metadata/syncer_test.go
+++ b/operator/validator/metadata/syncer_test.go
@@ -939,10 +939,14 @@ func TestSyncer_SyncAll_ExporterUnaffectedByForkPhase(t *testing.T) {
 			mockShareStorage.EXPECT().List(nil, gomock.Any()).DoAndReturn(
 				func(txn basedb.Reader, filters ...registrystorage.SharesFilter) []*ssvtypes.SSVShare {
 					var selected []*ssvtypes.SSVShare
+				sharesLoop:
 					for _, share := range shares {
-						if filters[0](share) {
-							selected = append(selected, share)
+						for _, filter := range filters {
+							if !filter(share) {
+								continue sharesLoop
+							}
 						}
+						selected = append(selected, share)
 					}
 					return selected
 				})

--- a/operator/validator/metadata/syncer_test.go
+++ b/operator/validator/metadata/syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -17,9 +18,11 @@ import (
 
 	"github.com/ssvlabs/ssv/beacon/goclient"
 	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
@@ -94,7 +97,7 @@ func TestUpdateValidatorMetadata(t *testing.T) {
 				return result, nil
 			}).AnyTimes()
 
-			syncer := NewSyncer(logger, sharesStorage, validatorStore, beaconNode, commons.ZeroSubnets)
+			syncer := NewSyncer(logger, networkconfig.TestNetwork, sharesStorage, validatorStore, beaconNode, commons.ZeroSubnets)
 			_, err := syncer.Sync(t.Context(), []spectypes.ValidatorPK{tc.testPublicKey})
 			if tc.sharesStorageErr != nil {
 				require.ErrorIs(t, err, tc.sharesStorageErr)
@@ -256,6 +259,7 @@ func TestSyncer_SyncAll(t *testing.T) {
 
 		syncer := &Syncer{
 			logger:         logger,
+			netCfg:         networkconfig.TestNetwork,
 			shareStorage:   mockShareStorage,
 			validatorStore: mockValidatorStore,
 		}
@@ -279,6 +283,7 @@ func TestSyncer_SyncAll(t *testing.T) {
 
 		syncer := &Syncer{
 			logger:         logger,
+			netCfg:         networkconfig.TestNetwork,
 			shareStorage:   mockShareStorage,
 			validatorStore: mockValidatorStore,
 			beaconNode:     defaultMockBeaconNode,
@@ -334,6 +339,7 @@ func TestSyncer_SyncAll(t *testing.T) {
 
 		syncer := &Syncer{
 			logger:         logger,
+			netCfg:         networkconfig.TestNetwork,
 			shareStorage:   mockShareStorage,
 			validatorStore: mockValidatorStore,
 			beaconNode:     errMockBeaconNode,
@@ -398,6 +404,7 @@ func TestSyncer_Stream(t *testing.T) {
 		// Syncer instance
 		syncer := &Syncer{
 			logger:            logger,
+			netCfg:            networkconfig.TestNetwork,
 			shareStorage:      mockShareStorage,
 			validatorStore:    mockValidatorStore,
 			beaconNode:        defaultMockBeaconNode,
@@ -500,6 +507,7 @@ func TestSyncer_Stream(t *testing.T) {
 		// Syncer instance
 		syncer := &Syncer{
 			logger:            logger,
+			netCfg:            networkconfig.TestNetwork,
 			shareStorage:      mockShareStorage,
 			validatorStore:    mockValidatorStore,
 			beaconNode:        errMockBeaconNode,
@@ -581,6 +589,7 @@ func TestSyncer_Stream(t *testing.T) {
 		// Syncer instance
 		syncer := &Syncer{
 			logger:            logger,
+			netCfg:            networkconfig.TestNetwork,
 			shareStorage:      mockShareStorage,
 			validatorStore:    mockValidatorStore,
 			beaconNode:        defaultMockBeaconNode,
@@ -661,6 +670,7 @@ func TestWithUpdateInterval(t *testing.T) {
 	// Create a Syncer with the WithSyncInterval option
 	syncer := NewSyncer(
 		logger,
+		networkconfig.TestNetwork,
 		mockShareStorage,
 		mockValidatorStore,
 		mockBeaconNode,
@@ -787,4 +797,159 @@ func TestSyncer_Sleep(t *testing.T) {
 		// Assert that the elapsed time is minimal.
 		require.Less(t, elapsed, 10*time.Millisecond, "Sleep with zero duration should return immediately")
 	})
+}
+
+// preForkNetwork, postForkNetwork and inTransitionWindowNetwork each build their own copy of
+// networkconfig.TestNetwork with an explicit Forks.Boole value, so the SSV_TEST_BOOLE_FORK env
+// override (see networkconfig/test-network.go) can't perturb which fork phase a test exercises.
+func preForkNetwork() *networkconfig.Network {
+	netCfg := *networkconfig.TestNetwork
+	ssvCfg := *netCfg.SSV
+	ssvCfg.Forks.Boole = math.MaxUint64
+	netCfg.SSV = &ssvCfg
+	return &netCfg
+}
+
+func postForkNetwork() *networkconfig.Network {
+	netCfg := *networkconfig.TestNetwork
+	ssvCfg := *netCfg.SSV
+	ssvCfg.Forks.Boole = 0
+	netCfg.SSV = &ssvCfg
+	return &netCfg
+}
+
+func inTransitionWindowNetwork() *networkconfig.Network {
+	netCfg := *networkconfig.TestNetwork
+	ssvCfg := *netCfg.SSV
+	ssvCfg.Forks.Boole = netCfg.EstimatedCurrentEpoch() + 1
+	netCfg.SSV = &ssvCfg
+	return &netCfg
+}
+
+// shareWithCommittee builds a minimal SSVShare whose committee is the given operator IDs — enough
+// to exercise BooleCommitteeSubnet/AlanCommitteeSubnet, which derive solely from the committee.
+func shareWithCommittee(operatorIDs ...spectypes.OperatorID) *ssvtypes.SSVShare {
+	committee := make([]*spectypes.ShareMember, len(operatorIDs))
+	for i, id := range operatorIDs {
+		committee[i] = &spectypes.ShareMember{Signer: id}
+	}
+	return &ssvtypes.SSVShare{
+		Share: spectypes.Share{Committee: committee},
+	}
+}
+
+// distinctSubnetShare returns a share whose Alan and Boole committee subnets differ, so pre-fork
+// and post-fork matching can be tested independently of one another.
+func distinctSubnetShare(t *testing.T) *ssvtypes.SSVShare {
+	t.Helper()
+	for id := spectypes.OperatorID(1); id <= 4096; id++ {
+		v := shareWithCommittee(id, id+1, id+2, id+3)
+		if v.AlanCommitteeSubnet() != v.BooleCommitteeSubnet() {
+			return v
+		}
+	}
+	t.Fatal("no committee found with distinct Alan/Boole subnets")
+	return nil
+}
+
+// TestSyncer_ShareInOwnSubnets_ForkAware locks in the fork-gated subnet-matching switch mirrored
+// from the fork-aware reference implementation: pre-fork only the Alan mapping is consulted,
+// post-fork only Boole, and inside the transition window either mapping is accepted. It also
+// verifies exporters (fixedSubnets == AllSubnets) match regardless of fork phase.
+func TestSyncer_ShareInOwnSubnets_ForkAware(t *testing.T) {
+	share := distinctSubnetShare(t)
+	alanSubnet := share.AlanCommitteeSubnet()
+	booleSubnet := share.BooleCommitteeSubnet()
+
+	var alanOnlySubnets commons.Subnets
+	alanOnlySubnets.Set(alanSubnet)
+
+	var booleOnlySubnets commons.Subnets
+	booleOnlySubnets.Set(booleSubnet)
+
+	t.Run("pre-fork matches only via the Alan mapping", func(t *testing.T) {
+		s := &Syncer{netCfg: preForkNetwork()}
+		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-subnet match should be selected pre-fork")
+		require.False(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-only match should not be selected pre-fork")
+	})
+
+	t.Run("post-fork matches only via the Boole mapping", func(t *testing.T) {
+		s := &Syncer{netCfg: postForkNetwork()}
+		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-subnet match should be selected post-fork")
+		require.False(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-only match should not be selected post-fork")
+	})
+
+	t.Run("in transition window matches via either mapping", func(t *testing.T) {
+		s := &Syncer{netCfg: inTransitionWindowNetwork()}
+		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-subnet match should be selected in the transition window")
+		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-subnet match should be selected in the transition window")
+	})
+
+	t.Run("exporter's AllSubnets matches regardless of fork phase", func(t *testing.T) {
+		for _, netCfg := range []*networkconfig.Network{preForkNetwork(), postForkNetwork(), inTransitionWindowNetwork()} {
+			s := &Syncer{netCfg: netCfg}
+			require.True(t, s.shareInOwnSubnets(share, commons.AllSubnets))
+		}
+	})
+}
+
+// TestSyncer_SyncAll_ExporterUnaffectedByForkPhase confirms that with fixedSubnets == AllSubnets
+// (the exporter configuration), selfSubnets() always resolves to AllSubnets regardless of fork
+// phase, so every non-liquidated share is selected for sync in all three fork phases.
+func TestSyncer_SyncAll_ExporterUnaffectedByForkPhase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := zap.NewNop()
+
+	share1 := &ssvtypes.SSVShare{
+		Share:      spectypes.Share{ValidatorPubKey: spectypes.ValidatorPK{0x1}, Committee: []*spectypes.ShareMember{{Signer: 1}}},
+		Liquidated: false,
+	}
+	share2 := &ssvtypes.SSVShare{
+		Share:      spectypes.Share{ValidatorPubKey: spectypes.ValidatorPK{0x2}, Committee: []*spectypes.ShareMember{{Signer: 2}}},
+		Liquidated: false,
+	}
+	shares := []*ssvtypes.SSVShare{share1, share2}
+
+	for name, netCfg := range map[string]*networkconfig.Network{
+		"pre-fork":  preForkNetwork(),
+		"post-fork": postForkNetwork(),
+		"in-window": inTransitionWindowNetwork(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockShareStorage := NewMockshareStorage(ctrl)
+			mockValidatorStore := NewMockselfValidatorStore(ctrl)
+			mockBeaconNode := beacon.NewMockBeaconNode(ctrl)
+			mockBeaconNode.EXPECT().GetValidatorData(gomock.Any(), gomock.Any()).Return(map[phase0.ValidatorIndex]*eth2apiv1.Validator{}, nil).AnyTimes()
+
+			syncer := &Syncer{
+				logger:         logger,
+				netCfg:         netCfg,
+				shareStorage:   mockShareStorage,
+				validatorStore: mockValidatorStore,
+				beaconNode:     mockBeaconNode,
+				fixedSubnets:   commons.AllSubnets,
+			}
+
+			mockValidatorStore.EXPECT().SelfValidators().Return([]*ssvtypes.SSVShare{}).AnyTimes()
+			mockShareStorage.EXPECT().List(nil, gomock.Any()).DoAndReturn(
+				func(txn basedb.Reader, filters ...registrystorage.SharesFilter) []*ssvtypes.SSVShare {
+					var selected []*ssvtypes.SSVShare
+					for _, share := range shares {
+						if filters[0](share) {
+							selected = append(selected, share)
+						}
+					}
+					return selected
+				})
+			mockShareStorage.EXPECT().UpdateValidatorsMetadata(gomock.Any()).Return(beacon.ValidatorMetadataMap{
+				share1.ValidatorPubKey: share1.BeaconMetadata(),
+				share2.ValidatorPubKey: share2.BeaconMetadata(),
+			}, nil)
+
+			_, err := syncer.SyncAll(t.Context())
+			require.NoError(t, err)
+		})
+	}
 }

--- a/operator/validator/metadata/syncer_test.go
+++ b/operator/validator/metadata/syncer_test.go
@@ -869,26 +869,29 @@ func TestSyncer_ShareInOwnSubnets_ForkAware(t *testing.T) {
 
 	t.Run("pre-fork matches only via the Alan mapping", func(t *testing.T) {
 		s := &Syncer{netCfg: preForkNetwork()}
-		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-subnet match should be selected pre-fork")
-		require.False(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-only match should not be selected pre-fork")
+		currentSlot := s.netCfg.EstimatedCurrentSlot()
+		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets, currentSlot), "Alan-subnet match should be selected pre-fork")
+		require.False(t, s.shareInOwnSubnets(share, booleOnlySubnets, currentSlot), "Boole-only match should not be selected pre-fork")
 	})
 
 	t.Run("post-fork matches only via the Boole mapping", func(t *testing.T) {
 		s := &Syncer{netCfg: postForkNetwork()}
-		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-subnet match should be selected post-fork")
-		require.False(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-only match should not be selected post-fork")
+		currentSlot := s.netCfg.EstimatedCurrentSlot()
+		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets, currentSlot), "Boole-subnet match should be selected post-fork")
+		require.False(t, s.shareInOwnSubnets(share, alanOnlySubnets, currentSlot), "Alan-only match should not be selected post-fork")
 	})
 
 	t.Run("in transition window matches via either mapping", func(t *testing.T) {
 		s := &Syncer{netCfg: inTransitionWindowNetwork()}
-		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets), "Alan-subnet match should be selected in the transition window")
-		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets), "Boole-subnet match should be selected in the transition window")
+		currentSlot := s.netCfg.EstimatedCurrentSlot()
+		require.True(t, s.shareInOwnSubnets(share, alanOnlySubnets, currentSlot), "Alan-subnet match should be selected in the transition window")
+		require.True(t, s.shareInOwnSubnets(share, booleOnlySubnets, currentSlot), "Boole-subnet match should be selected in the transition window")
 	})
 
 	t.Run("exporter's AllSubnets matches regardless of fork phase", func(t *testing.T) {
 		for _, netCfg := range []*networkconfig.Network{preForkNetwork(), postForkNetwork(), inTransitionWindowNetwork()} {
 			s := &Syncer{netCfg: netCfg}
-			require.True(t, s.shareInOwnSubnets(share, commons.AllSubnets))
+			require.True(t, s.shareInOwnSubnets(share, commons.AllSubnets, netCfg.EstimatedCurrentSlot()))
 		}
 	})
 }


### PR DESCRIPTION
Item 2 of #2952 (follow-up to #2941).

The metadata syncer's `selfSubnets` and both share-relevance filters (`SyncAll`, `nextBatchFromDB`) computed subnets exclusively via the Alan mapping. Post-fork the node's live topics are Boole subnets (~99% of committees map differently), so metadata would be kept fresh for the wrong neighbor set: committees sharing our Boole subnets but not our Alan subnets would never sync → their `ValidatorIndex`/metadata stays unset → reject-level message validation (`ErrNoValidators`) misfires on their gossip on our own topics.

This ports boole-fork's fork-aware switch verbatim (the resulting `syncer.go` is byte-identical to boole-fork's): `*networkconfig.Network` is injected into the `Syncer`, and the subnet mapping follows the fork phase — Alan pre-fork / **both** inside the transition window / Boole post-fork. The transition-window arm is deliberately evaluated before `BooleForkAtSlot`: the subsequent window is post-fork, and the flipped order would silently drop the old-topic neighbor set there.

- Pre-fork selection is byte-identical to the previous inline `SetCommitteeSubnet` logic (`Forks.Boole = MaxUint64` always hits the Alan arm), so this is behavior-neutral on today's networks.
- Exporters (`fixedSubnets = all`) are unaffected in every phase (covered by a test).
- New three-phase tests use per-test `TestNetwork` copies with `Forks.Boole` set explicitly, so the `SSV_TEST_BOOLE_FORK` env override can't perturb them.
- No mock changes (`netCfg` is a concrete type); `make generate` is diff-clean.