### PR TITLE
message/validation: cached committee subnets on the topic hot path (#2952 item 7)

### DIFF
--- a/message/validation/committee_info.go
+++ b/message/validation/committee_info.go
@@ -10,12 +10,23 @@ type CommitteeInfo struct {
 	committee        []spectypes.OperatorID
 	signerIndices    map[spectypes.OperatorID]int
 	validatorIndices []phase0.ValidatorIndex
+	// subnet is the Boole-fork committee subnet, precomputed once so the per-message
+	// validation hot path (validateTopicAtSlot) never has to recompute a SHA-256-derived subnet.
+	subnet uint64
+	// subnetAlan is the pre-fork (Alan) committee subnet, precomputed for the same reason.
+	subnetAlan uint64
 }
 
+// newCommitteeInfo requires the caller to supply both subnets explicitly (unlike the boole-fork
+// reference's struct-literal constructor, which silently defaults forgotten fields to zero - a
+// valid-looking-but-wrong subnet). Making them required parameters forces every call site to
+// compute and pass them, so a missing subnet is a compile error rather than a runtime bug.
 func newCommitteeInfo(
 	committeeID spectypes.CommitteeID,
 	operators []spectypes.OperatorID,
 	validatorIndices []phase0.ValidatorIndex,
+	booleSubnet uint64,
+	alanSubnet uint64,
 ) CommitteeInfo {
 	signerIndices := make(map[spectypes.OperatorID]int)
 	for i, operator := range operators {
@@ -27,6 +38,8 @@ func newCommitteeInfo(
 		committee:        operators,
 		signerIndices:    signerIndices,
 		validatorIndices: validatorIndices,
+		subnet:           booleSubnet,
+		subnetAlan:       alanSubnet,
 	}
 }
 

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -258,11 +258,11 @@ func (mv *messageValidator) validateDomainAllowlist(msgID spectypes.MessageID) e
 func (mv *messageValidator) validateTopicAtSlot(committeeInfo CommitteeInfo, topic string, slot phase0.Slot) error {
 	var expectedTopic string
 	if mv.netCfg.BooleForkAtSlot(slot) {
-		expectedTopic = commons.BooleTopic(mv.netCfg.SSV.Name, commons.BooleCommitteeSubnet(committeeInfo.committee))
+		expectedTopic = commons.BooleTopic(mv.netCfg.SSV.Name, committeeInfo.subnet)
 	} else {
-		// CommitteeTopicID(cid)[0] == SubnetTopicID(AlanCommitteeSubnet(cid)), which is what
+		// SubnetTopicID(committeeInfo.subnetAlan) == CommitteeTopicID(cid)[0], which is what
 		// BroadcastAtSlot publishes on the Alan side, so the full names byte-match.
-		expectedTopic = commons.GetTopicFullName(commons.CommitteeTopicID(committeeInfo.committeeID)[0])
+		expectedTopic = commons.GetTopicFullName(commons.SubnetTopicID(committeeInfo.subnetAlan))
 	}
 
 	// Rule: Check if message was sent in the correct topic
@@ -331,7 +331,7 @@ func (mv *messageValidator) getCommitteeAndValidatorIndices(msgID spectypes.Mess
 			return CommitteeInfo{}, ErrNoValidators
 		}
 
-		return newCommitteeInfo(committeeID, committee.Operators, committee.Indices), nil
+		return newCommitteeInfo(committeeID, committee.Operators, committee.Indices, committee.BooleCommitteeSubnet(), committee.AlanCommitteeSubnet()), nil
 	}
 
 	share, exists := mv.validatorStore.Validator(msgID.GetDutyExecutorID())
@@ -363,7 +363,7 @@ func (mv *messageValidator) getCommitteeAndValidatorIndices(msgID spectypes.Mess
 	}
 
 	indices := []phase0.ValidatorIndex{share.ValidatorIndex}
-	return newCommitteeInfo(share.CommitteeID(), operators, indices), nil
+	return newCommitteeInfo(share.CommitteeID(), operators, indices, share.BooleCommitteeSubnet(), share.AlanCommitteeSubnet()), nil
 }
 
 func (mv *messageValidator) validatorState(key spectypes.MessageID, committeeInfo CommitteeInfo) *ValidatorState {

--- a/message/validation/validation_bench_test.go
+++ b/message/validation/validation_bench_test.go
@@ -1,0 +1,140 @@
+package validation
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/networkconfig"
+)
+
+// oldValidateTopicAtSlot recomputes the subnet from scratch (SHA-256 over the committee for
+// Boole, big.Int mod for Alan) on every call, mirroring the pre-optimization implementation.
+// It exists only in this test-only benchmark file to give an apples-to-apples before/after
+// comparison against the memoized-subnet validateTopicAtSlot.
+func oldValidateTopicAtSlot(netCfg *networkconfig.Network, committeeID spectypes.CommitteeID, committee []spectypes.OperatorID, topic string, slot phase0.Slot) error {
+	var expectedTopic string
+	if netCfg.BooleForkAtSlot(slot) {
+		expectedTopic = commons.BooleTopic(netCfg.SSV.Name, commons.BooleCommitteeSubnet(committee))
+	} else {
+		expectedTopic = commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
+	}
+
+	if expectedTopic != topic {
+		e := ErrIncorrectTopic
+		e.got = topic
+		e.want = expectedTopic
+		return e
+	}
+
+	return nil
+}
+
+func benchCommitteeInfoAndNetCfg(boolePostFork bool) (*messageValidator, CommitteeInfo, string, phase0.Slot) {
+	ssvCfg := *networkconfig.TestNetwork.SSV
+	if boolePostFork {
+		ssvCfg.Forks = networkconfig.SSVForks{Boole: 0}
+	} else {
+		ssvCfg.Forks = networkconfig.SSVForks{Boole: math.MaxUint64}
+	}
+	netCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &ssvCfg}
+
+	committee := []spectypes.OperatorID{1, 2, 3, 4}
+	var committeeID spectypes.CommitteeID
+	copy(committeeID[:], big.NewInt(12345).Bytes())
+
+	booleSubnet := commons.BooleCommitteeSubnet(committee)
+	alanSubnet := commons.AlanCommitteeSubnet(committeeID)
+	committeeInfo := newCommitteeInfo(committeeID, committee, nil, booleSubnet, alanSubnet)
+
+	slot := netCfg.FirstSlotAtEpoch(1)
+
+	var topic string
+	if boolePostFork {
+		topic = commons.BooleTopic(netCfg.SSV.Name, booleSubnet)
+	} else {
+		topic = commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
+	}
+
+	mv := &messageValidator{netCfg: netCfg}
+
+	return mv, committeeInfo, topic, slot
+}
+
+// BenchmarkValidateTopicAtSlot_New_PostFork measures the memoized-subnet hot path (no hashing).
+func BenchmarkValidateTopicAtSlot_New_PostFork(b *testing.B) {
+	mv, committeeInfo, topic, slot := benchCommitteeInfoAndNetCfg(true)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := mv.validateTopicAtSlot(committeeInfo, topic, slot); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkValidateTopicAtSlot_Old_PostFork measures the pre-optimization per-message SHA-256
+// recompute, for comparison against BenchmarkValidateTopicAtSlot_New_PostFork.
+func BenchmarkValidateTopicAtSlot_Old_PostFork(b *testing.B) {
+	mv, committeeInfo, topic, slot := benchCommitteeInfoAndNetCfg(true)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := oldValidateTopicAtSlot(mv.netCfg, committeeInfo.committeeID, committeeInfo.committee, topic, slot); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkValidateTopicAtSlot_New_PreFork measures the memoized-subnet hot path pre-fork.
+func BenchmarkValidateTopicAtSlot_New_PreFork(b *testing.B) {
+	mv, committeeInfo, topic, slot := benchCommitteeInfoAndNetCfg(false)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := mv.validateTopicAtSlot(committeeInfo, topic, slot); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkValidateTopicAtSlot_Old_PreFork measures the pre-optimization big.Int-mod recompute
+// pre-fork, for comparison against BenchmarkValidateTopicAtSlot_New_PreFork.
+func BenchmarkValidateTopicAtSlot_Old_PreFork(b *testing.B) {
+	mv, committeeInfo, topic, slot := benchCommitteeInfoAndNetCfg(false)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := oldValidateTopicAtSlot(mv.netCfg, committeeInfo.committeeID, committeeInfo.committee, topic, slot); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Test_ValidateTopicAtSlot_NoSubnetRecomputeAllocs asserts the new hot path makes zero
+// big.Int/sha256-driven allocations: the only allocations left come from formatting the topic
+// string (fmt.Sprintf), which is identical work on both the old and new paths. We assert this by
+// comparing against the old (pre-optimization) recompute, which pays for the same formatting
+// plus the now-eliminated subnet computation - so new must allocate strictly less.
+func Test_ValidateTopicAtSlot_NoSubnetRecomputeAllocs(t *testing.T) {
+	mv, committeeInfo, topic, slot := benchCommitteeInfoAndNetCfg(true)
+
+	newAllocs := testing.AllocsPerRun(100, func() {
+		if err := mv.validateTopicAtSlot(committeeInfo, topic, slot); err != nil {
+			t.Fatal(err)
+		}
+	})
+	oldAllocs := testing.AllocsPerRun(100, func() {
+		if err := oldValidateTopicAtSlot(mv.netCfg, committeeInfo.committeeID, committeeInfo.committee, topic, slot); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	require.Less(t, newAllocs, oldAllocs)
+}

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -2560,7 +2560,7 @@ func Test_ForkBoundary_TopicParity(t *testing.T) {
 	// Boole activates one epoch from now, so FirstSlotAtEpoch(boole-1) is the last pre-fork
 	// slot and FirstSlotAtEpoch(boole) is the first post-fork slot - the boundary window.
 	boundarySSV := *networkconfig.TestNetwork.SSV
-	baseEpoch := networkconfig.TestNetwork.Beacon.EstimatedCurrentEpoch()
+	baseEpoch := networkconfig.TestNetwork.EstimatedCurrentEpoch()
 	booleEpoch := baseEpoch + 1
 	boundarySSV.Forks = networkconfig.SSVForks{Boole: booleEpoch}
 	netCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &boundarySSV}
@@ -2655,7 +2655,7 @@ func Test_CommitteeInfoSubnets(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		operators := make([]spectypes.OperatorID, 1+rnd.Intn(12))
 		for j := range operators {
-			operators[j] = spectypes.OperatorID(rnd.Uint64())
+			operators[j] = rnd.Uint64()
 		}
 
 		var committeeID spectypes.CommitteeID

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -201,6 +201,42 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorIs(t, err, ErrIncorrectTopic)
 	})
 
+	t.Run("committee consensus rejected on wrong-subnet boole topic post-fork", func(t *testing.T) {
+		validator := New(postBooleCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := postBooleCfg.FirstSlotAtEpoch(1)
+		booleIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), encodedCommitteeID, committeeRole)
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, booleIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+
+		// Same fork's topic scheme (Boole), but the wrong subnet number: must still be rejected.
+		wrongSubnet := (committeeInfo.subnet + 1) % commons.SubnetsCount
+		wrongSubnetTopic := commons.BooleTopic(postBooleCfg.SSV.Name, wrongSubnet)
+
+		receivedAt := postBooleCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, wrongSubnetTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
+	})
+
+	t.Run("committee consensus rejected on boole topic pre-fork", func(t *testing.T) {
+		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := netCfg.FirstSlotAtEpoch(1) // pre-fork (default TestNetwork Boole=MaxUint64)
+		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+
+		// A Boole-fork topic on a pre-fork slot must be rejected, even though it's a
+		// well-formed topic for this same committee (just for the wrong fork).
+		booleTopic := commons.BooleTopic(netCfg.SSV.Name, committeeInfo.subnet)
+		receivedAt := netCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
+	})
+
 	t.Run("committee consensus rejected with alan domain post-fork", func(t *testing.T) {
 		validator := New(postBooleCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
 
@@ -717,6 +753,88 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		receivedAt := postBooleCfg.SlotStartTime(slot)
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
 		require.ErrorIs(t, err, ErrInvalidRole)
+	})
+
+	// The non-committee (per-validator) path also now takes share.BooleCommitteeSubnet()/
+	// AlanCommitteeSubnet() for its CommitteeInfo (see getCommitteeAndValidatorIndices), so it
+	// needs the same topic-quadrant coverage as the committee-role path above. RoleProposer is
+	// used because it's valid at any slot pre- and post-fork (validRoleAtSlot), unlike
+	// RoleAggregator/RoleSyncCommitteeContribution which are pre-fork only.
+	t.Run("non-committee role accepted on boole topic post-fork", func(t *testing.T) {
+		slot := postBooleCfg.FirstSlotAtEpoch(1)
+		epoch := postBooleCfg.EstimatedEpochAtSlot(slot)
+
+		// RoleProposer requires a registered proposer duty (validateBeaconDuty), unlike the
+		// committee-role subtests above.
+		ds := dutystore.New()
+		ds.Proposer.Set(epoch, []dutystore.StoreDuty[eth2apiv1.ProposerDuty]{
+			{Slot: slot, ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.ProposerDuty{}, InCommittee: true},
+		})
+		validator := New(postBooleCfg, validatorStore, operators, ds, signatureVerifier).(*messageValidator)
+
+		proposerIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], spectypes.RoleProposer)
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, proposerIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+		booleTopic := expectedCommitteeTopic(postBooleCfg, committeeInfo, slot)
+
+		receivedAt := postBooleCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-committee role rejected on alan topic post-fork", func(t *testing.T) {
+		validator := New(postBooleCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := postBooleCfg.FirstSlotAtEpoch(1)
+		proposerIdentifier := spectypes.NewMsgID(postBooleCfg.DomainTypeAtSlot(slot), shares.active.ValidatorPubKey[:], spectypes.RoleProposer)
+		signedSSVMessage := buildBooleProposal(postBooleCfg, ks, committee, proposerIdentifier, slot)
+
+		alanTopic := commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
+		receivedAt := postBooleCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, alanTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
+	})
+
+	t.Run("non-committee role accepted on alan topic pre-fork", func(t *testing.T) {
+		slot := netCfg.FirstSlotAtEpoch(1)
+		epoch := netCfg.EstimatedEpochAtSlot(slot)
+
+		// RoleProposer requires a registered proposer duty (validateBeaconDuty), unlike the
+		// committee-role subtests above.
+		ds := dutystore.New()
+		ds.Proposer.Set(epoch, []dutystore.StoreDuty[eth2apiv1.ProposerDuty]{
+			{Slot: slot, ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.ProposerDuty{}, InCommittee: true},
+		})
+		validator := New(netCfg, validatorStore, operators, ds, signatureVerifier).(*messageValidator)
+
+		proposerIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.active.ValidatorPubKey[:], spectypes.RoleProposer)
+		signedSSVMessage := generateSignedMessage(ks, proposerIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+		alanTopic := expectedCommitteeTopic(netCfg, committeeInfo, slot)
+
+		receivedAt := netCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, alanTopic, peerID, receivedAt)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-committee role rejected on boole topic pre-fork", func(t *testing.T) {
+		validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+		slot := netCfg.FirstSlotAtEpoch(1)
+		proposerIdentifier := spectypes.NewMsgID(netCfg.DomainType, shares.active.ValidatorPubKey[:], spectypes.RoleProposer)
+		signedSSVMessage := generateSignedMessage(ks, proposerIdentifier, slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(signedSSVMessage.SSVMessage.GetID())
+		require.NoError(t, err)
+		booleTopic := commons.BooleTopic(netCfg.SSV.Name, committeeInfo.subnet)
+
+		receivedAt := netCfg.SlotStartTime(slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
 	})
 
 	// Perform validator registration or voluntary exit with a consensus type message will give an error
@@ -2333,6 +2451,200 @@ func Test_ValidateSSVMessage(t *testing.T) {
 	})
 }
 
+// Test_DegenerateCommittee_NeverReachesTopicValidation exercises the case where a committee has
+// no operators (commons.BooleCommitteeSubnet/AlanCommitteeSubnet would return UnknownSubnetId /
+// subnet(0) for it - see registry/storage.Committee.BooleCommitteeSubnet). We check whether such
+// a value can reach validateTopicAtSlot through the real entry point (handleSignedSSVMessage).
+//
+// It cannot: validateSignedSSVMessage rejects any message with zero signers (ErrNoSigners) before
+// getCommitteeAndValidatorIndices/validateTopicAtSlot ever run, and any message with at least one
+// signer is rejected by belongsToCommittee (ErrSignerNotInCommittee) - slices.Contains against an
+// empty committee is always false - which also runs strictly before validateTopicAtSlot. So a
+// degenerate empty-operator committee can never reach the topic check, let alone be accepted on
+// the "unknown" sentinel topic string. This test proves that guard holds through the real
+// pipeline, rather than asserting it only against the private helper in isolation.
+func Test_DegenerateCommittee_NeverReachesTopicValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	logger := zaptest.NewLogger(t)
+	db, err := kv.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+
+	ns, err := storage.NewNodeStorage(networkconfig.TestNetwork.Beacon, logger, db)
+	require.NoError(t, err)
+
+	preBooleSSV := *networkconfig.TestNetwork.SSV
+	preBooleSSV.Forks = networkconfig.SSVForks{Boole: phase0.Epoch(math.MaxUint64)}
+	netCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &preBooleSSV}
+
+	ks := spectestingutils.Testing4SharesSet()
+	_ = generateShares(t, ks, ns, netCfg)
+
+	dutyStore := dutystore.New()
+	validatorStore := mocks.NewMockValidatorStore(ctrl)
+	operators := mocks.NewMockOperators(ctrl)
+
+	degenerateCommitteeID := spectypes.CommitteeID{0xDE, 0xAD, 0xBE, 0xEF}
+
+	validatorStore.EXPECT().Committee(gomock.Any()).DoAndReturn(func(id spectypes.CommitteeID) (*registrystorage.Committee, bool) {
+		if id == degenerateCommitteeID {
+			// Operators deliberately empty, Indices deliberately non-empty: this is the only way
+			// to get past the `len(committee.Indices) == 0` guard in getCommitteeAndValidatorIndices
+			// while still carrying an empty committee (a well-behaved store never produces this;
+			// buildCommittee always populates Operators from the same shares as Indices).
+			return &registrystorage.Committee{
+				ID:        degenerateCommitteeID,
+				Operators: nil,
+				Indices:   []phase0.ValidatorIndex{1},
+			}, true
+		}
+		return nil, false
+	}).AnyTimes()
+
+	operators.EXPECT().OperatorsExist(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+
+	signatureVerifier := signatureverifier.NewMockSignatureVerifier(ctrl)
+	signatureVerifier.EXPECT().VerifySignature(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	peerID, err := libp2ptest.RandPeerID()
+	require.NoError(t, err)
+
+	validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+	slot := netCfg.FirstSlotAtEpoch(1)
+	encodedDegenerateCommitteeID := append(bytes.Repeat([]byte{0}, 16), degenerateCommitteeID[:]...)
+	degenerateIdentifier := spectypes.NewMsgID(netCfg.DomainType, encodedDegenerateCommitteeID, spectypes.RoleCommittee)
+
+	// Confirm the store lookup itself succeeds (committee "exists"), so we know the rejection
+	// below comes from belongsToCommittee, not from ErrNonExistentCommitteeID.
+	committeeInfo, err := validator.getCommitteeAndValidatorIndices(degenerateIdentifier)
+	require.NoError(t, err)
+	require.Empty(t, committeeInfo.committee)
+	require.Equal(t, uint64(commons.UnknownSubnetId), committeeInfo.subnet)
+
+	signedSSVMessage := generateSignedMessage(ks, degenerateIdentifier, slot)
+	receivedAt := netCfg.SlotStartTime(slot)
+
+	// Try every candidate topic we can think of, including the literal "unknown" sentinel
+	// (commons.UnknownSubnet) that BooleTopic emits for UnknownSubnetId: none must ever be
+	// accepted, and the rejection must come from the signer/committee guard, never a false
+	// "accept" via an unknown-subnet topic string match.
+	candidateTopics := []string{
+		commons.BooleTopic(netCfg.SSV.Name, commons.UnknownSubnetId),
+		commons.GetTopicFullName(commons.SubnetTopicID(commons.AlanCommitteeSubnet(degenerateCommitteeID))),
+		"incorrect",
+	}
+	for _, topic := range candidateTopics {
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrSignerNotInCommittee)
+	}
+}
+
+// Test_ForkBoundary_TopicParity confirms that at the exact Boole activation epoch boundary -
+// not deep pre/post fork like the Test_ValidateSSVMessage subtests above, but the last pre-fork
+// slot and the first post-fork slot - validateTopicAtSlot's choice of topic (reached through the
+// real entry point) matches BroadcastAtSlot's choice for the same slot. Both call the same
+// mv.netCfg.BooleForkAtSlot(slot)/n.cfg.NetworkConfig.BooleForkAtSlot(slot) boundary function, so
+// this also guards against a future change that makes one side use a different boundary (e.g.
+// InBooleTransitionWindow) while the other keeps the exact-epoch cutoff.
+func Test_ForkBoundary_TopicParity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	logger := zaptest.NewLogger(t)
+	db, err := kv.NewInMemory(logger, basedb.Options{})
+	require.NoError(t, err)
+
+	ns, err := storage.NewNodeStorage(networkconfig.TestNetwork.Beacon, logger, db)
+	require.NoError(t, err)
+
+	// Boole activates one epoch from now, so FirstSlotAtEpoch(boole-1) is the last pre-fork
+	// slot and FirstSlotAtEpoch(boole) is the first post-fork slot - the boundary window.
+	boundarySSV := *networkconfig.TestNetwork.SSV
+	baseEpoch := networkconfig.TestNetwork.Beacon.EstimatedCurrentEpoch()
+	booleEpoch := baseEpoch + 1
+	boundarySSV.Forks = networkconfig.SSVForks{Boole: booleEpoch}
+	netCfg := &networkconfig.Network{Beacon: networkconfig.TestNetwork.Beacon, SSV: &boundarySSV}
+
+	ks := spectestingutils.Testing4SharesSet()
+	shares := generateShares(t, ks, ns, netCfg)
+
+	dutyStore := dutystore.New()
+	validatorStore := mocks.NewMockValidatorStore(ctrl)
+	operators := mocks.NewMockOperators(ctrl)
+	operators.EXPECT().OperatorsExist(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+
+	committee := slices.Collect(maps.Keys(ks.Shares))
+	slices.Sort(committee)
+	committeeID := shares.active.CommitteeID()
+	encodedCommitteeID := append(bytes.Repeat([]byte{0}, 16), committeeID[:]...)
+
+	validatorStore.EXPECT().Committee(gomock.Any()).DoAndReturn(func(id spectypes.CommitteeID) (*registrystorage.Committee, bool) {
+		if id == committeeID {
+			return &registrystorage.Committee{
+				ID:        id,
+				Operators: committee,
+				Shares:    []*ssvtypes.SSVShare{shares.active},
+				Indices:   []phase0.ValidatorIndex{shares.active.ValidatorIndex},
+			}, true
+		}
+		return nil, false
+	}).AnyTimes()
+
+	signatureVerifier := signatureverifier.NewMockSignatureVerifier(ctrl)
+	signatureVerifier.EXPECT().VerifySignature(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	peerID, err := libp2ptest.RandPeerID()
+	require.NoError(t, err)
+
+	validator := New(netCfg, validatorStore, operators, dutyStore, signatureVerifier).(*messageValidator)
+
+	lastPreForkSlot := netCfg.FirstSlotAtEpoch(booleEpoch - 1)
+	firstPostForkSlot := netCfg.FirstSlotAtEpoch(booleEpoch)
+
+	require.False(t, netCfg.BooleForkAtSlot(lastPreForkSlot), "test setup: expected last slot before Boole epoch to be pre-fork")
+	require.True(t, netCfg.BooleForkAtSlot(firstPostForkSlot), "test setup: expected first slot at Boole epoch to be post-fork")
+
+	t.Run("last pre-fork slot accepts alan topic and rejects boole topic", func(t *testing.T) {
+		slot := lastPreForkSlot
+		identifier := spectypes.NewMsgID(netCfg.DomainTypeAtSlot(slot), encodedCommitteeID, spectypes.RoleCommittee)
+		// generateSignedMessage hardcodes operator 1 as signer, which is only the leader at
+		// heights where height%len(committee)==0. lastPreForkSlot depends on the wall-clock
+		// current epoch (test setup above), so we must compute the real leader instead of
+		// assuming operator 1, or this would flake depending on when the test runs.
+		signedSSVMessage := buildProposalWithRealLeader(netCfg, ks, committee, identifier, slot)
+		receivedAt := netCfg.SlotStartTime(slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(identifier)
+		require.NoError(t, err)
+
+		alanTopic := expectedCommitteeTopic(netCfg, committeeInfo, slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, alanTopic, peerID, receivedAt)
+		require.NoError(t, err)
+
+		booleTopic := commons.BooleTopic(netCfg.SSV.Name, committeeInfo.subnet)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
+	})
+
+	t.Run("first post-fork slot accepts boole topic and rejects alan topic", func(t *testing.T) {
+		slot := firstPostForkSlot
+		identifier := spectypes.NewMsgID(netCfg.DomainTypeAtSlot(slot), encodedCommitteeID, spectypes.RoleCommittee)
+		signedSSVMessage := buildBooleProposal(netCfg, ks, committee, identifier, slot)
+		receivedAt := netCfg.SlotStartTime(slot)
+
+		committeeInfo, err := validator.getCommitteeAndValidatorIndices(identifier)
+		require.NoError(t, err)
+
+		booleTopic := expectedCommitteeTopic(netCfg, committeeInfo, slot)
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, booleTopic, peerID, receivedAt)
+		require.NoError(t, err)
+
+		alanTopic := commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
+		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, alanTopic, peerID, receivedAt)
+		require.ErrorIs(t, err, ErrIncorrectTopic)
+	})
+}
+
 // Test_CommitteeInfoSubnets is the cross-check that CommitteeInfo.subnet/subnetAlan (whatever
 // value they were constructed with) equal what commons.* independently computes for the same
 // committee, for many random committees. It never reads the value back from any cache: the
@@ -2570,6 +2882,33 @@ func buildBooleProposal(
 		PrepareJustification:     [][]byte{},
 	}
 	leader := qbft.RoundRobinProposer(specqbft.Height(slot), specqbft.FirstRound, committee, netCfg)
+	signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
+	signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
+	return signedSSVMessage
+}
+
+// buildProposalWithRealLeader is like buildBooleProposal but fork-agnostic: it resolves the
+// leader via qbft.Proposer, which itself dispatches on netCfg.BooleForkAtSlot(slot), so it is
+// safe to use both pre- and post-fork. Unlike generateSignedMessage (which hardcodes operator 1
+// as signer), this must be used whenever the height isn't guaranteed to put operator 1 in the
+// leader seat - e.g. at a slot derived from the wall-clock current epoch.
+func buildProposalWithRealLeader(
+	netCfg *networkconfig.Network,
+	ks *spectestingutils.TestKeySet,
+	committee []spectypes.OperatorID,
+	msgID spectypes.MessageID,
+	slot phase0.Slot,
+) *spectypes.SignedSSVMessage {
+	qbftMessage := &specqbft.Message{
+		MsgType:                  specqbft.ProposalMsgType,
+		Height:                   specqbft.Height(slot),
+		Round:                    specqbft.FirstRound,
+		Identifier:               msgID[:],
+		Root:                     sha256.Sum256(spectestingutils.TestingQBFTFullData),
+		RoundChangeJustification: [][]byte{},
+		PrepareJustification:     [][]byte{},
+	}
+	leader := qbft.Proposer(specqbft.Height(slot), specqbft.FirstRound, committee, netCfg)
 	signedSSVMessage := spectestingutils.SignQBFTMsg(ks.OperatorKeys[leader], leader, qbftMessage)
 	signedSSVMessage.FullData = spectestingutils.TestingQBFTFullData
 	return signedSSVMessage

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	mathrand "math/rand"
 	"slices"
 	"testing"
 	"time"
@@ -2330,6 +2331,33 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(context.Background(), signedSSVMessage, topicID, peerID, receivedAt)
 		require.ErrorContains(t, err, ErrValidatorIndexMismatch.Error())
 	})
+}
+
+// Test_CommitteeInfoSubnets is the cross-check that CommitteeInfo.subnet/subnetAlan (whatever
+// value they were constructed with) equal what commons.* independently computes for the same
+// committee, for many random committees. It never reads the value back from any cache: the
+// expected side is recomputed from scratch via commons.BooleCommitteeSubnet/AlanCommitteeSubnet.
+func Test_CommitteeInfoSubnets(t *testing.T) {
+	rnd := mathrand.New(mathrand.NewSource(1)) //nolint:gosec
+
+	for i := 0; i < 200; i++ {
+		operators := make([]spectypes.OperatorID, 1+rnd.Intn(12))
+		for j := range operators {
+			operators[j] = spectypes.OperatorID(rnd.Uint64())
+		}
+
+		var committeeID spectypes.CommitteeID
+		_, err := rnd.Read(committeeID[:])
+		require.NoError(t, err)
+
+		booleSubnet := commons.BooleCommitteeSubnet(operators)
+		alanSubnet := commons.AlanCommitteeSubnet(committeeID)
+
+		info := newCommitteeInfo(committeeID, operators, nil, booleSubnet, alanSubnet)
+
+		require.Equal(t, commons.BooleCommitteeSubnet(operators), info.subnet)
+		require.Equal(t, commons.AlanCommitteeSubnet(committeeID), info.subnetAlan)
+	}
 }
 
 // Deep copy helper function for testing purposes only

--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -46,10 +46,6 @@ func SubnetTopicID(subnet uint64) string {
 	return fmt.Sprintf("%d", subnet)
 }
 
-func CommitteeTopicID(cid spectypes.CommitteeID) []string {
-	return []string{fmt.Sprintf("%d", AlanCommitteeSubnet(cid))}
-}
-
 // GetTopicFullName returns the topic full name, including prefix (Alan-side naming).
 func GetTopicFullName(baseName string) string {
 	return fmt.Sprintf("%s.%s", topicPrefix, baseName)

--- a/network/commons/testutils.go
+++ b/network/commons/testutils.go
@@ -6,7 +6,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-// CommitteeTopicID returns the Alan-side committee topic ID. Test-only: production code
+// CommitteeTopicID returns the Alan-side committee topic ID. Only referenced by tests: production code
 // derives topics from the cached committee subnets (SubnetTopicID/BooleTopic); tests keep
 // this as an independent derivation of the expected Alan topic from the committee ID.
 func CommitteeTopicID(cid spectypes.CommitteeID) []string {

--- a/network/commons/testutils.go
+++ b/network/commons/testutils.go
@@ -1,0 +1,14 @@
+package commons
+
+import (
+	"fmt"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+)
+
+// CommitteeTopicID returns the Alan-side committee topic ID. Test-only: production code
+// derives topics from the cached committee subnets (SubnetTopicID/BooleTopic); tests keep
+// this as an independent derivation of the expected Alan topic from the committee ID.
+func CommitteeTopicID(cid spectypes.CommitteeID) []string {
+	return []string{fmt.Sprintf("%d", AlanCommitteeSubnet(cid))}
+}

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -77,7 +77,7 @@ func (n *p2pNetwork) BroadcastAtSlot(msg *spectypes.SignedSSVMessage, slot phase
 			if !exists {
 				return fmt.Errorf("could not find share for committee %s", hex.EncodeToString(msg.SSVMessage.MsgID.GetDutyExecutorID()))
 			}
-			topic = commons.BooleTopic(n.cfg.NetworkConfig.SSV.Name, val.BooleSubnet)
+			topic = commons.BooleTopic(n.cfg.NetworkConfig.SSV.Name, val.BooleCommitteeSubnet())
 		} else {
 			topic = commons.GetTopicFullName(commons.SubnetTopicID(commons.AlanCommitteeSubnet(committeeID)))
 		}

--- a/network/topics/scoring.go
+++ b/network/topics/scoring.go
@@ -222,8 +222,8 @@ func filterCommitteesForTopic(netCfg *networkconfig.Network, topic string, commi
 	currentSlot := netCfg.EstimatedCurrentSlot()
 
 	for _, committee := range committees {
-		booleTopic := commons.BooleTopic(netCfg.SSV.Name, committee.BooleSubnet)
-		alanTopic := commons.GetTopicFullName(commons.SubnetTopicID(committee.AlanSubnet))
+		booleTopic := commons.BooleTopic(netCfg.SSV.Name, committee.BooleCommitteeSubnet())
+		alanTopic := commons.GetTopicFullName(commons.SubnetTopicID(committee.AlanCommitteeSubnet()))
 
 		switch {
 		case netCfg.InBooleTransitionWindow(currentSlot):

--- a/registry/storage/validatorstore.go
+++ b/registry/storage/validatorstore.go
@@ -67,6 +67,8 @@ type Committee struct {
 }
 
 // BooleCommitteeSubnet safely retrieves or computes the committee subnet for the Boole fork.
+// Note: for a committee with no Operators this returns the UnknownSubnetId sentinel,
+// whereas AlanCommitteeSubnet derives from ID and always returns a real subnet.
 func (c *Committee) BooleCommitteeSubnet() uint64 {
 	if ptr := c.booleCommitteeSubnet.Load(); ptr != nil {
 		return *ptr

--- a/registry/storage/validatorstore.go
+++ b/registry/storage/validatorstore.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -13,6 +14,7 @@ import (
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -53,12 +55,37 @@ type SelfValidatorStore interface {
 }
 
 type Committee struct {
-	ID          spectypes.CommitteeID
-	Operators   []spectypes.OperatorID
-	Shares      []*types.SSVShare
-	Indices     []phase0.ValidatorIndex
-	BooleSubnet uint64
-	AlanSubnet  uint64
+	ID        spectypes.CommitteeID
+	Operators []spectypes.OperatorID
+	Shares    []*types.SSVShare
+	Indices   []phase0.ValidatorIndex
+
+	// booleCommitteeSubnet is a cached value for committee subnet (post-Boole-fork) so we don't recompute it every time.
+	booleCommitteeSubnet atomic.Pointer[uint64]
+	// alanCommitteeSubnet is a cached value for committee subnet (Alan fork) so we don't recompute it every time.
+	alanCommitteeSubnet atomic.Pointer[uint64]
+}
+
+// BooleCommitteeSubnet safely retrieves or computes the committee subnet for the Boole fork.
+func (c *Committee) BooleCommitteeSubnet() uint64 {
+	if ptr := c.booleCommitteeSubnet.Load(); ptr != nil {
+		return *ptr
+	}
+
+	subnet := commons.BooleCommitteeSubnet(c.Operators)
+	c.booleCommitteeSubnet.Store(&subnet)
+	return subnet
+}
+
+// AlanCommitteeSubnet safely retrieves or computes the committee subnet for the Alan fork.
+func (c *Committee) AlanCommitteeSubnet() uint64 {
+	if ptr := c.alanCommitteeSubnet.Load(); ptr != nil {
+		return *ptr
+	}
+
+	subnet := commons.AlanCommitteeSubnet(c.ID)
+	c.alanCommitteeSubnet.Store(&subnet)
+	return subnet
 }
 
 // IsParticipating returns whether any validator in the committee should participate in the given epoch.
@@ -631,12 +658,6 @@ func buildCommittee(shares []*types.SSVShare) *Committee {
 		committee.Indices = append(committee.Indices, share.ValidatorIndex)
 	}
 	slices.Sort(committee.Operators)
-
-	// Some test shares might have a zero-length committee.
-	if len(shares[0].Committee) > 0 {
-		committee.BooleSubnet = shares[0].BooleCommitteeSubnet()
-		committee.AlanSubnet = shares[0].AlanCommitteeSubnet()
-	}
 
 	return committee
 }

--- a/registry/storage/validatorstore_test.go
+++ b/registry/storage/validatorstore_test.go
@@ -1475,7 +1475,7 @@ func TestCommittee_SubnetMemoization_MatchesIndependentRecompute(t *testing.T) {
 		operators := make([]spectypes.OperatorID, operatorCount)
 		committeeMembers := make([]*spectypes.ShareMember, operatorCount)
 		for j := 0; j < operatorCount; j++ {
-			opID := spectypes.OperatorID(rand.Uint64()) //nolint:gosec
+			opID := rand.Uint64() //nolint:gosec
 			operators[j] = opID
 			committeeMembers[j] = &spectypes.ShareMember{Signer: opID}
 		}

--- a/registry/storage/validatorstore_test.go
+++ b/registry/storage/validatorstore_test.go
@@ -24,6 +24,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/beacon/goclient"
+	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/networkconfig"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
@@ -1463,4 +1464,48 @@ func TestValidatorStore_PermanentIndexToPubkeyMapping(t *testing.T) {
 	pk, ok = store.ValidatorPubkey(share.ValidatorIndex)
 	require.True(t, ok)
 	require.Equal(t, share.ValidatorPubKey, pk)
+}
+
+// TestCommittee_SubnetMemoization_MatchesIndependentRecompute is a property test verifying the
+// memoized subnet accessors on Committee always agree with an independent recomputation from
+// the same population site (buildCommittee), for random operator sets.
+func TestCommittee_SubnetMemoization_MatchesIndependentRecompute(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		operatorCount := rand.Intn(13) + 1 // 1..13 operators
+		operators := make([]spectypes.OperatorID, operatorCount)
+		committeeMembers := make([]*spectypes.ShareMember, operatorCount)
+		for j := 0; j < operatorCount; j++ {
+			opID := spectypes.OperatorID(rand.Uint64()) //nolint:gosec
+			operators[j] = opID
+			committeeMembers[j] = &spectypes.ShareMember{Signer: opID}
+		}
+
+		share := &ssvtypes.SSVShare{
+			Share: spectypes.Share{
+				ValidatorIndex:  phase0.ValidatorIndex(i + 1),
+				ValidatorPubKey: spectypes.ValidatorPK{byte(i), byte(i + 1)},
+				Committee:       committeeMembers,
+			},
+		}
+
+		c := buildCommittee([]*ssvtypes.SSVShare{share})
+
+		require.Equal(t, commons.BooleCommitteeSubnet(c.Operators), c.BooleCommitteeSubnet())
+		require.Equal(t, commons.AlanCommitteeSubnet(c.ID), c.AlanCommitteeSubnet())
+
+		// Calling the accessors again must return the memoized (equal) value.
+		require.Equal(t, c.BooleCommitteeSubnet(), c.BooleCommitteeSubnet())
+		require.Equal(t, c.AlanCommitteeSubnet(), c.AlanCommitteeSubnet())
+	}
+}
+
+// TestCommittee_SubnetMemoization_EmptyCommittee verifies an empty committee (no operators) never
+// panics and returns UnknownSubnetId for the Boole subnet while still computing a valid Alan subnet
+// from its ID.
+func TestCommittee_SubnetMemoization_EmptyCommittee(t *testing.T) {
+	id := spectypes.CommitteeID{1, 2, 3}
+	c := &Committee{ID: id}
+
+	require.Equal(t, uint64(commons.UnknownSubnetId), c.BooleCommitteeSubnet())
+	require.Equal(t, commons.AlanCommitteeSubnet(id), c.AlanCommitteeSubnet())
 }


### PR DESCRIPTION
Item 7 of #2952 (follow-up to #2941) — the last "before fork ships" convergence gap.

`validateTopicAtSlot` recomputed the committee subnet on **every** message: a SHA-256 per operator post-fork (`BooleCommitteeSubnet`) and a `big.Int` mod pre-fork (`CommitteeTopicID`). Two commits, sequenced:

1. **`registry/storage`** — `Committee.BooleSubnet`/`AlanSubnet` were caller-populated fields (set only by `buildCommittee` under a `len` guard; ~20 test fixtures never set them). Replaced with memoized accessor methods (`atomic.Pointer`, mirroring the shipped `SSVShare` pattern) computed from `Operators`/`ID` on first access — an unpopulated cache is now unrepresentable. `BroadcastAtSlot` topic selection and pubsub scoring switch to the methods. No serialization of `Committee` exists anywhere (verified), so the field removal has no schema ripple.
2. **`message/validation`** — `CommitteeInfo` carries `subnet`/`subnetAlan` as **required** constructor parameters (deliberate divergence from boole-fork's zero-fillable struct-literal constructors), fed from the `Committee`/`SSVShare` memoized accessors. The hot path only reads two `uint64`s.

Receive-side topic checks now key off the same subnet source as `BroadcastAtSlot`, so publish and receive cannot diverge.

**Numbers:** post-fork topic check 331ns/6 allocs → 80ns/2 allocs; pre-fork 127ns/5 → 72ns/2 (benchmarks included).

**Test coverage** (the issue's ⚠️ was "correctness couples to every construction site"):
- property tests: cached accessor == independent `commons.*` recompute for random committees, on both `Committee` and `CommitteeInfo`;
- accept/reject through the real entry point, right + wrong topics, pre- and post-fork, for **both** the committee path and the previously-untested validator path (proposer);
- degenerate empty-committee guard-chain proof (`ErrSignerNotInCommittee` fires before topic validation — the unknown-subnet topic is unreachable);
- publish/receive topic parity at the exact fork-boundary slots (last pre-fork + first post-fork slot, live-clock window config);
- `-race` clean; alan topic-string byte-equivalence (`CommitteeTopicID(cid)[0] == SubnetTopicID(AlanCommitteeSubnet(cid))`) relied on and asserted.