### PR TITLE
networkconfig: document the storage fork-name policy (#2956)

### DIFF
--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -23,14 +23,21 @@ func (n Network) String() string {
 	return string(jsonBytes)
 }
 
-const alanForkName = "alan"
+// storageForkName is the fork suffix baked into StorageName. It is an opaque
+// compatibility token, not a statement of the network's current fork: changing it
+// makes every existing node fail startup with a config-lock mismatch until the DB
+// is removed, so it must only change when a fork invalidates the stored data
+// layout and a coordinated, network-wide resync is intended. The Boole fork keeps
+// the schema dual-fork-aware on the same DB, so the historical "alan" value stays.
+const storageForkName = "alan"
+
 const boolePriorWindowEpochs = phase0.Epoch(1)    // epochs before Boole to subscribe to both topic sets
 const booleSubsequentWindowSlots = phase0.Slot(1) // slots after Boole to keep accepting old-topic messages
 
 // StorageName returns a config name used to make sure the stored network doesn't differ.
 // It combines the network name with fork name.
 func (n Network) StorageName() string {
-	return fmt.Sprintf("%s:%s", n.SSV.Name, alanForkName) // TODO: decide what forks change DB fork name
+	return fmt.Sprintf("%s:%s", n.SSV.Name, storageForkName)
 }
 
 func (n Network) DomainTypeAtSlot(slot phase0.Slot) spectypes.DomainType {

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -23,21 +23,24 @@ func (n Network) String() string {
 	return string(jsonBytes)
 }
 
-// storageForkName is the fork suffix baked into StorageName. It is an opaque
-// compatibility token, not a statement of the network's current fork: changing it
-// makes every existing node fail startup with a config-lock mismatch until the DB
-// is removed, so it must only change when a fork invalidates the stored data
-// layout and a coordinated, network-wide resync is intended. The Boole fork keeps
+// storageCompatToken is the suffix baked into StorageName. It is an opaque
+// storage-compatibility token, not a statement of the network's current fork:
+// changing it makes every existing node fail startup with a config-lock mismatch
+// until the DB is removed. A change to the stored data layout is normally handled
+// by a migration instead — migrations run before the config-lock check and upgrade
+// data in place with this token untouched (e.g. the gob→ssz share re-encoding).
+// Bump the token only as the escape hatch for when old data is unrecoverable and
+// a deliberate, coordinated network-wide resync is intended. The Boole fork keeps
 // the schema dual-fork-aware on the same DB, so the historical "alan" value stays.
-const storageForkName = "alan"
+const storageCompatToken = "alan"
 
 const boolePriorWindowEpochs = phase0.Epoch(1)    // epochs before Boole to subscribe to both topic sets
 const booleSubsequentWindowSlots = phase0.Slot(1) // slots after Boole to keep accepting old-topic messages
 
 // StorageName returns a config name used to make sure the stored network doesn't differ.
-// It combines the network name with fork name.
+// It combines the network name with the storage-compatibility token.
 func (n Network) StorageName() string {
-	return fmt.Sprintf("%s:%s", n.SSV.Name, storageForkName)
+	return fmt.Sprintf("%s:%s", n.SSV.Name, storageCompatToken)
 }
 
 func (n Network) DomainTypeAtSlot(slot phase0.Slot) spectypes.DomainType {


### PR DESCRIPTION
Addresses the decision half of #2956.

`StorageName()` feeds `ConfigLock.NetworkName`, so any change to the suffix makes every existing node fail startup with "network mismatch… database must be removed or reinitialized" — and it does so at **binary-upgrade** time, not fork time, since the name is static. The Boole convergence deliberately keeps the schema dual-fork-aware on the same DB (that's what makes #2941 an in-place upgrade), so forcing a network-wide resync buys nothing.

This keeps the `alan` string byte-for-byte, renames the const to `storageForkName`, and replaces the TODO with the policy: the suffix changes only when a fork invalidates the stored layout and a coordinated resync is intended.

The `go.mod`/`ssvsigner/go.mod` pin to a tagged `v1.2.3` (also tracked in #2956) remains blocked: the tag doesn't exist on ssv-spec yet (latest is `v1.2.2`).